### PR TITLE
fix: restore binder-leather.png reference (re-applies #92)

### DIFF
--- a/.claude/skills/court-vision-design/README.md
+++ b/.claude/skills/court-vision-design/README.md
@@ -79,7 +79,7 @@ Both moods coexist on the same page — the court is black, the buttons hovering
 
 ### Backgrounds & textures
 - Court SVG (`assets/court.svg`) — used full-bleed at 10% opacity behind hero, and as the actual interactive playable surface.
-- Leather binder texture — `bg-[url('/textures/binder-leather.png')]` for the Project Binder page (texture file not imported; substitute with a wood-grain placeholder if needed).
+- Leather binder texture — `bg-[url('/textures/binder-leather.png')]` for the Project Binder page.
 - Vertical 3-stop gradient (`from-black via-neutral-900 to-black`) for full-page night surfaces.
 - Radial orange blur ("spotlight") — `bg-orange-500 blur-3xl opacity-30 rounded-full` centered.
 - No glassmorphism on arena pages. Locker zones do use a `backdrop-filter: blur(4px)` on `rgba(38,20,4,0.7)` for the modern ZoneAbout/About-Me chip.
@@ -152,7 +152,6 @@ Court Vision has a distinct, **hand-rolled SVG icon vocabulary** — no Lucide, 
 ### Substitutions flagged
 - **Geist & Geist Mono** — original site uses `next/font/google`. Loaded here from Google Fonts CDN — visually identical, no flag needed.
 - **Patrick Hand** — loaded from Google Fonts as in the source.
-- **Binder leather texture** (`/textures/binder-leather.png`) — not imported; if needed, substitute with a CSS wood-grain or solid `--hardwood-rich`.
 - **Lucas sprite PNGs** (`LucasIdle4/5`, `LucasDribbling2/3`) — not imported (1.5MB each). Reference by description; ask user before re-importing.
 
 ---

--- a/components/project-binder/ProjectGallery.tsx
+++ b/components/project-binder/ProjectGallery.tsx
@@ -119,7 +119,7 @@ export const ProjectGallery = () => {
   const rightColumn = projects.slice(mid)
 
   return (
-    <div className="relative min-h-screen bg-[url('/textures/binder-leather.jpg')] bg-cover bg-center px-2 sm:px-6 py-12 shadow-[inset_0_0_60px_rgba(0,0,0,0.3)]">
+    <div className="relative min-h-screen bg-[url('/textures/binder-leather.png')] bg-cover bg-center px-2 sm:px-6 py-12 shadow-[inset_0_0_60px_rgba(0,0,0,0.3)]">
       <div className="mx-auto w-full max-w-[1600px]">
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6 px-2 sm:px-4">
           {/* Left Column */}


### PR DESCRIPTION
## Summary
PR #90 (chore/screenshots-gitignore) accidentally reverted PR #92's binder-leather fix during its squash-merge. The texture path went `.png` → `.jpg`, which 404s because the asset on disk is `.png`. This PR re-applies #92's exact change set.

## What changed
- `components/project-binder/ProjectGallery.tsx:122` — `.jpg` → `.png`
- `.claude/skills/court-vision-design/README.md` — drop the two stale "binder texture not imported" notes

## Root cause
Interrupted local merge: WIP from an earlier `fix/39` branch followed across branch switches as staged changes, got stashed mid-merge, and the merge commit captured the chore-branch HEAD content (pre-fix `.jpg`) instead of the post-fix content from `origin/main`. When #90 squash-merged, that revert was applied to main.

## Test plan
- [x] `git diff main..fix/restore-binder-leather-png` is byte-identical to PR #92's net change
- [ ] Reviewer: confirm Project Binder loads the texture (no 404 in network tab)

🤖 Generated with [Claude Code](https://claude.com/claude-code)