### PR TITLE
feat(training-facility): bodyweight overlay utility for time-series (#56)

### DIFF
--- a/app/dev/charts/page.tsx
+++ b/app/dev/charts/page.tsx
@@ -149,7 +149,6 @@ export default function ChartsDemoPage(): JSX.Element {
             ]}
             width={720}
             height={300}
-            margin={{ right: 64 }}
             ariaLabel="Bodyweight overlay — pounds over time, secondary axis right"
           >
             <RoughLine
@@ -158,7 +157,6 @@ export default function ChartsDemoPage(): JSX.Element {
               y={(d) => d.vertical_in ?? 0}
               width={720}
               height={300}
-              margin={{ right: 64 }}
               xLabel="Date"
               yLabel="Vertical (in)"
               yTickFormat={(v) => `${v}`}

--- a/app/dev/charts/page.tsx
+++ b/app/dev/charts/page.tsx
@@ -1,11 +1,13 @@
 import type { JSX } from 'react'
 import { Patrick_Hand } from 'next/font/google'
 import {
+  BodyweightOverlay,
   RoughBar,
   RoughLine,
   RoughScatter,
   chartPalette,
 } from '@/components/training-facility/shared/charts'
+import type { Benchmark } from '@/types/movement'
 
 const patrickHand = Patrick_Hand({
   weight: '400',
@@ -33,6 +35,13 @@ const hrZoneData = [
   // Zero on purpose — exercises the "render a 1px baseline rather than
   // disappearing the category" path in RoughBar.
   { zone: 'Z5', minutes: 0 },
+]
+
+const overlayBenchmarks: Benchmark[] = [
+  { date: '2026-01-15', bodyweight_lbs: 240.5, vertical_in: 19.5 },
+  { date: '2026-02-15', bodyweight_lbs: 236.2, vertical_in: 20.25 },
+  { date: '2026-03-15', bodyweight_lbs: 232.8, vertical_in: 21.0 },
+  { date: '2026-04-15', bodyweight_lbs: 229.4, vertical_in: 22.0 },
 ]
 
 const paceVsHrData = [
@@ -129,6 +138,33 @@ export default function ChartsDemoPage(): JSX.Element {
             yTickFormat={(v) => v.toFixed(1)}
             ariaLabel="Pace in minutes per mile plotted against heart rate during a stair session"
           />
+        </Section>
+
+        <Section title="BodyweightOverlay — Vertical jump with bodyweight overlaid">
+          <BodyweightOverlay
+            benchmarks={overlayBenchmarks}
+            dateExtent={[
+              new Date(overlayBenchmarks[0].date),
+              new Date(overlayBenchmarks[overlayBenchmarks.length - 1].date),
+            ]}
+            width={720}
+            height={300}
+            margin={{ right: 64 }}
+            ariaLabel="Bodyweight overlay — pounds over time, secondary axis right"
+          >
+            <RoughLine
+              data={overlayBenchmarks}
+              x={(d) => new Date(d.date)}
+              y={(d) => d.vertical_in ?? 0}
+              width={720}
+              height={300}
+              margin={{ right: 64 }}
+              xLabel="Date"
+              yLabel="Vertical (in)"
+              yTickFormat={(v) => `${v}`}
+              ariaLabel="Vertical jump in inches by month"
+            />
+          </BodyweightOverlay>
         </Section>
 
         <Section title="Empty state — RoughLine with no data">

--- a/components/training-facility/shared/charts/BodyweightOverlay.tsx
+++ b/components/training-facility/shared/charts/BodyweightOverlay.tsx
@@ -117,11 +117,20 @@ export function BodyweightOverlay({
     onEnabledChange?.(next)
   }
 
+  // Clamp to the active chart window so out-of-range points don't drive the
+  // y-scale (would compress the visible series) or render outside the plot.
+  // Inclusive on both ends — caller's `dateExtent` is the visible domain.
+  const fromMs = dateExtent[0].getTime()
+  const toMs = dateExtent[1].getTime()
   const points: BodyweightPoint[] = benchmarks
     .filter((b): b is Benchmark & { bodyweight_lbs: number } =>
       typeof b.bodyweight_lbs === 'number' && b.is_complete !== false,
     )
     .map((b) => ({ date: new Date(b.date), bw: b.bodyweight_lbs }))
+    .filter((p) => {
+      const t = p.date.getTime()
+      return t >= fromMs && t <= toMs
+    })
     .sort((a, b) => a.date.getTime() - b.date.getTime())
 
   const m = resolveMargin(margin)

--- a/components/training-facility/shared/charts/BodyweightOverlay.tsx
+++ b/components/training-facility/shared/charts/BodyweightOverlay.tsx
@@ -1,0 +1,346 @@
+'use client'
+
+import { useEffect, useId, useState, type JSX, type ReactNode } from 'react'
+import { scaleLinear, scaleTime } from 'd3-scale'
+import rough from 'roughjs'
+import type { Benchmark } from '@/types/movement'
+import { Axis, type AxisTick } from './axes'
+import { chartPalette } from './palette'
+import { extent } from './rough-svg'
+import { resolveMargin, type ChartMargin } from './types'
+
+/**
+ * Drop-in wrapper that overlays bodyweight as a secondary right-side axis on
+ * any time-series chart. Renders the primary chart child and an absolutely-
+ * positioned SVG layer on top, plus a small toggle to hide/show the overlay.
+ *
+ * The wrapper does not size or scale the primary chart — caller must pass the
+ * same `width`, `height`, `margin`, and date domain as the chart child so the
+ * x-axes line up. PRD §4 + §7.8.
+ */
+export interface BodyweightOverlayProps {
+  /** Benchmark history. Entries without `bodyweight_lbs` and any with `is_complete === false` are skipped. */
+  benchmarks: Benchmark[]
+  /**
+   * Date domain shared with the primary chart. The overlay's x-scale matches
+   * this exactly — caller is responsible for passing the same span the chart
+   * child computes from its own data.
+   */
+  dateExtent: [Date, Date]
+  /** Total width in px — must match the primary chart. */
+  width: number
+  /** Total height in px — must match the primary chart. */
+  height: number
+  /** Chart margin — must match the primary chart so axes align. */
+  margin?: Partial<ChartMargin>
+  /** Initial toggle state. Defaults to `true` (overlay visible). Ignored when `enabled` is provided. */
+  defaultEnabled?: boolean
+  /** Controlled toggle state. When provided, `defaultEnabled` is ignored and the parent owns visibility. */
+  enabled?: boolean
+  /** Fires when the user toggles. Required reading when `enabled` is controlled. */
+  onEnabledChange?: (next: boolean) => void
+  /** Stroke color for the bodyweight line + dots. Defaults to a soft ink so it reads as secondary. */
+  stroke?: string
+  /** Override sketchiness — 0 = clean, 2+ = very wobbly. */
+  roughness?: number
+  /** Stable seed so re-renders don't re-jitter. */
+  seed?: number
+  /** Font for tick labels. Defaults to `inherit`. */
+  fontFamily?: string
+  /** Stroke for axis spines, ticks, and tick labels. */
+  axisColor?: string
+  /** Right-side axis label. Defaults to `Bodyweight (lbs)`. */
+  axisLabel?: string
+  /** Toggle button label. Defaults to `Bodyweight`. */
+  toggleLabel?: string
+  /** Number of ticks on the secondary y-axis. Defaults to 4. */
+  yTickCount?: number
+  /** Tick label formatter. Defaults to integer pounds. */
+  yTickFormat?: (value: number) => string
+  /** Optional class on the wrapping `<div>`. */
+  className?: string
+  /**
+   * Accessible name for the bodyweight overlay layer (the SVG, not the child
+   * chart). Without this, screen readers announce it as an unnamed graphic.
+   */
+  ariaLabel?: string
+  /** The primary chart to overlay. Should be sized to `width × height` with the same `margin` and date domain. */
+  children: ReactNode
+}
+
+interface BodyweightPoint {
+  date: Date
+  bw: number
+}
+
+export function BodyweightOverlay({
+  benchmarks,
+  dateExtent,
+  width,
+  height,
+  margin,
+  defaultEnabled = true,
+  enabled,
+  onEnabledChange,
+  stroke = chartPalette.inkSoft,
+  roughness = 1.4,
+  seed = 7,
+  fontFamily = 'inherit',
+  axisColor = chartPalette.inkSoft,
+  axisLabel = 'Bodyweight (lbs)',
+  toggleLabel = 'Bodyweight',
+  yTickCount = 4,
+  yTickFormat = (v) => `${Math.round(v)}`,
+  className,
+  ariaLabel = 'Bodyweight overlay',
+  children,
+}: BodyweightOverlayProps): JSX.Element {
+  const [internalEnabled, setInternalEnabled] = useState(defaultEnabled)
+  const isControlled = enabled !== undefined
+  const isOn = isControlled ? enabled : internalEnabled
+  const toggleId = useId()
+
+  // The rough.js layer is mounted only after hydration. The shared rough.js
+  // generator is non-deterministic across SSR vs client renders when other
+  // server-rendered charts on the page have already advanced its internal
+  // state — that desync produces a "didn't match the client properties"
+  // hydration error on the overlay's <path> elements. Deferring to a
+  // post-mount client-only render sidesteps the mismatch entirely.
+  const [hydrated, setHydrated] = useState(false)
+  useEffect(() => {
+    setHydrated(true)
+  }, [])
+
+  const handleToggle = (): void => {
+    const next = !isOn
+    if (!isControlled) setInternalEnabled(next)
+    onEnabledChange?.(next)
+  }
+
+  const points: BodyweightPoint[] = benchmarks
+    .filter((b): b is Benchmark & { bodyweight_lbs: number } =>
+      typeof b.bodyweight_lbs === 'number' && b.is_complete !== false,
+    )
+    .map((b) => ({ date: new Date(b.date), bw: b.bodyweight_lbs }))
+    .sort((a, b) => a.date.getTime() - b.date.getTime())
+
+  const m = resolveMargin(margin)
+  const innerW = width - m.left - m.right
+  const innerH = height - m.top - m.bottom
+
+  const showLayer = hydrated && isOn && points.length > 0
+
+  return (
+    <div
+      className={className}
+      style={{
+        position: 'relative',
+        width,
+        height,
+      }}
+    >
+      {children}
+      {showLayer && (
+        <BodyweightLayer
+          points={points}
+          dateExtent={dateExtent}
+          width={width}
+          height={height}
+          innerW={innerW}
+          innerH={innerH}
+          marginLeft={m.left}
+          marginTop={m.top}
+          stroke={stroke}
+          roughness={roughness}
+          seed={seed}
+          fontFamily={fontFamily}
+          axisColor={axisColor}
+          axisLabel={axisLabel}
+          yTickCount={yTickCount}
+          yTickFormat={yTickFormat}
+          ariaLabel={ariaLabel}
+        />
+      )}
+      <button
+        type="button"
+        id={toggleId}
+        onClick={handleToggle}
+        aria-pressed={isOn}
+        aria-label={`Toggle ${toggleLabel} overlay`}
+        style={{
+          position: 'absolute',
+          top: 8,
+          right: 8,
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: 6,
+          padding: '4px 10px',
+          fontFamily,
+          fontSize: 12,
+          lineHeight: 1,
+          color: chartPalette.inkBlack,
+          background: isOn ? chartPalette.courtLineCream : 'transparent',
+          border: `1px solid ${isOn ? chartPalette.inkSoft : chartPalette.hardwoodTan}`,
+          borderRadius: 999,
+          cursor: 'pointer',
+          opacity: points.length === 0 ? 0.5 : 1,
+        }}
+        disabled={points.length === 0}
+        title={
+          points.length === 0
+            ? 'No bodyweight entries in the selected range'
+            : isOn
+              ? `Hide ${toggleLabel.toLowerCase()} overlay`
+              : `Show ${toggleLabel.toLowerCase()} overlay`
+        }
+      >
+        <span
+          aria-hidden="true"
+          style={{
+            display: 'inline-block',
+            width: 8,
+            height: 8,
+            borderRadius: 999,
+            background: isOn ? stroke : 'transparent',
+            border: `1px solid ${stroke}`,
+          }}
+        />
+        {toggleLabel}
+      </button>
+    </div>
+  )
+}
+
+interface BodyweightLayerProps {
+  points: BodyweightPoint[]
+  dateExtent: [Date, Date]
+  width: number
+  height: number
+  innerW: number
+  innerH: number
+  marginLeft: number
+  marginTop: number
+  stroke: string
+  roughness: number
+  seed: number
+  fontFamily: string
+  axisColor: string
+  axisLabel: string
+  yTickCount: number
+  yTickFormat: (value: number) => string
+  ariaLabel: string
+}
+
+/**
+ * Internal rendering layer — split out so the parent stays declarative and the
+ * toggle JSX doesn't have to thread a dozen scale variables. Only mounted when
+ * the overlay is enabled and there's at least one bodyweight point.
+ */
+function BodyweightLayer({
+  points,
+  dateExtent,
+  width,
+  height,
+  innerW,
+  innerH,
+  marginLeft,
+  marginTop,
+  stroke,
+  roughness,
+  seed,
+  fontFamily,
+  axisColor,
+  axisLabel,
+  yTickCount,
+  yTickFormat,
+  ariaLabel,
+}: BodyweightLayerProps): JSX.Element {
+  const xScale = scaleTime().domain(dateExtent).range([0, innerW])
+
+  const bwValues = points.map((p) => p.bw)
+  const [yMin, yMax] = extent(bwValues)
+  const yPad = (yMax - yMin) * 0.15 || 1
+  const yScale = scaleLinear()
+    .domain([yMin - yPad, yMax + yPad])
+    .nice()
+    .range([innerH, 0])
+
+  const yTicks: AxisTick[] = yScale.ticks(yTickCount).map((tick) => ({
+    value: yTickFormat(tick),
+    offset: yScale(tick),
+  }))
+
+  const linePoints: [number, number][] = points.map((p) => [xScale(p.date), yScale(p.bw)])
+
+  // Fresh generator (not the shared singleton) — see the BodyweightOverlay
+  // hydration comment above. Cost is one allocation per render; output is
+  // deterministic given the seed.
+  const gen = rough.generator()
+  const linePath = gen.linearPath(linePoints, {
+    stroke,
+    strokeWidth: 1.5,
+    roughness,
+    seed,
+  })
+
+  return (
+    <svg
+      width={width}
+      height={height}
+      role="img"
+      aria-label={ariaLabel}
+      style={{
+        position: 'absolute',
+        inset: 0,
+        pointerEvents: 'none',
+      }}
+    >
+      <title>{ariaLabel}</title>
+      <g transform={`translate(${marginLeft},${marginTop})`}>
+        <Axis
+          orientation="right"
+          position={innerW}
+          start={0}
+          end={innerH}
+          ticks={yTicks}
+          label={axisLabel}
+          color={axisColor}
+          fontFamily={fontFamily}
+          roughness={roughness}
+          seed={seed + 200}
+        />
+        {gen.toPaths(linePath).map((p, i) => (
+          <path
+            key={`bw-line-${i}`}
+            d={p.d}
+            stroke={p.stroke}
+            strokeWidth={p.strokeWidth}
+            fill="none"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeDasharray="4 3"
+          />
+        ))}
+        {linePoints.map(([px, py], i) => {
+          const dot = gen.circle(px, py, 7, {
+            fill: stroke,
+            fillStyle: 'solid',
+            stroke,
+            strokeWidth: 1,
+            roughness: roughness * 0.6,
+            seed: seed + 300 + i,
+          })
+          return gen.toPaths(dot).map((p, j) => (
+            <path
+              key={`bw-dot-${i}-${j}`}
+              d={p.d}
+              stroke={p.stroke}
+              strokeWidth={p.strokeWidth}
+              fill={p.fill ?? 'none'}
+            />
+          ))
+        })}
+      </g>
+    </svg>
+  )
+}

--- a/components/training-facility/shared/charts/BodyweightOverlay.tsx
+++ b/components/training-facility/shared/charts/BodyweightOverlay.tsx
@@ -73,6 +73,22 @@ interface BodyweightPoint {
   bw: number
 }
 
+/**
+ * Wraps a time-series chart child with a secondary right-side bodyweight
+ * axis and a toggle. See {@link BodyweightOverlayProps} for prop semantics.
+ *
+ * - **Toggle:** uncontrolled by default (seeded with `defaultEnabled`); pass
+ *   `enabled` + `onEnabledChange` to lift state into a parent.
+ * - **Hydration:** the rough.js overlay layer mounts only after the first
+ *   client-side effect. The shared rough.js generator is non-deterministic
+ *   across SSR vs client renders when other server-rendered charts on the
+ *   page have already advanced its internal state, so deferring sidesteps
+ *   "didn't match the client properties" hydration errors on `<path>`
+ *   elements. The toggle button still SSRs immediately.
+ * - **Margin contract:** caller must pass the same `margin` to both the
+ *   wrapper and the chart child so the x-axes line up — the wrapper does
+ *   not size or scale the child.
+ */
 export function BodyweightOverlay({
   benchmarks,
   dateExtent,
@@ -100,12 +116,8 @@ export function BodyweightOverlay({
   const isOn = isControlled ? enabled : internalEnabled
   const toggleId = useId()
 
-  // The rough.js layer is mounted only after hydration. The shared rough.js
-  // generator is non-deterministic across SSR vs client renders when other
-  // server-rendered charts on the page have already advanced its internal
-  // state — that desync produces a "didn't match the client properties"
-  // hydration error on the overlay's <path> elements. Deferring to a
-  // post-mount client-only render sidesteps the mismatch entirely.
+  // Defer the overlay layer to post-hydration — see the function JSDoc for the
+  // SSR/client rough.js generator divergence this avoids.
   const [hydrated, setHydrated] = useState(false)
   useEffect(() => {
     setHydrated(true)

--- a/components/training-facility/shared/charts/axes.tsx
+++ b/components/training-facility/shared/charts/axes.tsx
@@ -216,13 +216,13 @@ export function Axis({
       )}
       {label && isRight && (
         <text
-          x={position + 36}
+          x={position + 32}
           y={(start + end) / 2}
           textAnchor="middle"
           fontFamily={fontFamily}
           fontSize={13}
           fill={color}
-          transform={`rotate(90 ${position + 36} ${(start + end) / 2})`}
+          transform={`rotate(90 ${position + 32} ${(start + end) / 2})`}
         >
           {label}
         </text>

--- a/components/training-facility/shared/charts/axes.tsx
+++ b/components/training-facility/shared/charts/axes.tsx
@@ -59,8 +59,8 @@ export interface AxisTick {
 }
 
 export interface AxisProps {
-  orientation: 'bottom' | 'left'
-  /** Cross-axis coordinate of the spine (y for bottom, x for left). */
+  orientation: 'bottom' | 'left' | 'right'
+  /** Cross-axis coordinate of the spine (y for bottom, x for left/right). */
   position: number
   /** Spine start coordinate along the primary axis (px). */
   start: number
@@ -92,6 +92,7 @@ export function Axis({
   seed,
 }: AxisProps): JSX.Element {
   const isBottom = orientation === 'bottom'
+  const isRight = orientation === 'right'
   const gen = getGenerator()
 
   const spine = isBottom
@@ -139,6 +140,31 @@ export function Axis({
           )
         }
         const y = start + tick.offset
+        if (isRight) {
+          return (
+            <g key={`tick-${i}`}>
+              <line
+                x1={position}
+                y1={y}
+                x2={position + tickLength}
+                y2={y}
+                stroke={color}
+                strokeWidth={1}
+              />
+              <text
+                x={position + tickLength + 4}
+                y={y}
+                textAnchor="start"
+                dominantBaseline="middle"
+                fontFamily={fontFamily}
+                fontSize={12}
+                fill={color}
+              >
+                {tick.value}
+              </text>
+            </g>
+          )
+        }
         return (
           <g key={`tick-${i}`}>
             <line
@@ -175,7 +201,7 @@ export function Axis({
           {label}
         </text>
       )}
-      {label && !isBottom && (
+      {label && !isBottom && !isRight && (
         <text
           x={position - 32}
           y={(start + end) / 2}
@@ -184,6 +210,19 @@ export function Axis({
           fontSize={13}
           fill={color}
           transform={`rotate(-90 ${position - 32} ${(start + end) / 2})`}
+        >
+          {label}
+        </text>
+      )}
+      {label && isRight && (
+        <text
+          x={position + 36}
+          y={(start + end) / 2}
+          textAnchor="middle"
+          fontFamily={fontFamily}
+          fontSize={13}
+          fill={color}
+          transform={`rotate(90 ${position + 36} ${(start + end) / 2})`}
         >
           {label}
         </text>

--- a/components/training-facility/shared/charts/index.ts
+++ b/components/training-facility/shared/charts/index.ts
@@ -1,6 +1,7 @@
 export { RoughLine, type RoughLineProps } from './RoughLine'
 export { RoughBar, type RoughBarProps } from './RoughBar'
 export { RoughScatter, type RoughScatterProps } from './RoughScatter'
+export { BodyweightOverlay, type BodyweightOverlayProps } from './BodyweightOverlay'
 export { Axis, EmptyChart, type AxisProps, type AxisTick, type EmptyChartProps } from './axes'
 export { chartPalette, type ChartPalette } from './palette'
 export { defaultMargin, type ChartCommonProps, type ChartMargin } from './types'

--- a/components/training-facility/shared/charts/types.ts
+++ b/components/training-facility/shared/charts/types.ts
@@ -9,9 +9,14 @@ export interface ChartMargin {
 // which renders at position + 32 with a 13px font (~6px below baseline).
 // 52 keeps the label inside the SVG box without callers having to override
 // `margin` every time they pass `xLabel`.
+//
+// right needs ~33px for right-axis tick labels (text-anchor="start", values
+// like "240" run ~24px wide past the spine) plus a label offset; 40 gives
+// room for both without callers having to override `margin` whenever a
+// secondary right axis is used (e.g. BodyweightOverlay).
 export const defaultMargin: ChartMargin = {
   top: 16,
-  right: 24,
+  right: 40,
   bottom: 52,
   left: 56,
 }

--- a/components/training-facility/shared/charts/types.ts
+++ b/components/training-facility/shared/charts/types.ts
@@ -5,15 +5,17 @@ export interface ChartMargin {
   left: number
 }
 
-// bottom is sized to fit a tick row (~12px) + the optional axis label,
-// which renders at position + 32 with a 13px font (~6px below baseline).
-// 52 keeps the label inside the SVG box without callers having to override
-// `margin` every time they pass `xLabel`.
-//
-// right needs ~33px for right-axis tick labels (text-anchor="start", values
-// like "240" run ~24px wide past the spine) plus a label offset; 40 gives
-// room for both without callers having to override `margin` whenever a
-// secondary right axis is used (e.g. BodyweightOverlay).
+/**
+ * Shared default {@link ChartMargin} for every chart primitive — sized so
+ * common axis labels fit inside the SVG without callers overriding `margin`.
+ *
+ * - `bottom: 52` — fits a tick row (~12px) plus an optional `xLabel`
+ *   rendered at `position + 32` with a 13px font (~6px below baseline).
+ * - `right: 40` — fits right-axis tick labels (text-anchor="start", values
+ *   like "240" run ~24px past the spine) plus the rotated axis label, so a
+ *   secondary right axis (e.g. {@link BodyweightOverlay}) renders cleanly
+ *   without callers having to override `margin.right`.
+ */
 export const defaultMargin: ChartMargin = {
   top: 16,
   right: 40,


### PR DESCRIPTION
## Summary
- Adds `BodyweightOverlay` — a drop-in wrapper that overlays bodyweight as a secondary right-side axis on any time-series chart (PRD §4, §7.8). Used by Combine and Gym detail views downstream (#62, #68, #69, #73).
- Extends the shared hand-drawn `Axis` with a `'right'` orientation so the secondary axis reuses the same rough.js primitives instead of forking.
- Includes a toggle button to hide/show the overlay; toggle is uncontrolled by default but supports a controlled `enabled` / `onEnabledChange` API for parents that want to persist state.

## Implementation notes
- `components/training-facility/shared/charts/BodyweightOverlay.tsx` — composition wrapper. Renders the primary chart child plus an absolutely-positioned overlay SVG sharing the same `width × height × margin × dateExtent`.
- The overlay layer uses its own fresh `rough.generator()` (not the module-shared singleton) and is mounted only after hydration via `useEffect`. The shared singleton picks up state from earlier server-rendered charts on the same page, which would otherwise cause hydration mismatches when the client component re-renders the overlay.
- Filters out benchmarks with no `bodyweight_lbs` and any with `is_complete === false`.
- Bodyweight series renders as a dashed line + dots in `inkSoft` so it reads as secondary to the primary chart.

## Test plan
- [ ] Visit `/dev/charts` on the preview — fourth section "BodyweightOverlay — Vertical jump with bodyweight overlaid" should show the orange jump line on the left axis and a dashed gray bodyweight line on the right axis labeled \`Bodyweight (lbs)\`.
- [ ] Toggle button (top-right of the chart frame) shows a filled orange dot when on, hollow when off; click toggles overlay visibility without affecting the primary chart.
- [ ] No console errors — particularly, no React hydration warnings about path attributes mismatching.
- [ ] Other primitives' sections (RoughLine, RoughBar, RoughScatter, empty state) render unchanged.
- [ ] \`aria-pressed\` reflects toggle state; \`aria-label="Toggle Bodyweight overlay"\` is announced; the SVG layer carries \`role="img"\` with the \`ariaLabel\` prop.

Closes #56.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bodyweight overlay visualization for training charts with toggle controls
  * Extended chart axis support to include right-side axes for secondary metrics
  * Integrated vertical jump benchmark data with bodyweight metrics for comprehensive performance tracking
  * Enhanced chart layout to accommodate secondary axis display

<!-- end of auto-generated comment: release notes by coderabbit.ai -->