### PR TITLE
Refactor movement system with unified game loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Hall of Strategy** – Architecture write-ups
 - **Press Room** – Blog & media entries, changelog, etc
 
+## [0.2.9] - 2026-04-12
+
+### Changed
+- Refactored movement system with a unified `requestAnimationFrame` game loop using delta time for frame-rate independent movement.
+- Springs (`springX`/`springY`) now properly drive the DOM via `style` instead of unused `animate` prop.
+- Normalized diagonal keyboard movement so it matches cardinal speed.
+
+### Fixed
+- Player spawn position was outside court bounds.
+- Movement speed varied across different refresh rates (60Hz vs 120Hz).
+
+### Removed
+- Unused duplicate `getScaledFloorBounds` function.
+- `any` types in `useCourtResizeClamp` replaced with `MotionValue<number>`.
 
 ## [0.2.8] - 2026-01-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.2.9] - 2026-04-12
 
 ### Changed
-- Refactored movement system with a unified `requestAnimationFrame` game loop using delta time for frame-rate independent movement.
+- Refactored movement system with a unified `requestAnimationFrame` game loop using delta time for frame-rate-independent movement.
 - Springs (`springX`/`springY`) now properly drive the DOM via `style` instead of unused `animate` prop.
 - Normalized diagonal keyboard movement so it matches cardinal speed.
+- `useCourtResizeClamp` now types `x`/`y` as `MotionValue<number>` instead of `any`.
 
 ### Fixed
 - Player spawn position was outside court bounds.
@@ -24,7 +25,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 - Unused duplicate `getScaledFloorBounds` function.
-- `any` types in `useCourtResizeClamp` replaced with `MotionValue<number>`.
 
 ## [0.2.8] - 2026-01-18
 

--- a/components/court/FreeRoamPlayer.tsx
+++ b/components/court/FreeRoamPlayer.tsx
@@ -72,10 +72,9 @@ export function FreeRoamPlayer({
 
   // Recalculate sprite scale when viewport changes
   useEffect(() => {
-    const svg = boundsRef.current
-    if (!svg) return
-
     const updateScaleAndBounds = () => {
+      const svg = boundsRef.current
+      if (!svg) return
       const rawScale = svg.clientWidth / 1536
       setScale(Math.min(Math.max(rawScale, 0.5), 1))
       boundsCache.current = getScaledCourtBounds(svg)

--- a/components/court/FreeRoamPlayer.tsx
+++ b/components/court/FreeRoamPlayer.tsx
@@ -44,9 +44,10 @@ export function FreeRoamPlayer({
   // Refs for input state (no re-renders needed)
   const keysRef = useRef(new Set<string>())
   const clickTargetRef = useRef<{ x: number; y: number } | null>(null)
-  const lastMoveTimeRef = useRef(Date.now())
+  const lastMoveTimeRef = useRef(performance.now())
   const walkFrameTimeRef = useRef(0)
   const gameLoopRef = useRef(0)
+  const boundsCache = useRef<ReturnType<typeof getScaledCourtBounds> | null>(null)
 
   // Visual state (triggers re-renders for sprite changes)
   const [facingLeft, setFacingLeft] = useState(false)
@@ -63,17 +64,18 @@ export function FreeRoamPlayer({
     const svg = boundsRef.current
     if (!svg) return
 
-    const updateScale = () => {
+    const updateScaleAndBounds = () => {
       const rawScale = svg.clientWidth / 1536
       setScale(Math.min(Math.max(rawScale, 0.5), 1))
+      boundsCache.current = getScaledCourtBounds(svg)
     }
 
-    updateScale()
-    window.addEventListener('resize', updateScale)
-    window.addEventListener('orientationchange', updateScale)
+    updateScaleAndBounds()
+    window.addEventListener('resize', updateScaleAndBounds)
+    window.addEventListener('orientationchange', updateScaleAndBounds)
     return () => {
-      window.removeEventListener('resize', updateScale)
-      window.removeEventListener('orientationchange', updateScale)
+      window.removeEventListener('resize', updateScaleAndBounds)
+      window.removeEventListener('orientationchange', updateScaleAndBounds)
     }
   }, [boundsRef])
 
@@ -100,11 +102,15 @@ export function FreeRoamPlayer({
       keysRef.current.delete(e.key.toLowerCase())
     }
 
+    const handleBlur = () => keysRef.current.clear()
+
     window.addEventListener('keydown', handleKeyDown)
     window.addEventListener('keyup', handleKeyUp)
+    window.addEventListener('blur', handleBlur)
     return () => {
       window.removeEventListener('keydown', handleKeyDown)
       window.removeEventListener('keyup', handleKeyUp)
+      window.removeEventListener('blur', handleBlur)
     }
   }, [])
 
@@ -119,13 +125,11 @@ export function FreeRoamPlayer({
       const dt = Math.min((now - prevTime) / 1000, 0.1) // cap to prevent teleporting after tab-away
       prevTime = now
 
-      const svg = boundsRef.current
-      if (!svg) {
+      const bounds = boundsCache.current
+      if (!bounds) {
         gameLoopRef.current = requestAnimationFrame(tick)
         return
       }
-
-      const bounds = getScaledCourtBounds(svg)
       const keys = keysRef.current
       let dx = 0
       let dy = 0

--- a/components/court/FreeRoamPlayer.tsx
+++ b/components/court/FreeRoamPlayer.tsx
@@ -87,7 +87,20 @@ export function FreeRoamPlayer({
 
   // Keyboard input — only tracks which keys are held, movement happens in game loop
   useEffect(() => {
+    const isEditableTarget = (target: EventTarget | null) => {
+      const el = target as HTMLElement | null
+      if (!el || typeof el.tagName !== 'string') return false
+      const tag = el.tagName
+      return (
+        tag === 'INPUT' ||
+        tag === 'TEXTAREA' ||
+        tag === 'SELECT' ||
+        el.isContentEditable === true
+      )
+    }
+
     const handleKeyDown = (e: KeyboardEvent) => {
+      if (isEditableTarget(e.target)) return
       if (['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(e.key)) {
         e.preventDefault()
       }
@@ -252,6 +265,7 @@ export function FreeRoamPlayer({
       >
         <img
           src={currentSprite}
+          alt=""
           style={{
             width: PLAYER_SIZE,
             height: PLAYER_SIZE,

--- a/components/court/FreeRoamPlayer.tsx
+++ b/components/court/FreeRoamPlayer.tsx
@@ -57,6 +57,16 @@ export function FreeRoamPlayer({
   const [isShootingPose, setIsShootingPose] = useState(false)
   const [scale, setScale] = useState(1)
 
+  // Mirrors of state for the idle-pose interval to read without re-running
+  const isMovingRef = useRef(false)
+  const isShootingPoseRef = useRef(false)
+  useEffect(() => {
+    isMovingRef.current = isMoving
+  }, [isMoving])
+  useEffect(() => {
+    isShootingPoseRef.current = isShootingPose
+  }, [isShootingPose])
+
   // Keep player clamped inside court on resize
   useCourtResizeClamp(boundsRef, x, y, PLAYER_SIZE, PLAYER_SIZE)
 
@@ -221,18 +231,19 @@ export function FreeRoamPlayer({
     return () => cancelAnimationFrame(gameLoopRef.current)
   }, [boundsRef, x, y])
 
-  // Idle shooting pose — triggers after player stands still for a while
+  // Idle shooting pose — triggers after player stands still for a while.
+  // Deps are intentionally empty: re-running on state change would clear the
+  // pending shoot-pose-exit timeout scheduled inside the same tick.
   useEffect(() => {
     const interval = setInterval(() => {
-      if (!isMoving && !isShootingPose) {
-        if (performance.now() - lastMoveTimeRef.current > IDLE_TIMEOUT_MS) {
-          setIsShootingPose(true)
-          shootPoseTimeoutRef.current = setTimeout(() => {
-            setIsShootingPose(false)
-            lastMoveTimeRef.current = performance.now()
-            shootPoseTimeoutRef.current = null
-          }, SHOOT_POSE_MS)
-        }
+      if (isMovingRef.current || isShootingPoseRef.current) return
+      if (performance.now() - lastMoveTimeRef.current > IDLE_TIMEOUT_MS) {
+        setIsShootingPose(true)
+        shootPoseTimeoutRef.current = setTimeout(() => {
+          setIsShootingPose(false)
+          lastMoveTimeRef.current = performance.now()
+          shootPoseTimeoutRef.current = null
+        }, SHOOT_POSE_MS)
       }
     }, 1000)
     return () => {
@@ -242,7 +253,7 @@ export function FreeRoamPlayer({
         shootPoseTimeoutRef.current = null
       }
     }
-  }, [isMoving, isShootingPose])
+  }, [])
 
   const currentSprite = isShootingPose
     ? SHOOTING_FRAME
@@ -261,6 +272,10 @@ export function FreeRoamPlayer({
           y: springY,
           scale,
           scaleX: shouldFlip ? -1 : 1,
+          // x/y are the sprite's center per clampToCourt; offset so the box's
+          // center lands on (x, y) instead of its top-left.
+          marginLeft: -PLAYER_SIZE / 2,
+          marginTop: -PLAYER_SIZE / 2,
         }}
       >
         <img

--- a/components/court/FreeRoamPlayer.tsx
+++ b/components/court/FreeRoamPlayer.tsx
@@ -47,6 +47,7 @@ export function FreeRoamPlayer({
   const lastMoveTimeRef = useRef(performance.now())
   const walkFrameTimeRef = useRef(0)
   const gameLoopRef = useRef(0)
+  const shootPoseTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const boundsCache = useRef<ReturnType<typeof getScaledCourtBounds> | null>(null)
 
   // Visual state (triggers re-renders for sprite changes)
@@ -79,9 +80,8 @@ export function FreeRoamPlayer({
     }
   }, [boundsRef])
 
-  // Sync click target prop into ref (keyboard will clear it, click will set it)
+  // Sync click target prop into ref (keyboard clears it, click sets it, upstream null cancels it)
   useEffect(() => {
-    if (!target) return
     clickTargetRef.current = target
   }, [target])
 
@@ -181,7 +181,14 @@ export function FreeRoamPlayer({
       if (moved !== wasMoving) {
         wasMoving = moved
         setIsMoving(moved)
-        if (moved) setIsShootingPose(false)
+        if (moved) {
+          // Cancel a pending shoot-pose callback so it can't overwrite lastMoveTimeRef later
+          if (shootPoseTimeoutRef.current) {
+            clearTimeout(shootPoseTimeoutRef.current)
+            shootPoseTimeoutRef.current = null
+          }
+          setIsShootingPose(false)
+        }
       }
 
       if (moved) {
@@ -207,14 +214,21 @@ export function FreeRoamPlayer({
       if (!isMoving && !isShootingPose) {
         if (performance.now() - lastMoveTimeRef.current > IDLE_TIMEOUT_MS) {
           setIsShootingPose(true)
-          setTimeout(() => {
+          shootPoseTimeoutRef.current = setTimeout(() => {
             setIsShootingPose(false)
             lastMoveTimeRef.current = performance.now()
+            shootPoseTimeoutRef.current = null
           }, SHOOT_POSE_MS)
         }
       }
     }, 1000)
-    return () => clearInterval(interval)
+    return () => {
+      clearInterval(interval)
+      if (shootPoseTimeoutRef.current) {
+        clearTimeout(shootPoseTimeoutRef.current)
+        shootPoseTimeoutRef.current = null
+      }
+    }
   }, [isMoving, isShootingPose])
 
   const currentSprite = isShootingPose

--- a/components/court/FreeRoamPlayer.tsx
+++ b/components/court/FreeRoamPlayer.tsx
@@ -81,9 +81,20 @@ export function FreeRoamPlayer({
     }
 
     updateScaleAndBounds()
+
+    // Observe the SVG directly so layout-driven size changes (flexbox/grid
+    // reflow, ancestor CSS changes) refresh bounds without a window resize.
+    const svg = boundsRef.current
+    const observer =
+      svg && typeof ResizeObserver !== 'undefined'
+        ? new ResizeObserver(updateScaleAndBounds)
+        : null
+    if (observer && svg) observer.observe(svg)
+
     window.addEventListener('resize', updateScaleAndBounds)
     window.addEventListener('orientationchange', updateScaleAndBounds)
     return () => {
+      observer?.disconnect()
       window.removeEventListener('resize', updateScaleAndBounds)
       window.removeEventListener('orientationchange', updateScaleAndBounds)
     }

--- a/components/court/FreeRoamPlayer.tsx
+++ b/components/court/FreeRoamPlayer.tsx
@@ -5,7 +5,26 @@ import { motion, useMotionValue, useSpring } from 'framer-motion'
 import { clampToCourt, getScaledCourtBounds } from '@/utils/movements'
 import { useCourtResizeClamp } from '@/utils/hooks/useCourtResizeClamp'
 import { PLAYER_SIZE } from '@/constants/playerSize'
-import { useMotionValueEvent } from 'framer-motion'
+
+// Movement speeds in screen-space pixels per second
+const KEYBOARD_SPEED = 280
+const CLICK_SPEED = 180
+const CLICK_THRESHOLD = 2
+
+// Animation timing (ms)
+const WALK_FRAME_MS = 150
+const IDLE_TIMEOUT_MS = 4000
+const SHOOT_POSE_MS = 1800
+
+// Spring config — snappy enough to track keyboard, smooth enough for click-to-move
+const SPRING_CONFIG = { stiffness: 170, damping: 22 }
+
+const DRIBBLE_FRAMES = ['/sprites/LucasDribbling2.png', '/sprites/LucasDribbling3.png']
+const IDLE_FRAME = '/sprites/LucasIdle4.png'
+const SHOOTING_FRAME = '/sprites/LucasShooting2.png'
+
+// Keys we care about (lowercased for comparison)
+const MOVE_KEYS = new Set(['w', 'a', 's', 'd', 'arrowup', 'arrowdown', 'arrowleft', 'arrowright'])
 
 export function FreeRoamPlayer({
   boundsRef,
@@ -14,104 +33,71 @@ export function FreeRoamPlayer({
   boundsRef: React.RefObject<SVGSVGElement | null>
   target: { x: number; y: number } | null
 }) {
-  const x = useMotionValue(730)
-  const y = useMotionValue(1340)
-  const springX = useSpring(x, { stiffness: 50, damping: 10 })
-  const springY = useSpring(y, { stiffness: 50, damping: 10 })
+  // Raw position values — the game loop writes to these
+  const x = useMotionValue(400)
+  const y = useMotionValue(400)
 
-  const lastMoveTime = useRef(Date.now())
-  const clickAnimationRef = useRef<number | null>(null)
+  // Springs follow the raw values and drive the DOM
+  const springX = useSpring(x, SPRING_CONFIG)
+  const springY = useSpring(y, SPRING_CONFIG)
 
+  // Refs for input state (no re-renders needed)
+  const keysRef = useRef(new Set<string>())
+  const clickTargetRef = useRef<{ x: number; y: number } | null>(null)
+  const lastMoveTimeRef = useRef(Date.now())
+  const walkFrameTimeRef = useRef(0)
+  const gameLoopRef = useRef(0)
+
+  // Visual state (triggers re-renders for sprite changes)
   const [facingLeft, setFacingLeft] = useState(false)
   const [isMoving, setIsMoving] = useState(false)
   const [frameIndex, setFrameIndex] = useState(0)
   const [isShootingPose, setIsShootingPose] = useState(false)
   const [scale, setScale] = useState(1)
 
-  const dribbleFrames = ['/sprites/LucasDribbling2.png', '/sprites/LucasDribbling3.png']
-  const idleFrame = '/sprites/LucasIdle4.png'
-  const shootingFrame = '/sprites/LucasShooting2.png'
-
-  // Resize clamp — keep player on court when resized
+  // Keep player clamped inside court on resize
   useCourtResizeClamp(boundsRef, x, y, PLAYER_SIZE, PLAYER_SIZE)
 
-  // Dynamic scale calculation
+  // Recalculate sprite scale when viewport changes
   useEffect(() => {
     const svg = boundsRef.current
     if (!svg) return
 
     const updateScale = () => {
-      const viewBoxWidth = 1536
-      const pixelWidth = svg.clientWidth
-      const rawScale = pixelWidth / viewBoxWidth
-      const clampedScale = Math.min(Math.max(rawScale, 0.5), 1)
-      setScale(clampedScale)
+      const rawScale = svg.clientWidth / 1536
+      setScale(Math.min(Math.max(rawScale, 0.5), 1))
     }
 
     updateScale()
     window.addEventListener('resize', updateScale)
     window.addEventListener('orientationchange', updateScale)
-
     return () => {
       window.removeEventListener('resize', updateScale)
       window.removeEventListener('orientationchange', updateScale)
     }
   }, [boundsRef])
 
-  // Keyboard movement
+  // Sync click target prop into ref (keyboard will clear it, click will set it)
   useEffect(() => {
-    const speed = 8
-    const keysPressed = new Set<string>()
+    if (!target) return
+    clickTargetRef.current = target
+  }, [target])
 
+  // Keyboard input — only tracks which keys are held, movement happens in game loop
+  useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(e.key)) {
         e.preventDefault()
       }
-
-      if (clickAnimationRef.current !== null) {
-        cancelAnimationFrame(clickAnimationRef.current)
-        clickAnimationRef.current = null
+      const key = e.key.toLowerCase()
+      if (MOVE_KEYS.has(key)) {
+        keysRef.current.add(key)
+        clickTargetRef.current = null // keyboard overrides click-to-move
       }
-
-      keysPressed.add(e.key)
-
-      let dx = 0
-      let dy = 0
-
-      if (keysPressed.has('w') || keysPressed.has('ArrowUp')) dy -= speed
-      if (keysPressed.has('s') || keysPressed.has('ArrowDown')) dy += speed
-      if (keysPressed.has('a') || keysPressed.has('ArrowLeft')) dx -= speed
-      if (keysPressed.has('d') || keysPressed.has('ArrowRight')) dx += speed
-
-      if (dx !== 0 || dy !== 0) {
-        lastMoveTime.current = Date.now()
-        setIsShootingPose(false)
-        setIsMoving(true)
-        setFacingLeft(dx < 0)
-      }
-
-      const svg = boundsRef.current
-      if (!svg) return
-
-      const bounds = getScaledCourtBounds(svg)
-      const { x: nextX, y: nextY } = clampToCourt(
-        x.get() + dx,
-        y.get() + dy,
-        bounds,
-        PLAYER_SIZE,
-        PLAYER_SIZE
-      )
-
-      x.set(nextX)
-      y.set(nextY)
     }
 
     const handleKeyUp = (e: KeyboardEvent) => {
-      keysPressed.delete(e.key)
-      if (keysPressed.size === 0) {
-        setIsMoving(false)
-        lastMoveTime.current = Date.now()
-      }
+      keysRef.current.delete(e.key.toLowerCase())
     }
 
     window.addEventListener('keydown', handleKeyDown)
@@ -120,90 +106,118 @@ export function FreeRoamPlayer({
       window.removeEventListener('keydown', handleKeyDown)
       window.removeEventListener('keyup', handleKeyUp)
     }
-  }, [x, y, boundsRef])
+  }, [])
 
-  // Click-to-move
+  // ── Unified game loop ──────────────────────────────────────────────
+  // Single RAF loop handles both keyboard and click-to-move with delta time,
+  // so movement speed is consistent regardless of frame rate.
   useEffect(() => {
-    if (!target) return
-    const svg = boundsRef.current
-    if (!svg) return
+    let prevTime = performance.now()
+    let wasMoving = false
 
-    const bounds = getScaledCourtBounds(svg)
-    const { x: targetX, y: targetY } = clampToCourt(
-      target.x,
-      target.y,
-      bounds,
-      PLAYER_SIZE,
-      PLAYER_SIZE
-    )
+    const tick = (now: number) => {
+      const dt = Math.min((now - prevTime) / 1000, 0.1) // cap to prevent teleporting after tab-away
+      prevTime = now
 
-    setFacingLeft(targetX < x.get())
-    setIsShootingPose(false)
-    setIsMoving(true)
-
-    const speed = 2.5
-    const threshold = 1.5
-
-    const step = () => {
-      const dx = targetX - x.get()
-      const dy = targetY - y.get()
-      const distance = Math.sqrt(dx * dx + dy * dy)
-
-      if (distance < threshold) {
-        setIsMoving(false)
-        if (clickAnimationRef.current !== null) {
-          cancelAnimationFrame(clickAnimationRef.current)
-          clickAnimationRef.current = null
-        }
+      const svg = boundsRef.current
+      if (!svg) {
+        gameLoopRef.current = requestAnimationFrame(tick)
         return
       }
 
-      const angle = Math.atan2(dy, dx)
-      x.set(x.get() + Math.cos(angle) * speed)
-      y.set(y.get() + Math.sin(angle) * speed)
+      const bounds = getScaledCourtBounds(svg)
+      const keys = keysRef.current
+      let dx = 0
+      let dy = 0
+      let moved = false
 
-      clickAnimationRef.current = requestAnimationFrame(step)
+      // ── Keyboard movement ──
+      if (keys.has('w') || keys.has('arrowup')) dy -= 1
+      if (keys.has('s') || keys.has('arrowdown')) dy += 1
+      if (keys.has('a') || keys.has('arrowleft')) dx -= 1
+      if (keys.has('d') || keys.has('arrowright')) dx += 1
+
+      if (dx !== 0 || dy !== 0) {
+        // Normalize so diagonal isn't faster
+        const len = Math.sqrt(dx * dx + dy * dy)
+        dx = (dx / len) * KEYBOARD_SPEED * dt
+        dy = (dy / len) * KEYBOARD_SPEED * dt
+
+        const clamped = clampToCourt(x.get() + dx, y.get() + dy, bounds, PLAYER_SIZE, PLAYER_SIZE)
+        x.set(clamped.x)
+        y.set(clamped.y)
+        moved = true
+
+        if (dx < 0) setFacingLeft(true)
+        else if (dx > 0) setFacingLeft(false)
+      }
+      // ── Click-to-move ──
+      else if (clickTargetRef.current) {
+        const tgt = clickTargetRef.current
+        const clampedTarget = clampToCourt(tgt.x, tgt.y, bounds, PLAYER_SIZE, PLAYER_SIZE)
+        const tdx = clampedTarget.x - x.get()
+        const tdy = clampedTarget.y - y.get()
+        const dist = Math.sqrt(tdx * tdx + tdy * tdy)
+
+        if (dist < CLICK_THRESHOLD) {
+          clickTargetRef.current = null
+        } else {
+          const step = Math.min(CLICK_SPEED * dt, dist) // don't overshoot
+          const angle = Math.atan2(tdy, tdx)
+          x.set(x.get() + Math.cos(angle) * step)
+          y.set(y.get() + Math.sin(angle) * step)
+          moved = true
+
+          if (tdx < 0) setFacingLeft(true)
+          else if (tdx > 0) setFacingLeft(false)
+        }
+      }
+
+      // ── Update movement state ──
+      if (moved !== wasMoving) {
+        wasMoving = moved
+        setIsMoving(moved)
+        if (moved) setIsShootingPose(false)
+      }
+
+      if (moved) {
+        lastMoveTimeRef.current = now
+
+        // Walk cycle sprite swap
+        if (now - walkFrameTimeRef.current > WALK_FRAME_MS) {
+          setFrameIndex(prev => (prev + 1) % DRIBBLE_FRAMES.length)
+          walkFrameTimeRef.current = now
+        }
+      }
+
+      gameLoopRef.current = requestAnimationFrame(tick)
     }
 
-    step()
-  }, [target, x, y, boundsRef])
+    gameLoopRef.current = requestAnimationFrame(tick)
+    return () => cancelAnimationFrame(gameLoopRef.current)
+  }, [boundsRef, x, y])
 
-  const lastFrameTime = useRef(0)
-
-  // Walk cycle
-  useMotionValueEvent(x, 'change', () => {
-    if (!isMoving) return
-
-    const now = Date.now()
-    if (now - lastFrameTime.current > 150) {
-      setFrameIndex(prev => (prev + 1) % dribbleFrames.length)
-      lastFrameTime.current = now
-    }
-  })
-
-  // Idle shooting pose
+  // Idle shooting pose — triggers after player stands still for a while
   useEffect(() => {
-    const checkIdle = setInterval(() => {
+    const interval = setInterval(() => {
       if (!isMoving && !isShootingPose) {
-        const now = Date.now()
-        const idleTime = now - lastMoveTime.current
-        if (idleTime > 4000) {
+        if (performance.now() - lastMoveTimeRef.current > IDLE_TIMEOUT_MS) {
           setIsShootingPose(true)
           setTimeout(() => {
             setIsShootingPose(false)
-            lastMoveTime.current = Date.now()
-          }, 1800)
+            lastMoveTimeRef.current = performance.now()
+          }, SHOOT_POSE_MS)
         }
       }
     }, 1000)
-    return () => clearInterval(checkIdle)
+    return () => clearInterval(interval)
   }, [isMoving, isShootingPose])
 
   const currentSprite = isShootingPose
-    ? shootingFrame
+    ? SHOOTING_FRAME
     : isMoving
-      ? dribbleFrames[frameIndex]
-      : idleFrame
+      ? DRIBBLE_FRAMES[frameIndex]
+      : IDLE_FRAME
 
   const shouldFlip = isShootingPose ? !facingLeft : facingLeft
 
@@ -211,21 +225,11 @@ export function FreeRoamPlayer({
     <div className="absolute w-full h-full pointer-events-none">
       <motion.div
         className="absolute z-50 pointer-events-none"
-        animate={{
-          x: x.get(),
-          y: y.get(),
-          scale: scale,
-          scaleX: shouldFlip ? -1 : 1,
-        }}
-        transition={{
-          type: 'spring',
-          stiffness: 50,
-          damping: 10,
-          scaleX: { duration: 0 },
-        }}
         style={{
-          touchAction: 'auto',
-          willChange: 'auto',
+          x: springX,
+          y: springY,
+          scale,
+          scaleX: shouldFlip ? -1 : 1,
         }}
       >
         <img

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "my-court",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/utils/hooks/useCourtResizeClamp.ts
+++ b/utils/hooks/useCourtResizeClamp.ts
@@ -1,19 +1,11 @@
 import { useEffect } from 'react'
+import type { MotionValue } from 'framer-motion'
 import { getScaledCourtBounds, clampToCourt } from '@/utils/movements'
 
-/**
- * Keeps player clamped inside court on resize and orientation change.
- *
- * @param svgRef - ref to your court SVG element
- * @param x - motion value for player X position
- * @param y - motion value for player Y position
- * @param playerWidth - width of player sprite in px
- * @param playerHeight - height of player sprite in px
- */
 export function useCourtResizeClamp(
   svgRef: React.RefObject<SVGSVGElement | null>,
-  x: any, // motionValue
-  y: any, // motionValue
+  x: MotionValue<number>,
+  y: MotionValue<number>,
   playerWidth: number,
   playerHeight: number
 ) {

--- a/utils/movements.ts
+++ b/utils/movements.ts
@@ -31,29 +31,6 @@ export function getScaledCourtBounds(svg: SVGSVGElement): ScaledCourtBounds {
   }
 }
 
-export function getScaledFloorBounds(svg: SVGSVGElement): ScaledCourtBounds {
-  const rect = svg.getBoundingClientRect()
-  const viewBoxWidth = 1536
-  const viewBoxHeight = 1024
-
-  const scaleX = rect.width / viewBoxWidth
-  const scaleY = rect.height / viewBoxHeight
-
-  const pxCourtX = COURT_X * scaleX
-  const pxCourtY = COURT_Y * scaleY
-  const pxCourtWidth = COURT_WIDTH * scaleX
-  const pxCourtHeight = COURT_HEIGHT * scaleY
-
-  return {
-    pxCourtX,
-    pxCourtY,
-    pxCourtWidth,
-    pxCourtHeight,
-    scaleX,
-    scaleY,
-  }
-}
-
 /**
  * Clamps a screen-space position to the playable area of the court.
  *


### PR DESCRIPTION
## Summary
- Replace per-keydown keyboard handler and separate click-to-move RAF loop with a **single unified `requestAnimationFrame` game loop** using delta time — movement speed is now consistent regardless of frame rate
- **Normalize diagonal movement** so pressing W+D isn't ~41% faster than pressing just W
- **Fix springs being unused** — `springX`/`springY` were created via `useSpring` but the component used `animate` prop instead; now properly bound via `style` prop for smooth, re-render-free position updates
- Fix initial spawn position (was outside court bounds at y=1340, court max is ~870)
- Remove unused duplicate `getScaledFloorBounds` function
- Replace `any` types with `MotionValue<number>` in `useCourtResizeClamp`

## Test plan
- [ ] WASD / arrow key movement feels smooth and consistent
- [ ] Diagonal movement is the same speed as cardinal directions
- [ ] Click-to-move paths smoothly to target
- [ ] Keyboard input overrides active click-to-move
- [ ] Player stays in bounds on window resize
- [ ] Idle shooting pose still triggers after ~4s of inactivity
- [ ] Sprite direction flipping works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changed**
  * Unified movement for smoother, frame-rate–independent motion; keyboard and click-to-move use a single game loop and diagonal speed is normalized.
  * Walk animations and idle/shoot timing are more consistent; sprites are correctly centered during movement.

* **Bug Fixes**
  * Fixed players spawning outside court bounds.
  * Fixed movement speed varying with display refresh rate.

* **Performance**
  * Reduced per-frame work for improved responsiveness.

* **Chores**
  * Release bumped to 0.2.9 and changelog updated; removed an unused floor-bounds helper.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->