### PR TITLE
chore(security): add baseline response headers (#48)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,16 @@
 import type { NextConfig } from 'next'
 
+/**
+ * Baseline CSP directives emitted in report-only mode during the
+ * security-hardening rollout.
+ *
+ * The value is serialized as a single semicolon-delimited header
+ * string so it can be passed directly to
+ * `Content-Security-Policy-Report-Only`. The current allowlist keeps
+ * the policy compatible with the existing app shell, inline JSON-LD,
+ * Framer Motion styles, and Vercel Analytics
+ * (`https://va.vercel-scripts.com`).
+ */
 const contentSecurityPolicyReportOnly = [
   "default-src 'self'",
   "base-uri 'self'",
@@ -15,6 +26,14 @@ const contentSecurityPolicyReportOnly = [
 ].join('; ')
 
 const nextConfig: NextConfig = {
+  /**
+   * Applies baseline security response headers to every route in the
+   * app, including public assets and App Router pages.
+   *
+   * @returns Next.js header rules that enforce the non-CSP headers now
+   *   and emit CSP in report-only mode while the app is still being
+   *   tuned for stricter inline-script/style handling.
+   */
   async headers() {
     return [
       {

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,54 @@
 import type { NextConfig } from 'next'
 
+const contentSecurityPolicyReportOnly = [
+  "default-src 'self'",
+  "base-uri 'self'",
+  "form-action 'self'",
+  "frame-ancestors 'none'",
+  "object-src 'none'",
+  "script-src 'self' 'unsafe-inline' https://va.vercel-scripts.com",
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' data: blob:",
+  "font-src 'self' data:",
+  "connect-src 'self' https://va.vercel-scripts.com",
+  'upgrade-insecure-requests',
+].join('; ')
+
 const nextConfig: NextConfig = {
-  /* config options here */
+  async headers() {
+    return [
+      {
+        source: '/:path*',
+        headers: [
+          {
+            key: 'Content-Security-Policy-Report-Only',
+            value: contentSecurityPolicyReportOnly,
+          },
+          {
+            key: 'Strict-Transport-Security',
+            value: 'max-age=63072000; includeSubDomains; preload',
+          },
+          {
+            key: 'X-Frame-Options',
+            value: 'DENY',
+          },
+          {
+            key: 'X-Content-Type-Options',
+            value: 'nosniff',
+          },
+          {
+            key: 'Referrer-Policy',
+            value: 'strict-origin-when-cross-origin',
+          },
+          {
+            key: 'Permissions-Policy',
+            value:
+              'accelerometer=(), autoplay=(), camera=(), display-capture=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), midi=(), payment=(), usb=(), browsing-topics=()',
+          },
+        ],
+      },
+    ]
+  },
 }
 
 export default nextConfig


### PR DESCRIPTION
## Summary
- add site-wide response headers in `next.config.ts` via `headers()`
- enforce `Strict-Transport-Security`, `X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`, and `Permissions-Policy`
- add a pragmatic `Content-Security-Policy-Report-Only` header instead of enforcing CSP immediately

## Notes
- CSP stays in `Report-Only` for this pass because the app currently relies on App Router inline scripts, inline JSON-LD in `app/layout.tsx`, Framer Motion inline styling behavior, and Vercel Analytics
- the policy still tightens the baseline with `default-src 'self'`, `base-uri 'self'`, `form-action 'self'`, `frame-ancestors 'none'`, and `object-src 'none'`
- follow-up hardening can replace the permissive inline allowances with a nonce/hash strategy once the app is ready

## Test plan
- [ ] Run `npx next build`
- [ ] Run `npx tsc --noEmit` after build generation (current repo quirk: `.next/types` must exist first in a cold worktree)
- [ ] Start `next start` locally and verify `/` returns these headers:
  - `Content-Security-Policy-Report-Only`
  - `Strict-Transport-Security`
  - `X-Frame-Options`
  - `X-Content-Type-Options`
  - `Referrer-Policy`
  - `Permissions-Policy`
- [ ] After deploy, verify the production site reports the same headers and check the result in SecurityHeaders.com

Closes #48.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Applied comprehensive security headers globally across all routes.
  * Added a report-only Content-Security-Policy to surface potential violations without blocking.
  * Enabled strict transport security (HSTS) and clickjacking protection (X-Frame-Options: DENY).
  * Enforced MIME sniffing prevention (X-Content-Type-Options: nosniff), a strict referrer policy, and a restrictive Permissions-Policy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->