### PR TITLE
feat(combine): Scoreboard summary header (#63)

### DIFF
--- a/app/dev/scoreboard/page.tsx
+++ b/app/dev/scoreboard/page.tsx
@@ -1,0 +1,144 @@
+import type { JSX, ReactNode } from 'react'
+import { Scoreboard } from '@/components/training-facility/shared/Scoreboard'
+import { deriveCombineScoreboardCells } from '@/components/training-facility/shared/scoreboard-utils'
+import type { Benchmark } from '@/types/movement'
+
+/** Page metadata — hidden from search since `/dev/*` routes are dev-only smoke surfaces. */
+export const metadata = {
+  title: 'Scoreboard — dev',
+  robots: { index: false, follow: false },
+}
+
+/**
+ * Synthetic four-month history with values trending in the right
+ * direction across all four metrics (vertical up; weight, shuttle, sprint
+ * down). Lets the dev page exercise the all-improvement visual state of
+ * the scoreboard without needing real benchmark data on disk.
+ */
+const fullHistory: Benchmark[] = [
+  {
+    date: '2026-01-15',
+    bodyweight_lbs: 240.5,
+    shuttle_5_10_5_s: 5.62,
+    vertical_in: 19.5,
+    sprint_10y_s: 1.98,
+  },
+  {
+    date: '2026-02-15',
+    bodyweight_lbs: 237.0,
+    shuttle_5_10_5_s: 5.51,
+    vertical_in: 20.25,
+    sprint_10y_s: 1.95,
+  },
+  {
+    date: '2026-03-15',
+    bodyweight_lbs: 234.2,
+    shuttle_5_10_5_s: 5.45,
+    vertical_in: 21.0,
+    sprint_10y_s: 1.93,
+  },
+  {
+    date: '2026-04-15',
+    bodyweight_lbs: 231.4,
+    shuttle_5_10_5_s: 5.38,
+    vertical_in: 22.0,
+    sprint_10y_s: 1.91,
+  },
+]
+
+/** A single-entry "baseline" history — every metric should render as value === baseline (no delta line). */
+const baselineOnly: Benchmark[] = [fullHistory[0]]
+
+/** A mixed-direction history: vertical regressed; weight/shuttle/sprint improved. Exercises both green and red deltas. */
+const mixedHistory: Benchmark[] = [
+  fullHistory[0],
+  {
+    date: '2026-04-15',
+    bodyweight_lbs: 231.4,
+    shuttle_5_10_5_s: 5.38,
+    vertical_in: 18.5, // worse than baseline 19.5 — should render red
+    sprint_10y_s: 1.91,
+  },
+]
+
+/**
+ * Hidden dev-only smoke page for the {@link Scoreboard} component.
+ * Renders three states stacked: full history with all improvements, a
+ * mixed history with one regression, and a single-entry "no delta" view.
+ */
+export default function ScoreboardDemoPage(): JSX.Element {
+  return (
+    <div
+      style={{
+        backgroundColor: '#0a0a0a',
+        color: '#f5f1e6',
+        minHeight: '100vh',
+        padding: '3rem 1.5rem',
+        fontFamily: 'system-ui, sans-serif',
+      }}
+    >
+      <div style={{ maxWidth: 960, margin: '0 auto' }}>
+        <header style={{ marginBottom: '2rem' }}>
+          <p
+            style={{
+              fontFamily: 'ui-monospace, monospace',
+              fontSize: 12,
+              letterSpacing: '0.16em',
+              textTransform: 'uppercase',
+              color: '#fb923c',
+              margin: 0,
+            }}
+          >
+            Training Facility / dev
+          </p>
+          <h1 style={{ fontSize: '2.25rem', margin: '0.25rem 0 0.5rem', fontWeight: 800 }}>
+            Scoreboard
+          </h1>
+          <p style={{ fontSize: 14, color: '#a3a3a3', maxWidth: '60ch' }}>
+            Issue #63 — split-flap summary header for the Combine page. Reload the page to
+            replay the cell-by-cell flip animation and the delta count-up.
+          </p>
+        </header>
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '2rem' }}>
+          <Section title="Full history — all four metrics improved">
+            <Scoreboard cells={deriveCombineScoreboardCells(fullHistory)} />
+          </Section>
+
+          <Section title="Mixed — vertical regressed; everything else improved">
+            <Scoreboard cells={deriveCombineScoreboardCells(mixedHistory)} />
+          </Section>
+
+          <Section title="Single entry — value equals baseline, no delta line">
+            <Scoreboard cells={deriveCombineScoreboardCells(baselineOnly)} />
+          </Section>
+
+          <Section title="Empty history — em-dash placeholders">
+            <Scoreboard cells={deriveCombineScoreboardCells([])} />
+          </Section>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function Section({ title, children }: { title: string; children: ReactNode }): JSX.Element {
+  return (
+    <section style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
+      <h2
+        style={{
+          fontFamily: 'system-ui, sans-serif',
+          fontSize: 13,
+          fontWeight: 600,
+          letterSpacing: '0.05em',
+          textTransform: 'uppercase',
+          color: '#737373',
+          margin: 0,
+        }}
+      >
+        {title}
+      </h2>
+      {children}
+    </section>
+  )
+}

--- a/app/training-facility/combine/page.tsx
+++ b/app/training-facility/combine/page.tsx
@@ -58,7 +58,7 @@ export default function TrainingFacilityCombinePage(): JSX.Element {
           </p>
         </header>
 
-        <Scoreboard cells={cells} />
+        <Scoreboard cells={cells} ariaLabel="Combine scoreboard summary" />
       </div>
     </main>
   )

--- a/app/training-facility/combine/page.tsx
+++ b/app/training-facility/combine/page.tsx
@@ -1,0 +1,65 @@
+'use client'
+
+import { useEffect, useState, type JSX } from 'react'
+import { Scoreboard } from '@/components/training-facility/shared/Scoreboard'
+import { deriveCombineScoreboardCells } from '@/components/training-facility/shared/scoreboard-utils'
+import { getMovementBenchmarks } from '@/lib/data/movement'
+import type { Benchmark } from '@/types/movement'
+
+/**
+ * Combine sub-area page (PRD §9). The first deployment of the shared
+ * scoreboard summary header (PRD §9.1) sits at the top; richer
+ * visualizations (Trading Card, Silhouette, Shuttle Trace, Sprint Race,
+ * Radar) land in subsequent issues.
+ *
+ * The page is a client component because the data layer fetches
+ * `public/data/movement_benchmarks.json` at runtime via a relative URL
+ * (see {@link getMovementBenchmarks}). When no benchmarks exist yet the
+ * scoreboard renders em-dash placeholders, the documented empty state.
+ */
+export default function TrainingFacilityCombinePage(): JSX.Element {
+  const [entries, setEntries] = useState<Benchmark[] | undefined>(undefined)
+
+  useEffect(() => {
+    let cancelled = false
+    getMovementBenchmarks()
+      .then((data) => {
+        if (!cancelled) setEntries(data)
+      })
+      .catch(() => {
+        if (!cancelled) setEntries([])
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const cells = deriveCombineScoreboardCells(entries ?? [])
+
+  return (
+    <main className="relative min-h-svh overflow-hidden bg-[#120d0a] text-[#f7ead9]">
+      <div
+        aria-hidden="true"
+        className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(255,255,255,0.08),transparent_28%),linear-gradient(180deg,#241811_0%,#120d0a_52%,#0b0806_100%)]"
+      />
+
+      <div className="relative z-10 mx-auto flex w-full max-w-5xl flex-col gap-10 px-6 py-12 sm:px-8 lg:px-12">
+        <header>
+          <p className="font-mono text-[11px] uppercase tracking-[0.32em] text-amber-300/80">
+            Training Facility / Combine
+          </p>
+          <h1 className="mt-2 text-4xl font-black uppercase tracking-[0.06em] text-[#fff7ec] sm:text-5xl">
+            The Combine
+          </h1>
+          <p className="mt-3 max-w-2xl text-sm leading-7 text-[#e8d5be] sm:text-base">
+            Tier-1 movement benchmarks: bodyweight, 5-10-5 shuttle, vertical jump, and 10-yard
+            sprint. The scoreboard tracks the latest values against the first-ever entry per
+            metric.
+          </p>
+        </header>
+
+        <Scoreboard cells={cells} />
+      </div>
+    </main>
+  )
+}

--- a/components/training-facility/shared/Scoreboard.test.ts
+++ b/components/training-facility/shared/Scoreboard.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect } from 'vitest'
+import {
+  classifyDelta,
+  deriveCombineScoreboardCells,
+  pickMetricBaseline,
+  pickMetricLatest,
+  SCOREBOARD_METRIC_ORDER,
+} from './scoreboard-utils'
+import type { Benchmark } from '@/types/movement'
+
+const baseline: Benchmark = {
+  date: '2026-01-15',
+  bodyweight_lbs: 240.5,
+  shuttle_5_10_5_s: 5.62,
+  vertical_in: 19.5,
+  sprint_10y_s: 1.98,
+}
+
+const middle: Benchmark = {
+  date: '2026-02-15',
+  bodyweight_lbs: 237.0,
+  shuttle_5_10_5_s: 5.5,
+  vertical_in: 20.5,
+  sprint_10y_s: 1.95,
+}
+
+const latest: Benchmark = {
+  date: '2026-04-15',
+  bodyweight_lbs: 231.4,
+  shuttle_5_10_5_s: 5.38,
+  vertical_in: 22.0,
+  sprint_10y_s: 1.91,
+}
+
+describe('pickMetricLatest', () => {
+  it('returns the most recent value for the metric', () => {
+    expect(pickMetricLatest([baseline, middle, latest], 'vertical_in')).toBe(22.0)
+  })
+
+  it('does not depend on input order', () => {
+    expect(pickMetricLatest([latest, baseline, middle], 'vertical_in')).toBe(22.0)
+  })
+
+  it('skips entries marked is_complete: false', () => {
+    const incomplete: Benchmark = { ...latest, is_complete: false }
+    expect(pickMetricLatest([baseline, middle, incomplete], 'vertical_in')).toBe(20.5)
+  })
+
+  it('skips entries lacking a value for the requested metric (per-metric latest)', () => {
+    // A bodyweight-only "weekly" entry should not block a later vertical
+    // jump entry from being the vertical latest.
+    const partial: Benchmark = { date: '2026-04-20', bodyweight_lbs: 230 }
+    expect(pickMetricLatest([baseline, latest, partial], 'vertical_in')).toBe(22.0)
+    expect(pickMetricLatest([baseline, latest, partial], 'bodyweight_lbs')).toBe(230)
+  })
+
+  it('returns undefined when no entry has the metric', () => {
+    expect(pickMetricLatest([], 'vertical_in')).toBeUndefined()
+    const onlyBodyweight: Benchmark = { date: '2026-03-01', bodyweight_lbs: 235 }
+    expect(pickMetricLatest([onlyBodyweight], 'vertical_in')).toBeUndefined()
+  })
+})
+
+describe('pickMetricBaseline', () => {
+  it('returns the earliest value for the metric', () => {
+    expect(pickMetricBaseline([baseline, middle, latest], 'vertical_in')).toBe(19.5)
+  })
+
+  it('uses per-metric baseline so a later entry can baseline a metric the earliest entry lacked', () => {
+    const veryEarly: Benchmark = { date: '2026-01-01', bodyweight_lbs: 245 } // no vertical
+    expect(pickMetricBaseline([veryEarly, baseline, latest], 'vertical_in')).toBe(19.5)
+    expect(pickMetricBaseline([veryEarly, baseline, latest], 'bodyweight_lbs')).toBe(245)
+  })
+
+  it('skips entries marked is_complete: false even if they are earliest', () => {
+    const incomplete: Benchmark = { ...baseline, is_complete: false }
+    expect(pickMetricBaseline([incomplete, middle, latest], 'vertical_in')).toBe(20.5)
+  })
+
+  it('returns undefined when no entry has the metric', () => {
+    expect(pickMetricBaseline([], 'vertical_in')).toBeUndefined()
+  })
+})
+
+describe('classifyDelta', () => {
+  it('lower-is-better: smaller latest is improvement', () => {
+    expect(classifyDelta(5.38, 5.62, 'lower')).toBe('improvement')
+  })
+
+  it('lower-is-better: larger latest is regression', () => {
+    expect(classifyDelta(5.7, 5.62, 'lower')).toBe('regression')
+  })
+
+  it('higher-is-better: larger latest is improvement', () => {
+    expect(classifyDelta(22.0, 19.5, 'higher')).toBe('improvement')
+  })
+
+  it('higher-is-better: smaller latest is regression', () => {
+    expect(classifyDelta(18.0, 19.5, 'higher')).toBe('regression')
+  })
+
+  it('returns neutral for identical values', () => {
+    expect(classifyDelta(20.0, 20.0, 'lower')).toBe('neutral')
+    expect(classifyDelta(20.0, 20.0, 'higher')).toBe('neutral')
+  })
+
+  it('returns null when either side is missing', () => {
+    expect(classifyDelta(undefined, 20.0, 'higher')).toBeNull()
+    expect(classifyDelta(22.0, undefined, 'higher')).toBeNull()
+    expect(classifyDelta(undefined, undefined, 'lower')).toBeNull()
+  })
+})
+
+describe('deriveCombineScoreboardCells', () => {
+  it('returns four cells in PRD §9.1 order', () => {
+    const cells = deriveCombineScoreboardCells([baseline, middle, latest])
+    expect(cells.map((c) => c.label)).toEqual(['WT', '5-10-5', 'VERT', '10Y'])
+    expect(SCOREBOARD_METRIC_ORDER).toEqual([
+      'bodyweight_lbs',
+      'shuttle_5_10_5_s',
+      'vertical_in',
+      'sprint_10y_s',
+    ])
+  })
+
+  it('binds latest value, baseline, direction, precision, and unit per cell', () => {
+    const cells = deriveCombineScoreboardCells([baseline, middle, latest])
+    const vert = cells.find((c) => c.label === 'VERT')!
+    expect(vert.value).toBe(22.0)
+    expect(vert.baseline).toBe(19.5)
+    expect(vert.direction).toBe('higher')
+    expect(vert.precision).toBe(1)
+    expect(vert.unit).toBe('"')
+
+    const shuttle = cells.find((c) => c.label === '5-10-5')!
+    expect(shuttle.value).toBe(5.38)
+    expect(shuttle.baseline).toBe(5.62)
+    expect(shuttle.direction).toBe('lower')
+    expect(shuttle.precision).toBe(2)
+    expect(shuttle.unit).toBe('s')
+  })
+
+  it('emits cells with undefined value/baseline when history is empty', () => {
+    const cells = deriveCombineScoreboardCells([])
+    for (const cell of cells) {
+      expect(cell.value).toBeUndefined()
+      expect(cell.baseline).toBeUndefined()
+    }
+  })
+
+  it('with a single entry, value === baseline so no delta is implied', () => {
+    const cells = deriveCombineScoreboardCells([baseline])
+    for (const cell of cells) {
+      expect(cell.value).toBe(cell.baseline)
+    }
+  })
+})

--- a/components/training-facility/shared/Scoreboard.test.ts
+++ b/components/training-facility/shared/Scoreboard.test.ts
@@ -82,6 +82,18 @@ describe('pickMetricBaseline', () => {
   })
 })
 
+describe('classifyDelta + display precision (sub-precision noise should not flag improvement)', () => {
+  // Real-world scenario: shuttle precision is 2 decimals. A raw delta of
+  // -0.003 (5.381 vs 5.384) classifies as "improvement" mathematically
+  // but renders as "Δ −0.00s", which is misleading. The view layer
+  // suppresses the line by rounding to display precision before deciding;
+  // these unit tests pin the classifier behavior on raw inputs so the
+  // rule is documented and the upstream call site can rely on it.
+  it('still classifies sub-precision improvements as improvement on raw inputs', () => {
+    expect(classifyDelta(5.381, 5.384, 'lower')).toBe('improvement')
+  })
+})
+
 describe('classifyDelta', () => {
   it('lower-is-better: smaller latest is improvement', () => {
     expect(classifyDelta(5.38, 5.62, 'lower')).toBe('improvement')

--- a/components/training-facility/shared/Scoreboard.tsx
+++ b/components/training-facility/shared/Scoreboard.tsx
@@ -28,6 +28,14 @@ export {
 export interface ScoreboardProps {
   /** Cells rendered left-to-right. Length is unconstrained — the Combine view supplies four. */
   cells: readonly ScoreboardCell[]
+  /**
+   * Accessible name for the scoreboard region. Override per use site —
+   * the Combine page sets "Combine scoreboard summary"; the future Gym
+   * wall scoreboard will set its own contextual label. Defaults to a
+   * generic "Scoreboard" so consumers that forget still get something
+   * sensible.
+   */
+  ariaLabel?: string
   /** Tailwind classes appended to the outer container. */
   className?: string
 }
@@ -67,12 +75,16 @@ function formatDeltaValue(delta: number, precision: number, unit: string): strin
  * `deriveCombineScoreboardCells` (Combine page) or hand-build them
  * (Gym wall scoreboard, future). See {@link ScoreboardProps} for prop docs.
  */
-export function Scoreboard({ cells, className = '' }: ScoreboardProps): JSX.Element {
+export function Scoreboard({
+  cells,
+  ariaLabel = 'Scoreboard',
+  className = '',
+}: ScoreboardProps): JSX.Element {
   const reduceMotion = useReducedMotion()
   return (
     <div
       role="group"
-      aria-label="Combine scoreboard summary"
+      aria-label={ariaLabel}
       className={`grid grid-cols-2 gap-px overflow-hidden rounded-xl border border-amber-300/40 bg-black/85 shadow-[0_12px_36px_-16px_rgba(0,0,0,0.7)] sm:grid-cols-4 ${className}`}
     >
       {cells.map((cell, index) => (
@@ -238,9 +250,12 @@ function DeltaLine({
         ? 'text-rose-400'
         : 'text-amber-200/80'
 
+  // No `role="status"` / `aria-live`: this is a static value that
+  // animates visually on mount, not a live update. With four cells
+  // counting up simultaneously a polite live region would queue a flood
+  // of announcements during the entrance animation.
   return (
     <span
-      role="status"
       aria-label={`Delta ${text} versus baseline`}
       className={`font-mono text-[11px] font-medium uppercase tracking-[0.2em] ${colorClass}`}
     >

--- a/components/training-facility/shared/Scoreboard.tsx
+++ b/components/training-facility/shared/Scoreboard.tsx
@@ -1,0 +1,250 @@
+'use client'
+
+import { useEffect, useState, type CSSProperties, type JSX } from 'react'
+import {
+  animate,
+  motion,
+  useMotionValue,
+  useMotionValueEvent,
+  useReducedMotion,
+} from 'framer-motion'
+import {
+  classifyDelta,
+  type DeltaStatus,
+  type ScoreboardCell,
+} from './scoreboard-utils'
+
+export {
+  SCOREBOARD_METRIC_ORDER,
+  classifyDelta,
+  deriveCombineScoreboardCells,
+  pickMetricBaseline,
+  pickMetricLatest,
+  type DeltaStatus,
+  type ScoreboardCell,
+} from './scoreboard-utils'
+
+/** Props for {@link Scoreboard}. */
+export interface ScoreboardProps {
+  /** Cells rendered left-to-right. Length is unconstrained — the Combine view supplies four. */
+  cells: readonly ScoreboardCell[]
+  /** Tailwind classes appended to the outer container. */
+  className?: string
+}
+
+const CELL_STAGGER_S = 0.4
+const DIGIT_STAGGER_S = 0.05
+const DIGIT_FLIP_S = 0.45
+const DELTA_COUNTUP_S = 0.6
+const DELTA_DELAY_AFTER_CELL_S = 0.3
+
+/** Format the cell's main value, or em-dash placeholder when absent. */
+function formatValue(
+  value: number | undefined,
+  precision: number,
+  unit: string,
+): string {
+  if (typeof value !== 'number') return '—'
+  return `${value.toFixed(precision)}${unit}`
+}
+
+/** Format a signed delta with a leading +/− glyph and the metric unit. */
+function formatDeltaValue(delta: number, precision: number, unit: string): string {
+  const sign = delta > 0 ? '+' : delta < 0 ? '−' : '±'
+  const abs = Math.abs(delta)
+  return `${sign}${abs.toFixed(precision)}${unit}`
+}
+
+/**
+ * `Scoreboard` — arena-style summary header (PRD §9.1).
+ *
+ * Renders cells side-by-side. Each cell shows a label, the latest value
+ * in scoreboard digits, and a delta-vs-baseline line color-coded by
+ * direction-of-improvement. On mount, digits flip in cell-by-cell
+ * (split-flap style) and the delta counts up from zero.
+ *
+ * The component is pure display: parents derive cell models with
+ * `deriveCombineScoreboardCells` (Combine page) or hand-build them
+ * (Gym wall scoreboard, future). See {@link ScoreboardProps} for prop docs.
+ */
+export function Scoreboard({ cells, className = '' }: ScoreboardProps): JSX.Element {
+  const reduceMotion = useReducedMotion()
+  return (
+    <div
+      role="group"
+      aria-label="Combine scoreboard summary"
+      className={`grid grid-cols-2 gap-px overflow-hidden rounded-xl border border-amber-300/40 bg-black/85 shadow-[0_12px_36px_-16px_rgba(0,0,0,0.7)] sm:grid-cols-4 ${className}`}
+    >
+      {cells.map((cell, index) => (
+        <ScoreboardCellView
+          key={cell.label}
+          cell={cell}
+          index={index}
+          reduceMotion={!!reduceMotion}
+        />
+      ))}
+    </div>
+  )
+}
+
+interface ScoreboardCellViewProps {
+  cell: ScoreboardCell
+  index: number
+  reduceMotion: boolean
+}
+
+function ScoreboardCellView({
+  cell,
+  index,
+  reduceMotion,
+}: ScoreboardCellViewProps): JSX.Element {
+  const display = formatValue(cell.value, cell.precision, cell.unit)
+  const status = classifyDelta(cell.value, cell.baseline, cell.direction)
+  // Suppress the delta line when there's no comparison to make OR the
+  // values are exactly equal — a "Δ ±0.00s" line on the first session
+  // (when baseline === latest === today's value) reads as noise.
+  const delta =
+    cell.value !== undefined && cell.baseline !== undefined
+      ? cell.value - cell.baseline
+      : undefined
+  const showDelta = delta !== undefined && delta !== 0 && status !== null
+  const cellDelay = reduceMotion ? 0 : index * CELL_STAGGER_S
+
+  return (
+    <div className="flex flex-col items-center gap-2 bg-neutral-950 px-4 py-5">
+      <span className="font-mono text-[10px] uppercase tracking-[0.28em] text-amber-300/70">
+        {cell.label}
+      </span>
+      <SplitFlapDigits text={display} delay={cellDelay} reduceMotion={reduceMotion} />
+      {showDelta ? (
+        <DeltaLine
+          delta={delta as number}
+          status={status as DeltaStatus}
+          precision={cell.precision}
+          unit={cell.unit}
+          delay={cellDelay + (reduceMotion ? 0 : DELTA_DELAY_AFTER_CELL_S)}
+          reduceMotion={reduceMotion}
+        />
+      ) : (
+        // Reserved spacer keeps cell heights uniform so the scoreboard
+        // stays aligned even when some cells lack a delta.
+        <span aria-hidden="true" className="block h-4" />
+      )}
+    </div>
+  )
+}
+
+interface SplitFlapDigitsProps {
+  text: string
+  delay: number
+  reduceMotion: boolean
+}
+
+const DIGIT_STYLE: CSSProperties = {
+  display: 'inline-block',
+  transformOrigin: 'center top',
+  transformStyle: 'preserve-3d',
+}
+
+/**
+ * Renders a string as a row of split-flap-style digits, each flipping
+ * down into place with a small per-character stagger.
+ */
+function SplitFlapDigits({
+  text,
+  delay,
+  reduceMotion,
+}: SplitFlapDigitsProps): JSX.Element {
+  const chars = Array.from(text)
+  return (
+    <span
+      aria-label={text}
+      className="font-mono text-3xl font-bold tabular-nums tracking-tight text-amber-300 sm:text-4xl"
+      style={{ perspective: '600px' }}
+    >
+      {chars.map((char, i) => (
+        <motion.span
+          // Key includes the text identity so a future value swap on the
+          // same cell retriggers the flip animation; with just `i` the
+          // span would mutate without re-animating.
+          key={`${text}-${i}`}
+          aria-hidden="true"
+          style={DIGIT_STYLE}
+          initial={reduceMotion ? false : { rotateX: -90, opacity: 0 }}
+          animate={reduceMotion ? undefined : { rotateX: 0, opacity: 1 }}
+          transition={{
+            duration: DIGIT_FLIP_S,
+            ease: [0.16, 1, 0.3, 1],
+            delay: delay + i * DIGIT_STAGGER_S,
+          }}
+        >
+          {char}
+        </motion.span>
+      ))}
+    </span>
+  )
+}
+
+interface DeltaLineProps {
+  delta: number
+  status: DeltaStatus
+  precision: number
+  unit: string
+  delay: number
+  reduceMotion: boolean
+}
+
+/**
+ * Single delta line that counts up from zero to the final value on
+ * mount. With reduced motion, jumps to the final value immediately.
+ */
+function DeltaLine({
+  delta,
+  status,
+  precision,
+  unit,
+  delay,
+  reduceMotion,
+}: DeltaLineProps): JSX.Element {
+  const motionValue = useMotionValue(reduceMotion ? delta : 0)
+  const [text, setText] = useState(() =>
+    formatDeltaValue(reduceMotion ? delta : 0, precision, unit),
+  )
+
+  useMotionValueEvent(motionValue, 'change', (v) => {
+    setText(formatDeltaValue(v, precision, unit))
+  })
+
+  useEffect(() => {
+    if (reduceMotion) {
+      motionValue.set(delta)
+      return
+    }
+    motionValue.set(0)
+    const controls = animate(motionValue, delta, {
+      duration: DELTA_COUNTUP_S,
+      delay,
+      ease: 'easeOut',
+    })
+    return () => {
+      controls.stop()
+    }
+  }, [delta, delay, reduceMotion, motionValue])
+
+  const colorClass =
+    status === 'improvement'
+      ? 'text-emerald-400'
+      : status === 'regression'
+        ? 'text-rose-400'
+        : 'text-amber-200/80'
+
+  return (
+    <span
+      role="status"
+      aria-label={`Delta ${text} versus baseline`}
+      className={`font-mono text-[11px] font-medium uppercase tracking-[0.2em] ${colorClass}`}
+    >
+      Δ {text}
+    </span>
+  )
+}

--- a/components/training-facility/shared/Scoreboard.tsx
+++ b/components/training-facility/shared/Scoreboard.tsx
@@ -50,14 +50,10 @@ const DIGIT_FLIP_S = 0.45
 const DELTA_COUNTUP_S = 0.6
 const DELTA_DELAY_AFTER_CELL_S = 0.3
 
-/** Format the cell's main value, or em-dash placeholder when absent. */
-function formatValue(
-  value: number | undefined,
-  precision: number,
-  unit: string,
-): string {
+/** Format the cell's numeric value alone (no unit), or em-dash when absent. The unit renders separately at a smaller size — see {@link ScoreboardCellView}. */
+function formatDigits(value: number | undefined, precision: number): string {
   if (typeof value !== 'number') return '—'
-  return `${value.toFixed(precision)}${unit}`
+  return value.toFixed(precision)
 }
 
 /** Format a signed delta with a leading +/− glyph and the metric unit. */
@@ -127,7 +123,8 @@ function ScoreboardCellView({
   index,
   reduceMotion,
 }: ScoreboardCellViewProps): JSX.Element {
-  const display = formatValue(cell.value, cell.precision, cell.unit)
+  const digits = formatDigits(cell.value, cell.precision)
+  const showUnit = typeof cell.value === 'number'
   const status = classifyDelta(cell.value, cell.baseline, cell.direction)
   // Suppress the delta line when there's no comparison to make OR the
   // delta would render as "±0.00" at the cell's display precision.
@@ -149,7 +146,12 @@ function ScoreboardCellView({
       <span className="font-mono text-[10px] uppercase tracking-[0.28em] text-amber-300/70">
         {cell.label}
       </span>
-      <SplitFlapDigits text={display} delay={cellDelay} reduceMotion={reduceMotion} />
+      <SplitFlapDigits
+        digits={digits}
+        unit={showUnit ? cell.unit : undefined}
+        delay={cellDelay}
+        reduceMotion={reduceMotion}
+      />
       {showDelta && displayedDelta !== undefined && status !== null ? (
         <DeltaLine
           delta={displayedDelta}
@@ -169,7 +171,10 @@ function ScoreboardCellView({
 }
 
 interface SplitFlapDigitsProps {
-  text: string
+  /** The numeric portion that flips into place (e.g. "231.4", "5.38", or "—"). */
+  digits: string
+  /** Optional unit suffix (e.g. " lbs", "s", "\""). Rendered smaller and static beside the digits so it doesn't overrun the cell on narrow screens. */
+  unit?: string
   delay: number
   reduceMotion: boolean
 }
@@ -181,40 +186,60 @@ const DIGIT_STYLE: CSSProperties = {
 }
 
 /**
- * Renders a string as a row of split-flap-style digits, each flipping
- * down into place with a small per-character stagger.
+ * Renders a number as a row of split-flap-style digits with a small
+ * per-character stagger, plus an optional smaller-text unit suffix
+ * appended inline. The unit is intentionally not animated — it's
+ * static metadata, and shrinking it keeps `231.4 lbs` from wrapping
+ * inside narrow mobile cells.
  */
 function SplitFlapDigits({
-  text,
+  digits,
+  unit,
   delay,
   reduceMotion,
 }: SplitFlapDigitsProps): JSX.Element {
-  const chars = Array.from(text)
+  const chars = Array.from(digits)
+  // Trim leading whitespace from the unit before rendering: " lbs"
+  // included a leading space so it appeared as "231.4 lbs" when
+  // concatenated; with the unit in its own span we control spacing
+  // via the inline-flex gap instead.
+  const trimmedUnit = unit?.replace(/^\s+/, '')
+  const ariaLabel = unit ? `${digits} ${trimmedUnit ?? ''}`.trim() : digits
   return (
     <span
-      aria-label={text}
-      className="font-mono text-3xl font-bold tabular-nums tracking-tight text-amber-300 sm:text-4xl"
+      aria-label={ariaLabel}
+      className="inline-flex items-baseline gap-0.5"
       style={{ perspective: '600px' }}
     >
-      {chars.map((char, i) => (
-        <motion.span
-          // Key includes the text identity so a future value swap on the
-          // same cell retriggers the flip animation; with just `i` the
-          // span would mutate without re-animating.
-          key={`${text}-${i}`}
+      <span className="font-mono text-2xl font-bold tabular-nums tracking-tight text-amber-300 sm:text-4xl">
+        {chars.map((char, i) => (
+          <motion.span
+            // Key includes the digit string identity so a future value
+            // swap on the same cell retriggers the flip animation;
+            // with just `i` the span would mutate without re-animating.
+            key={`${digits}-${i}`}
+            aria-hidden="true"
+            style={DIGIT_STYLE}
+            initial={reduceMotion ? false : { rotateX: -90, opacity: 0 }}
+            animate={reduceMotion ? undefined : { rotateX: 0, opacity: 1 }}
+            transition={{
+              duration: DIGIT_FLIP_S,
+              ease: [0.16, 1, 0.3, 1],
+              delay: delay + i * DIGIT_STAGGER_S,
+            }}
+          >
+            {char}
+          </motion.span>
+        ))}
+      </span>
+      {trimmedUnit && (
+        <span
           aria-hidden="true"
-          style={DIGIT_STYLE}
-          initial={reduceMotion ? false : { rotateX: -90, opacity: 0 }}
-          animate={reduceMotion ? undefined : { rotateX: 0, opacity: 1 }}
-          transition={{
-            duration: DIGIT_FLIP_S,
-            ease: [0.16, 1, 0.3, 1],
-            delay: delay + i * DIGIT_STAGGER_S,
-          }}
+          className="font-mono text-sm font-semibold uppercase tracking-wide text-amber-300/80 sm:text-base"
         >
-          {char}
-        </motion.span>
-      ))}
+          {trimmedUnit}
+        </span>
+      )}
     </span>
   )
 }

--- a/components/training-facility/shared/Scoreboard.tsx
+++ b/components/training-facility/shared/Scoreboard.tsx
@@ -32,11 +32,15 @@ export interface ScoreboardProps {
    * Accessible name for the scoreboard region. Override per use site —
    * the Combine page sets "Combine scoreboard summary"; the future Gym
    * wall scoreboard will set its own contextual label. Defaults to a
-   * generic "Scoreboard" so consumers that forget still get something
+   * generic `"Scoreboard"` so consumers that forget still get something
    * sensible.
    */
   ariaLabel?: string
-  /** Tailwind classes appended to the outer container. */
+  /**
+   * Tailwind classes appended to the outer grid container. Defaults to
+   * `''`; pass utility classes to override spacing or column counts
+   * (e.g. `grid-cols-3 sm:grid-cols-3` for a future 3-cell variant).
+   */
   className?: string
 }
 
@@ -64,6 +68,16 @@ function formatDeltaValue(delta: number, precision: number, unit: string): strin
 }
 
 /**
+ * Round a value to the cell's display precision. Used to decide whether
+ * a delta should render at all — sub-precision differences (5.381 vs
+ * 5.384 with `precision=2`) round to zero and should not show the line.
+ */
+function roundToPrecision(value: number, precision: number): number {
+  const factor = Math.pow(10, precision)
+  return Math.round(value * factor) / factor
+}
+
+/**
  * `Scoreboard` — arena-style summary header (PRD §9.1).
  *
  * Renders cells side-by-side. Each cell shows a label, the latest value
@@ -73,7 +87,10 @@ function formatDeltaValue(delta: number, precision: number, unit: string): strin
  *
  * The component is pure display: parents derive cell models with
  * `deriveCombineScoreboardCells` (Combine page) or hand-build them
- * (Gym wall scoreboard, future). See {@link ScoreboardProps} for prop docs.
+ * (Gym wall scoreboard, future). The `cells` array is read-only — the
+ * component never mutates it.
+ *
+ * @param props - {@link ScoreboardProps}.
  */
 export function Scoreboard({
   cells,
@@ -113,13 +130,18 @@ function ScoreboardCellView({
   const display = formatValue(cell.value, cell.precision, cell.unit)
   const status = classifyDelta(cell.value, cell.baseline, cell.direction)
   // Suppress the delta line when there's no comparison to make OR the
-  // values are exactly equal — a "Δ ±0.00s" line on the first session
-  // (when baseline === latest === today's value) reads as noise.
+  // delta would render as "±0.00" at the cell's display precision.
+  // Comparing the *rounded* delta (not the raw float) avoids a
+  // misleading "Δ −0.00s" green badge for sub-precision noise like
+  // 5.381 vs 5.384 with `precision=2`.
   const delta =
     cell.value !== undefined && cell.baseline !== undefined
       ? cell.value - cell.baseline
       : undefined
-  const showDelta = delta !== undefined && delta !== 0 && status !== null
+  const displayedDelta =
+    delta !== undefined ? roundToPrecision(delta, cell.precision) : undefined
+  const showDelta =
+    displayedDelta !== undefined && displayedDelta !== 0 && status !== null
   const cellDelay = reduceMotion ? 0 : index * CELL_STAGGER_S
 
   return (
@@ -128,10 +150,10 @@ function ScoreboardCellView({
         {cell.label}
       </span>
       <SplitFlapDigits text={display} delay={cellDelay} reduceMotion={reduceMotion} />
-      {showDelta ? (
+      {showDelta && displayedDelta !== undefined && status !== null ? (
         <DeltaLine
-          delta={delta as number}
-          status={status as DeltaStatus}
+          delta={displayedDelta}
+          status={status}
           precision={cell.precision}
           unit={cell.unit}
           delay={cellDelay + (reduceMotion ? 0 : DELTA_DELAY_AFTER_CELL_S)}

--- a/components/training-facility/shared/scoreboard-utils.ts
+++ b/components/training-facility/shared/scoreboard-utils.ts
@@ -1,0 +1,126 @@
+import type { Benchmark } from '@/types/movement'
+import { BENCHMARKS, type MetricKey } from '@/constants/benchmarks'
+
+/**
+ * Display order for the Combine scoreboard cells per PRD §9.1:
+ * Bodyweight → 5-10-5 → Vertical → 10y Sprint. Differs from the canonical
+ * `METRIC_KEYS` order (which leads with vertical) because the scoreboard
+ * reads left-to-right starting with body context.
+ */
+export const SCOREBOARD_METRIC_ORDER: readonly MetricKey[] = [
+  'bodyweight_lbs',
+  'shuttle_5_10_5_s',
+  'vertical_in',
+  'sprint_10y_s',
+] as const
+
+/**
+ * One cell of the scoreboard. The parent supplies already-derived numbers
+ * and metric metadata so the component stays purely a display surface
+ * (the same shape will drive the future Gym wall scoreboard, where the
+ * "metrics" are session totals, not Combine benchmarks).
+ */
+export interface ScoreboardCell {
+  /** Header label rendered above the digits — short form (e.g. "VERT", "5-10-5"). */
+  label: string
+  /** Latest value, or `undefined` when no qualifying entry exists. */
+  value?: number
+  /** Baseline value used to derive the delta. `undefined` skips delta rendering. */
+  baseline?: number
+  /** Which direction means "improvement" — drives delta color. */
+  direction: 'lower' | 'higher'
+  /** Decimals to render. Time metrics use 2; vertical/weight use 1. */
+  precision: number
+  /** Unit suffix appended after the value (e.g. "s", "\"", " lbs"). */
+  unit: string
+}
+
+/**
+ * Pick the most recent value for a single metric across a benchmark
+ * history. Skips entries that explicitly set `is_complete: false`
+ * (test/incomplete sessions per PRD §7.11) and entries with no value for
+ * the metric (partial entries are valid per `Benchmark` type docs).
+ *
+ * Returns `undefined` when no qualifying entry exists.
+ */
+export function pickMetricLatest(
+  entries: readonly Benchmark[],
+  key: MetricKey,
+): number | undefined {
+  let best: { date: string; value: number } | undefined
+  for (const entry of entries) {
+    if (entry.is_complete === false) continue
+    const value = entry[key]
+    if (typeof value !== 'number') continue
+    if (!best || entry.date > best.date) best = { date: entry.date, value }
+  }
+  return best?.value
+}
+
+/**
+ * Pick the earliest value for a single metric — the per-metric baseline.
+ *
+ * Per-metric (rather than per-entry) baselining matters because partial
+ * entries are valid: a January bodyweight-only week is a legitimate
+ * bodyweight baseline even when it lacks a vertical. Same skip rules as
+ * {@link pickMetricLatest}.
+ */
+export function pickMetricBaseline(
+  entries: readonly Benchmark[],
+  key: MetricKey,
+): number | undefined {
+  let best: { date: string; value: number } | undefined
+  for (const entry of entries) {
+    if (entry.is_complete === false) continue
+    const value = entry[key]
+    if (typeof value !== 'number') continue
+    if (!best || entry.date < best.date) best = { date: entry.date, value }
+  }
+  return best?.value
+}
+
+/**
+ * Improvement state of a delta given the metric's direction. `'neutral'`
+ * means the values are identical (no color change); `null` means the
+ * delta can't be computed (one side missing).
+ */
+export type DeltaStatus = 'improvement' | 'regression' | 'neutral'
+
+/**
+ * Classify `latest` vs `baseline` according to whether lower or higher is
+ * better for this metric. Use the result to color-code the delta line.
+ */
+export function classifyDelta(
+  latest: number | undefined,
+  baseline: number | undefined,
+  direction: 'lower' | 'higher',
+): DeltaStatus | null {
+  if (latest === undefined || baseline === undefined) return null
+  if (latest === baseline) return 'neutral'
+  const beats = direction === 'lower' ? latest < baseline : latest > baseline
+  return beats ? 'improvement' : 'regression'
+}
+
+/**
+ * Build the four-cell Combine scoreboard model from a benchmark history.
+ *
+ * Pure function — adding a metric to the scoreboard is a config change in
+ * `constants/benchmarks.ts` plus an entry in {@link SCOREBOARD_METRIC_ORDER}.
+ * Iterates the order constant rather than `Object.keys(BENCHMARKS)` so
+ * the on-screen sequence stays stable.
+ */
+export function deriveCombineScoreboardCells(
+  entries: readonly Benchmark[],
+): ScoreboardCell[] {
+  return SCOREBOARD_METRIC_ORDER.map((key) => {
+    const spec = BENCHMARKS[key]
+    return {
+      label: spec.shortLabel,
+      value: pickMetricLatest(entries, key),
+      baseline: pickMetricBaseline(entries, key),
+      direction: spec.direction,
+      precision: spec.precision,
+      unit: spec.unit,
+    }
+  })
+}

--- a/components/training-facility/shared/scoreboard-utils.ts
+++ b/components/training-facility/shared/scoreboard-utils.ts
@@ -42,6 +42,9 @@ export interface ScoreboardCell {
  * the metric (partial entries are valid per `Benchmark` type docs).
  *
  * Returns `undefined` when no qualifying entry exists.
+ *
+ * @param entries Benchmark history. Order does not matter; the function compares dates.
+ * @param key     Which metric to inspect.
  */
 export function pickMetricLatest(
   entries: readonly Benchmark[],
@@ -64,6 +67,9 @@ export function pickMetricLatest(
  * entries are valid: a January bodyweight-only week is a legitimate
  * bodyweight baseline even when it lacks a vertical. Same skip rules as
  * {@link pickMetricLatest}.
+ *
+ * @param entries Benchmark history. Order does not matter.
+ * @param key     Which metric to inspect.
  */
 export function pickMetricBaseline(
   entries: readonly Benchmark[],
@@ -89,6 +95,10 @@ export type DeltaStatus = 'improvement' | 'regression' | 'neutral'
 /**
  * Classify `latest` vs `baseline` according to whether lower or higher is
  * better for this metric. Use the result to color-code the delta line.
+ *
+ * @param latest    Most recent value for the metric.
+ * @param baseline  Reference value to compare against (typically the earliest entry's value).
+ * @param direction Which direction is "improvement" — `'lower'` for time/weight metrics, `'higher'` for vertical jump.
  */
 export function classifyDelta(
   latest: number | undefined,
@@ -108,6 +118,8 @@ export function classifyDelta(
  * `constants/benchmarks.ts` plus an entry in {@link SCOREBOARD_METRIC_ORDER}.
  * Iterates the order constant rather than `Object.keys(BENCHMARKS)` so
  * the on-screen sequence stays stable.
+ *
+ * @param entries Benchmark history. Order does not matter; the helpers compare dates.
  */
 export function deriveCombineScoreboardCells(
   entries: readonly Benchmark[],


### PR DESCRIPTION
## Summary
- Shared `Scoreboard` component (`components/training-facility/shared/Scoreboard.tsx`) — split-flap digit flip + delta count-up via Framer Motion. Honors `prefers-reduced-motion`.
- Pure helpers in `scoreboard-utils.ts` (`pickMetricLatest`, `pickMetricBaseline`, `classifyDelta`, `deriveCombineScoreboardCells`) so callers can derive cells without crossing the `'use client'` boundary. Per-metric baselining handles partial entries.
- Combine page (`app/training-facility/combine/page.tsx`) wires it in: fetches `getMovementBenchmarks()` and renders the four-cell summary at the top.
- Dev smoke route at `/dev/scoreboard` covers all-improvement, mixed (regression on vertical), single-entry (no delta), and empty states.
- Vitest coverage on the pure helpers — order, partial entries, `is_complete: false` skipping, direction-aware classification.

Cell order per PRD §9.1: **Bodyweight | 5-10-5 | Vertical | 10y Sprint**. Improvement is green; regression is red. Empty history → em-dash placeholders, no delta line.

> **Heads up:** there's no overlap with PR #108 (Training Facility shell) on `main` yet — that PR's placeholder `app/training-facility/combine/page.tsx` is replaced here. When #108 lands first, this branch rebases cleanly with this version winning.

## Test plan
- [ ] `npx tsc --noEmit` clean
- [ ] `npm test` — 122 tests pass (51 of which cover the scoreboard helpers and prior Vitest suites)
- [ ] `npx next build` clean; `/dev/scoreboard` and `/training-facility/combine` show in route table
- [ ] Visit `/dev/scoreboard` — verify cell-by-cell flip animation, count-up deltas, green/red color coding by direction, single-entry section shows no delta line, empty section shows four em-dashes
- [ ] Visit `/training-facility/combine` — header reads "The Combine"; with no `public/data/movement_benchmarks.json` on disk, the scoreboard renders em-dashes (the documented empty state)
- [ ] Toggle OS-level reduced-motion and reload `/dev/scoreboard` — animations skip; final values render immediately
- [ ] Mobile width: cells stack 2x2 instead of 1x4

Closes #63.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New interactive Scoreboard UI showing metric cells with animated flip-style values, delta indicators, and empty/baseline fallbacks
  * Training Facility "Combine" page to load and display benchmark entries in the Scoreboard
  * Dev-only Scoreboard demo page showcasing multiple benchmark scenarios (all-improvement, mixed regressions, baseline-only, empty)

* **Utilities**
  * Added pure utilities to derive scoreboard cells, pick latest/baseline metric values, and classify deltas

* **Tests**
  * Comprehensive tests for metric selection, baseline/latest logic, delta classification, and cell derivation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->