### PR TITLE
Prod fix sprite

### DIFF
--- a/components/court/FreeRoamPlayer.tsx
+++ b/components/court/FreeRoamPlayer.tsx
@@ -210,14 +210,13 @@ export function FreeRoamPlayer({
           x: x.get(),
           y: y.get(),
           scale: scale,
-        }}
-        style={{
-          transform: `scaleX(${shouldFlip ? -1 : 1})`,
+          scaleX: shouldFlip ? -1 : 1,
         }}
         transition={{
           type: 'spring',
           stiffness: 50,
           damping: 10,
+          scaleX: { duration: 0 }, // instant flip
         }}
       >
         <img


### PR DESCRIPTION
Title
Fix player movement and flip animation for consistent production behavior

Description
This MR addresses production animation issues for FreeRoamPlayer:

Previously, mixing animate={{ x, y }} with manual style.transform caused transform conflicts in production (desktop), resulting in no movement or janky behavior.

Manually applying scaleX(-1) via style.transform also led to flip timing mismatches.

In dev, React double render masked these issues; in production, optimized transforms caused visible jank.

Changes:
✅ Moved to a fully Framer Motion-managed animate={{ x, y, scale, scaleX }}
✅ Added instant flip for direction change via scaleX: { duration: 0 }
✅ Removed manual transform string to avoid conflicts
✅ Animation now runs smooth + consistent on desktop and mobile
✅ Behavior now matches dev behavior in production build

