### PR TITLE
feat(zone): add Training Facility shell (#60)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,12 @@ npm run dev
 
 Then visit [http://localhost:3000](http://localhost:3000)
 
-No `.env` needed — everything lives in the repo.
+No `.env` is required for the main site. To expose the unfinished
+Training Facility routes locally, set:
+
+```bash
+NEXT_PUBLIC_ENABLE_TRAINING_FACILITY=true
+```
 
 ---
 

--- a/app/training-facility/combine/page.tsx
+++ b/app/training-facility/combine/page.tsx
@@ -1,0 +1,20 @@
+import { TrainingFacilitySubareaShell } from '@/components/training-facility/TrainingFacilitySubareaShell'
+
+/**
+ * Renders the placeholder Combine route so the Training Facility shell has a live destination.
+ */
+export default function TrainingFacilityCombinePage() {
+  return (
+    <TrainingFacilitySubareaShell
+      eyebrow="Movement wing"
+      title="The Combine"
+      description="This room is reserved for benchmark testing: sprint, shuttle, jump, and bodyweight context, all framed like a basketball combine rather than a generic dashboard."
+      accentClassName="bg-gradient-to-r from-sky-300 via-cyan-400 to-blue-500"
+      nextSteps={[
+        'Build the Combine room scene and scoreboard framing.',
+        'Wire benchmark entry and results views into the destination.',
+        'Connect the shared date filter and bodyweight overlays.',
+      ]}
+    />
+  )
+}

--- a/app/training-facility/combine/page.tsx
+++ b/app/training-facility/combine/page.tsx
@@ -1,9 +1,13 @@
+import { isTrainingFacilityEnabled } from '@/lib/feature-flags'
 import { TrainingFacilitySubareaShell } from '@/components/training-facility/TrainingFacilitySubareaShell'
+import { notFound } from 'next/navigation'
 
 /**
  * Renders the placeholder Combine route so the Training Facility shell has a live destination.
  */
 export default function TrainingFacilityCombinePage() {
+  if (!isTrainingFacilityEnabled()) notFound()
+
   return (
     <TrainingFacilitySubareaShell
       eyebrow="Movement wing"

--- a/app/training-facility/gym/page.tsx
+++ b/app/training-facility/gym/page.tsx
@@ -1,9 +1,13 @@
+import { isTrainingFacilityEnabled } from '@/lib/feature-flags'
 import { TrainingFacilitySubareaShell } from '@/components/training-facility/TrainingFacilitySubareaShell'
+import { notFound } from 'next/navigation'
 
 /**
  * Renders the placeholder Gym route so the Training Facility shell has a live destination.
  */
 export default function TrainingFacilityGymPage() {
+  if (!isTrainingFacilityEnabled()) notFound()
+
   return (
     <TrainingFacilitySubareaShell
       eyebrow="Cardio wing"

--- a/app/training-facility/gym/page.tsx
+++ b/app/training-facility/gym/page.tsx
@@ -1,0 +1,20 @@
+import { TrainingFacilitySubareaShell } from '@/components/training-facility/TrainingFacilitySubareaShell'
+
+/**
+ * Renders the placeholder Gym route so the Training Facility shell has a live destination.
+ */
+export default function TrainingFacilityGymPage() {
+  return (
+    <TrainingFacilitySubareaShell
+      eyebrow="Cardio wing"
+      title="The Gym"
+      description="This is where the cardio side of the Training Facility takes shape: the migrated stair-climber dashboard, running and walking views, and the stat wall that pulls the metrics into one room."
+      accentClassName="bg-gradient-to-r from-amber-300 via-orange-400 to-amber-500"
+      nextSteps={[
+        'Build the Gym scene art and equipment entry points.',
+        'Wire cardio.json into the room-level visualizations.',
+        'Add the All Cardio overview and per-equipment detail views.',
+      ]}
+    />
+  )
+}

--- a/app/training-facility/page.tsx
+++ b/app/training-facility/page.tsx
@@ -1,8 +1,12 @@
+import { isTrainingFacilityEnabled } from '@/lib/feature-flags'
 import { TrainingFacilityShell } from '@/components/training-facility/TrainingFacilityShell'
+import { notFound } from 'next/navigation'
 
 /**
  * Renders the top-level Training Facility shell scene.
  */
 export default function TrainingFacilityPage() {
+  if (!isTrainingFacilityEnabled()) notFound()
+
   return <TrainingFacilityShell />
 }

--- a/app/training-facility/page.tsx
+++ b/app/training-facility/page.tsx
@@ -1,0 +1,8 @@
+import { TrainingFacilityShell } from '@/components/training-facility/TrainingFacilityShell'
+
+/**
+ * Renders the top-level Training Facility shell scene.
+ */
+export default function TrainingFacilityPage() {
+  return <TrainingFacilityShell />
+}

--- a/components/training-facility/TrainingFacilityCourtEntry.tsx
+++ b/components/training-facility/TrainingFacilityCourtEntry.tsx
@@ -9,7 +9,7 @@ type TrainingFacilityCourtEntryProps = {
   /**
    * Invoked when the visitor activates the court-side tunnel entry.
    */
-  onClick?: () => void
+  onClick: () => void
 }
 
 /**
@@ -19,7 +19,7 @@ type TrainingFacilityCourtEntryProps = {
  * another utility button stacked with the top-right navigation controls.
  *
  * @param props.id - Optional DOM id used for testing hooks or guided-tour targeting.
- * @param props.onClick - Optional activation handler invoked when a visitor enters the tunnel.
+ * @param props.onClick - Activation handler invoked when a visitor enters the tunnel.
  */
 export function TrainingFacilityCourtEntry({
   id,

--- a/components/training-facility/TrainingFacilityCourtEntry.tsx
+++ b/components/training-facility/TrainingFacilityCourtEntry.tsx
@@ -17,6 +17,9 @@ type TrainingFacilityCourtEntryProps = {
  *
  * The visual treatment intentionally reads like an in-world doorway rather than
  * another utility button stacked with the top-right navigation controls.
+ *
+ * @param props.id - Optional DOM id used for testing hooks or guided-tour targeting.
+ * @param props.onClick - Optional activation handler invoked when a visitor enters the tunnel.
  */
 export function TrainingFacilityCourtEntry({
   id,

--- a/components/training-facility/TrainingFacilityCourtEntry.tsx
+++ b/components/training-facility/TrainingFacilityCourtEntry.tsx
@@ -1,0 +1,50 @@
+'use client'
+
+type TrainingFacilityCourtEntryProps = {
+  /**
+   * Optional DOM id used for a11y targeting and future guided-tour steps.
+   */
+  id?: string
+
+  /**
+   * Invoked when the visitor activates the court-side tunnel entry.
+   */
+  onClick?: () => void
+}
+
+/**
+ * Court-side tunnel marker that links the main court into the Training Facility.
+ *
+ * The visual treatment intentionally reads like an in-world doorway rather than
+ * another utility button stacked with the top-right navigation controls.
+ */
+export function TrainingFacilityCourtEntry({
+  id,
+  onClick,
+}: TrainingFacilityCourtEntryProps) {
+  return (
+    <button
+      id={id}
+      type="button"
+      onClick={onClick}
+      aria-label="Enter the Training Facility"
+      className="group flex h-full w-full cursor-pointer flex-col justify-between rounded-[28px] border-2 border-amber-300/80 bg-[#2d180f]/95 p-3 text-amber-50 shadow-[0_16px_28px_rgba(0,0,0,0.35)] transition duration-200 hover:-translate-y-1 hover:bg-[#3a2014] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-amber-200"
+    >
+      <div className="rounded-full border border-amber-200/35 bg-black/20 px-2 py-1 text-center text-[10px] font-semibold uppercase tracking-[0.32em] text-amber-100">
+        Training Facility
+      </div>
+
+      <div className="mx-auto flex h-20 w-24 items-end justify-center rounded-t-[999px] rounded-b-lg border border-amber-100/25 bg-gradient-to-b from-[#5a331d] via-[#24130c] to-[#120905] px-3 pb-3 shadow-inner">
+        <div className="w-full rounded-t-[999px] rounded-b-md border border-dashed border-amber-100/20 bg-black/45 px-2 py-2 text-center text-[9px] font-semibold uppercase tracking-[0.28em] text-amber-100/85">
+          Gym
+          <br />
+          Combine
+        </div>
+      </div>
+
+      <div className="text-center text-[10px] font-medium uppercase tracking-[0.22em] text-amber-100/80">
+        Enter tunnel
+      </div>
+    </button>
+  )
+}

--- a/components/training-facility/TrainingFacilityDoor.tsx
+++ b/components/training-facility/TrainingFacilityDoor.tsx
@@ -50,6 +50,12 @@ type TrainingFacilityDoorProps = {
   disabled?: boolean
 }
 
+/**
+ * Tailwind class groups keyed by `TrainingFacilityDoorTone`.
+ *
+ * Each tone entry defines the frame, placard, doorway glow, and text classes
+ * used to style a Training Facility door card consistently across variants.
+ */
 const toneClasses: Record<
   TrainingFacilityDoorTone,
   {
@@ -81,6 +87,15 @@ const toneClasses: Record<
 
 /**
  * Door card used by the Training Facility shell to represent sub-area entry points.
+ *
+ * @param props.eyebrow - Small overline used to categorize the destination.
+ * @param props.title - Main destination label shown on the door placard.
+ * @param props.href - Optional route target; omitted only when rendering a non-link fallback.
+ * @param props.description - Supporting copy explaining what the destination contains.
+ * @param props.doorwayHint - Short phrase rendered in the doorway window to hint at the contents.
+ * @param props.footer - Footer copy used as a route status or roadmap note.
+ * @param props.tone - Visual tone key used to look up the door styling classes.
+ * @param props.disabled - When true, disables navigation and renders the door as an inert roadmap placeholder.
  */
 export function TrainingFacilityDoor({
   eyebrow,

--- a/components/training-facility/TrainingFacilityDoor.tsx
+++ b/components/training-facility/TrainingFacilityDoor.tsx
@@ -108,11 +108,16 @@ export function TrainingFacilityDoor({
   disabled = false,
 }: TrainingFacilityDoorProps) {
   const colors = toneClasses[tone]
+  const isInteractive = !disabled && Boolean(href)
   const baseClassName = [
     'group flex h-full min-h-[21rem] flex-col rounded-[2rem] border p-5 text-left shadow-[0_20px_50px_rgba(0,0,0,0.28)] transition duration-200',
     colors.frame,
     colors.text,
-    disabled ? 'cursor-not-allowed opacity-80' : 'cursor-pointer hover:-translate-y-1 hover:shadow-[0_24px_60px_rgba(0,0,0,0.34)]',
+    disabled
+      ? 'cursor-not-allowed opacity-80'
+      : isInteractive
+        ? 'cursor-pointer hover:-translate-y-1 hover:shadow-[0_24px_60px_rgba(0,0,0,0.34)]'
+        : 'cursor-default',
   ].join(' ')
 
   const content = (

--- a/components/training-facility/TrainingFacilityDoor.tsx
+++ b/components/training-facility/TrainingFacilityDoor.tsx
@@ -1,0 +1,145 @@
+import Link from 'next/link'
+
+/**
+ * Supported color treatments for Training Facility door cards.
+ */
+type TrainingFacilityDoorTone = 'amber' | 'sky' | 'slate'
+
+/**
+ * Props for a navigable or disabled Training Facility door.
+ */
+type TrainingFacilityDoorProps = {
+  /**
+   * Small overline shown above the main label.
+   */
+  eyebrow: string
+
+  /**
+   * Main destination name rendered on the door placard.
+   */
+  title: string
+
+  /**
+   * Route target when the door is active.
+   */
+  href?: string
+
+  /**
+   * Supporting copy describing the destination.
+   */
+  description: string
+
+  /**
+   * Short phrase rendered inside the doorway window to hint at the contents.
+   */
+  doorwayHint: string
+
+  /**
+   * Footer copy used as a route label or roadmap note.
+   */
+  footer: string
+
+  /**
+   * Visual color treatment used to distinguish destinations.
+   */
+  tone: TrainingFacilityDoorTone
+
+  /**
+   * When true, the door is presented as a visible roadmap item but does not navigate.
+   */
+  disabled?: boolean
+}
+
+const toneClasses: Record<
+  TrainingFacilityDoorTone,
+  {
+    frame: string
+    placard: string
+    glow: string
+    text: string
+  }
+> = {
+  amber: {
+    frame: 'border-amber-200/45 bg-[#2e1c13]/90',
+    placard: 'border-amber-200/30 bg-amber-100/10',
+    glow: 'from-[#66401d] via-[#24130c] to-[#120905]',
+    text: 'text-amber-50',
+  },
+  sky: {
+    frame: 'border-sky-200/40 bg-[#182333]/90',
+    placard: 'border-sky-200/25 bg-sky-100/10',
+    glow: 'from-[#274968] via-[#112031] to-[#09121c]',
+    text: 'text-sky-50',
+  },
+  slate: {
+    frame: 'border-stone-200/25 bg-[#26211d]/85',
+    placard: 'border-stone-200/20 bg-stone-100/5',
+    glow: 'from-[#504741] via-[#1d1815] to-[#0e0a09]',
+    text: 'text-stone-100',
+  },
+}
+
+/**
+ * Door card used by the Training Facility shell to represent sub-area entry points.
+ */
+export function TrainingFacilityDoor({
+  eyebrow,
+  title,
+  href,
+  description,
+  doorwayHint,
+  footer,
+  tone,
+  disabled = false,
+}: TrainingFacilityDoorProps) {
+  const colors = toneClasses[tone]
+  const baseClassName = [
+    'group flex h-full min-h-[21rem] flex-col rounded-[2rem] border p-5 text-left shadow-[0_20px_50px_rgba(0,0,0,0.28)] transition duration-200',
+    colors.frame,
+    colors.text,
+    disabled ? 'cursor-not-allowed opacity-80' : 'cursor-pointer hover:-translate-y-1 hover:shadow-[0_24px_60px_rgba(0,0,0,0.34)]',
+  ].join(' ')
+
+  const content = (
+    <>
+      <div className={`rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-[0.3em] ${colors.placard}`}>
+        {eyebrow}
+      </div>
+
+      <div className="mt-4">
+        <h2 className="text-3xl font-black uppercase tracking-[0.08em] sm:text-[2.1rem]">
+          {title}
+        </h2>
+        <p className="mt-3 text-sm leading-6 text-current/80">{description}</p>
+      </div>
+
+      <div className={`mt-6 flex flex-1 items-end rounded-[999px_999px_1rem_1rem] border border-white/10 bg-gradient-to-b p-4 ${colors.glow}`}>
+        <div className="flex h-full w-full items-end justify-center rounded-[999px_999px_0.8rem_0.8rem] border border-dashed border-white/15 bg-black/35 px-4 py-5 text-center text-sm font-semibold uppercase tracking-[0.24em] text-white/85 shadow-inner">
+          {doorwayHint}
+        </div>
+      </div>
+
+      <div className="mt-4 text-xs font-medium uppercase tracking-[0.24em] text-current/65">
+        {footer}
+      </div>
+    </>
+  )
+
+  if (disabled) {
+    return (
+      <button type="button" disabled aria-disabled="true" className={baseClassName}>
+        {content}
+      </button>
+    )
+  }
+
+  if (!href) {
+    return <div className={baseClassName}>{content}</div>
+  }
+
+  return (
+    <Link href={href} className={baseClassName}>
+      {content}
+    </Link>
+  )
+}

--- a/components/training-facility/TrainingFacilityShell.tsx
+++ b/components/training-facility/TrainingFacilityShell.tsx
@@ -1,0 +1,80 @@
+import { BackToCourtButton } from '@/components/common/BackToCourtButton'
+import { TrainingFacilityDoor } from '@/components/training-facility/TrainingFacilityDoor'
+
+/**
+ * Main Training Facility shell scene rendered from the new top-level route.
+ *
+ * This deliberately ships a route-first hallway scene with wired navigation,
+ * while leaving the bespoke Gym / Combine SVG build for the follow-up issue.
+ */
+export function TrainingFacilityShell() {
+  return (
+    <div className="relative min-h-svh overflow-hidden bg-[#160f0c] text-[#f7ead9]">
+      <div
+        aria-hidden="true"
+        className="absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(248,214,170,0.18),transparent_28%),radial-gradient(circle_at_bottom,rgba(117,65,35,0.35),transparent_35%),linear-gradient(180deg,#271711_0%,#160f0c_50%,#0f0907_100%)]"
+      />
+      <div
+        aria-hidden="true"
+        className="absolute inset-x-0 top-0 h-36 bg-[repeating-linear-gradient(90deg,transparent_0,transparent_8%,rgba(255,255,255,0.06)_8%,rgba(255,255,255,0.06)_9%,transparent_9%,transparent_18%)] opacity-40"
+      />
+      <div
+        aria-hidden="true"
+        className="absolute inset-x-0 bottom-0 h-48 bg-[linear-gradient(180deg,transparent_0%,rgba(0,0,0,0.14)_8%,rgba(0,0,0,0.55)_100%)]"
+      />
+
+      <div className="relative z-10 mx-auto flex min-h-svh w-full max-w-7xl flex-col px-6 py-8 sm:px-8 lg:px-12">
+        <div className="flex items-center justify-between gap-4">
+          <BackToCourtButton />
+          <div className="rounded-full border border-amber-100/20 bg-black/20 px-4 py-2 text-xs font-semibold uppercase tracking-[0.32em] text-amber-100/75">
+            Phase 1 shell
+          </div>
+        </div>
+
+        <div className="mx-auto mt-10 w-full max-w-4xl text-center">
+          <div className="mx-auto inline-flex rounded-full border border-amber-100/25 bg-[#2b1a13]/80 px-5 py-2 text-xs font-semibold uppercase tracking-[0.42em] text-amber-100/85">
+            Training Facility
+          </div>
+          <h1 className="mt-5 text-4xl font-black uppercase tracking-[0.08em] text-[#fff6ea] sm:text-6xl">
+            Pick a door.
+          </h1>
+          <p className="mx-auto mt-5 max-w-3xl text-base leading-7 text-[#e8d5be] sm:text-lg">
+            The Gym carries the cardio side of the project. The Combine holds the
+            movement benchmark work. The Weight Room stays on the roadmap as a later
+            expansion, but the entrance is already reserved here in the space.
+          </p>
+        </div>
+
+        <div className="mt-14 grid gap-6 lg:grid-cols-3">
+          <TrainingFacilityDoor
+            eyebrow="Cardio wing"
+            title="The Gym"
+            href="/training-facility/gym"
+            description="The cardio dashboard moves into courtfolio here: stair-climber work, running, walking, and the stat wall that ties them together."
+            doorwayHint="Stairs + treadmill"
+            footer="Route live now"
+            tone="amber"
+          />
+          <TrainingFacilityDoor
+            eyebrow="Movement wing"
+            title="The Combine"
+            href="/training-facility/combine"
+            description="This side houses the benchmark tests: shuttle times, sprint work, jump numbers, and the bodyweight context that makes them meaningful."
+            doorwayHint="Cones + stopwatch"
+            footer="Route live now"
+            tone="sky"
+          />
+          <TrainingFacilityDoor
+            eyebrow="Roadmap"
+            title="Weight Room"
+            description="Grease-the-groove bodyweight work belongs here later. For now, the room stays blocked off so the Phase 1 shell matches the PRD without opening a dead route."
+            doorwayHint="Coming soon"
+            footer="Reserved for post-v1"
+            tone="slate"
+            disabled
+          />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/training-facility/TrainingFacilitySubareaShell.tsx
+++ b/components/training-facility/TrainingFacilitySubareaShell.tsx
@@ -1,0 +1,108 @@
+import Link from 'next/link'
+
+import { BackToCourtButton } from '@/components/common/BackToCourtButton'
+
+/**
+ * Props for the placeholder Training Facility sub-area shell used by Gym and Combine.
+ */
+type TrainingFacilitySubareaShellProps = {
+  /**
+   * Small contextual label shown above the main title.
+   */
+  eyebrow: string
+
+  /**
+   * Main page title for the sub-area.
+   */
+  title: string
+
+  /**
+   * Short explanation of what the finished space will hold.
+   */
+  description: string
+
+  /**
+   * Accent color used to differentiate the room.
+   */
+  accentClassName: string
+
+  /**
+   * Concrete next-phase items that make the placeholder route useful today.
+   */
+  nextSteps: string[]
+}
+
+/**
+ * Shared shell for the early Gym and Combine routes.
+ *
+ * The route exists now so the Training Facility navigation is real, but the
+ * interactive detail builds can land in later issues without breaking the shell.
+ */
+export function TrainingFacilitySubareaShell({
+  eyebrow,
+  title,
+  description,
+  accentClassName,
+  nextSteps,
+}: TrainingFacilitySubareaShellProps) {
+  return (
+    <div className="relative min-h-svh overflow-hidden bg-[#120d0a] text-[#f7ead9]">
+      <div
+        aria-hidden="true"
+        className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(255,255,255,0.08),transparent_28%),linear-gradient(180deg,#241811_0%,#120d0a_52%,#0b0806_100%)]"
+      />
+
+      <div className="relative z-10 mx-auto flex min-h-svh w-full max-w-5xl flex-col px-6 py-8 sm:px-8 lg:px-12">
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <BackToCourtButton />
+          <Link
+            href="/training-facility"
+            className="rounded-full border border-white/15 bg-white/5 px-4 py-2 text-xs font-semibold uppercase tracking-[0.28em] text-white/80 transition hover:bg-white/10"
+          >
+            Back to Training Facility
+          </Link>
+        </div>
+
+        <div className="mt-16 overflow-hidden rounded-[2rem] border border-white/10 bg-white/5 shadow-[0_28px_70px_rgba(0,0,0,0.34)] backdrop-blur-sm">
+          <div className={`h-2 w-full ${accentClassName}`} />
+          <div className="px-6 py-8 sm:px-10 sm:py-10">
+            <div className="text-xs font-semibold uppercase tracking-[0.38em] text-white/60">
+              {eyebrow}
+            </div>
+            <h1 className="mt-4 text-4xl font-black uppercase tracking-[0.08em] text-[#fff7ec] sm:text-6xl">
+              {title}
+            </h1>
+            <p className="mt-5 max-w-3xl text-base leading-7 text-[#e8d5be] sm:text-lg">
+              {description}
+            </p>
+
+            <div className="mt-10 grid gap-6 lg:grid-cols-[1.35fr_0.9fr]">
+              <div className="rounded-[1.6rem] border border-white/10 bg-black/25 p-6">
+                <div className="text-xs font-semibold uppercase tracking-[0.32em] text-white/55">
+                  Why this route exists now
+                </div>
+                <p className="mt-4 text-sm leading-7 text-white/75">
+                  Issue #60 wires the Training Facility structure end to end. That
+                  means the top-level shell, the home-court entrance, and these two
+                  destination routes are all real before the richer room art and data
+                  views land in later phases.
+                </p>
+              </div>
+
+              <div className="rounded-[1.6rem] border border-white/10 bg-black/25 p-6">
+                <div className="text-xs font-semibold uppercase tracking-[0.32em] text-white/55">
+                  Next up
+                </div>
+                <ul className="mt-4 space-y-3 text-sm leading-6 text-white/75">
+                  {nextSteps.map(step => (
+                    <li key={step}>{step}</li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/training-facility/TrainingFacilitySubareaShell.tsx
+++ b/components/training-facility/TrainingFacilitySubareaShell.tsx
@@ -37,6 +37,12 @@ type TrainingFacilitySubareaShellProps = {
  *
  * The route exists now so the Training Facility navigation is real, but the
  * interactive detail builds can land in later issues without breaking the shell.
+ *
+ * @param props.eyebrow - Small contextual label shown above the room title.
+ * @param props.title - Main sub-area title rendered as the page heading.
+ * @param props.description - Short explanation of what the finished sub-area will contain.
+ * @param props.accentClassName - Tailwind class string used for the room's accent bar.
+ * @param props.nextSteps - Ordered list of follow-up implementation items for the sub-area.
  */
 export function TrainingFacilitySubareaShell({
   eyebrow,

--- a/lib/feature-flags.ts
+++ b/lib/feature-flags.ts
@@ -1,0 +1,15 @@
+/**
+ * Centralized runtime flags for unfinished or staged features.
+ *
+ * Keep user-facing route gates in one place so client navigation and
+ * server-rendered pages stay in sync when a feature is hidden.
+ */
+
+/**
+ * True when the Training Facility routes should be visible and
+ * navigable. Defaults to `false` until the route family is ready to
+ * ship publicly.
+ */
+export function isTrainingFacilityEnabled(): boolean {
+  return process.env.NEXT_PUBLIC_ENABLE_TRAINING_FACILITY === 'true'
+}

--- a/utils/hooks/useZoneContent.tsx
+++ b/utils/hooks/useZoneContent.tsx
@@ -12,6 +12,7 @@ import { ZoneCareerStats } from '@/components/court/zones/ZoneCareerStats'
 import { ZoneProjects } from '@/components/court/zones/ZoneProjects'
 import { ZoneEntryButton } from '@/components/common/ZoneEntryButton'
 import { TrainingFacilityCourtEntry } from '@/components/training-facility/TrainingFacilityCourtEntry'
+import { isTrainingFacilityEnabled } from '@/lib/feature-flags'
 
 type ZoneContentMap = Record<string, React.ReactNode>
 
@@ -39,6 +40,7 @@ export function useZoneContent({
   reset,
 }: UseZoneContentProps): ZoneContentMap {
   const router = useRouter()
+  const trainingFacilityEnabled = isTrainingFacilityEnabled()
 
   const baseZones = useMemo<ZoneContentMap>(
     () => ({
@@ -156,18 +158,22 @@ export function useZoneContent({
           </SafeSvgHtml>
         </CourtZone>
       ),
-      'training-facility-entry': (
-        <CourtZone x={1115} y={680} width={180} height={160} className="ui-layer z-[105]">
-          <SafeSvgHtml>
-            <TrainingFacilityCourtEntry
-              id="enter-training-facility"
-              onClick={() => router.push('/training-facility')}
-            />
-          </SafeSvgHtml>
-        </CourtZone>
-      ),
+      ...(trainingFacilityEnabled
+        ? {
+            'training-facility-entry': (
+              <CourtZone x={1115} y={680} width={180} height={160} className="ui-layer z-[105]">
+                <SafeSvgHtml>
+                  <TrainingFacilityCourtEntry
+                    id="enter-training-facility"
+                    onClick={() => router.push('/training-facility')}
+                  />
+                </SafeSvgHtml>
+              </CourtZone>
+            ),
+          }
+        : {}),
     }),
-    [router]
+    [router, trainingFacilityEnabled]
   )
 
   const zoneContent: ZoneContentMap = { ...baseZones }

--- a/utils/hooks/useZoneContent.tsx
+++ b/utils/hooks/useZoneContent.tsx
@@ -11,6 +11,7 @@ import { ZoneBioCard } from '@/components/court/zones/ZoneBioCard'
 import { ZoneCareerStats } from '@/components/court/zones/ZoneCareerStats'
 import { ZoneProjects } from '@/components/court/zones/ZoneProjects'
 import { ZoneEntryButton } from '@/components/common/ZoneEntryButton'
+import { TrainingFacilityCourtEntry } from '@/components/training-facility/TrainingFacilityCourtEntry'
 
 type ZoneContentMap = Record<string, React.ReactNode>
 
@@ -152,6 +153,16 @@ export function useZoneContent({
                 onClick={() => (window.location.href = '/projects')}
               />
             </div>
+          </SafeSvgHtml>
+        </CourtZone>
+      ),
+      'training-facility-entry': (
+        <CourtZone x={1115} y={680} width={180} height={160} className="ui-layer z-[105]">
+          <SafeSvgHtml>
+            <TrainingFacilityCourtEntry
+              id="enter-training-facility"
+              onClick={() => router.push('/training-facility')}
+            />
           </SafeSvgHtml>
         </CourtZone>
       ),


### PR DESCRIPTION
## Summary
- add a new top-level `/training-facility` route with an in-world shell scene
- add clickable Gym and Combine placeholder routes plus an inert Weight Room placeholder door
- add a new Training Facility tunnel entry on the main court so the zone is reachable from home

## Test plan
- [ ] Run `npx tsc --noEmit`
- [ ] Run `npx next build`
- [ ] Open `/` and verify the new Training Facility tunnel appears on the lower-right side of the main court
- [ ] Click the Training Facility tunnel and verify it routes to `/training-facility`
- [ ] Click `The Gym` door and verify it routes to `/training-facility/gym`
- [ ] Click `The Combine` door and verify it routes to `/training-facility/combine`
- [ ] Verify the `Weight Room` door is visible but does not navigate
- [ ] Verify the new routes render on both desktop and mobile widths without layout breakage

Closes #60.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Training Facility section with a court entry point, hallway shell, and interactive door cards.
  * Added Gym and Combine subarea pages with guided copy, accent styling, and "Next up" steps; Weight Room shown as "Coming soon."
  * Accessible entry button and updated in-app navigation to/from the Training Facility.

* **Documentation**
  * README updated with local dev instructions to enable the Training Facility via an environment flag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->