### PR TITLE
feat(training-facility): flippable Combine trading card (#53)

### DIFF
--- a/app/dev/trading-card/page.tsx
+++ b/app/dev/trading-card/page.tsx
@@ -8,6 +8,13 @@ export const metadata = {
   robots: { index: false, follow: false },
 }
 
+/**
+ * Four months of synthetic Combine entries used purely as a fixture for
+ * this dev-only smoke page. Values trend in the right direction (vertical
+ * up; shuttle, sprint, weight all down) so the latest entry sets a
+ * personal best on every metric — exercising the all-PB visual state
+ * without needing real benchmark data.
+ */
 const history: Benchmark[] = [
   {
     date: '2026-01-15',

--- a/app/dev/trading-card/page.tsx
+++ b/app/dev/trading-card/page.tsx
@@ -1,7 +1,8 @@
-import type { JSX } from 'react'
+import type { JSX, ReactNode } from 'react'
 import { TradingCard } from '@/components/training-facility/shared/TradingCard'
 import type { Benchmark } from '@/types/movement'
 
+/** Page metadata — hidden from search since `/dev/*` routes are dev-only smoke surfaces. */
 export const metadata = {
   title: 'Trading card — dev',
   robots: { index: false, follow: false },
@@ -45,6 +46,13 @@ const history: Benchmark[] = [
 const latestEntry = history[history.length - 1]
 const baselineEntry = history[0]
 
+/**
+ * Hidden dev-only smoke page for the {@link TradingCard} component.
+ * Renders two cards side-by-side: one with full history (latest entry sets
+ * a PB on every metric) and one as a baseline (no prior history → no PB
+ * badge). Used to visually verify the flip animation and PB detection
+ * without wiring the card into a real consumer page.
+ */
 export default function TradingCardDemoPage(): JSX.Element {
   return (
     <main
@@ -104,7 +112,7 @@ export default function TradingCardDemoPage(): JSX.Element {
   )
 }
 
-function Section({ title, children }: { title: string; children: React.ReactNode }): JSX.Element {
+function Section({ title, children }: { title: string; children: ReactNode }): JSX.Element {
   return (
     <section style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
       <h2

--- a/app/dev/trading-card/page.tsx
+++ b/app/dev/trading-card/page.tsx
@@ -1,0 +1,126 @@
+import type { JSX } from 'react'
+import { TradingCard } from '@/components/training-facility/shared/TradingCard'
+import type { Benchmark } from '@/types/movement'
+
+export const metadata = {
+  title: 'Trading card — dev',
+  robots: { index: false, follow: false },
+}
+
+const history: Benchmark[] = [
+  {
+    date: '2026-01-15',
+    bodyweight_lbs: 240.5,
+    shuttle_5_10_5_s: 5.62,
+    vertical_in: 19.5,
+    sprint_10y_s: 1.98,
+    notes: 'First baseline. Felt sluggish on the second 5-10-5.',
+  },
+  {
+    date: '2026-02-15',
+    bodyweight_lbs: 237.0,
+    shuttle_5_10_5_s: 5.51,
+    vertical_in: 20.25,
+    sprint_10y_s: 1.95,
+    notes: 'Better warmup, looser hips.',
+  },
+  {
+    date: '2026-03-15',
+    bodyweight_lbs: 234.2,
+    shuttle_5_10_5_s: 5.45,
+    vertical_in: 21.0,
+    sprint_10y_s: 1.93,
+    notes: 'Shorter rest between attempts. Tracking weight loss as a lever.',
+  },
+  {
+    date: '2026-04-15',
+    bodyweight_lbs: 231.4,
+    shuttle_5_10_5_s: 5.38,
+    vertical_in: 22.0,
+    sprint_10y_s: 1.91,
+    notes: 'PB across the board — first session feeling clean off the line.',
+  },
+]
+
+const latestEntry = history[history.length - 1]
+const baselineEntry = history[0]
+
+export default function TradingCardDemoPage(): JSX.Element {
+  return (
+    <main
+      style={{
+        backgroundColor: '#0a0a0a',
+        color: '#f5f1e6',
+        minHeight: '100vh',
+        padding: '3rem 1.5rem',
+        fontFamily: 'system-ui, sans-serif',
+      }}
+    >
+      <div style={{ maxWidth: 960, margin: '0 auto' }}>
+        <header style={{ marginBottom: '2rem' }}>
+          <p
+            style={{
+              fontFamily: 'ui-monospace, monospace',
+              fontSize: 12,
+              letterSpacing: '0.16em',
+              textTransform: 'uppercase',
+              color: '#fb923c',
+              margin: 0,
+            }}
+          >
+            Training Facility / dev
+          </p>
+          <h1 style={{ fontSize: '2.25rem', margin: '0.25rem 0 0.5rem', fontWeight: 800 }}>
+            Trading card
+          </h1>
+          <p style={{ fontSize: 14, color: '#a3a3a3', maxWidth: '60ch' }}>
+            Issue #53 — flippable Combine stat card. Click either card to flip. The left card has
+            full history (latest is a PB across all four metrics), the right has no prior sessions
+            (no PB badge possible).
+          </p>
+        </header>
+
+        <div style={{ display: 'flex', gap: '2rem', flexWrap: 'wrap', alignItems: 'flex-start' }}>
+          <Section title="Latest entry with full history (all PBs)">
+            <TradingCard
+              entry={latestEntry}
+              history={history}
+              playerNumber={11}
+              playerName="Lucas L."
+            />
+          </Section>
+
+          <Section title="First-ever entry (no history yet)">
+            <TradingCard
+              entry={baselineEntry}
+              history={[baselineEntry]}
+              playerNumber={11}
+              playerName="Lucas L."
+            />
+          </Section>
+        </div>
+      </div>
+    </main>
+  )
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }): JSX.Element {
+  return (
+    <section style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
+      <h2
+        style={{
+          fontFamily: 'system-ui, sans-serif',
+          fontSize: 13,
+          fontWeight: 600,
+          letterSpacing: '0.05em',
+          textTransform: 'uppercase',
+          color: '#737373',
+          margin: 0,
+        }}
+      >
+        {title}
+      </h2>
+      {children}
+    </section>
+  )
+}

--- a/components/training-facility/shared/TradingCard.tsx
+++ b/components/training-facility/shared/TradingCard.tsx
@@ -101,6 +101,10 @@ function seasonFromDate(date: string): string {
  * The card is data-shape-driven (PRD §7.13): it takes a `Benchmark` plus
  * its history and emits no state. It does not assume the entry belongs to
  * any particular user, so it stays reusable when multi-tenancy lands.
+ *
+ * See {@link TradingCardProps} for prop-level docs on each field.
+ *
+ * @param props - {@link TradingCardProps}.
  */
 export function TradingCard({
   entry,

--- a/components/training-facility/shared/TradingCard.tsx
+++ b/components/training-facility/shared/TradingCard.tsx
@@ -1,0 +1,308 @@
+'use client'
+
+import { useMemo, useState, type CSSProperties, type JSX } from 'react'
+import { motion } from 'framer-motion'
+import type { Benchmark } from '@/types/movement'
+
+/**
+ * Display config for the four Tier-1 Combine metrics rendered on the card.
+ * Lives inline until issue #57 lands a shared `BENCHMARKS` config module —
+ * at that point this collapses into an import. Keeps the component
+ * self-contained for now without coupling to a not-yet-merged module.
+ */
+type MetricKey = 'vertical_in' | 'shuttle_5_10_5_s' | 'sprint_10y_s' | 'bodyweight_lbs'
+
+interface MetricSpec {
+  key: MetricKey
+  /** Three-letter card-back label (Panini-style brevity). */
+  label: string
+  /** Suffix appended after the value on the front of the card. */
+  unit: string
+  /** 'lower' = times/weight (less is more athletic); 'higher' = vertical jump. */
+  direction: 'lower' | 'higher'
+  /** Decimal places to render. */
+  precision: number
+}
+
+const METRICS: readonly MetricSpec[] = [
+  { key: 'vertical_in', label: 'VERT', unit: '"', direction: 'higher', precision: 1 },
+  { key: 'shuttle_5_10_5_s', label: '5-10-5', unit: 's', direction: 'lower', precision: 2 },
+  { key: 'sprint_10y_s', label: '10Y', unit: 's', direction: 'lower', precision: 2 },
+  { key: 'bodyweight_lbs', label: 'WT', unit: ' lbs', direction: 'lower', precision: 1 },
+] as const
+
+/** Props for {@link TradingCard}. */
+export interface TradingCardProps {
+  /** The card's subject — the entry whose stats fill the front. Usually the latest benchmark. */
+  entry: Benchmark
+  /** Full benchmark history (including `entry`). Used to detect personal bests and to populate the back-of-card mini-table. Order doesn't matter; the card sorts internally. */
+  history: Benchmark[]
+  /** Display label rendered at the bottom of the front face. Defaults to a season derived from `entry.date`. */
+  season?: string
+  /** Optional jersey number painted on the top of the front face. Defaults to "00". */
+  playerNumber?: string | number
+  /** Optional player name. Defaults to "Combine ’26" framing label. */
+  playerName?: string
+  /** Tailwind classes appended to the card's outer container. */
+  className?: string
+  /** How many history rows to show on the back. Defaults to 5 (newest first). */
+  historyLimit?: number
+}
+
+/**
+ * Determine whether `entry`'s value for `metric` is strictly better than
+ * every prior entry's value for the same metric. Returns false when the
+ * entry has no value for the metric, or when no prior entry has one
+ * (you can't break a record that doesn't exist).
+ */
+function isPersonalBest(entry: Benchmark, history: readonly Benchmark[], spec: MetricSpec): boolean {
+  const value = entry[spec.key]
+  if (typeof value !== 'number') return false
+  const priorValues = history
+    .filter((h) => h.date !== entry.date && h.is_complete !== false && typeof h[spec.key] === 'number')
+    .map((h) => h[spec.key] as number)
+  if (priorValues.length === 0) return false
+  return spec.direction === 'lower'
+    ? priorValues.every((v) => value < v)
+    : priorValues.every((v) => value > v)
+}
+
+/** Format a benchmark value for the front-of-card line, or em-dash when absent. */
+function formatValue(value: number | undefined, spec: MetricSpec): string {
+  if (typeof value !== 'number') return '—'
+  return `${value.toFixed(spec.precision)}${spec.unit}`
+}
+
+/** Derive a "2026 Spring"-style season label from a `YYYY-MM-DD` benchmark date. */
+function seasonFromDate(date: string): string {
+  const [yearStr, monthStr] = date.split('-')
+  const month = Number(monthStr)
+  const season =
+    month >= 3 && month <= 5
+      ? 'Spring'
+      : month >= 6 && month <= 8
+        ? 'Summer'
+        : month >= 9 && month <= 11
+          ? 'Fall'
+          : 'Winter'
+  return `${yearStr} ${season}`
+}
+
+/**
+ * `TradingCard` — Panini/NBA-2K-style flippable benchmark card (PRD §9.2).
+ *
+ * Front renders the entry's stats. Back reveals a mini history table and
+ * the latest notes. Tap/click flips between faces. A small PB badge
+ * pulses on the front whenever the entry sets a new record on any
+ * metric (per-metric PB is checked against `history`).
+ *
+ * The card is data-shape-driven (PRD §7.13): it takes a `Benchmark` plus
+ * its history and emits no state. It does not assume the entry belongs to
+ * any particular user, so it stays reusable when multi-tenancy lands.
+ */
+export function TradingCard({
+  entry,
+  history,
+  season,
+  playerNumber = '00',
+  playerName = 'Combine ’26',
+  className = '',
+  historyLimit = 5,
+}: TradingCardProps): JSX.Element {
+  const [flipped, setFlipped] = useState(false)
+
+  /** PB flags for each metric on the front, plus a single "any PB" indicator for the badge. */
+  const pbState = useMemo(() => {
+    const perMetric = new Map<MetricKey, boolean>()
+    let any = false
+    for (const spec of METRICS) {
+      const isPb = isPersonalBest(entry, history, spec)
+      perMetric.set(spec.key, isPb)
+      if (isPb) any = true
+    }
+    return { perMetric, any }
+  }, [entry, history])
+
+  /** Newest-first history slice rendered on the back (always includes `entry`). */
+  const sortedHistory = useMemo(() => {
+    return [...history].sort((a, b) => b.date.localeCompare(a.date)).slice(0, historyLimit)
+  }, [history, historyLimit])
+
+  const seasonLabel = season ?? seasonFromDate(entry.date)
+
+  // 3D flip needs preserve-3d on the parent and backface-hidden on each face.
+  // Tailwind ships these as `[transform-style:preserve-3d]` arbitraries which
+  // are reliable across browsers; CSS variables here keep the magic numbers
+  // readable in one place.
+  const cardStyle: CSSProperties = {
+    transformStyle: 'preserve-3d',
+    perspective: '1000px',
+  }
+
+  return (
+    <motion.button
+      type="button"
+      onClick={() => setFlipped((f) => !f)}
+      aria-pressed={flipped}
+      aria-label={`Trading card for ${seasonLabel} — ${flipped ? 'showing history, click to show stats' : 'showing stats, click to show history'}`}
+      whileHover={{ rotate: 1.2, y: -3 }}
+      transition={{ type: 'spring', stiffness: 220, damping: 18 }}
+      style={cardStyle}
+      className={`relative block w-[250px] cursor-pointer rounded-xl border border-amber-300/40 bg-transparent p-0 text-left shadow-[0_8px_24px_-12px_rgba(0,0,0,0.6)] focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-400 ${className}`}
+    >
+      <motion.div
+        animate={{ rotateY: flipped ? 180 : 0 }}
+        transition={{ type: 'spring', stiffness: 180, damping: 20 }}
+        style={{ transformStyle: 'preserve-3d' }}
+        className="relative aspect-[5/7] w-full"
+      >
+        <CardFront
+          entry={entry}
+          pbState={pbState}
+          seasonLabel={seasonLabel}
+          playerNumber={playerNumber}
+          playerName={playerName}
+        />
+        <CardBack history={sortedHistory} latestNotes={entry.notes} />
+      </motion.div>
+    </motion.button>
+  )
+}
+
+interface CardFrontProps {
+  entry: Benchmark
+  pbState: { perMetric: Map<MetricKey, boolean>; any: boolean }
+  seasonLabel: string
+  playerNumber: string | number
+  playerName: string
+}
+
+function CardFront({ entry, pbState, seasonLabel, playerNumber, playerName }: CardFrontProps): JSX.Element {
+  return (
+    <div
+      // backfaceVisibility hides this face when rotated 180°; the parent's
+      // preserve-3d makes the rotation actually go through space rather
+      // than collapsing to a 2D scale.
+      style={{ backfaceVisibility: 'hidden' }}
+      className="absolute inset-0 flex flex-col rounded-xl border border-amber-300/30 bg-gradient-to-b from-neutral-900 via-neutral-950 to-black px-4 pb-4 pt-3 text-amber-100"
+    >
+      <header className="flex items-baseline justify-between border-b border-amber-300/20 pb-2">
+        <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-amber-300/80">
+          {playerName}
+        </span>
+        <span className="font-sans text-3xl font-extrabold text-orange-400 leading-none">
+          #{playerNumber}
+        </span>
+      </header>
+
+      <ul className="mt-3 flex flex-col gap-1.5 font-mono text-sm">
+        {METRICS.map((spec) => {
+          const value = entry[spec.key]
+          const isPb = pbState.perMetric.get(spec.key)
+          return (
+            <li
+              key={spec.key}
+              className="flex items-baseline justify-between gap-2 border-b border-amber-300/10 pb-1 last:border-b-0"
+            >
+              <span className="text-[11px] uppercase tracking-wider text-amber-300/70">
+                {spec.label}
+              </span>
+              <span className="flex items-baseline gap-1.5 text-amber-50">
+                {isPb && (
+                  <span aria-label="personal best" className="text-orange-400" title="Personal best">
+                    ★
+                  </span>
+                )}
+                <span className="font-semibold tabular-nums">
+                  {formatValue(value, spec)}
+                </span>
+              </span>
+            </li>
+          )
+        })}
+      </ul>
+
+      <footer className="mt-auto flex items-end justify-between pt-3 text-[11px] uppercase tracking-wider">
+        <span className="font-mono text-amber-300/70">{seasonLabel}</span>
+        {pbState.any && (
+          <motion.span
+            // Pulse the PB badge gently; spring on `scale` keeps it organic.
+            // Repeat-yoyo style via Framer's `repeatType: "reverse"`.
+            animate={{ scale: [1, 1.12, 1] }}
+            transition={{ duration: 1.6, repeat: Infinity, ease: 'easeInOut' }}
+            className="rounded-full border border-orange-400/70 bg-orange-500/20 px-2 py-0.5 font-mono text-[9px] font-bold uppercase tracking-[0.2em] text-orange-200 shadow-[0_0_12px_rgba(249,115,22,0.5)]"
+          >
+            ★ PB
+          </motion.span>
+        )}
+      </footer>
+    </div>
+  )
+}
+
+interface CardBackProps {
+  history: readonly Benchmark[]
+  latestNotes?: string
+}
+
+function CardBack({ history, latestNotes }: CardBackProps): JSX.Element {
+  return (
+    <div
+      // The back face is rotated 180° on Y so it sits behind the front in
+      // 3D; backfaceVisibility hidden on both faces means only the
+      // currently-front-facing one renders.
+      style={{ backfaceVisibility: 'hidden', transform: 'rotateY(180deg)' }}
+      className="absolute inset-0 flex flex-col rounded-xl border border-amber-300/30 bg-gradient-to-b from-amber-100/95 to-amber-50/95 p-4 text-neutral-900"
+    >
+      <h3 className="font-mono text-[10px] uppercase tracking-[0.18em] text-neutral-700">
+        Career Log
+      </h3>
+      <table className="mt-2 w-full text-[11px] font-mono">
+        <thead>
+          <tr className="border-b border-neutral-700/30 text-left text-[10px] uppercase tracking-wider text-neutral-600">
+            <th className="font-semibold">Date</th>
+            <th className="font-semibold">VERT</th>
+            <th className="font-semibold">5-10-5</th>
+            <th className="font-semibold">10Y</th>
+            <th className="font-semibold">WT</th>
+          </tr>
+        </thead>
+        <tbody>
+          {history.length === 0 && (
+            <tr>
+              <td colSpan={5} className="pt-2 text-center text-neutral-500">
+                No prior sessions
+              </td>
+            </tr>
+          )}
+          {history.map((row) => (
+            <tr key={row.date} className="border-b border-neutral-700/10 last:border-b-0">
+              <td className="py-1 text-neutral-700">{row.date.slice(5)}</td>
+              <td className="py-1 tabular-nums">{formatCell(row.vertical_in)}</td>
+              <td className="py-1 tabular-nums">{formatCell(row.shuttle_5_10_5_s)}</td>
+              <td className="py-1 tabular-nums">{formatCell(row.sprint_10y_s)}</td>
+              <td className="py-1 tabular-nums">{formatCell(row.bodyweight_lbs)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      {latestNotes && (
+        <section className="mt-auto pt-3">
+          <h4 className="font-mono text-[10px] uppercase tracking-[0.18em] text-neutral-700">
+            Notes
+          </h4>
+          <p className="mt-1 line-clamp-4 text-[11px] leading-snug text-neutral-800">
+            {latestNotes}
+          </p>
+        </section>
+      )}
+    </div>
+  )
+}
+
+/** Compact cell value for the back-of-card history table. */
+function formatCell(value: number | undefined): string {
+  if (typeof value !== 'number') return '—'
+  return Number.isInteger(value) ? String(value) : value.toFixed(1)
+}

--- a/components/training-facility/shared/TradingCard.tsx
+++ b/components/training-facility/shared/TradingCard.tsx
@@ -51,15 +51,17 @@ export interface TradingCardProps {
 
 /**
  * Determine whether `entry`'s value for `metric` is strictly better than
- * every prior entry's value for the same metric. Returns false when the
- * entry has no value for the metric, or when no prior entry has one
- * (you can't break a record that doesn't exist).
+ * every PRIOR entry (date < `entry.date`). Returns false when the entry
+ * has no value for the metric, or when no prior entry has one
+ * (you can't break a record that doesn't exist). The "prior only"
+ * comparison matters when the card is used to browse a non-latest entry:
+ * a March session shouldn't lose its PB badge just because April beat it.
  */
 function isPersonalBest(entry: Benchmark, history: readonly Benchmark[], spec: MetricSpec): boolean {
   const value = entry[spec.key]
   if (typeof value !== 'number') return false
   const priorValues = history
-    .filter((h) => h.date !== entry.date && h.is_complete !== false && typeof h[spec.key] === 'number')
+    .filter((h) => h.date < entry.date && h.is_complete !== false && typeof h[spec.key] === 'number')
     .map((h) => h[spec.key] as number)
   if (priorValues.length === 0) return false
   return spec.direction === 'lower'
@@ -261,16 +263,17 @@ function CardBack({ history, latestNotes }: CardBackProps): JSX.Element {
         <thead>
           <tr className="border-b border-neutral-700/30 text-left text-[10px] uppercase tracking-wider text-neutral-600">
             <th className="font-semibold">Date</th>
-            <th className="font-semibold">VERT</th>
-            <th className="font-semibold">5-10-5</th>
-            <th className="font-semibold">10Y</th>
-            <th className="font-semibold">WT</th>
+            {METRICS.map((spec) => (
+              <th key={spec.key} className="font-semibold">
+                {spec.label}
+              </th>
+            ))}
           </tr>
         </thead>
         <tbody>
           {history.length === 0 && (
             <tr>
-              <td colSpan={5} className="pt-2 text-center text-neutral-500">
+              <td colSpan={1 + METRICS.length} className="pt-2 text-center text-neutral-500">
                 No prior sessions
               </td>
             </tr>
@@ -278,10 +281,11 @@ function CardBack({ history, latestNotes }: CardBackProps): JSX.Element {
           {history.map((row) => (
             <tr key={row.date} className="border-b border-neutral-700/10 last:border-b-0">
               <td className="py-1 text-neutral-700">{row.date.slice(5)}</td>
-              <td className="py-1 tabular-nums">{formatCell(row.vertical_in)}</td>
-              <td className="py-1 tabular-nums">{formatCell(row.shuttle_5_10_5_s)}</td>
-              <td className="py-1 tabular-nums">{formatCell(row.sprint_10y_s)}</td>
-              <td className="py-1 tabular-nums">{formatCell(row.bodyweight_lbs)}</td>
+              {METRICS.map((spec) => (
+                <td key={spec.key} className="py-1 tabular-nums">
+                  {formatCell(row[spec.key], spec)}
+                </td>
+              ))}
             </tr>
           ))}
         </tbody>
@@ -301,8 +305,12 @@ function CardBack({ history, latestNotes }: CardBackProps): JSX.Element {
   )
 }
 
-/** Compact cell value for the back-of-card history table. */
-function formatCell(value: number | undefined): string {
+/**
+ * Compact cell value for the back-of-card history table. Honors the
+ * metric's declared precision so timed metrics (shuttle, 10y) keep their
+ * hundredths digit instead of rounding 1.98 → 2.0.
+ */
+function formatCell(value: number | undefined, spec: MetricSpec): string {
   if (typeof value !== 'number') return '—'
-  return Number.isInteger(value) ? String(value) : value.toFixed(1)
+  return Number.isInteger(value) ? String(value) : value.toFixed(spec.precision)
 }

--- a/components/training-facility/shared/TradingCard.tsx
+++ b/components/training-facility/shared/TradingCard.tsx
@@ -24,6 +24,13 @@ interface MetricSpec {
   precision: number
 }
 
+/**
+ * The four Tier-1 Combine metrics rendered on the card, in display order
+ * (top of the front face, left-to-right on the back-of-card history table).
+ * Both the front stat list and the back table iterate this array, so adding
+ * or reordering a metric is a single-source-of-truth edit. Replaced by an
+ * import from the shared `BENCHMARKS` config when issue #57 lands.
+ */
 const METRICS: readonly MetricSpec[] = [
   { key: 'vertical_in', label: 'VERT', unit: '"', direction: 'higher', precision: 1 },
   { key: 'shuttle_5_10_5_s', label: '5-10-5', unit: 's', direction: 'lower', precision: 2 },


### PR DESCRIPTION
Closes #53.

## Summary
- Panini-style stat card for the Combine, flippable via Framer Motion 3D rotation. Front: four Tier-1 metrics (VERT / 5-10-5 / 10Y / WT) + jersey number + season + pulsing PB badge. Back: newest-first mini history table + latest notes.
- Per-metric ★ markers when the entry beats every prior entry in `history` for that metric (direction-aware: lower for times/weight, higher for vertical).
- PB badge in the footer pulses gently when ANY metric is a personal best.
- Hover wobble (slight rotate + lift) via Framer spring.

## Implementation notes
- Inline `METRICS` config (label, unit, direction, precision) lives in the component until #57 lands a shared `BENCHMARKS` module — at that point it's a one-line import swap.
- Hidden demo at `/dev/trading-card` (noindex) shows two cards: one with full history (all PBs visible) and one as the first-ever entry (no PB badge possible).
- Component is data-shape-driven per PRD §7.13 — takes `Benchmark` + `Benchmark[]`, doesn't assume anything about user identity.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx next build` clean
- [x] Demo page verified locally:
  - Front renders four stat lines with ★ on PB metrics
  - Click flips to the back (Career Log table + notes)
  - Card with no history shows no ★ stars and no PB badge
  - `aria-pressed` toggles correctly with the flip
- [ ] Reviewer: visit Vercel preview at \`/dev/trading-card\`, click each card to confirm flip animation, verify PB badge pulses on the all-PBs card

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive 3D flippable trading card to view benchmark stats front/back
  * Per-metric personal-best (★) badges with subtle animation for record values
  * Back face shows a compact, newest-first career history table and optional notes
  * Metric values display proper decimal/units and em-dash for missing data
  * Dev demo page showcasing both with-prior-history and no-prior-sessions card states; dev-only page excluded from search indexing
<!-- end of auto-generated comment: release notes by coderabbit.ai -->