### PR TITLE
feat(a11y): add main landmark and skip-to-content link (#45)

### DIFF
--- a/app/dev/charts/page.tsx
+++ b/app/dev/charts/page.tsx
@@ -49,7 +49,7 @@ const paceVsHrData = [
 
 export default function ChartsDemoPage(): JSX.Element {
   return (
-    <main
+    <div
       className={patrickHand.variable}
       style={{
         backgroundColor: chartPalette.courtLineCream,
@@ -143,7 +143,7 @@ export default function ChartsDemoPage(): JSX.Element {
           />
         </Section>
       </div>
-    </main>
+    </div>
   )
 }
 

--- a/app/dev/trading-card/page.tsx
+++ b/app/dev/trading-card/page.tsx
@@ -62,7 +62,7 @@ const baselineEntry = history[0]
  */
 export default function TradingCardDemoPage(): JSX.Element {
   return (
-    <main
+    <div
       style={{
         backgroundColor: '#0a0a0a',
         color: '#f5f1e6',
@@ -115,7 +115,7 @@ export default function TradingCardDemoPage(): JSX.Element {
           </Section>
         </div>
       </div>
-    </main>
+    </div>
   )
 }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -63,9 +63,9 @@ export default function RootLayout({
         {/*
          * Skip-to-content link — first focusable element in the document.
          * Visually hidden by default; becomes visible when a keyboard user
-         * Tabs into it. Targets the `<main id="main">` landmark below so
+         * Tabs into it. Targets the <main id="main"> landmark below so
          * screen-reader and keyboard users can bypass any future header
-         * chrome and jump straight to page content. (issue #45)
+         * chrome and jump straight to page content.
          */}
         <a
           href="#main"
@@ -73,7 +73,15 @@ export default function RootLayout({
         >
           Skip to main content
         </a>
-        <main id="main">{children}</main>
+        {/*
+         * tabindex="-1" makes <main> a programmatic focus target so the
+         * skip link reliably moves focus into the landmark across
+         * browsers (Safari in particular won't shift focus to a non-
+         * focusable fragment target on its own).
+         */}
+        <main id="main" tabIndex={-1}>
+          {children}
+        </main>
         <Analytics />
       </body>
     </html>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -60,7 +60,20 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased touch-pan-x touch-pan-y`}
       >
-        {children}
+        {/*
+         * Skip-to-content link — first focusable element in the document.
+         * Visually hidden by default; becomes visible when a keyboard user
+         * Tabs into it. Targets the `<main id="main">` landmark below so
+         * screen-reader and keyboard users can bypass any future header
+         * chrome and jump straight to page content. (issue #45)
+         */}
+        <a
+          href="#main"
+          className="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-[1000] focus:rounded focus:bg-black focus:px-4 focus:py-2 focus:text-sm focus:font-semibold focus:text-white focus:outline-none focus:ring-2 focus:ring-orange-500"
+        >
+          Skip to main content
+        </a>
+        <main id="main">{children}</main>
         <Analytics />
       </body>
     </html>

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -27,8 +27,8 @@ export default function ProjectPage() {
         </div>
       </SectionContainer>
 
-      {/* Main content */}
-      <main className="flex-grow w-full">
+      {/* Page content — wrapped by the root layout's <main id="main"> landmark. */}
+      <div className="flex-grow w-full">
         <SectionContainer className="pt-2 pb-1">
           <div className="text-yellow-200 uppercase tracking-wide text-sm font-mono">
             Lucas Lawrence // Tech Stack Binder
@@ -42,7 +42,7 @@ export default function ProjectPage() {
         </SectionContainer>
 
         <ProjectGallery />
-      </main>
+      </div>
     </div>
   )
 }

--- a/components/court/CourtLayout.tsx
+++ b/components/court/CourtLayout.tsx
@@ -5,14 +5,14 @@ import { CourtSvg } from './CourtSvg'
 
 export const CourtLayout = ({ children }: { children: ReactNode }) => {
   return (
-    <main className="min-h-screen bg-white text-black px-6 py-20 relative overflow-hidden">
+    <div className="min-h-screen bg-white text-black px-6 py-20 relative overflow-hidden">
       {/* Decorative SVG background court */}
       <div className="absolute inset-0 z-0 opacity-5 pointer-events-none" aria-hidden="true">
         <CourtSvg className="w-full h-full" />
       </div>
 
-      {/* Foreground content */}
+      {/* Foreground content — wrapped by the root layout's <main id="main"> landmark. */}
       <div className="relative z-10">{children}</div>
-    </main>
+    </div>
   )
 }

--- a/components/court/CourtLayout.tsx
+++ b/components/court/CourtLayout.tsx
@@ -3,6 +3,14 @@
 import { ReactNode } from 'react'
 import { CourtSvg } from './CourtSvg'
 
+/**
+ * CourtLayout is the wrapper used by court-themed routes that need a
+ * faded full-bleed CourtSvg background plus a centered foreground
+ * content well. Renders a `<div>` (not `<main>`) so it nests cleanly
+ * inside the root layout's `<main id="main">` landmark.
+ *
+ * @param children - The page content rendered above the decorative court SVG.
+ */
 export const CourtLayout = ({ children }: { children: ReactNode }) => {
   return (
     <div className="min-h-screen bg-white text-black px-6 py-20 relative overflow-hidden">

--- a/components/court/HalfCourtAbout.tsx
+++ b/components/court/HalfCourtAbout.tsx
@@ -5,7 +5,7 @@ import { CourtSvg } from './CourtSvg'
 
 export function HalfCourtAbout() {
   return (
-    <main className="relative min-h-screen overflow-hidden bg-white text-black">
+    <div className="relative min-h-screen overflow-hidden bg-white text-black">
       {/* Background SVG court */}
       <div className="absolute inset-0 z-0 pointer-events-none opacity-60">
         <CourtSvg />
@@ -62,6 +62,6 @@ export function HalfCourtAbout() {
           </Link>
         </div>
       </div>
-    </main>
+    </div>
   )
 }

--- a/components/court/HalfCourtAbout.tsx
+++ b/components/court/HalfCourtAbout.tsx
@@ -3,6 +3,12 @@
 import Link from 'next/link'
 import { CourtSvg } from './CourtSvg'
 
+/**
+ * HalfCourtAbout renders the static "About Lucas" half-court page —
+ * faded CourtSvg backdrop, name + tagline hero, two info cards, and a
+ * pair of CTAs back to projects/contact. Returns a `<div>` so the root
+ * layout's `<main id="main">` remains the single landmark for the route.
+ */
 export function HalfCourtAbout() {
   return (
     <div className="relative min-h-screen overflow-hidden bg-white text-black">

--- a/components/not-found/AirballScene.tsx
+++ b/components/not-found/AirballScene.tsx
@@ -19,7 +19,7 @@ export function AirballScene() {
   const pathname = usePathname()
 
   return (
-    <main
+    <div
       className="fixed inset-0 isolate overflow-hidden bg-neutral-950 text-white"
       style={{
         background:
@@ -155,6 +155,6 @@ export function AirballScene() {
         </p>
         <BackToCourtButton />
       </div>
-    </main>
+    </div>
   )
 }


### PR DESCRIPTION
Closes #45.

## Summary
- Root layout now wraps every route in `<main id="main">` and renders a visually-hidden "Skip to main content" link as the very first focusable element.
- Existing pages/components that rendered their own `<main>` are converted to `<div>` so each route has exactly one canonical landmark (no nested `<main>` elements).
- Verified with keyboard nav: Tab reveals the link with a visible orange ring, Enter jumps to `#main`. Confirmed exactly one `<main>` in the rendered HTML for `/`, `/projects`, `/banners`, `/contact`, `/locker-room`, `/dev/charts`, and the 404 page.

## Files touched
- `app/layout.tsx` — skip link + `<main id="main">` wrapper
- `app/projects/page.tsx`, `app/dev/charts/page.tsx`, `app/dev/trading-card/page.tsx` — `<main>` → `<div>`
- `components/court/CourtLayout.tsx`, `components/court/HalfCourtAbout.tsx`, `components/not-found/AirballScene.tsx` — `<main>` → `<div>`

## Test plan
- [ ] Hard-reload `/`, press Tab once → orange-ringed "Skip to main content" appears top-left
- [ ] Press Enter → URL gets `#main` fragment, focus moves into the main landmark
- [ ] Tab again from any page (`/projects`, `/contact`, `/locker-room`, `/banners`) — same behavior
- [ ] Mouse-only flow looks unchanged (link should be invisible without keyboard focus)
- [ ] 404 (`/anything-not-real`) still renders the AIRBALL scene full-bleed
- [ ] Run an axe / Lighthouse a11y check — landmark + bypass-block rule should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Added skip-to-content navigation link allowing keyboard and screen reader users to jump directly to main content
  * Restructured page landmarks for improved compatibility with assistive technologies

* **Refactor**
  * Consolidated page layout structure across multiple pages for consistent semantic HTML organization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->