### PR TITLE
feat(constants): benchmark + HR-zone config modules (#57)

### DIFF
--- a/components/training-facility/shared/TradingCard.tsx
+++ b/components/training-facility/shared/TradingCard.tsx
@@ -3,40 +3,17 @@
 import { useMemo, useState, type CSSProperties, type JSX } from 'react'
 import { motion } from 'framer-motion'
 import type { Benchmark } from '@/types/movement'
+import { BENCHMARKS, METRIC_KEYS, type BenchmarkConfig, type MetricKey } from '@/constants/benchmarks'
 
 /**
- * Display config for the four Tier-1 Combine metrics rendered on the card.
- * Lives inline until issue #57 lands a shared `BENCHMARKS` config module —
- * at that point this collapses into an import. Keeps the component
- * self-contained for now without coupling to a not-yet-merged module.
+ * The card iterates {@link METRIC_KEYS} (not `Object.keys(BENCHMARKS)`) to
+ * guarantee stable display order even if the config object's key order
+ * ever changes. Each entry is the `(key, spec)` pair the front and back
+ * faces need to render a metric.
  */
-type MetricKey = 'vertical_in' | 'shuttle_5_10_5_s' | 'sprint_10y_s' | 'bodyweight_lbs'
-
-interface MetricSpec {
-  key: MetricKey
-  /** Three-letter card-back label (Panini-style brevity). */
-  label: string
-  /** Suffix appended after the value on the front of the card. */
-  unit: string
-  /** 'lower' = times/weight (less is more athletic); 'higher' = vertical jump. */
-  direction: 'lower' | 'higher'
-  /** Decimal places to render. */
-  precision: number
-}
-
-/**
- * The four Tier-1 Combine metrics rendered on the card, in display order
- * (top of the front face, left-to-right on the back-of-card history table).
- * Both the front stat list and the back table iterate this array, so adding
- * or reordering a metric is a single-source-of-truth edit. Replaced by an
- * import from the shared `BENCHMARKS` config when issue #57 lands.
- */
-const METRICS: readonly MetricSpec[] = [
-  { key: 'vertical_in', label: 'VERT', unit: '"', direction: 'higher', precision: 1 },
-  { key: 'shuttle_5_10_5_s', label: '5-10-5', unit: 's', direction: 'lower', precision: 2 },
-  { key: 'sprint_10y_s', label: '10Y', unit: 's', direction: 'lower', precision: 2 },
-  { key: 'bodyweight_lbs', label: 'WT', unit: ' lbs', direction: 'lower', precision: 1 },
-] as const
+const CARD_METRICS: ReadonlyArray<{ key: MetricKey; spec: BenchmarkConfig }> = METRIC_KEYS.map(
+  (key) => ({ key, spec: BENCHMARKS[key] }),
+)
 
 /** Props for {@link TradingCard}. */
 export interface TradingCardProps {
@@ -57,19 +34,24 @@ export interface TradingCardProps {
 }
 
 /**
- * Determine whether `entry`'s value for `metric` is strictly better than
+ * Determine whether `entry`'s value for `key` is strictly better than
  * every PRIOR entry (date < `entry.date`). Returns false when the entry
  * has no value for the metric, or when no prior entry has one
  * (you can't break a record that doesn't exist). The "prior only"
  * comparison matters when the card is used to browse a non-latest entry:
  * a March session shouldn't lose its PB badge just because April beat it.
  */
-function isPersonalBest(entry: Benchmark, history: readonly Benchmark[], spec: MetricSpec): boolean {
-  const value = entry[spec.key]
+function isPersonalBest(
+  entry: Benchmark,
+  history: readonly Benchmark[],
+  key: MetricKey,
+  spec: BenchmarkConfig,
+): boolean {
+  const value = entry[key]
   if (typeof value !== 'number') return false
   const priorValues = history
-    .filter((h) => h.date < entry.date && h.is_complete !== false && typeof h[spec.key] === 'number')
-    .map((h) => h[spec.key] as number)
+    .filter((h) => h.date < entry.date && h.is_complete !== false && typeof h[key] === 'number')
+    .map((h) => h[key] as number)
   if (priorValues.length === 0) return false
   return spec.direction === 'lower'
     ? priorValues.every((v) => value < v)
@@ -77,7 +59,7 @@ function isPersonalBest(entry: Benchmark, history: readonly Benchmark[], spec: M
 }
 
 /** Format a benchmark value for the front-of-card line, or em-dash when absent. */
-function formatValue(value: number | undefined, spec: MetricSpec): string {
+function formatValue(value: number | undefined, spec: BenchmarkConfig): string {
   if (typeof value !== 'number') return '—'
   return `${value.toFixed(spec.precision)}${spec.unit}`
 }
@@ -128,9 +110,9 @@ export function TradingCard({
   const pbState = useMemo(() => {
     const perMetric = new Map<MetricKey, boolean>()
     let any = false
-    for (const spec of METRICS) {
-      const isPb = isPersonalBest(entry, history, spec)
-      perMetric.set(spec.key, isPb)
+    for (const { key, spec } of CARD_METRICS) {
+      const isPb = isPersonalBest(entry, history, key, spec)
+      perMetric.set(key, isPb)
       if (isPb) any = true
     }
     return { perMetric, any }
@@ -209,16 +191,16 @@ function CardFront({ entry, pbState, seasonLabel, playerNumber, playerName }: Ca
       </header>
 
       <ul className="mt-3 flex flex-col gap-1.5 font-mono text-sm">
-        {METRICS.map((spec) => {
-          const value = entry[spec.key]
-          const isPb = pbState.perMetric.get(spec.key)
+        {CARD_METRICS.map(({ key, spec }) => {
+          const value = entry[key]
+          const isPb = pbState.perMetric.get(key)
           return (
             <li
-              key={spec.key}
+              key={key}
               className="flex items-baseline justify-between gap-2 border-b border-amber-300/10 pb-1 last:border-b-0"
             >
               <span className="text-[11px] uppercase tracking-wider text-amber-300/70">
-                {spec.label}
+                {spec.shortLabel}
               </span>
               <span className="flex items-baseline gap-1.5 text-amber-50">
                 {isPb && (
@@ -274,9 +256,9 @@ function CardBack({ history, latestNotes }: CardBackProps): JSX.Element {
         <thead>
           <tr className="border-b border-neutral-700/30 text-left text-[10px] uppercase tracking-wider text-neutral-600">
             <th className="font-semibold">Date</th>
-            {METRICS.map((spec) => (
-              <th key={spec.key} className="font-semibold">
-                {spec.label}
+            {CARD_METRICS.map(({ key, spec }) => (
+              <th key={key} className="font-semibold">
+                {spec.shortLabel}
               </th>
             ))}
           </tr>
@@ -284,7 +266,7 @@ function CardBack({ history, latestNotes }: CardBackProps): JSX.Element {
         <tbody>
           {history.length === 0 && (
             <tr>
-              <td colSpan={1 + METRICS.length} className="pt-2 text-center text-neutral-500">
+              <td colSpan={1 + CARD_METRICS.length} className="pt-2 text-center text-neutral-500">
                 No prior sessions
               </td>
             </tr>
@@ -292,9 +274,9 @@ function CardBack({ history, latestNotes }: CardBackProps): JSX.Element {
           {history.map((row) => (
             <tr key={row.date} className="border-b border-neutral-700/10 last:border-b-0">
               <td className="py-1 text-neutral-700">{row.date.slice(5)}</td>
-              {METRICS.map((spec) => (
-                <td key={spec.key} className="py-1 tabular-nums">
-                  {formatCell(row[spec.key], spec)}
+              {CARD_METRICS.map(({ key, spec }) => (
+                <td key={key} className="py-1 tabular-nums">
+                  {formatCell(row[key], spec)}
                 </td>
               ))}
             </tr>
@@ -321,7 +303,7 @@ function CardBack({ history, latestNotes }: CardBackProps): JSX.Element {
  * metric's declared precision so timed metrics (shuttle, 10y) keep their
  * hundredths digit instead of rounding 1.98 → 2.0.
  */
-function formatCell(value: number | undefined, spec: MetricSpec): string {
+function formatCell(value: number | undefined, spec: BenchmarkConfig): string {
   if (typeof value !== 'number') return '—'
   return Number.isInteger(value) ? String(value) : value.toFixed(spec.precision)
 }

--- a/constants/benchmarks.ts
+++ b/constants/benchmarks.ts
@@ -1,0 +1,116 @@
+/**
+ * Tier-1 Combine benchmark display config (PRD §7.7).
+ *
+ * Single source of truth for how each metric is named, formatted, and
+ * scored. All visualizations (TradingCard, signature Combine viz, history
+ * tables, future radar charts) read from {@link BENCHMARKS}. Adding or
+ * modifying a metric is a config change here — never a chart rewrite.
+ *
+ * The keys mirror the snake_case fields on {@link Benchmark} (see
+ * `types/movement.ts`), so a chart can iterate the config and use each
+ * key directly to read entry values:
+ * ```ts
+ * for (const [key, spec] of Object.entries(BENCHMARKS)) {
+ *   const value = entry[key as MetricKey];
+ *   render(spec.shortLabel, value, spec.unit);
+ * }
+ * ```
+ */
+
+/**
+ * Subset of {@link Benchmark} fields that are numeric metrics (not `date`,
+ * `notes`, or `is_complete`). The four Tier-1 Combine measurements per
+ * PRD §5.
+ */
+export type MetricKey = 'shuttle_5_10_5_s' | 'vertical_in' | 'sprint_10y_s' | 'bodyweight_lbs'
+
+/**
+ * Display + scoring config for one numeric benchmark metric. Mirrors the
+ * shape sketched in PRD §7.7 with two added display fields (`shortLabel`,
+ * `precision`) needed by the Trading Card and other compact surfaces.
+ */
+export interface BenchmarkConfig {
+  /** Long display name — e.g. "5-10-5 Shuttle". Used in tooltips, axis labels, page headers. */
+  label: string
+  /** Short Panini-style label — e.g. "5-10-5", "VERT". Used in card stat blocks and dense tables. */
+  shortLabel: string
+  /** Suffix appended after the value when rendered — e.g. "s", "\"", " lbs". */
+  unit: string
+  /**
+   * Which direction is "more athletic." `'lower'` for time/weight metrics
+   * (a smaller shuttle time is faster); `'higher'` for vertical jump.
+   * Drives PB detection and the orientation of any progress gauge.
+   */
+  direction: 'lower' | 'higher'
+  /** Decimal places to render. Vertical/weight: 1; timed events: 2 (hundredths matter). */
+  precision: number
+  /**
+   * Reasonable display range `[a, b]` where `a < b`. Direction-aware:
+   * for `'lower'` metrics the elite end is `a`, for `'higher'` it's `b`.
+   * Used by gauges, radar axes, and color mapping; never for clamping
+   * raw entry values.
+   */
+  targetRange: readonly [number, number]
+}
+
+/**
+ * The Tier-1 metrics, in canonical display order. Iterating
+ * `Object.values(BENCHMARKS)` gives the order used on the Trading Card
+ * front and the back-of-card history table; iterating
+ * `Object.keys(BENCHMARKS)` gives the corresponding entry-field names
+ * for {@link Benchmark}.
+ */
+export const BENCHMARKS: Readonly<Record<MetricKey, BenchmarkConfig>> = {
+  vertical_in: {
+    label: 'Vertical Jump',
+    shortLabel: 'VERT',
+    unit: '"',
+    direction: 'higher',
+    precision: 1,
+    targetRange: [16, 32],
+  },
+  shuttle_5_10_5_s: {
+    label: '5-10-5 Shuttle',
+    shortLabel: '5-10-5',
+    unit: 's',
+    direction: 'lower',
+    precision: 2,
+    targetRange: [4.5, 6.0],
+  },
+  sprint_10y_s: {
+    label: '10-Yard Sprint',
+    shortLabel: '10Y',
+    unit: 's',
+    direction: 'lower',
+    precision: 2,
+    targetRange: [1.6, 2.2],
+  },
+  bodyweight_lbs: {
+    label: 'Bodyweight',
+    shortLabel: 'WT',
+    unit: ' lbs',
+    direction: 'lower',
+    precision: 1,
+    targetRange: [210, 240],
+  },
+} as const
+
+/**
+ * Ordered list of metric keys for callers that want to iterate without
+ * relying on `Object.keys` insertion order. Same content as
+ * `Object.keys(BENCHMARKS)` but typed as `MetricKey[]` and stable.
+ */
+export const METRIC_KEYS: readonly MetricKey[] = [
+  'vertical_in',
+  'shuttle_5_10_5_s',
+  'sprint_10y_s',
+  'bodyweight_lbs',
+] as const
+
+/**
+ * Type guard narrowing an arbitrary string to a {@link MetricKey}. Useful
+ * when reading config keys back out of `Object.keys` typed as `string[]`.
+ */
+export function isMetricKey(value: string): value is MetricKey {
+  return value in BENCHMARKS
+}

--- a/constants/benchmarks.ts
+++ b/constants/benchmarks.ts
@@ -110,7 +110,10 @@ export const METRIC_KEYS: readonly MetricKey[] = [
 /**
  * Type guard narrowing an arbitrary string to a {@link MetricKey}. Useful
  * when reading config keys back out of `Object.keys` typed as `string[]`.
+ *
+ * Uses `Object.hasOwn` rather than `in` so inherited props (`toString`,
+ * `__proto__`, etc.) don't slip through as false positives.
  */
 export function isMetricKey(value: string): value is MetricKey {
-  return value in BENCHMARKS
+  return Object.hasOwn(BENCHMARKS, value)
 }

--- a/constants/hr-zones.ts
+++ b/constants/hr-zones.ts
@@ -63,8 +63,13 @@ export const DEFAULT_MAX_HR = 185
  * Estimate max heart rate (Fox formula). Returns BPM. Callers with a
  * measured max from a treadmill or watch should pass that directly to
  * {@link hrZoneForBpm} instead of using this estimator.
+ *
+ * @throws {RangeError} when `age` is not a finite number in `[1, 120]`.
  */
 export function estimateMaxHr(age: number): number {
+  if (!Number.isFinite(age) || age < 1 || age > 120) {
+    throw new RangeError(`estimateMaxHr: age must be a finite number in [1, 120], got ${age}`)
+  }
   return 220 - age
 }
 

--- a/constants/hr-zones.ts
+++ b/constants/hr-zones.ts
@@ -1,0 +1,107 @@
+/**
+ * Heart-rate zone config for the Gym (cardio) viz (PRD §7.2, §7.7).
+ *
+ * Zones are expressed as fractions of a person's max HR; the actual BPM
+ * boundaries depend on whose data is being visualized. Visualizations
+ * resolve a session's HR samples into zones via {@link hrZoneForBpm}
+ * given the user's max-HR estimate.
+ *
+ * The default max-HR estimate uses the Fox formula (`220 - age`); callers
+ * with a measured max should override. Tanaka (`208 - 0.7 * age`) is more
+ * accurate for older athletes — adopt-when-needed, not pre-built.
+ */
+
+/** Zone identifiers, lowest intensity to highest. */
+export type HrZoneId = 'Z1' | 'Z2' | 'Z3' | 'Z4' | 'Z5'
+
+/**
+ * One heart-rate zone as a fraction of max HR. Bounds are inclusive on
+ * `minPct` and exclusive on `maxPct` except for `Z5`, whose `maxPct` is
+ * inclusive — otherwise a sample at exactly 100% maxHR falls outside
+ * every zone.
+ */
+export interface HrZoneConfig {
+  /** Stable zone id used as a categorical key in charts/configs. */
+  id: HrZoneId
+  /** Long display name — e.g. "Aerobic Base". Used in tooltips and legends. */
+  label: string
+  /** Short label — e.g. "Z2". Used on dense axes and badges. */
+  shortLabel: string
+  /** Lower bound as a fraction of max HR. Inclusive. */
+  minPct: number
+  /**
+   * Upper bound as a fraction of max HR. Exclusive (`< maxPct`) for
+   * Z1–Z4, inclusive (`<= maxPct`) for Z5 so 100% maxHR samples fall in
+   * Z5 instead of off the chart.
+   */
+  maxPct: number
+  /**
+   * Display color for charts/legends — green→red gradient roughly
+   * tracking effort. Hex strings rather than Tailwind classes so the
+   * config stays consumable by SVG/canvas viz that can't read Tailwind.
+   */
+  color: string
+}
+
+/**
+ * The five training zones, lowest intensity first. Matches the cardio
+ * dashboard's existing 5-zone model (the source data set being migrated
+ * per PRD §7.2).
+ */
+export const HR_ZONES: readonly HrZoneConfig[] = [
+  { id: 'Z1', label: 'Recovery', shortLabel: 'Z1', minPct: 0.5, maxPct: 0.6, color: '#22c55e' },
+  { id: 'Z2', label: 'Aerobic Base', shortLabel: 'Z2', minPct: 0.6, maxPct: 0.7, color: '#84cc16' },
+  { id: 'Z3', label: 'Tempo', shortLabel: 'Z3', minPct: 0.7, maxPct: 0.8, color: '#eab308' },
+  { id: 'Z4', label: 'Threshold', shortLabel: 'Z4', minPct: 0.8, maxPct: 0.9, color: '#f97316' },
+  { id: 'Z5', label: 'VO2 Max', shortLabel: 'Z5', minPct: 0.9, maxPct: 1.0, color: '#dc2626' },
+] as const
+
+/** Default max-HR estimate when the consumer doesn't pass one. ~35-year-old via Fox formula. */
+export const DEFAULT_MAX_HR = 185
+
+/**
+ * Estimate max heart rate (Fox formula). Returns BPM. Callers with a
+ * measured max from a treadmill or watch should pass that directly to
+ * {@link hrZoneForBpm} instead of using this estimator.
+ */
+export function estimateMaxHr(age: number): number {
+  return 220 - age
+}
+
+/**
+ * Bucket a single BPM sample into one of the five zones. Returns `null`
+ * for samples below Z1's lower bound (resting / sub-aerobic) so callers
+ * can decide whether to count "below Z1" time toward Z1 or display it
+ * separately. Above-100% samples (rare; usually a sensor glitch) clamp
+ * into Z5.
+ *
+ * @param bpm - Sample heart rate in beats per minute.
+ * @param maxHr - User's max HR in BPM. Defaults to {@link DEFAULT_MAX_HR}.
+ */
+export function hrZoneForBpm(bpm: number, maxHr: number = DEFAULT_MAX_HR): HrZoneId | null {
+  if (maxHr <= 0) return null
+  const pct = bpm / maxHr
+  for (const zone of HR_ZONES) {
+    const isLast = zone.id === 'Z5'
+    if (pct >= zone.minPct && (isLast ? pct <= zone.maxPct : pct < zone.maxPct)) {
+      return zone.id
+    }
+  }
+  // Above 100% maxHR — clamp into the top zone rather than dropping the sample.
+  if (pct > 1) return 'Z5'
+  return null
+}
+
+/**
+ * Resolve a zone's literal BPM range for a given user. Useful when a
+ * chart wants to label axis ticks with concrete BPM values rather than
+ * percentages.
+ *
+ * @returns `[minBpm, maxBpm]` rounded to whole BPM.
+ */
+export function bpmRangeForZone(
+  zone: HrZoneConfig,
+  maxHr: number = DEFAULT_MAX_HR,
+): [number, number] {
+  return [Math.round(zone.minPct * maxHr), Math.round(zone.maxPct * maxHr)]
+}


### PR DESCRIPTION
Closes #57.

## Summary
- New `constants/benchmarks.ts` — single source of truth for metric display config (label, shortLabel, unit, direction, precision, targetRange) for the four Tier-1 Combine metrics. Per PRD §7.7.
- New `constants/hr-zones.ts` — Z1–Z5 zones with min/max max-HR fractions, color, plus `hrZoneForBpm`/`bpmRangeForZone`/`estimateMaxHr` helpers.
- Refactor `TradingCard` to read from `BENCHMARKS` + `METRIC_KEYS` (was inline `METRICS`). Front stat list, back-of-card header, and history rows all iterate the shared list — proves the indirection.

## Why
Every chart and card so far has duplicated metric labels/units/precision inline (with TODO comments pointing at this issue). Centralizing the config means adding a metric is a one-line config edit, not a chart-by-chart rewrite. Same pattern is now in place for cardio HR zones, which #58/#62 will consume immediately.

## Done-when
- [x] `constants/benchmarks.ts` exists, typed
- [x] `constants/hr-zones.ts` exists, typed
- [x] A representative chart pulls from the config — `TradingCard` consumes `BENCHMARKS`/`METRIC_KEYS`
- [x] `npx tsc --noEmit` clean
- [x] `npx next build` clean

## Test plan
- [ ] Reviewer: visit Vercel preview at \`/dev/trading-card\`, confirm cards still render identically — front stat lines (VERT / 5-10-5 / 10Y / WT), PB stars, pulsing PB badge, flip-to-back with history table. The data path changed (inline → config import) but the visual output should be identical to PR #95.
- [ ] Spot-check `constants/benchmarks.ts` for the metric definitions you'd want surfaced in the Combine — labels, unit suffixes, target ranges (vertical jump 16–32", shuttle 4.5–6.0s, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Heart-rate zone system: five training zones, age-based max-HR estimation, BPM ranges, and color-coded zones for charts.
  * Central benchmark configuration: standardized metric keys, labels, units, scoring direction, precision, and target ranges for consistent display.

* **Refactor**
  * Training cards and tables now use the shared benchmark config for stable metric order, unified formatting, improved personal-best detection, and corrected table column alignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->