### PR TITLE
feat(a11y): main landmark + skip-to-content link (#45)

### DIFF
--- a/app/dev/charts/page.tsx
+++ b/app/dev/charts/page.tsx
@@ -47,6 +47,13 @@ const paceVsHrData = [
   { hr: 170, pace: 8.1 },
 ]
 
+/**
+ * Dev-only demo page that exercises the chart primitives in isolation.
+ *
+ * Renders a grid of chart variants (line, area, candlestick, etc.) using
+ * fixture data so each visual treatment can be verified without depending on
+ * the live training-facility data pipeline.
+ */
 export default function ChartsDemoPage(): JSX.Element {
   return (
     <div

--- a/app/dev/charts/page.tsx
+++ b/app/dev/charts/page.tsx
@@ -49,7 +49,7 @@ const paceVsHrData = [
 
 export default function ChartsDemoPage(): JSX.Element {
   return (
-    <main
+    <div
       className={patrickHand.variable}
       style={{
         backgroundColor: chartPalette.courtLineCream,
@@ -143,7 +143,7 @@ export default function ChartsDemoPage(): JSX.Element {
           />
         </Section>
       </div>
-    </main>
+    </div>
   )
 }
 

--- a/app/dev/trading-card/page.tsx
+++ b/app/dev/trading-card/page.tsx
@@ -62,7 +62,7 @@ const baselineEntry = history[0]
  */
 export default function TradingCardDemoPage(): JSX.Element {
   return (
-    <main
+    <div
       style={{
         backgroundColor: '#0a0a0a',
         color: '#f5f1e6',
@@ -115,7 +115,7 @@ export default function TradingCardDemoPage(): JSX.Element {
           </Section>
         </div>
       </div>
-    </main>
+    </div>
   )
 }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -60,7 +60,15 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased touch-pan-x touch-pan-y`}
       >
-        {children}
+        <a
+          href="#main"
+          className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[9999] focus:px-4 focus:py-2 focus:bg-orange-400 focus:text-black focus:rounded-md focus:font-semibold focus:outline focus:outline-2 focus:outline-white"
+        >
+          Skip to main content
+        </a>
+        <main id="main" tabIndex={-1} className="outline-none">
+          {children}
+        </main>
         <Analytics />
       </body>
     </html>

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -28,7 +28,7 @@ export default function ProjectPage() {
       </SectionContainer>
 
       {/* Main content */}
-      <main className="flex-grow w-full">
+      <div className="flex-grow w-full">
         <SectionContainer className="pt-2 pb-1">
           <div className="text-yellow-200 uppercase tracking-wide text-sm font-mono">
             Lucas Lawrence // Tech Stack Binder
@@ -42,7 +42,7 @@ export default function ProjectPage() {
         </SectionContainer>
 
         <ProjectGallery />
-      </main>
+      </div>
     </div>
   )
 }

--- a/components/not-found/AirballScene.tsx
+++ b/components/not-found/AirballScene.tsx
@@ -19,7 +19,7 @@ export function AirballScene() {
   const pathname = usePathname()
 
   return (
-    <main
+    <div
       className="fixed inset-0 isolate overflow-hidden bg-neutral-950 text-white"
       style={{
         background:
@@ -155,6 +155,6 @@ export function AirballScene() {
         </p>
         <BackToCourtButton />
       </div>
-    </main>
+    </div>
   )
 }


### PR DESCRIPTION
Closes #45.

## Summary
Adds a single `<main id="main">` landmark at the root layout and a visually-hidden skip-to-content link as the first focusable element on every page. Production audit flagged `no_main_landmark` and `no_skip_link`; both should clear on the next run.

## Changes (+15 / −7)
- **`app/layout.tsx`** — first child of `<body>` is now `<a href="#main" class="sr-only focus:not-sr-only ...">Skip to main content</a>`. The link uses Tailwind's `sr-only` utility to stay invisible until it receives keyboard focus, then jumps to the top-left as a focused button. `{children}` is wrapped in `<main id="main" tabIndex={-1}>` so the skip link can move focus into the content area.
- **`app/projects/page.tsx`**, **`app/dev/trading-card/page.tsx`**, **`app/dev/charts/page.tsx`** — replaced their inner `<main>` tags with `<div>` so the document has exactly one `<main>` landmark per route (avoids invalid nested-main HTML).

## Test plan
- [ ] On preview URL: load `/`, press Tab once → an orange "Skip to main content" button appears top-left
- [ ] Press Enter on the focused skip link → focus moves into the main content area (Tab continues from inside `<main>`, not from page chrome)
- [ ] DevTools → Elements: confirm exactly one `<main id="main">` element on `/`, `/contact`, `/projects`, `/banners`, `/locker-room`, `/dev/charts`, `/dev/trading-card`
- [ ] Lighthouse a11y on `/` should now pass `bypass` and `landmark-one-main`
- [ ] No console errors/warnings introduced (the existing 8 image-sizes warnings on `/projects` are pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified several page and scene wrappers for more consistent layout and visual testing.
  * Added a keyboard-accessible skip-navigation anchor and a focusable main content wrapper to improve keyboard and screen-reader navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->