### PR TITLE
feat(api): local-dev-only Next.js route for benchmark writes (#59)

### DIFF
--- a/app/api/dev/movement-benchmarks/[date]/route.ts
+++ b/app/api/dev/movement-benchmarks/[date]/route.ts
@@ -1,0 +1,99 @@
+/**
+ * Dev-only item endpoint for movement benchmark updates and deletes
+ * (PRD §7.3, §7.11). The collection POST lives one directory up; this
+ * file owns PUT (overwrite by date) and DELETE (remove by date).
+ *
+ * Both handlers return 404 when not running under `next dev` so a
+ * production build never exposes a write surface.
+ */
+
+import { NextResponse, type NextRequest } from 'next/server'
+import { ZodError } from 'zod'
+import {
+  BenchmarkUpdateSchema,
+  isDevRuntime,
+  isValidDate,
+  readBenchmarks,
+  writeBenchmarks,
+} from '@/lib/dev/movement-benchmarks-store'
+
+interface Context {
+  params: Promise<{ date: string }>
+}
+
+/**
+ * Overwrite the benchmark identified by `date` with the partial fields
+ * in the body (`BenchmarkUpdate` shape — never the date itself).
+ *
+ * Status codes:
+ * - 200 — updated
+ * - 400 — bad date format or payload failed Zod validation
+ * - 404 — not running under `next dev`, OR no benchmark exists for `date`
+ */
+export async function PUT(request: NextRequest, ctx: Context): Promise<NextResponse> {
+  if (!isDevRuntime()) return notFound()
+
+  const { date } = await ctx.params
+  if (!isValidDate(date)) {
+    return NextResponse.json({ error: 'date must be YYYY-MM-DD.' }, { status: 400 })
+  }
+
+  let payload: unknown
+  try {
+    payload = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Body must be valid JSON.' }, { status: 400 })
+  }
+
+  let updates
+  try {
+    updates = BenchmarkUpdateSchema.parse(payload)
+  } catch (err) {
+    if (err instanceof ZodError) {
+      return NextResponse.json({ error: 'Validation failed.', issues: err.flatten() }, { status: 400 })
+    }
+    throw err
+  }
+
+  const list = await readBenchmarks()
+  const idx = list.findIndex((b) => b.date === date)
+  if (idx === -1) {
+    return NextResponse.json({ error: `No benchmark for ${date}.` }, { status: 404 })
+  }
+
+  const merged = { ...list[idx], ...updates }
+  list[idx] = merged
+  await writeBenchmarks(list)
+  return NextResponse.json(merged, { status: 200 })
+}
+
+/**
+ * Remove the benchmark identified by `date`.
+ *
+ * Status codes:
+ * - 200 — deleted (response body echoes the removed entry)
+ * - 400 — bad date format
+ * - 404 — not running under `next dev`, OR no benchmark exists for `date`
+ */
+export async function DELETE(_request: NextRequest, ctx: Context): Promise<NextResponse> {
+  if (!isDevRuntime()) return notFound()
+
+  const { date } = await ctx.params
+  if (!isValidDate(date)) {
+    return NextResponse.json({ error: 'date must be YYYY-MM-DD.' }, { status: 400 })
+  }
+
+  const list = await readBenchmarks()
+  const idx = list.findIndex((b) => b.date === date)
+  if (idx === -1) {
+    return NextResponse.json({ error: `No benchmark for ${date}.` }, { status: 404 })
+  }
+
+  const [removed] = list.splice(idx, 1)
+  await writeBenchmarks(list)
+  return NextResponse.json(removed, { status: 200 })
+}
+
+function notFound(): NextResponse {
+  return new NextResponse(null, { status: 404 })
+}

--- a/app/api/dev/movement-benchmarks/[date]/route.ts
+++ b/app/api/dev/movement-benchmarks/[date]/route.ts
@@ -29,6 +29,10 @@ interface Context {
  * - 200 — updated
  * - 400 — bad date format or payload failed Zod validation
  * - 404 — not running under `next dev`, OR no benchmark exists for `date`
+ *
+ * @param request Incoming JSON request whose body is a partial-update payload.
+ * @param ctx Next.js route context; `ctx.params.date` is the entry's primary key.
+ * @throws Propagates filesystem errors from {@link readBenchmarks} / {@link writeBenchmarks}.
  */
 export async function PUT(request: NextRequest, ctx: Context): Promise<NextResponse> {
   if (!isDevRuntime()) return notFound()
@@ -74,6 +78,10 @@ export async function PUT(request: NextRequest, ctx: Context): Promise<NextRespo
  * - 200 — deleted (response body echoes the removed entry)
  * - 400 — bad date format
  * - 404 — not running under `next dev`, OR no benchmark exists for `date`
+ *
+ * @param _request Unused — DELETE has no body. Required by Next.js handler signature.
+ * @param ctx Next.js route context; `ctx.params.date` is the entry's primary key.
+ * @throws Propagates filesystem errors from {@link readBenchmarks} / {@link writeBenchmarks}.
  */
 export async function DELETE(_request: NextRequest, ctx: Context): Promise<NextResponse> {
   if (!isDevRuntime()) return notFound()

--- a/app/api/dev/movement-benchmarks/route.ts
+++ b/app/api/dev/movement-benchmarks/route.ts
@@ -26,6 +26,9 @@ import {
  * - 400 — payload failed Zod validation (response body has Zod's flattened error)
  * - 404 — not running under `next dev`
  * - 409 — an entry already exists for `date` (use PUT to overwrite)
+ *
+ * @param request Incoming JSON request whose body is the full benchmark payload.
+ * @throws Propagates filesystem errors from {@link readBenchmarks} / {@link writeBenchmarks}.
  */
 export async function POST(request: NextRequest): Promise<NextResponse> {
   if (!isDevRuntime()) return notFound()

--- a/app/api/dev/movement-benchmarks/route.ts
+++ b/app/api/dev/movement-benchmarks/route.ts
@@ -1,0 +1,65 @@
+/**
+ * Dev-only collection endpoint for movement benchmark writes.
+ *
+ * Per PRD §7.3 the production site is purely static; the only write
+ * surface is this route, which exists exclusively under `next dev`.
+ * In any other build the handler returns 404 so a leak doesn't expose
+ * a write endpoint on the public site.
+ *
+ * Pair with `[date]/route.ts` for PUT/DELETE.
+ */
+
+import { NextResponse, type NextRequest } from 'next/server'
+import { ZodError } from 'zod'
+import {
+  BenchmarkSchema,
+  isDevRuntime,
+  readBenchmarks,
+  writeBenchmarks,
+} from '@/lib/dev/movement-benchmarks-store'
+
+/**
+ * Append a new benchmark entry. Body must conform to {@link BenchmarkSchema}.
+ *
+ * Status codes:
+ * - 201 — created
+ * - 400 — payload failed Zod validation (response body has Zod's flattened error)
+ * - 404 — not running under `next dev`
+ * - 409 — an entry already exists for `date` (use PUT to overwrite)
+ */
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  if (!isDevRuntime()) return notFound()
+
+  let payload: unknown
+  try {
+    payload = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Body must be valid JSON.' }, { status: 400 })
+  }
+
+  let entry
+  try {
+    entry = BenchmarkSchema.parse(payload)
+  } catch (err) {
+    if (err instanceof ZodError) {
+      return NextResponse.json({ error: 'Validation failed.', issues: err.flatten() }, { status: 400 })
+    }
+    throw err
+  }
+
+  const list = await readBenchmarks()
+  if (list.some((b) => b.date === entry.date)) {
+    return NextResponse.json(
+      { error: `Benchmark for ${entry.date} already exists. Use PUT to overwrite.` },
+      { status: 409 },
+    )
+  }
+
+  list.push(entry)
+  await writeBenchmarks(list)
+  return NextResponse.json(entry, { status: 201 })
+}
+
+function notFound(): NextResponse {
+  return new NextResponse(null, { status: 404 })
+}

--- a/lib/data/movement.ts
+++ b/lib/data/movement.ts
@@ -71,14 +71,24 @@ export async function deleteBenchmark(date: BenchmarkDate): Promise<void> {
   if (!res.ok) throw await writeError(res, 'delete');
 }
 
-/** Builds a descriptive Error for a failed write, distinguishing prod-404 from real failures. */
+/**
+ * Builds a descriptive Error for a failed write.
+ *
+ * The route returns 404 in two cases that look identical from a status code alone:
+ * 1. The dev-gate (route-level guard for `NODE_ENV !== 'development'`) — empty body.
+ * 2. A missing benchmark (PUT/DELETE against a date that doesn't exist) — JSON body with an `error` field.
+ *
+ * Disambiguating by body lets the form surface a "no entry for that date"
+ * domain error without misreporting it as "dev API unavailable" while
+ * developing locally.
+ */
 async function writeError(res: Response, action: string): Promise<Error> {
-  if (res.status === 404) {
+  const detail = await res.text().catch(() => '');
+  if (res.status === 404 && detail.trim() === '') {
     return new Error(
       `Cannot ${action} benchmark: dev-only write API is unavailable in this environment.`,
     );
   }
-  const detail = await res.text().catch(() => '');
   return new Error(
     `Failed to ${action} benchmark: ${res.status} ${res.statusText}${detail ? ` — ${detail}` : ''}`,
   );

--- a/lib/dev/movement-benchmarks-store.ts
+++ b/lib/dev/movement-benchmarks-store.ts
@@ -1,0 +1,106 @@
+/**
+ * Server-only helpers for the dev-only movement-benchmarks write API
+ * (PRD §7.3, §7.10). The actual API routes live under
+ * `app/api/dev/movement-benchmarks/`; this module owns the Zod schema,
+ * filesystem path, and read/write primitives so both the collection
+ * (POST) and item (PUT/DELETE) routes stay thin.
+ */
+
+import { promises as fs } from 'node:fs'
+import path from 'node:path'
+import { z } from 'zod'
+
+/** ISO calendar date in `YYYY-MM-DD` form. Matches `BenchmarkDate` from `types/movement.ts`. */
+const DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/
+
+/**
+ * Zod schema for a complete {@link Benchmark}. Mirrors the type in
+ * `types/movement.ts`; kept in sync manually since Zod is the runtime
+ * source of truth (PRD §7.14) but the static type is the IDE source.
+ *
+ * `.strict()` rejects unknown fields so a typo in the payload (e.g.
+ * `bodyweight_lb` instead of `bodyweight_lbs`) fails loudly instead of
+ * silently dropping data into the JSON file.
+ */
+export const BenchmarkSchema = z
+  .object({
+    date: z.string().regex(DATE_REGEX, 'date must be YYYY-MM-DD'),
+    bodyweight_lbs: z.number().positive().optional(),
+    shuttle_5_10_5_s: z.number().positive().optional(),
+    vertical_in: z.number().positive().optional(),
+    sprint_10y_s: z.number().positive().optional(),
+    notes: z.string().optional(),
+    is_complete: z.boolean().optional(),
+  })
+  .strict()
+
+/**
+ * Zod schema for the partial-update payload sent to PUT. The `date` is
+ * the URL key and cannot be changed in-place, so it's omitted here.
+ */
+export const BenchmarkUpdateSchema = BenchmarkSchema.omit({ date: true }).partial().strict()
+
+/** Validated benchmark shape. `Inferred from {@link BenchmarkSchema}`. */
+export type ValidatedBenchmark = z.infer<typeof BenchmarkSchema>
+
+/** Validated partial update. Inferred from {@link BenchmarkUpdateSchema}. */
+export type ValidatedBenchmarkUpdate = z.infer<typeof BenchmarkUpdateSchema>
+
+/**
+ * Absolute path to `public/data/movement_benchmarks.json`. The dev write
+ * routes read and overwrite this file; the production site fetches it
+ * statically.
+ */
+export const BENCHMARKS_FILE = path.join(process.cwd(), 'public', 'data', 'movement_benchmarks.json')
+
+/**
+ * Read the on-disk benchmark list. Returns `[]` if the file doesn't
+ * exist yet (typical pre-baseline state) or if the file is empty —
+ * those are normal "no data" conditions, not errors.
+ *
+ * @throws when the file exists but is malformed JSON or doesn't parse
+ *   as a `Benchmark[]`.
+ */
+export async function readBenchmarks(): Promise<ValidatedBenchmark[]> {
+  let raw: string
+  try {
+    raw = await fs.readFile(BENCHMARKS_FILE, 'utf8')
+  } catch (err) {
+    if (isFileNotFound(err)) return []
+    throw err
+  }
+  const trimmed = raw.trim()
+  if (trimmed === '') return []
+  const parsed = JSON.parse(trimmed)
+  return z.array(BenchmarkSchema).parse(parsed)
+}
+
+/**
+ * Sort the list newest-first by date and write it back to disk.
+ * Creates the parent `public/data/` directory if it doesn't exist so
+ * the very first POST against an empty repo succeeds.
+ */
+export async function writeBenchmarks(list: ValidatedBenchmark[]): Promise<void> {
+  const sorted = [...list].sort((a, b) => b.date.localeCompare(a.date))
+  await fs.mkdir(path.dirname(BENCHMARKS_FILE), { recursive: true })
+  // Trailing newline so the file plays nicely with `git diff` / editors.
+  await fs.writeFile(BENCHMARKS_FILE, JSON.stringify(sorted, null, 2) + '\n', 'utf8')
+}
+
+/**
+ * True when this build is running under `next dev`. Both the route
+ * 404-gate and any future feature flags should funnel through this
+ * helper rather than re-checking the env var inline.
+ */
+export function isDevRuntime(): boolean {
+  return process.env.NODE_ENV === 'development'
+}
+
+/** Validate a URL `[date]` segment as `YYYY-MM-DD`. */
+export function isValidDate(value: string): boolean {
+  return DATE_REGEX.test(value)
+}
+
+function isFileNotFound(err: unknown): boolean {
+  return typeof err === 'object' && err !== null && 'code' in err && (err as { code: string }).code === 'ENOENT'
+}

--- a/lib/dev/movement-benchmarks-store.ts
+++ b/lib/dev/movement-benchmarks-store.ts
@@ -79,6 +79,9 @@ export async function readBenchmarks(): Promise<ValidatedBenchmark[]> {
  * Sort the list newest-first by date and write it back to disk.
  * Creates the parent `public/data/` directory if it doesn't exist so
  * the very first POST against an empty repo succeeds.
+ *
+ * @param list Validated benchmark entries to persist; mutated only via the local copy made before sort.
+ * @throws Propagates filesystem errors from `mkdir`/`writeFile`.
  */
 export async function writeBenchmarks(list: ValidatedBenchmark[]): Promise<void> {
   const sorted = [...list].sort((a, b) => b.date.localeCompare(a.date))
@@ -96,7 +99,12 @@ export function isDevRuntime(): boolean {
   return process.env.NODE_ENV === 'development'
 }
 
-/** Validate a URL `[date]` segment as `YYYY-MM-DD`. */
+/**
+ * Validate a URL `[date]` segment as `YYYY-MM-DD`.
+ *
+ * @param value Raw string from the URL — typically `ctx.params.date`.
+ * @returns `true` when `value` matches the ISO calendar-date shape.
+ */
 export function isValidDate(value: string): boolean {
   return DATE_REGEX.test(value)
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-simple-typewriter": "^5.0.1",
-        "roughjs": "^4.6.6"
+        "roughjs": "^4.6.6",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -6867,7 +6868,6 @@
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-simple-typewriter": "^5.0.1",
-    "roughjs": "^4.6.6"
+    "roughjs": "^4.6.6",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",


### PR DESCRIPTION
Closes #59.

## Summary
- New `app/api/dev/movement-benchmarks/route.ts` — POST creates a new entry, returns 409 if the date already exists.
- New `app/api/dev/movement-benchmarks/[date]/route.ts` — PUT merges partial updates, DELETE removes by date.
- Shared `lib/dev/movement-benchmarks-store.ts` — Zod schemas (`BenchmarkSchema`, `BenchmarkUpdateSchema`), \`isDevRuntime()\`, file I/O. Writes are sorted newest-first per the issue.
- Adds `zod` (~57KB minified) — picked by PRD §7.14 as the validation source.

## Why
Per PRD §7.3 the site is purely static; the only write surface is this route, used by the (future) Combine entry form via the existing `lib/data/movement.ts` write functions (`logBenchmark`, `updateBenchmark`, `deleteBenchmark`). Every handler 404s when `NODE_ENV !== 'development'` — the route is registered in the production build but exposes no writable endpoint.

## Done-when
- [x] POST/PUT/DELETE all work in dev (smoke-tested via curl)
- [x] Payload validation rejects malformed entries (Zod `.strict()`, returns 400 with `error.flatten()`)
- [x] Smoke test: write an entry, see file change on disk
- [x] `npx tsc --noEmit` clean
- [x] `npx next build` clean

## Test plan
- [ ] In dev: \`POST /api/dev/movement-benchmarks\` with a valid Benchmark payload → 201, see new entry in `public/data/movement_benchmarks.json`
- [ ] Re-POST same date → 409
- [ ] POST with typo'd field (e.g., `bodyweight_lb`) → 400 with Zod issues
- [ ] POST with malformed date (e.g., `04-15-2026`) → 400
- [ ] \`PUT /api/dev/movement-benchmarks/<date>\` with partial update → 200, file shows merged entry
- [ ] PUT against non-existent date → 404
- [ ] \`DELETE /api/dev/movement-benchmarks/<date>\` → 200, entry removed from file
- [ ] DELETE against non-existent date → 404
- [ ] **Production build:** `npx next build && npx next start`, then any method against `/api/dev/movement-benchmarks` → 404 (the route exists in the build output but the handler 404s when `NODE_ENV !== 'development'`)

## Smoke-test results (local)
\`\`\`
POST valid → 201
POST duplicate → 409
POST malformed payload → 400
POST bad date → 400
PUT valid (merge) → 200
PUT non-existent → 404
PUT bad URL date → 400
DELETE valid → 200
DELETE non-existent → 404
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dev-only API endpoints to create, update, and delete movement benchmark entries by date.
  * Server-side storage and validation for benchmark data with strict date validation and safe read/write.

* **Improvements**
  * More precise error responses for benchmark operations (distinct cases for missing dev-only API vs. other failures).

* **Chores**
  * Added runtime validation library dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->