### PR TITLE
fix(a11y): exactly one h1 per route (#42)

### DIFF
--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -26,6 +26,7 @@ import React from 'react'
 export default function ContactPage() {
   return (
     <SvgLayoutContainer>
+      <h1 className="sr-only">Front Office — Contact Lucas Lawrence</h1>
       <FrontOfficeSvg
         zoneContent={{
           whiteboard: (

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -16,6 +16,7 @@ import { ProjectGallery } from '@/components/project-binder/ProjectGallery'
 export default function ProjectPage() {
   return (
     <div className="bg-[url('/textures/binder-leather.png')] bg-center bg-cover bg-no-repeat min-h-screen flex flex-col relative">
+      <h1 className="sr-only">Project Binder — Lucas Lawrence</h1>
       {/* Header Controls */}
       <SectionContainer className="pt-4 pb-2 z-10 flex justify-between">
         <div className="text-xs bg-black/30 text-white px-3 py-1 font-mono rounded-tr-md">

--- a/components/court/CourtTitleSolo.tsx
+++ b/components/court/CourtTitleSolo.tsx
@@ -4,15 +4,18 @@ import React from 'react'
 
 /**
  * CourtTitleSolo displays a single orange title, centered.
+ *
+ * Renders as `<h1>` so the home court view has a page-level heading once the
+ * tunnel intro (which has its own `<h1>Lucas Lawrence</h1>`) has finished.
  */
 export const CourtTitleSolo: React.FC<{
   title: string
 }> = ({ title }) => {
   return (
     <div className="flex items-center justify-center text-center w-full h-full">
-      <h2 className="text-orange-400 text-base sm:text-lg md:text-xl font-semibold leading-tight font-mono">
+      <h1 className="text-orange-400 text-base sm:text-lg md:text-xl font-semibold leading-tight font-mono">
         {title}
-      </h2>
+      </h1>
     </div>
   )
 }


### PR DESCRIPTION
Closes #42.

## Problem
The home court (`/`) renders only an `<h2>` (\"Welcome to the Court\") once the TunnelHero intro has transitioned out — leaving the page with no `<h1>`. Lighthouse / external accessibility audits flagged this as a missing page-level heading. While auditing, I found the same issue on `/contact` and `/projects`, both of which render no `<h1>` at all.

## Changes (+7 / −2)
- **`components/court/CourtTitleSolo.tsx`** — render the title as `<h1>` instead of `<h2>`. Single call site (the `court-title` zone in `useZoneContent`), so no shared-component semantics change elsewhere.
- **`app/contact/page.tsx`** — add `<h1 className=\"sr-only\">Front Office — Contact Lucas Lawrence</h1>` ahead of the SVG layout. The page is SVG-driven with no natural place for visible heading text; sr-only preserves the visual design.
- **`app/projects/page.tsx`** — same pattern — sr-only `Project Binder — Lucas Lawrence` ahead of the binder layout.

## Verification
Walked all four routes with Playwright, asserting `document.querySelectorAll('h1').length === 1`:

| Route | h1 count | h1 text |
|---|---|---|
| `/` (intro) | 1 | Lucas Lawrence |
| `/` (court) | 1 | Welcome to the Court |
| `/contact` | 1 | Front Office — Contact Lucas Lawrence |
| `/projects` | 1 | Project Binder — Lucas Lawrence |

Routes already passing (unchanged): `/banners`, `/locker-room`, `/dev/charts`, `/dev/trading-card`.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] Dev server: `/` (both intro + court), `/contact`, `/projects` each render with exactly one `<h1>`
- [x] No console errors introduced (the 8 warnings on `/projects` are pre-existing Next.js Image \"missing sizes prop\" warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved semantic HTML structure with proper heading hierarchy across multiple pages for enhanced screen reader and assistive technology support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->