### PR TITLE
test(training-facility): cover movement-benchmarks store + dev API + lib/data (#104, step 2)

### DIFF
--- a/app/api/dev/movement-benchmarks/[date]/route.test.ts
+++ b/app/api/dev/movement-benchmarks/[date]/route.test.ts
@@ -1,0 +1,139 @@
+// @vitest-environment node
+
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+import { promises as fs } from 'node:fs'
+import path from 'node:path'
+import os from 'node:os'
+import { DELETE, PUT } from './route'
+
+/**
+ * Direct-handler tests for PUT/DELETE /api/dev/movement-benchmarks/[date].
+ * Mirrors the collection route harness: tmp file via env stub, dev-only gate
+ * via NODE_ENV stub.
+ */
+
+let tmpDir: string
+let tmpFile: string
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'movement-item-route-'))
+  tmpFile = path.join(tmpDir, 'movement_benchmarks.json')
+  vi.stubEnv('MOVEMENT_BENCHMARKS_FILE', tmpFile)
+  vi.stubEnv('NODE_ENV', 'development')
+})
+
+afterEach(async () => {
+  vi.unstubAllEnvs()
+  await fs.rm(tmpDir, { recursive: true, force: true })
+})
+
+function ctxFor(date: string): { params: Promise<{ date: string }> } {
+  return { params: Promise.resolve({ date }) }
+}
+
+function putRequest(body: unknown): NextRequest {
+  return new NextRequest('http://localhost/api/dev/movement-benchmarks/2026-04-15', {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+function deleteRequest(): NextRequest {
+  return new NextRequest('http://localhost/api/dev/movement-benchmarks/2026-04-15', {
+    method: 'DELETE',
+  })
+}
+
+async function seed(entries: Array<{ date: string } & Record<string, unknown>>): Promise<void> {
+  await fs.writeFile(tmpFile, JSON.stringify(entries), 'utf8')
+}
+
+describe('PUT /api/dev/movement-benchmarks/[date]', () => {
+  it('200 — merges partial update into the existing entry', async () => {
+    await seed([{ date: '2026-04-15', bodyweight_lbs: 232, vertical_in: 21 }])
+    const res = await PUT(putRequest({ vertical_in: 23.5 }), ctxFor('2026-04-15'))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    // Original bodyweight_lbs preserved, vertical_in updated.
+    expect(body).toMatchObject({ date: '2026-04-15', bodyweight_lbs: 232, vertical_in: 23.5 })
+
+    const onDisk = JSON.parse(await fs.readFile(tmpFile, 'utf8'))
+    expect(onDisk[0].vertical_in).toBe(23.5)
+    expect(onDisk[0].bodyweight_lbs).toBe(232)
+  })
+
+  it('404 — no benchmark exists for the URL date', async () => {
+    await seed([{ date: '2026-03-15' }])
+    const res = await PUT(putRequest({ vertical_in: 22 }), ctxFor('2026-04-15'))
+    expect(res.status).toBe(404)
+    const body = await res.json()
+    expect(body.error).toMatch(/2026-04-15/)
+  })
+
+  it('400 — bad date format in URL segment', async () => {
+    const res = await PUT(putRequest({ vertical_in: 22 }), ctxFor('not-a-date'))
+    expect(res.status).toBe(400)
+  })
+
+  it('400 — non-JSON body', async () => {
+    await seed([{ date: '2026-04-15' }])
+    const req = new NextRequest('http://localhost/api/dev/movement-benchmarks/2026-04-15', {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: '{not json',
+    })
+    const res = await PUT(req, ctxFor('2026-04-15'))
+    expect(res.status).toBe(400)
+  })
+
+  it('400 — Zod rejects date field in the update body (caller cannot rename via PUT)', async () => {
+    await seed([{ date: '2026-04-15' }])
+    const res = await PUT(
+      putRequest({ date: '2026-05-15', vertical_in: 22 }),
+      ctxFor('2026-04-15'),
+    )
+    expect(res.status).toBe(400)
+  })
+
+  it('404 — prod-gate when NODE_ENV is not development', async () => {
+    vi.stubEnv('NODE_ENV', 'production')
+    const res = await PUT(putRequest({ vertical_in: 22 }), ctxFor('2026-04-15'))
+    expect(res.status).toBe(404)
+  })
+})
+
+describe('DELETE /api/dev/movement-benchmarks/[date]', () => {
+  it('200 — removes the entry and echoes it back', async () => {
+    await seed([
+      { date: '2026-04-15', bodyweight_lbs: 232 },
+      { date: '2026-03-15', bodyweight_lbs: 235 },
+    ])
+    const res = await DELETE(deleteRequest(), ctxFor('2026-04-15'))
+    expect(res.status).toBe(200)
+    const removed = await res.json()
+    expect(removed.bodyweight_lbs).toBe(232)
+
+    const onDisk = JSON.parse(await fs.readFile(tmpFile, 'utf8'))
+    expect(onDisk).toHaveLength(1)
+    expect(onDisk[0].date).toBe('2026-03-15')
+  })
+
+  it('404 — no benchmark exists for the URL date', async () => {
+    await seed([{ date: '2026-03-15' }])
+    const res = await DELETE(deleteRequest(), ctxFor('2026-04-15'))
+    expect(res.status).toBe(404)
+  })
+
+  it('400 — bad date format in URL segment', async () => {
+    const res = await DELETE(deleteRequest(), ctxFor('not-a-date'))
+    expect(res.status).toBe(400)
+  })
+
+  it('404 — prod-gate when NODE_ENV is not development', async () => {
+    vi.stubEnv('NODE_ENV', 'production')
+    const res = await DELETE(deleteRequest(), ctxFor('2026-04-15'))
+    expect(res.status).toBe(404)
+  })
+})

--- a/app/api/dev/movement-benchmarks/route.test.ts
+++ b/app/api/dev/movement-benchmarks/route.test.ts
@@ -1,0 +1,91 @@
+// @vitest-environment node
+
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+import { promises as fs } from 'node:fs'
+import path from 'node:path'
+import os from 'node:os'
+import { POST } from './route'
+
+/**
+ * Direct-handler tests for the dev-only POST /api/dev/movement-benchmarks
+ * route. Each test stubs MOVEMENT_BENCHMARKS_FILE at a fresh tmp file so
+ * the real fixture is never touched, and stubs NODE_ENV=development so
+ * the route's prod-gate doesn't 404 us.
+ */
+
+let tmpDir: string
+let tmpFile: string
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'movement-route-'))
+  tmpFile = path.join(tmpDir, 'movement_benchmarks.json')
+  vi.stubEnv('MOVEMENT_BENCHMARKS_FILE', tmpFile)
+  vi.stubEnv('NODE_ENV', 'development')
+})
+
+afterEach(async () => {
+  vi.unstubAllEnvs()
+  await fs.rm(tmpDir, { recursive: true, force: true })
+})
+
+function jsonRequest(body: unknown): NextRequest {
+  return new NextRequest('http://localhost/api/dev/movement-benchmarks', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('POST /api/dev/movement-benchmarks', () => {
+  it('201 — creates a new benchmark and persists it sorted', async () => {
+    const res = await POST(jsonRequest({ date: '2026-04-15', bodyweight_lbs: 232 }))
+    expect(res.status).toBe(201)
+    const echoed = await res.json()
+    expect(echoed.date).toBe('2026-04-15')
+
+    const onDisk = JSON.parse(await fs.readFile(tmpFile, 'utf8'))
+    expect(onDisk).toHaveLength(1)
+    expect(onDisk[0].bodyweight_lbs).toBe(232)
+  })
+
+  it('409 — rejects a duplicate date with PUT-instead guidance', async () => {
+    await fs.writeFile(tmpFile, JSON.stringify([{ date: '2026-04-15' }]), 'utf8')
+    const res = await POST(jsonRequest({ date: '2026-04-15', vertical_in: 22 }))
+    expect(res.status).toBe(409)
+    const body = await res.json()
+    expect(body.error).toMatch(/already exists/i)
+    expect(body.error).toMatch(/PUT/)
+  })
+
+  it('400 — non-JSON body', async () => {
+    const req = new NextRequest('http://localhost/api/dev/movement-benchmarks', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: '{not json',
+    })
+    const res = await POST(req)
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.error).toMatch(/JSON/)
+  })
+
+  it('400 — Zod validation failure (missing required date)', async () => {
+    const res = await POST(jsonRequest({ bodyweight_lbs: 232 }))
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.error).toMatch(/Validation/)
+    expect(body.issues).toBeDefined()
+  })
+
+  it('400 — Zod rejects unknown fields (.strict() prevents typo data loss)', async () => {
+    const res = await POST(jsonRequest({ date: '2026-04-15', bodyweight_lb: 232 }))
+    expect(res.status).toBe(400)
+  })
+
+  it('404 — prod-gate when NODE_ENV is not development', async () => {
+    vi.stubEnv('NODE_ENV', 'production')
+    const res = await POST(jsonRequest({ date: '2026-04-15' }))
+    expect(res.status).toBe(404)
+  })
+})

--- a/lib/data/cardio.test.ts
+++ b/lib/data/cardio.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest'
+import { getCardioData } from './cardio'
+
+/**
+ * `getCardioData` is a thin fetch wrapper. Issue #104's checklist says it
+ * should "return [] on 404, throw on other failures" but the current
+ * implementation throws on all non-OK responses (and `CardioData` is an
+ * object — `[]` wouldn't typecheck). These tests pin current behavior; the
+ * `[]`-on-404 refactor is its own concern outside this PR's scope.
+ */
+
+let fetchMock: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  fetchMock = vi.fn()
+  vi.stubGlobal('fetch', fetchMock)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('getCardioData', () => {
+  it('fetches /data/cardio.json by default', async () => {
+    const payload = {
+      imported_at: '2026-04-26T00:00:00Z',
+      sessions: [],
+      resting_hr_trend: [],
+      vo2max_trend: [],
+    }
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(payload), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    )
+    await expect(getCardioData()).resolves.toEqual(payload)
+
+    const [url] = fetchMock.mock.calls[0]
+    expect(url).toBe('/data/cardio.json')
+  })
+
+  it('throws on 404 (current behavior — no empty-state shortcut)', async () => {
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 404, statusText: 'Not Found' }))
+    await expect(getCardioData()).rejects.toThrow(/Failed to load cardio data: 404/)
+  })
+
+  it('throws on 500 with status code in the message', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(null, { status: 500, statusText: 'Internal Server Error' }),
+    )
+    await expect(getCardioData()).rejects.toThrow(/500/)
+  })
+
+  it('throws when the response is OK but the body is invalid JSON', async () => {
+    // Response.json() rejects on bad JSON — getCardioData lets that bubble up.
+    fetchMock.mockResolvedValueOnce(
+      new Response('not valid json', {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    )
+    await expect(getCardioData()).rejects.toThrow()
+  })
+})

--- a/lib/data/movement.test.ts
+++ b/lib/data/movement.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest'
+import {
+  deleteBenchmark,
+  getMovementBenchmarks,
+  logBenchmark,
+  updateBenchmark,
+} from './movement'
+
+/**
+ * Tests the client-side data-access wrappers in `lib/data/movement.ts`.
+ *
+ * The wrappers are thin — they call `fetch`, branch on `res.ok`, and build
+ * descriptive Error messages. We mock `fetch` per test rather than spinning
+ * up the real route handlers, since the route handlers are tested directly
+ * in `app/api/dev/movement-benchmarks/route.test.ts`.
+ */
+
+let fetchMock: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  fetchMock = vi.fn()
+  vi.stubGlobal('fetch', fetchMock)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+function jsonResponse(body: unknown, init: ResponseInit = { status: 200 }): Response {
+  return new Response(JSON.stringify(body), {
+    ...init,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+describe('getMovementBenchmarks', () => {
+  it('returns the parsed array on 200', async () => {
+    const data = [{ date: '2026-04-15', bodyweight_lbs: 232 }]
+    fetchMock.mockResolvedValueOnce(jsonResponse(data))
+    await expect(getMovementBenchmarks()).resolves.toEqual(data)
+  })
+
+  it('returns [] on 404 (file not yet created — pre-baseline state)', async () => {
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 404 }))
+    await expect(getMovementBenchmarks()).resolves.toEqual([])
+  })
+
+  it('throws on other non-OK responses (e.g. 500)', async () => {
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 500, statusText: 'oops' }))
+    await expect(getMovementBenchmarks()).rejects.toThrow(/500/)
+  })
+})
+
+describe('logBenchmark', () => {
+  it('POSTs JSON to the dev write route', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ ok: true }, { status: 201 }))
+    const entry = { date: '2026-04-15', bodyweight_lbs: 232 }
+    await logBenchmark(entry)
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe('/api/dev/movement-benchmarks')
+    expect(init.method).toBe('POST')
+    expect(init.headers['Content-Type']).toBe('application/json')
+    expect(JSON.parse(init.body)).toEqual(entry)
+  })
+
+  it('throws the dev-only-API message when the route 404s (prod-gate)', async () => {
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 404 }))
+    await expect(logBenchmark({ date: '2026-04-15' })).rejects.toThrow(
+      /dev-only write API is unavailable/i,
+    )
+  })
+
+  it('throws a descriptive message on other non-OK responses', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response('payload too big', { status: 413, statusText: 'Payload Too Large' }),
+    )
+    await expect(logBenchmark({ date: '2026-04-15' })).rejects.toThrow(/413/)
+  })
+
+  it('does not throw on a successful response (caller wraps fire-and-forget UX)', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ ok: true }, { status: 201 }))
+    await expect(logBenchmark({ date: '2026-04-15' })).resolves.toBeUndefined()
+  })
+})
+
+describe('updateBenchmark', () => {
+  it('PUTs to the date-keyed URL with URL-encoded segment', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ ok: true }))
+    await updateBenchmark('2026-04-15', { vertical_in: 23.5 })
+
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe('/api/dev/movement-benchmarks/2026-04-15')
+    expect(init.method).toBe('PUT')
+    expect(JSON.parse(init.body)).toEqual({ vertical_in: 23.5 })
+  })
+
+  it('encodes special characters in the date segment defensively', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ ok: true }))
+    // A real date will never contain '/', but encodeURIComponent should still
+    // protect us if a caller passes a malformed key.
+    await updateBenchmark('2026/04/15', { vertical_in: 23 })
+    const [url] = fetchMock.mock.calls[0]
+    expect(url).toBe('/api/dev/movement-benchmarks/2026%2F04%2F15')
+  })
+
+  it('throws the dev-only-API message on 404', async () => {
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 404 }))
+    await expect(updateBenchmark('2026-04-15', { vertical_in: 23 })).rejects.toThrow(
+      /dev-only write API is unavailable/i,
+    )
+  })
+})
+
+describe('deleteBenchmark', () => {
+  it('DELETEs the date-keyed URL', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ ok: true }))
+    await deleteBenchmark('2026-04-15')
+
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe('/api/dev/movement-benchmarks/2026-04-15')
+    expect(init.method).toBe('DELETE')
+  })
+
+  it('throws the dev-only-API message on 404', async () => {
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 404 }))
+    await expect(deleteBenchmark('2026-04-15')).rejects.toThrow(
+      /dev-only write API is unavailable/i,
+    )
+  })
+})

--- a/lib/dev/movement-benchmarks-store.test.ts
+++ b/lib/dev/movement-benchmarks-store.test.ts
@@ -1,0 +1,222 @@
+// @vitest-environment node
+
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest'
+import { promises as fs } from 'node:fs'
+import path from 'node:path'
+import os from 'node:os'
+import {
+  BenchmarkSchema,
+  BenchmarkUpdateSchema,
+  getBenchmarksFile,
+  isDevRuntime,
+  isValidDate,
+  readBenchmarks,
+  writeBenchmarks,
+} from './movement-benchmarks-store'
+
+/**
+ * Per-test tmp dir for filesystem isolation. We don't want any test in this
+ * file (or the API route tests downstream) to mutate the real
+ * `public/data/movement_benchmarks.json` fixture.
+ */
+let tmpDir: string
+let tmpFile: string
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'movement-store-'))
+  tmpFile = path.join(tmpDir, 'movement_benchmarks.json')
+  vi.stubEnv('MOVEMENT_BENCHMARKS_FILE', tmpFile)
+})
+
+afterEach(async () => {
+  vi.unstubAllEnvs()
+  await fs.rm(tmpDir, { recursive: true, force: true })
+})
+
+describe('getBenchmarksFile', () => {
+  it('returns the env override when set', () => {
+    expect(getBenchmarksFile()).toBe(tmpFile)
+  })
+
+  it('falls back to public/data/ default when env is unset', () => {
+    vi.unstubAllEnvs()
+    vi.stubEnv('MOVEMENT_BENCHMARKS_FILE', '')
+    const resolved = getBenchmarksFile()
+    expect(resolved.endsWith(path.join('public', 'data', 'movement_benchmarks.json'))).toBe(true)
+  })
+
+  it('treats empty-string override as missing', () => {
+    vi.stubEnv('MOVEMENT_BENCHMARKS_FILE', '')
+    expect(getBenchmarksFile().endsWith('movement_benchmarks.json')).toBe(true)
+    expect(getBenchmarksFile()).not.toBe('')
+  })
+})
+
+describe('BenchmarkSchema', () => {
+  it('accepts a full valid payload', () => {
+    const valid = {
+      date: '2026-04-15',
+      bodyweight_lbs: 232.4,
+      shuttle_5_10_5_s: 5.12,
+      vertical_in: 22,
+      sprint_10y_s: 1.85,
+      notes: 'felt fast',
+      is_complete: true,
+    }
+    expect(() => BenchmarkSchema.parse(valid)).not.toThrow()
+  })
+
+  it('accepts a minimal payload (only date)', () => {
+    expect(() => BenchmarkSchema.parse({ date: '2026-04-15' })).not.toThrow()
+  })
+
+  it.each([
+    '2026-4-15', // missing leading zero
+    '2026/04/15', // wrong separator
+    '04-15-2026', // wrong order
+    '2026-04-15T00:00:00Z', // ISO timestamp, not calendar date
+    '',
+    'tomorrow',
+  ])('rejects non-ISO date %s', (date) => {
+    expect(() => BenchmarkSchema.parse({ date })).toThrow()
+  })
+
+  it('rejects non-positive numeric metrics', () => {
+    expect(() => BenchmarkSchema.parse({ date: '2026-04-15', bodyweight_lbs: 0 })).toThrow()
+    expect(() => BenchmarkSchema.parse({ date: '2026-04-15', bodyweight_lbs: -1 })).toThrow()
+    expect(() => BenchmarkSchema.parse({ date: '2026-04-15', vertical_in: -22 })).toThrow()
+  })
+
+  it('rejects unknown fields (.strict prevents typo data loss)', () => {
+    // The whole point of .strict() — `bodyweight_lb` instead of `bodyweight_lbs` should fail loudly.
+    expect(() =>
+      BenchmarkSchema.parse({ date: '2026-04-15', bodyweight_lb: 232 }),
+    ).toThrow()
+  })
+})
+
+describe('BenchmarkUpdateSchema', () => {
+  it('strips date — passing date is treated as an unknown field under .strict()', () => {
+    expect(() =>
+      BenchmarkUpdateSchema.parse({ date: '2026-04-15', bodyweight_lbs: 232 }),
+    ).toThrow()
+  })
+
+  it('accepts an empty update (all fields optional)', () => {
+    expect(() => BenchmarkUpdateSchema.parse({})).not.toThrow()
+  })
+
+  it('accepts a single-field update', () => {
+    expect(() => BenchmarkUpdateSchema.parse({ vertical_in: 23.5 })).not.toThrow()
+  })
+
+  it('rejects unknown fields', () => {
+    expect(() => BenchmarkUpdateSchema.parse({ bodyweight_lb: 232 })).toThrow()
+  })
+})
+
+describe('readBenchmarks', () => {
+  it('returns [] when the file is missing (pre-baseline state)', async () => {
+    await expect(readBenchmarks()).resolves.toEqual([])
+  })
+
+  it('returns [] when the file exists but is empty', async () => {
+    await fs.writeFile(tmpFile, '', 'utf8')
+    await expect(readBenchmarks()).resolves.toEqual([])
+  })
+
+  it('returns [] when the file is whitespace-only', async () => {
+    await fs.writeFile(tmpFile, '  \n\n  ', 'utf8')
+    await expect(readBenchmarks()).resolves.toEqual([])
+  })
+
+  it('throws when the file is malformed JSON', async () => {
+    await fs.writeFile(tmpFile, '{not valid json', 'utf8')
+    await expect(readBenchmarks()).rejects.toThrow()
+  })
+
+  it('parses valid JSON into an array of benchmarks', async () => {
+    const raw = JSON.stringify([
+      { date: '2026-04-15', bodyweight_lbs: 232 },
+      { date: '2026-03-15', bodyweight_lbs: 235 },
+    ])
+    await fs.writeFile(tmpFile, raw, 'utf8')
+    const result = await readBenchmarks()
+    expect(result).toHaveLength(2)
+    expect(result[0].date).toBe('2026-04-15')
+  })
+
+  it('throws when an entry has unknown fields (strict mode propagates)', async () => {
+    const raw = JSON.stringify([{ date: '2026-04-15', bodyweight_lb: 232 }])
+    await fs.writeFile(tmpFile, raw, 'utf8')
+    await expect(readBenchmarks()).rejects.toThrow()
+  })
+})
+
+describe('writeBenchmarks', () => {
+  it('sorts entries newest-first by date', async () => {
+    await writeBenchmarks([
+      { date: '2026-01-15' },
+      { date: '2026-04-15' },
+      { date: '2026-02-15' },
+    ])
+    const written = JSON.parse(await fs.readFile(tmpFile, 'utf8'))
+    expect(written.map((b: { date: string }) => b.date)).toEqual([
+      '2026-04-15',
+      '2026-02-15',
+      '2026-01-15',
+    ])
+  })
+
+  it('creates the parent directory if it does not exist (first-POST case)', async () => {
+    const nested = path.join(tmpDir, 'deeply', 'nested', 'benchmarks.json')
+    vi.stubEnv('MOVEMENT_BENCHMARKS_FILE', nested)
+    await writeBenchmarks([{ date: '2026-04-15' }])
+    await expect(fs.access(nested)).resolves.toBeUndefined()
+  })
+
+  it('writes a trailing newline so git diffs stay clean', async () => {
+    await writeBenchmarks([{ date: '2026-04-15' }])
+    const raw = await fs.readFile(tmpFile, 'utf8')
+    expect(raw.endsWith('\n')).toBe(true)
+  })
+
+  it('does not mutate the caller-supplied array order', async () => {
+    const input = [
+      { date: '2026-01-15' },
+      { date: '2026-04-15' },
+    ]
+    await writeBenchmarks(input)
+    expect(input.map((b) => b.date)).toEqual(['2026-01-15', '2026-04-15'])
+  })
+})
+
+describe('isValidDate', () => {
+  it.each(['2026-04-15', '2000-01-01', '9999-12-31'])('accepts ISO calendar date %s', (d) => {
+    expect(isValidDate(d)).toBe(true)
+  })
+
+  it.each(['2026-4-15', '2026/04/15', '04-15-2026', '2026-04-15T00:00:00Z', '', 'today'])(
+    'rejects non-ISO format %s',
+    (d) => {
+      expect(isValidDate(d)).toBe(false)
+    },
+  )
+})
+
+describe('isDevRuntime', () => {
+  it('returns true under NODE_ENV=development', () => {
+    vi.stubEnv('NODE_ENV', 'development')
+    expect(isDevRuntime()).toBe(true)
+  })
+
+  it('returns false under NODE_ENV=production', () => {
+    vi.stubEnv('NODE_ENV', 'production')
+    expect(isDevRuntime()).toBe(false)
+  })
+
+  it('returns false under NODE_ENV=test (the default for vitest runs)', () => {
+    vi.stubEnv('NODE_ENV', 'test')
+    expect(isDevRuntime()).toBe(false)
+  })
+})

--- a/lib/dev/movement-benchmarks-store.ts
+++ b/lib/dev/movement-benchmarks-store.ts
@@ -51,7 +51,7 @@ export type ValidatedBenchmarkUpdate = z.infer<typeof BenchmarkUpdateSchema>
  * and overwrite. Defaults to `public/data/movement_benchmarks.json` — the
  * static asset the production site fetches.
  *
- * Tests override by stubbing `process.env.MOVEMENT_getBenchmarksFile()` so they
+ * Tests override by stubbing `process.env.MOVEMENT_BENCHMARKS_FILE` so they
  * can point at a tmp dir instead of mutating the real fixture. Resolved at
  * call time (not module-load) so an env stub set in test setup actually
  * takes effect.

--- a/lib/dev/movement-benchmarks-store.ts
+++ b/lib/dev/movement-benchmarks-store.ts
@@ -47,11 +47,20 @@ export type ValidatedBenchmark = z.infer<typeof BenchmarkSchema>
 export type ValidatedBenchmarkUpdate = z.infer<typeof BenchmarkUpdateSchema>
 
 /**
- * Absolute path to `public/data/movement_benchmarks.json`. The dev write
- * routes read and overwrite this file; the production site fetches it
- * statically.
+ * Absolute path to the benchmarks JSON file the dev write routes read from
+ * and overwrite. Defaults to `public/data/movement_benchmarks.json` — the
+ * static asset the production site fetches.
+ *
+ * Tests override by stubbing `process.env.MOVEMENT_getBenchmarksFile()` so they
+ * can point at a tmp dir instead of mutating the real fixture. Resolved at
+ * call time (not module-load) so an env stub set in test setup actually
+ * takes effect.
  */
-export const BENCHMARKS_FILE = path.join(process.cwd(), 'public', 'data', 'movement_benchmarks.json')
+export function getBenchmarksFile(): string {
+  const override = process.env.MOVEMENT_BENCHMARKS_FILE
+  if (override && override.length > 0) return override
+  return path.join(process.cwd(), 'public', 'data', 'movement_benchmarks.json')
+}
 
 /**
  * Read the on-disk benchmark list. Returns `[]` if the file doesn't
@@ -64,7 +73,7 @@ export const BENCHMARKS_FILE = path.join(process.cwd(), 'public', 'data', 'movem
 export async function readBenchmarks(): Promise<ValidatedBenchmark[]> {
   let raw: string
   try {
-    raw = await fs.readFile(BENCHMARKS_FILE, 'utf8')
+    raw = await fs.readFile(getBenchmarksFile(), 'utf8')
   } catch (err) {
     if (isFileNotFound(err)) return []
     throw err
@@ -85,9 +94,9 @@ export async function readBenchmarks(): Promise<ValidatedBenchmark[]> {
  */
 export async function writeBenchmarks(list: ValidatedBenchmark[]): Promise<void> {
   const sorted = [...list].sort((a, b) => b.date.localeCompare(a.date))
-  await fs.mkdir(path.dirname(BENCHMARKS_FILE), { recursive: true })
+  await fs.mkdir(path.dirname(getBenchmarksFile()), { recursive: true })
   // Trailing newline so the file plays nicely with `git diff` / editors.
-  await fs.writeFile(BENCHMARKS_FILE, JSON.stringify(sorted, null, 2) + '\n', 'utf8')
+  await fs.writeFile(getBenchmarksFile(), JSON.stringify(sorted, null, 2) + '\n', 'utf8')
 }
 
 /**

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -33,6 +33,7 @@ export default defineConfig({
         'lib/**/*.{ts,tsx}',
         'constants/**/*.{ts,tsx}',
         'components/training-facility/shared/**/*.{ts,tsx}',
+        'app/api/**/*.{ts,tsx}',
       ],
       exclude: ['**/*.test.{ts,tsx}', '**/*.d.ts'],
     },


### PR DESCRIPTION
## Summary
Step 2 of #104. Adds 71 tests across 5 files plus a small refactor that makes the benchmark file path testable without polluting \`public/data/movement_benchmarks.json\`.

### Refactor
\`lib/dev/movement-benchmarks-store.ts\`: replaces the module-load \`BENCHMARKS_FILE\` const with a \`getBenchmarksFile()\` helper that reads \`process.env.MOVEMENT_BENCHMARKS_FILE\` first and falls back to the canonical \`public/data/\` path. Resolved at call time so test env stubs actually take effect. No external callers — the file's only consumers were internal.

### Tests added
- **\`lib/dev/movement-benchmarks-store.test.ts\`** (35 tests)
  - \`BenchmarkSchema\`: full + minimal payloads, ISO-date regex (rejects \`2026-4-15\`, \`04-15-2026\`, ISO timestamps), positive-only metric values, \`.strict()\` rejects \`bodyweight_lb\` (the typo case the schema exists to catch).
  - \`BenchmarkUpdateSchema\`: rejects \`date\` field, accepts \`{}\`, accepts single-field updates, rejects unknown fields.
  - \`readBenchmarks\`: missing file → \`[]\`, empty / whitespace-only file → \`[]\`, malformed JSON → throws, strict mode propagates to nested entries.
  - \`writeBenchmarks\`: sorts newest-first, creates missing parent dir, writes trailing newline, doesn't mutate caller's array.
  - \`isValidDate\`: ISO-date passes, every common malformed shape fails.
  - \`isDevRuntime\`: dev / prod / test env behavior.
  - \`getBenchmarksFile\`: env override, default fallback, empty-string treated as missing.
- **\`app/api/dev/movement-benchmarks/route.test.ts\`** (6 tests) — POST 201/400/404/409 matrix, prod-gate via \`NODE_ENV=production\`, \`.strict()\` typo rejection through the handler.
- **\`app/api/dev/movement-benchmarks/[date]/route.test.ts\`** (10 tests) — PUT/DELETE 200/400/404, partial-merge correctness, date-in-PUT-body rejection, prod-gate.
- **\`lib/data/movement.test.ts\`** (11 tests) — \`fetch\` mocked per test; verifies URL / method / encoded date segment / Content-Type / body for each CRUD wrapper, plus the dev-only-API message on 404.
- **\`lib/data/cardio.test.ts\`** (4 tests) — pins current behavior (throws on all non-OK including 404).

### Approach notes
- API route tests **call the exported handlers directly** with hand-built \`NextRequest\` and a resolved \`ctx.params\` Promise. No extra dep, no Next test rig. Plays cleanly with Vitest.
- Filesystem tests use \`fs.mkdtemp\` per test + \`fs.rm({ recursive: true, force: true })\` in \`afterEach\`. \`MOVEMENT_BENCHMARKS_FILE\` is stubbed via \`vi.stubEnv\`.
- API route + store tests opt into \`// @vitest-environment node\` (no need for jsdom; faster and matches the runtime they actually execute under).
- Coverage \`include\` extended to \`app/api/**\` so the route handlers show up in reports.

### Cardio 404 discrepancy (flagged, not fixed)
Issue #104's checklist says \`getCardioData\` "returns \`[]\` on 404, throws on other failures." Current code throws on all non-OK, and \`CardioData\` is an object — \`[]\` wouldn't typecheck. Tests pin **current** behavior; the refactor (probably adding a separate \`tryGetCardioData\` or returning an "empty dataset" sentinel) is its own concern and not in scope here.

## Test plan
- [ ] \`npm install && npm run test\` → 103 tests pass across 8 files in ~20s
- [ ] \`npm run test:coverage\` — \`movement-benchmarks-store.ts\`, \`movement.ts\`, \`cardio.ts\`, and the two API route files now show coverage in the HTML report
- [ ] \`npx tsc --noEmit\` clean
- [ ] \`npx next build\` clean — \`/api/dev/movement-benchmarks\` and \`/api/dev/movement-benchmarks/[date]\` are still served as dynamic routes
- [ ] Sanity-check that no test is touching \`public/data/movement_benchmarks.json\` (the real fixture is unchanged after a full test run)

Refs #104.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive test coverage for movement benchmarks API and cardio data retrieval functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->