### PR TITLE
feat(seo): expand title + meta + OG + JSON-LD (#41, #43)

### DIFF
--- a/app/banners/page.tsx
+++ b/app/banners/page.tsx
@@ -1,9 +1,31 @@
+import type { Metadata } from 'next'
 import dynamic from 'next/dynamic'
+
+/**
+ * Rafters & Banners metadata. Title participates in the root layout's
+ * `'%s | Lucas Lawrence'` template; description is route-specific.
+ */
+export const metadata: Metadata = {
+  title: 'Rafters & Banners',
+  description:
+    "Lucas Lawrence's rafters — career milestones, awards, and standout achievements hanging as banners above the court.",
+  alternates: { canonical: '/banners' },
+  openGraph: {
+    title: 'Rafters & Banners | Lucas Lawrence',
+    description:
+      "Lucas Lawrence's rafters — career milestones, awards, and standout achievements hanging as banners above the court.",
+    url: '/banners',
+  },
+}
 
 const BannersClient = dynamic(() => import('@/components/banners/BannersClient'), {
   loading: () => <div className="text-center text-white py-12">Loading banners...</div>,
 })
 
+/**
+ * Server-component page wrapper that ships {@link metadata} and lazy-loads
+ * the interactive banners client.
+ */
 export default function BannersPage() {
   return <BannersClient />
 }

--- a/app/contact/layout.tsx
+++ b/app/contact/layout.tsx
@@ -1,0 +1,33 @@
+/**
+ * @file Server-component layout for the Front Office (contact) route.
+ * Exists solely to export route-specific {@link metadata}, which the
+ * client-component `page.tsx` cannot do directly.
+ */
+
+import type { Metadata } from 'next'
+import type { JSX, ReactNode } from 'react'
+
+/**
+ * Front Office metadata. Title participates in the root layout's
+ * `'%s | Lucas Lawrence'` template; description is route-specific.
+ */
+export const metadata: Metadata = {
+  title: 'Front Office',
+  description:
+    'Front office of lucasklawrence.com — get in touch with Lucas Lawrence by email, LinkedIn, or download the full résumé.',
+  alternates: { canonical: '/contact' },
+  openGraph: {
+    title: 'Front Office | Lucas Lawrence',
+    description:
+      'Front office of lucasklawrence.com — get in touch with Lucas Lawrence by email, LinkedIn, or download the full résumé.',
+    url: '/contact',
+  },
+}
+
+/**
+ * Pass-through layout. Metadata is resolved at the route segment;
+ * children render unchanged.
+ */
+export default function ContactLayout({ children }: { children: ReactNode }): JSX.Element {
+  return <>{children}</>
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -23,12 +23,71 @@ const geistMono = Geist_Mono({
 })
 
 /**
- * Global metadata configuration for the site.
- * This metadata is used for SEO and browser tab titles.
+ * Canonical site origin. Used by Next.js to resolve relative URLs in
+ * `openGraph.images`, `twitter.images`, and `alternates.canonical` so that
+ * crawlers, social cards, and JSON-LD all see absolute URLs.
+ */
+const SITE_URL = 'https://lucasklawrence.com'
+
+/**
+ * Site-wide description used as the default meta description and the
+ * Open Graph / Twitter description on routes that don't override it.
+ * Kept under ~160 chars for snippet compatibility.
+ */
+const SITE_DESCRIPTION =
+  'Software engineer at Snap building interactive, basketball-themed product experiences with Next.js, React, TypeScript, and Java. Patent holder.'
+
+/**
+ * Site-wide root title used when a route does not export its own title.
+ * Routes that set `title` participate in the `title.template` below and
+ * render as `<route> | Lucas Lawrence`.
+ */
+const SITE_TITLE = 'Lucas Lawrence — Software Engineer at Snap & Patent Holder'
+
+/**
+ * JSON-LD Person schema describing Lucas Lawrence for search engines.
+ * Inlined as `<script type="application/ld+json">` in the document head.
+ * Lives at the site root so the Person entity is associated with the
+ * domain itself rather than a single inner route.
+ */
+const PERSON_JSON_LD = {
+  '@context': 'https://schema.org',
+  '@type': 'Person',
+  name: 'Lucas Lawrence',
+  jobTitle: 'Software Engineer',
+  url: SITE_URL,
+  worksFor: { '@type': 'Organization', name: 'Snap Inc.' },
+  email: 'mailto:lucasklawrence@gmail.com',
+  sameAs: ['https://github.com/lucasklawrence', 'https://linkedin.com/in/lucasklawrence'],
+}
+
+/**
+ * Global metadata configuration for the site. Per-route layouts may
+ * override `title` (which then participates in the template below),
+ * `description`, `openGraph`, and `alternates.canonical`.
  */
 export const metadata: Metadata = {
-  title: 'Lucas Lawrence | Court Site',
-  description: 'Digital home court of Lucas Lawrence',
+  metadataBase: new URL(SITE_URL),
+  title: {
+    default: SITE_TITLE,
+    template: '%s | Lucas Lawrence',
+  },
+  description: SITE_DESCRIPTION,
+  alternates: { canonical: '/' },
+  openGraph: {
+    type: 'website',
+    siteName: 'Lucas Lawrence',
+    title: SITE_TITLE,
+    description: SITE_DESCRIPTION,
+    url: SITE_URL,
+    locale: 'en_US',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: SITE_TITLE,
+    description: SITE_DESCRIPTION,
+  },
+  robots: { index: true, follow: true },
 }
 
 /**
@@ -56,6 +115,17 @@ export default function RootLayout({
 
         {/* Optional: theme color for mobile browsers */}
         <meta name="theme-color" content="#000000" />
+
+        {/*
+         * JSON-LD Person schema. Helps Google associate the site with
+         * Lucas Lawrence as an entity (knowledge panel, sameAs links).
+         * Inlined rather than emitted via next/script so the bytes are
+         * present in the static HTML and readable by non-JS crawlers.
+         */}
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(PERSON_JSON_LD) }}
+        />
       </head>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased touch-pan-x touch-pan-y`}

--- a/app/locker-room/layout.tsx
+++ b/app/locker-room/layout.tsx
@@ -1,0 +1,33 @@
+/**
+ * @file Server-component layout for the Locker Room route.
+ * Exists solely to export route-specific {@link metadata}, which the
+ * client-component `page.tsx` cannot do directly.
+ */
+
+import type { Metadata } from 'next'
+import type { JSX, ReactNode } from 'react'
+
+/**
+ * Locker Room metadata. Title participates in the root layout's
+ * `'%s | Lucas Lawrence'` template; description is route-specific.
+ */
+export const metadata: Metadata = {
+  title: 'Locker Room',
+  description:
+    "Step into Lucas Lawrence's locker room — jerseys, shoes, gear, patents, and the personal items behind the engineer.",
+  alternates: { canonical: '/locker-room' },
+  openGraph: {
+    title: 'Locker Room | Lucas Lawrence',
+    description:
+      "Step into Lucas Lawrence's locker room — jerseys, shoes, gear, patents, and the personal items behind the engineer.",
+    url: '/locker-room',
+  },
+}
+
+/**
+ * Pass-through layout. Metadata is resolved at the route segment;
+ * children render unchanged.
+ */
+export default function LockerRoomLayout({ children }: { children: ReactNode }): JSX.Element {
+  return <>{children}</>
+}

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -1,0 +1,141 @@
+/**
+ * @file Programmatic Open Graph image at the site root.
+ * Next.js automatically serves this as the default `og:image` (and
+ * Twitter card image) for any route that doesn't override it. Generated
+ * via `next/og`'s {@link ImageResponse} so the image lives in code and
+ * follows the brand palette without a separate static asset.
+ */
+
+import { ImageResponse } from 'next/og'
+
+/** Open Graph image dimensions per the spec — 1200×630 renders cleanly across Twitter, LinkedIn, Slack, and Facebook. */
+export const size = { width: 1200, height: 630 }
+
+/** PNG output from `next/og` — declared so Next emits the right Content-Type. */
+export const contentType = 'image/png'
+
+/** Alt text surfaced to assistive tech and as the `twitter:image:alt` fallback. */
+export const alt = 'Lucas Lawrence — Software Engineer at Snap'
+
+/**
+ * Court Vision palette. Mirrors the chart palette used elsewhere
+ * (`components/training-facility/shared/charts`) so social previews
+ * and the site itself feel like the same brand.
+ */
+const palette = {
+  inkBlack: '#0a0a0a',
+  rimOrange: '#fb923c',
+  courtLineCream: '#f5f1e6',
+  inkSoft: '#a3a3a3',
+  hardwoodTan: '#c8a06a',
+}
+
+/**
+ * Default OG image generator. Renders a court-themed 1200×630 social
+ * card with name, role, and URL on a black background with a rim-orange
+ * accent stripe. Edge runtime is used so the image is generated at the
+ * CDN edge on first request and then cached.
+ */
+export default async function OpengraphImage(): Promise<ImageResponse> {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          backgroundColor: palette.inkBlack,
+          color: palette.courtLineCream,
+          fontFamily: 'system-ui, sans-serif',
+          position: 'relative',
+        }}
+      >
+        {/* Rim-orange accent stripe down the left edge — court out-of-bounds line. */}
+        <div
+          style={{
+            width: 24,
+            height: '100%',
+            backgroundColor: palette.rimOrange,
+          }}
+        />
+
+        {/* Faint hardwood-tan court-line arc bottom-right — gives the card a half-court feel. */}
+        <div
+          style={{
+            position: 'absolute',
+            right: -180,
+            bottom: -180,
+            width: 520,
+            height: 520,
+            borderRadius: '50%',
+            border: `4px solid ${palette.hardwoodTan}`,
+            opacity: 0.35,
+            display: 'flex',
+          }}
+        />
+
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            justifyContent: 'space-between',
+            padding: '72px 80px',
+            flex: 1,
+            zIndex: 1,
+          }}
+        >
+          <div
+            style={{
+              display: 'flex',
+              fontSize: 22,
+              letterSpacing: '0.24em',
+              textTransform: 'uppercase',
+              color: palette.rimOrange,
+              fontFamily: 'ui-monospace, monospace',
+            }}
+          >
+            Court Vision
+          </div>
+
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 20 }}>
+            <div
+              style={{
+                fontSize: 96,
+                fontWeight: 800,
+                lineHeight: 1,
+                letterSpacing: '-0.02em',
+                display: 'flex',
+              }}
+            >
+              Lucas Lawrence
+            </div>
+            <div
+              style={{
+                fontSize: 40,
+                color: palette.inkSoft,
+                fontWeight: 500,
+                lineHeight: 1.2,
+                display: 'flex',
+              }}
+            >
+              Software Engineer at Snap · Patent Holder
+            </div>
+          </div>
+
+          <div
+            style={{
+              display: 'flex',
+              fontSize: 24,
+              fontFamily: 'ui-monospace, monospace',
+              color: palette.inkSoft,
+              letterSpacing: '0.04em',
+            }}
+          >
+            lucasklawrence.com
+          </div>
+        </div>
+      </div>
+    ),
+    { ...size }
+  )
+}

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -33,8 +33,8 @@ const palette = {
 /**
  * Default OG image generator. Renders a court-themed 1200×630 social
  * card with name, role, and URL on a black background with a rim-orange
- * accent stripe. Edge runtime is used so the image is generated at the
- * CDN edge on first request and then cached.
+ * accent stripe. Statically generated at build time and served as an
+ * immutable asset — re-deploy to update the image.
  */
 export default async function OpengraphImage(): Promise<ImageResponse> {
   return new ImageResponse(

--- a/app/projects/layout.tsx
+++ b/app/projects/layout.tsx
@@ -1,0 +1,33 @@
+/**
+ * @file Server-component layout for the Project Binder route.
+ * Exists solely to export route-specific {@link metadata}, which the
+ * client-component `page.tsx` cannot do directly.
+ */
+
+import type { Metadata } from 'next'
+import type { JSX, ReactNode } from 'react'
+
+/**
+ * Project Binder metadata. Title participates in the root layout's
+ * `'%s | Lucas Lawrence'` template; description is route-specific.
+ */
+export const metadata: Metadata = {
+  title: 'Project Binder',
+  description:
+    "Lucas Lawrence's project binder — featured engineering work, side projects, and the tech stack behind each one.",
+  alternates: { canonical: '/projects' },
+  openGraph: {
+    title: 'Project Binder | Lucas Lawrence',
+    description:
+      "Lucas Lawrence's project binder — featured engineering work, side projects, and the tech stack behind each one.",
+    url: '/projects',
+  },
+}
+
+/**
+ * Pass-through layout. Metadata is resolved at the route segment;
+ * children render unchanged.
+ */
+export default function ProjectsLayout({ children }: { children: ReactNode }): JSX.Element {
+  return <>{children}</>
+}


### PR DESCRIPTION
## Summary

Closes #41 and #43 together — both are SEO/metadata work touching the same files, so they ship as one PR.

**Title + description (#41):**
- Root title: `Lucas Lawrence — Software Engineer at Snap & Patent Holder` (~57 chars)
- Title template `%s | Lucas Lawrence` so per-route titles are short and the suffix is automatic
- Per-route titles: `Locker Room`, `Project Binder`, `Front Office`, `Rafters & Banners`
- Per-route descriptions tailored to each room (~120–150 chars)

**Open Graph / Twitter / canonical / JSON-LD (#43):**
- `metadataBase` set to `https://lucasklawrence.com` so Next resolves OG/Twitter image URLs absolutely
- Open Graph tags (`og:title`, `og:description`, `og:url`, `og:type`, `og:site_name`, `og:image` via the OG route below)
- Twitter card `summary_large_image` (creator/site left blank — no handle)
- `alternates.canonical` per route
- Programmatic 1200×630 OG image at `app/opengraph-image.tsx` using `next/og` `ImageResponse`. Court-themed: ink-black background, rim-orange accent stripe, hardwood-tan court arc, name + role + URL.
- JSON-LD `Person` schema inlined in the document head with `name`, `jobTitle: "Software Engineer"`, `worksFor: Snap Inc.`, `email`, and `sameAs` (GitHub, LinkedIn).

**Implementation note:** the four interactive routes (`/`, `/locker-room`, `/projects`, `/contact`) are `'use client'` components and cannot export `metadata` directly. Each non-root route gets a tiny server-component `layout.tsx` that exports metadata and passes `{children}` through unchanged. `/banners` was already a server component, so its metadata was added inline. Root `/` uses the layout default.

## Test plan

- [ ] **Build:** `npx next build` is clean and `/opengraph-image` appears in the route table.
- [ ] **OG image renders:** open `<preview>/opengraph-image` directly in a browser and confirm a 1200×630 court-themed PNG with name, role, and URL.
- [ ] **Per-route titles:** open each route and confirm browser tab text:
  - `/` → `Lucas Lawrence — Software Engineer at Snap & Patent Holder`
  - `/locker-room` → `Locker Room | Lucas Lawrence`
  - `/projects` → `Project Binder | Lucas Lawrence`
  - `/contact` → `Front Office | Lucas Lawrence`
  - `/banners` → `Rafters & Banners | Lucas Lawrence`
- [ ] **View source on `/`:** confirm `<meta name="description">`, `<meta property="og:title|og:description|og:image|og:url|og:type">`, `<meta name="twitter:card" content="summary_large_image">`, `<link rel="canonical">`, and `<script type="application/ld+json">` with the Person schema are all present.
- [ ] **Social validators:** drop the preview URL into the [Facebook Sharing Debugger](https://developers.facebook.com/tools/debug/) and the [Twitter Card Validator](https://cards-dev.twitter.com/validator) — image and copy should render.
- [ ] **Rich Results:** [Schema.org validator](https://validator.schema.org/) on `/` should show the Person entity with all four `sameAs` fields.
- [ ] **No visual regressions:** existing pages render identically — metadata is additive only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)