### PR TITLE
test(training-facility): cover TradingCard, DateFilter, chart primitives (#104, step 3)

### DIFF
--- a/components/training-facility/shared/DateFilter.test.tsx
+++ b/components/training-facility/shared/DateFilter.test.tsx
@@ -1,0 +1,255 @@
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import {
+  DateFilter,
+  endOfDay,
+  isInRange,
+  parseInputValue,
+  rangeForPreset,
+  startOfDay,
+  subtractMonths,
+  toInputValue,
+  type DateRange,
+} from './DateFilter'
+
+/**
+ * Pure-helper coverage plus interaction-driven RTL tests for DateFilter.
+ *
+ * The visibilitychange re-anchor effect is intentionally not exercised — it
+ * requires patching `document.visibilityState` and provides little signal
+ * beyond the `selectPreset` path already covered.
+ *
+ * `rangeForPreset` and the preset-click test rely on the system clock for
+ * "today"; tests that need a deterministic anchor use vi.setSystemTime.
+ */
+
+beforeEach(() => {
+  // Mid-month so subtractMonths edge cases don't accidentally fire on day 1/31.
+  // `shouldAdvanceTime: true` lets userEvent's internal scheduled work run
+  // against real wall time while keeping `Date.now()` / `new Date()` frozen
+  // — without it, awaited userEvent calls hang indefinitely under fake timers.
+  vi.useFakeTimers({ shouldAdvanceTime: true })
+  vi.setSystemTime(new Date(2026, 3, 15, 12, 0, 0)) // April 15 2026 noon (local)
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('startOfDay / endOfDay', () => {
+  it('startOfDay zeroes the time portion', () => {
+    const d = new Date(2026, 3, 15, 14, 32, 17, 555)
+    const s = startOfDay(d)
+    expect(s.getHours()).toBe(0)
+    expect(s.getMinutes()).toBe(0)
+    expect(s.getSeconds()).toBe(0)
+    expect(s.getMilliseconds()).toBe(0)
+  })
+
+  it('endOfDay sets the time to 23:59:59.999', () => {
+    const d = new Date(2026, 3, 15, 0, 0, 0, 0)
+    const e = endOfDay(d)
+    expect(e.getHours()).toBe(23)
+    expect(e.getMinutes()).toBe(59)
+    expect(e.getSeconds()).toBe(59)
+    expect(e.getMilliseconds()).toBe(999)
+  })
+})
+
+describe('subtractMonths', () => {
+  it('subtracts a typical month', () => {
+    const d = new Date(2026, 3, 15) // April 15 2026
+    const r = subtractMonths(d, 1)
+    expect(r.getFullYear()).toBe(2026)
+    expect(r.getMonth()).toBe(2) // March
+    expect(r.getDate()).toBe(15)
+  })
+
+  it('crosses year boundaries', () => {
+    const d = new Date(2026, 1, 15) // Feb 15 2026
+    const r = subtractMonths(d, 12)
+    expect(r.getFullYear()).toBe(2025)
+    expect(r.getMonth()).toBe(1) // Feb
+    expect(r.getDate()).toBe(15)
+  })
+
+  it('clamps Mar 31 → Feb 28 in a non-leap year (no rollover into March 3)', () => {
+    const d = new Date(2025, 2, 31) // March 31 2025 — non-leap
+    const r = subtractMonths(d, 1)
+    expect(r.getMonth()).toBe(1) // Feb
+    expect(r.getDate()).toBe(28)
+  })
+
+  it('clamps Mar 31 → Feb 29 in a leap year', () => {
+    const d = new Date(2024, 2, 31) // March 31 2024 — leap
+    const r = subtractMonths(d, 1)
+    expect(r.getMonth()).toBe(1) // Feb
+    expect(r.getDate()).toBe(29)
+  })
+
+  it('subtracts many months', () => {
+    const d = new Date(2026, 3, 15)
+    const r = subtractMonths(d, 36)
+    expect(r.getFullYear()).toBe(2023)
+    expect(r.getMonth()).toBe(3)
+  })
+})
+
+describe('toInputValue / parseInputValue', () => {
+  it('toInputValue zero-pads single-digit month and day', () => {
+    expect(toInputValue(new Date(2026, 0, 5))).toBe('2026-01-05')
+    expect(toInputValue(new Date(2026, 11, 31))).toBe('2026-12-31')
+  })
+
+  it('parseInputValue returns null on empty input', () => {
+    expect(parseInputValue('')).toBeNull()
+  })
+
+  it('parseInputValue returns null on malformed input', () => {
+    expect(parseInputValue('not-a-date')).toBeNull()
+  })
+
+  it('round-trips a date through toInputValue → parseInputValue', () => {
+    const original = new Date(2026, 3, 15) // April 15 local
+    const parsed = parseInputValue(toInputValue(original))
+    expect(parsed?.getFullYear()).toBe(2026)
+    expect(parsed?.getMonth()).toBe(3)
+    expect(parsed?.getDate()).toBe(15)
+  })
+})
+
+describe('rangeForPreset', () => {
+  const earliest = new Date(2024, 0, 1)
+
+  it('1M returns a one-month-back start anchored at today', () => {
+    const r = rangeForPreset('1M', earliest)
+    expect(r.start.getMonth()).toBe(2) // March (April - 1)
+    expect(r.start.getDate()).toBe(15)
+    expect(r.end.getDate()).toBe(15) // April 15
+    expect(r.end.getHours()).toBe(23) // endOfDay
+  })
+
+  it('ALL clamps to today when earliestDate is in the future', () => {
+    const future = new Date(2030, 0, 1)
+    const r = rangeForPreset('ALL', future)
+    expect(r.start.getTime()).toBeLessThanOrEqual(r.end.getTime()) // start <= end invariant
+  })
+
+  it('ALL uses the earliestDate when it is in the past', () => {
+    const r = rangeForPreset('ALL', earliest)
+    expect(r.start.getFullYear()).toBe(2024)
+    expect(r.start.getMonth()).toBe(0)
+    expect(r.start.getDate()).toBe(1)
+  })
+
+  it('start <= end always holds', () => {
+    for (const preset of ['1M', '3M', '6M', '1Y', 'ALL'] as const) {
+      const r = rangeForPreset(preset, earliest)
+      expect(r.start.getTime()).toBeLessThanOrEqual(r.end.getTime())
+    }
+  })
+})
+
+describe('isInRange', () => {
+  it('inclusive on both ends', () => {
+    const range: DateRange = {
+      start: new Date(2026, 3, 1, 0, 0, 0, 0),
+      end: new Date(2026, 3, 30, 23, 59, 59, 999),
+    }
+    expect(isInRange(new Date(2026, 3, 1, 0, 0, 0, 0), range)).toBe(true)
+    expect(isInRange(new Date(2026, 3, 30, 23, 59, 59, 999), range)).toBe(true)
+    expect(isInRange(new Date(2026, 3, 15), range)).toBe(true)
+  })
+
+  it('false outside the range', () => {
+    const range: DateRange = {
+      start: new Date(2026, 3, 1),
+      end: new Date(2026, 3, 30, 23, 59, 59, 999),
+    }
+    expect(isInRange(new Date(2026, 2, 31), range)).toBe(false) // day before start
+    expect(isInRange(new Date(2026, 4, 1), range)).toBe(false) // day after end
+  })
+})
+
+describe('DateFilter render', () => {
+  it('renders five preset buttons with the documented labels', () => {
+    render(<DateFilter onChange={() => {}} />)
+    expect(screen.getByRole('radio', { name: '1M' })).toBeInTheDocument()
+    expect(screen.getByRole('radio', { name: '3M' })).toBeInTheDocument()
+    expect(screen.getByRole('radio', { name: '6M' })).toBeInTheDocument()
+    expect(screen.getByRole('radio', { name: '1Y' })).toBeInTheDocument()
+    expect(screen.getByRole('radio', { name: 'All' })).toBeInTheDocument()
+  })
+
+  it('marks the default preset as checked on mount', () => {
+    render(<DateFilter onChange={() => {}} defaultPreset="3M" />)
+    expect(screen.getByRole('radio', { name: '3M' })).toHaveAttribute('aria-checked', 'true')
+    expect(screen.getByRole('radio', { name: '1M' })).toHaveAttribute('aria-checked', 'false')
+  })
+
+  it('preset click fires onChange with a range matching rangeForPreset', async () => {
+    const onChange = vi.fn()
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    render(<DateFilter onChange={onChange} />)
+    onChange.mockClear() // ignore mount-time emission if any
+
+    await user.click(screen.getByRole('radio', { name: '6M' }))
+    expect(onChange).toHaveBeenCalledTimes(1)
+    const range = onChange.mock.calls[0][0] as DateRange
+    // System clock is April 15 2026 (set in beforeEach). 6 months back = October 15 2025.
+    expect(range.start.getFullYear()).toBe(2025)
+    expect(range.start.getMonth()).toBe(9) // October
+    expect(range.start.getDate()).toBe(15)
+  })
+
+  it('changing the start-date input deselects the preset (custom mode)', () => {
+    render(<DateFilter onChange={() => {}} defaultPreset="1M" />)
+
+    expect(screen.getByRole('radio', { name: '1M' })).toHaveAttribute('aria-checked', 'true')
+
+    // <input type="date"> doesn't accept char-by-char typing reliably under
+    // jsdom; fire the change event directly with the parsed date string the
+    // way the browser would after a date picker selection.
+    fireEvent.change(screen.getByLabelText('Start date'), { target: { value: '2026-01-01' } })
+
+    // After a custom edit, no preset should be checked.
+    expect(screen.getByRole('radio', { name: '1M' })).toHaveAttribute('aria-checked', 'false')
+    expect(screen.getByRole('radio', { name: '3M' })).toHaveAttribute('aria-checked', 'false')
+  })
+
+  it('ArrowRight advances focus + selection through the radiogroup, wrapping at the end', async () => {
+    const onChange = vi.fn()
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    render(<DateFilter onChange={onChange} defaultPreset="1M" />)
+
+    const oneM = screen.getByRole('radio', { name: '1M' })
+    oneM.focus()
+    expect(oneM).toHaveFocus()
+
+    await user.keyboard('{ArrowRight}')
+    expect(screen.getByRole('radio', { name: '3M' })).toHaveFocus()
+    expect(screen.getByRole('radio', { name: '3M' })).toHaveAttribute('aria-checked', 'true')
+  })
+
+  it('Home jumps to the first preset and End to the last', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    render(<DateFilter onChange={() => {}} defaultPreset="3M" />)
+
+    screen.getByRole('radio', { name: '3M' }).focus()
+    await user.keyboard('{End}')
+    expect(screen.getByRole('radio', { name: 'All' })).toHaveFocus()
+
+    await user.keyboard('{Home}')
+    expect(screen.getByRole('radio', { name: '1M' })).toHaveFocus()
+  })
+
+  it('ArrowLeft from the first preset wraps to the last', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    render(<DateFilter onChange={() => {}} defaultPreset="1M" />)
+
+    screen.getByRole('radio', { name: '1M' }).focus()
+    await user.keyboard('{ArrowLeft}')
+    expect(screen.getByRole('radio', { name: 'All' })).toHaveFocus()
+  })
+})

--- a/components/training-facility/shared/DateFilter.tsx
+++ b/components/training-facility/shared/DateFilter.tsx
@@ -35,12 +35,12 @@ type DateFilterProps = {
 }
 
 /** Local start-of-day (00:00:00.000) for `d`. */
-function startOfDay(d: Date): Date {
+export function startOfDay(d: Date): Date {
   return new Date(d.getFullYear(), d.getMonth(), d.getDate(), 0, 0, 0, 0)
 }
 
 /** Local end-of-day (23:59:59.999) for `d`. */
-function endOfDay(d: Date): Date {
+export function endOfDay(d: Date): Date {
   return new Date(d.getFullYear(), d.getMonth(), d.getDate(), 23, 59, 59, 999)
 }
 
@@ -50,7 +50,7 @@ function endOfDay(d: Date): Date {
  * silent rollover (e.g., March 31 → setMonth(-1) producing March 3
  * instead of February 28/29).
  */
-function subtractMonths(d: Date, months: number): Date {
+export function subtractMonths(d: Date, months: number): Date {
   const targetMonthIndex = d.getMonth() - months
   const result = new Date(d.getFullYear(), targetMonthIndex, d.getDate())
   // The Date constructor normalizes negative/overflowing month indices,
@@ -69,7 +69,7 @@ function subtractMonths(d: Date, months: number): Date {
  * day-normalized (start: 00:00, end: 23:59:59.999) so the resulting
  * range is independent of the click time.
  */
-function rangeForPreset(preset: PresetId, earliest: Date): DateRange {
+export function rangeForPreset(preset: PresetId, earliest: Date): DateRange {
   const today = new Date()
   const end = endOfDay(today)
   if (preset === 'ALL') {
@@ -84,7 +84,7 @@ function rangeForPreset(preset: PresetId, earliest: Date): DateRange {
 }
 
 /** Format a `Date` as `YYYY-MM-DD` for `<input type="date">`. */
-function toInputValue(d: Date): string {
+export function toInputValue(d: Date): string {
   const y = d.getFullYear()
   const m = String(d.getMonth() + 1).padStart(2, '0')
   const day = String(d.getDate()).padStart(2, '0')
@@ -96,7 +96,7 @@ function toInputValue(d: Date): string {
  * midnight. Returns `null` for empty input or unparseable values so the
  * caller can no-op rather than storing `Invalid Date`.
  */
-function parseInputValue(s: string): Date | null {
+export function parseInputValue(s: string): Date | null {
   if (!s) return null
   const d = new Date(`${s}T00:00:00`)
   return Number.isNaN(d.getTime()) ? null : d

--- a/components/training-facility/shared/DateFilter.tsx
+++ b/components/training-facility/shared/DateFilter.tsx
@@ -49,6 +49,10 @@ export function endOfDay(d: Date): Date {
  * the target month when the source day doesn't exist there. Avoids JS's
  * silent rollover (e.g., March 31 → setMonth(-1) producing March 3
  * instead of February 28/29).
+ *
+ * @param d - Source date.
+ * @param months - Number of calendar months to subtract. Negative values
+ *   are not handled — callers want a backward-looking lookback only.
  */
 export function subtractMonths(d: Date, months: number): Date {
   const targetMonthIndex = d.getMonth() - months
@@ -68,6 +72,11 @@ export function subtractMonths(d: Date, months: number): Date {
  * Compute a `DateRange` for one of the preset buttons. Bounds are
  * day-normalized (start: 00:00, end: 23:59:59.999) so the resulting
  * range is independent of the click time.
+ *
+ * @param preset - Which preset to compute (`1M` / `3M` / `6M` / `1Y` / `ALL`).
+ * @param earliest - Lower bound used by the `ALL` preset; ignored otherwise.
+ *   Clamped to today if it sits in the future, so the `start <= end`
+ *   invariant is preserved against a misconfigured prop.
  */
 export function rangeForPreset(preset: PresetId, earliest: Date): DateRange {
   const today = new Date()
@@ -95,6 +104,9 @@ export function toInputValue(d: Date): string {
  * Parse a `YYYY-MM-DD` string from `<input type="date">` as local
  * midnight. Returns `null` for empty input or unparseable values so the
  * caller can no-op rather than storing `Invalid Date`.
+ *
+ * @param s - Raw `<input type="date">` value, expected as `YYYY-MM-DD`.
+ *   Empty or malformed strings return `null`.
  */
 export function parseInputValue(s: string): Date | null {
   if (!s) return null

--- a/components/training-facility/shared/TradingCard.test.tsx
+++ b/components/training-facility/shared/TradingCard.test.tsx
@@ -1,0 +1,236 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { BENCHMARKS } from '@/constants/benchmarks'
+import type { Benchmark } from '@/types/movement'
+import {
+  TradingCard,
+  formatCell,
+  formatValue,
+  isPersonalBest,
+  seasonFromDate,
+} from './TradingCard'
+
+/**
+ * Pure-helper coverage for the trading-card module plus a thin set of RTL
+ * renders that pin the visible-on-front contract (4 metrics, click flips,
+ * PB badge gated on prior history).
+ */
+
+const verticalSpec = BENCHMARKS.vertical_in
+const shuttleSpec = BENCHMARKS.shuttle_5_10_5_s
+const bodyweightSpec = BENCHMARKS.bodyweight_lbs
+
+describe('isPersonalBest', () => {
+  const entry: Benchmark = { date: '2026-04-15', vertical_in: 23, shuttle_5_10_5_s: 4.9 }
+
+  it('returns false when the entry has no value for the metric', () => {
+    const noValue: Benchmark = { date: '2026-04-15' }
+    expect(isPersonalBest(noValue, [], 'vertical_in', verticalSpec)).toBe(false)
+  })
+
+  it('returns false when no prior entry has a value (cannot break a record that does not exist)', () => {
+    const onlyEntry: Benchmark = { date: '2026-04-15', vertical_in: 23 }
+    expect(isPersonalBest(onlyEntry, [onlyEntry], 'vertical_in', verticalSpec)).toBe(false)
+  })
+
+  it('higher-is-better: PB when entry strictly beats every prior value', () => {
+    const history: Benchmark[] = [
+      { date: '2026-01-15', vertical_in: 19 },
+      { date: '2026-03-15', vertical_in: 22 },
+      entry,
+    ]
+    expect(isPersonalBest(entry, history, 'vertical_in', verticalSpec)).toBe(true)
+  })
+
+  it('higher-is-better: not a PB when a prior value ties or beats it', () => {
+    const tied: Benchmark[] = [{ date: '2026-03-15', vertical_in: 23 }, entry]
+    expect(isPersonalBest(entry, tied, 'vertical_in', verticalSpec)).toBe(false)
+  })
+
+  it('lower-is-better: PB when entry is strictly faster than every prior value', () => {
+    const history: Benchmark[] = [
+      { date: '2026-01-15', shuttle_5_10_5_s: 5.4 },
+      { date: '2026-03-15', shuttle_5_10_5_s: 5.1 },
+      entry,
+    ]
+    expect(isPersonalBest(entry, history, 'shuttle_5_10_5_s', shuttleSpec)).toBe(true)
+  })
+
+  it('lower-is-better: not a PB when a prior value ties or is faster', () => {
+    const tied: Benchmark[] = [{ date: '2026-03-15', shuttle_5_10_5_s: 4.9 }, entry]
+    expect(isPersonalBest(entry, tied, 'shuttle_5_10_5_s', shuttleSpec)).toBe(false)
+  })
+
+  it('only considers strictly-prior entries (a March entry does not lose its PB to April)', () => {
+    const march: Benchmark = { date: '2026-03-15', vertical_in: 22 }
+    const history: Benchmark[] = [
+      { date: '2026-01-15', vertical_in: 19 },
+      march,
+      { date: '2026-04-15', vertical_in: 24 }, // newer; should not affect march's PB-ness
+    ]
+    expect(isPersonalBest(march, history, 'vertical_in', verticalSpec)).toBe(true)
+  })
+
+  it('skips entries marked is_complete=false', () => {
+    const history: Benchmark[] = [
+      { date: '2026-01-15', vertical_in: 25, is_complete: false }, // would block PB if counted
+      { date: '2026-03-15', vertical_in: 22 },
+      entry,
+    ]
+    expect(isPersonalBest(entry, history, 'vertical_in', verticalSpec)).toBe(true)
+  })
+
+  it('skips prior entries missing the metric', () => {
+    const history: Benchmark[] = [
+      { date: '2026-01-15', shuttle_5_10_5_s: 5.4 }, // no vertical_in
+      { date: '2026-03-15', vertical_in: 22 },
+      entry,
+    ]
+    expect(isPersonalBest(entry, history, 'vertical_in', verticalSpec)).toBe(true)
+  })
+})
+
+describe('formatValue', () => {
+  it('returns em-dash when value is missing', () => {
+    expect(formatValue(undefined, verticalSpec)).toBe('—')
+  })
+
+  it('honors metric precision and unit', () => {
+    expect(formatValue(22, verticalSpec)).toBe('22.0"') // precision 1, unit "
+    expect(formatValue(4.9, shuttleSpec)).toBe('4.90s') // precision 2, unit s
+    expect(formatValue(232.4, bodyweightSpec)).toBe('232.4 lbs') // precision 1, unit " lbs"
+  })
+
+  it('rounds rather than truncates', () => {
+    expect(formatValue(22.05, verticalSpec)).toBe('22.1"') // toFixed(1) rounds half-up
+  })
+})
+
+describe('formatCell', () => {
+  it('returns em-dash when value is missing', () => {
+    expect(formatCell(undefined, verticalSpec)).toBe('—')
+  })
+
+  it('emits integers without a decimal point', () => {
+    expect(formatCell(22, verticalSpec)).toBe('22')
+  })
+
+  it('preserves precision for non-integers (timed metrics keep hundredths)', () => {
+    expect(formatCell(1.98, BENCHMARKS.sprint_10y_s)).toBe('1.98')
+    expect(formatCell(4.9, shuttleSpec)).toBe('4.90')
+  })
+})
+
+describe('seasonFromDate', () => {
+  it.each([
+    ['2026-03-15', '2026 Spring'],
+    ['2026-05-31', '2026 Spring'],
+    ['2026-06-01', '2026 Summer'],
+    ['2026-08-31', '2026 Summer'],
+    ['2026-09-01', '2026 Fall'],
+    ['2026-11-30', '2026 Fall'],
+    ['2026-12-15', '2026 Winter'],
+    ['2026-01-01', '2026 Winter'],
+    ['2026-02-28', '2026 Winter'],
+  ])('maps %s → %s', (date, expected) => {
+    expect(seasonFromDate(date)).toBe(expected)
+  })
+})
+
+describe('TradingCard render', () => {
+  const entry: Benchmark = {
+    date: '2026-04-15',
+    vertical_in: 23,
+    shuttle_5_10_5_s: 4.9,
+    sprint_10y_s: 1.85,
+    bodyweight_lbs: 232,
+  }
+
+  it('renders all 4 metrics on the front face with values and short labels', () => {
+    render(<TradingCard entry={entry} history={[entry]} />)
+    // Short labels appear in both the front <li> and the back-of-card <th>
+    // (the back is in the DOM permanently, just hidden via 3D rotation).
+    // Each label should match exactly twice.
+    expect(screen.getAllByText('VERT')).toHaveLength(2)
+    expect(screen.getAllByText('5-10-5')).toHaveLength(2)
+    expect(screen.getAllByText('10Y')).toHaveLength(2)
+    expect(screen.getAllByText('WT')).toHaveLength(2)
+    // Front-face values use formatValue (precision + unit). The back uses
+    // formatCell which renders integers without a trailing decimal, so these
+    // formatted strings are unique to the front.
+    expect(screen.getByText('23.0"')).toBeInTheDocument()
+    expect(screen.getByText('4.90s')).toBeInTheDocument()
+    expect(screen.getByText('1.85s')).toBeInTheDocument()
+    expect(screen.getByText('232.0 lbs')).toBeInTheDocument()
+  })
+
+  it('uses a season-derived label when season prop is omitted', () => {
+    render(<TradingCard entry={entry} history={[entry]} />)
+    // 2026-04-15 → Spring
+    expect(screen.getByText('2026 Spring')).toBeInTheDocument()
+  })
+
+  it('honors custom season + playerName + playerNumber', () => {
+    render(
+      <TradingCard
+        entry={entry}
+        history={[entry]}
+        season="Custom Season"
+        playerName="Test Player"
+        playerNumber={42}
+      />,
+    )
+    expect(screen.getByText('Custom Season')).toBeInTheDocument()
+    expect(screen.getByText('Test Player')).toBeInTheDocument()
+    expect(screen.getByText('#42')).toBeInTheDocument()
+  })
+
+  it('flips between front and back when clicked (aria-pressed reflects state)', async () => {
+    const user = userEvent.setup()
+    render(<TradingCard entry={entry} history={[entry]} />)
+    const card = screen.getByRole('button')
+    expect(card).toHaveAttribute('aria-pressed', 'false')
+
+    await user.click(card)
+    expect(card).toHaveAttribute('aria-pressed', 'true')
+
+    await user.click(card)
+    expect(card).toHaveAttribute('aria-pressed', 'false')
+  })
+
+  it('shows the PB badge when the entry sets a personal best (with prior history)', () => {
+    const prior: Benchmark = { date: '2026-01-15', vertical_in: 19, shuttle_5_10_5_s: 5.4 }
+    render(<TradingCard entry={entry} history={[prior, entry]} />)
+    // "★ PB" rendered in the front footer
+    expect(screen.getByText(/★\s*PB/i)).toBeInTheDocument()
+  })
+
+  it('does NOT show the PB badge when no prior history exists', () => {
+    render(<TradingCard entry={entry} history={[entry]} />)
+    expect(screen.queryByText(/★\s*PB/i)).not.toBeInTheDocument()
+  })
+
+  it('shows "No prior sessions" on the back when history is empty', () => {
+    // The empty-table branch fires on `sortedHistory.length === 0` — meaning
+    // the caller passed `history={[]}` (no entries at all). When even just
+    // `entry` is in the history list the table renders that single row
+    // instead of the empty-state message.
+    render(<TradingCard entry={entry} history={[]} />)
+    expect(screen.getByText(/No prior sessions/i)).toBeInTheDocument()
+  })
+
+  it('renders prior session rows in the back-of-card history table', () => {
+    const prior: Benchmark = { date: '2026-01-15', vertical_in: 19 }
+    render(<TradingCard entry={entry} history={[prior, entry]} historyLimit={5} />)
+    // Date column slices YYYY-MM-DD to MM-DD ("01-15", "04-15").
+    expect(screen.getByText('01-15')).toBeInTheDocument()
+    expect(screen.getByText('04-15')).toBeInTheDocument()
+  })
+
+  it('renders notes on the back when the entry has them', () => {
+    const withNotes: Benchmark = { ...entry, notes: 'felt strong' }
+    render(<TradingCard entry={withNotes} history={[withNotes]} />)
+    expect(screen.getByText(/felt strong/i)).toBeInTheDocument()
+  })
+})

--- a/components/training-facility/shared/TradingCard.tsx
+++ b/components/training-facility/shared/TradingCard.tsx
@@ -40,6 +40,14 @@ export interface TradingCardProps {
  * (you can't break a record that doesn't exist). The "prior only"
  * comparison matters when the card is used to browse a non-latest entry:
  * a March session shouldn't lose its PB badge just because April beat it.
+ *
+ * @param entry - The benchmark being judged. Must have a `date` field.
+ * @param history - Full benchmark history. May or may not include `entry`;
+ *   only entries with `date < entry.date` and `is_complete !== false` count
+ *   toward the comparison.
+ * @param key - Which metric to evaluate (e.g. `vertical_in`).
+ * @param spec - The metric's display + scoring config; `spec.direction`
+ *   determines whether lower or higher values win.
  */
 export function isPersonalBest(
   entry: Benchmark,
@@ -64,7 +72,12 @@ export function formatValue(value: number | undefined, spec: BenchmarkConfig): s
   return `${value.toFixed(spec.precision)}${spec.unit}`
 }
 
-/** Derive a "2026 Spring"-style season label from a `YYYY-MM-DD` benchmark date. */
+/**
+ * Derive a "2026 Spring"-style season label from a `YYYY-MM-DD` benchmark date.
+ *
+ * @param date - ISO calendar date (`YYYY-MM-DD`); the month determines which
+ *   meteorological season label is returned.
+ */
 export function seasonFromDate(date: string): string {
   const [yearStr, monthStr] = date.split('-')
   const month = Number(monthStr)

--- a/components/training-facility/shared/TradingCard.tsx
+++ b/components/training-facility/shared/TradingCard.tsx
@@ -41,7 +41,7 @@ export interface TradingCardProps {
  * comparison matters when the card is used to browse a non-latest entry:
  * a March session shouldn't lose its PB badge just because April beat it.
  */
-function isPersonalBest(
+export function isPersonalBest(
   entry: Benchmark,
   history: readonly Benchmark[],
   key: MetricKey,
@@ -59,13 +59,13 @@ function isPersonalBest(
 }
 
 /** Format a benchmark value for the front-of-card line, or em-dash when absent. */
-function formatValue(value: number | undefined, spec: BenchmarkConfig): string {
+export function formatValue(value: number | undefined, spec: BenchmarkConfig): string {
   if (typeof value !== 'number') return '—'
   return `${value.toFixed(spec.precision)}${spec.unit}`
 }
 
 /** Derive a "2026 Spring"-style season label from a `YYYY-MM-DD` benchmark date. */
-function seasonFromDate(date: string): string {
+export function seasonFromDate(date: string): string {
   const [yearStr, monthStr] = date.split('-')
   const month = Number(monthStr)
   const season =
@@ -303,7 +303,7 @@ function CardBack({ history, latestNotes }: CardBackProps): JSX.Element {
  * metric's declared precision so timed metrics (shuttle, 10y) keep their
  * hundredths digit instead of rounding 1.98 → 2.0.
  */
-function formatCell(value: number | undefined, spec: BenchmarkConfig): string {
+export function formatCell(value: number | undefined, spec: BenchmarkConfig): string {
   if (typeof value !== 'number') return '—'
   return Number.isInteger(value) ? String(value) : value.toFixed(spec.precision)
 }

--- a/components/training-facility/shared/charts/primitives.test.tsx
+++ b/components/training-facility/shared/charts/primitives.test.tsx
@@ -1,0 +1,150 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { RoughBar, RoughLine, RoughScatter } from './'
+
+/**
+ * Minimal render coverage for the chart primitives. Per the issue's P2 list:
+ *
+ * - empty-data branch returns the EmptyChart placeholder
+ * - ariaLabel + ariaLabelledBy plumbed onto the SVG (so screen readers
+ *   actually announce something for hand-drawn data)
+ *
+ * Path output (from rough.js) is intentionally not asserted — the visual is
+ * spot-checked on the dev/charts preview, and re-rendering an SVG with a
+ * stable seed already happens in production every time the page loads.
+ */
+
+describe('RoughLine', () => {
+  it('renders the EmptyChart placeholder when data is empty', () => {
+    render(
+      <RoughLine
+        data={[] as Array<{ x: number; y: number }>}
+        x={(d) => d.x}
+        y={(d) => d.y}
+        width={400}
+        height={200}
+        ariaLabel="line chart"
+        emptyMessage="No data yet"
+      />,
+    )
+    // EmptyChart renders the message as a <text> element inside the SVG.
+    expect(screen.getByText('No data yet')).toBeInTheDocument()
+  })
+
+  it('uses the default empty message when none is provided', () => {
+    render(
+      <RoughLine
+        data={[] as Array<{ x: number; y: number }>}
+        x={(d) => d.x}
+        y={(d) => d.y}
+        width={400}
+        height={200}
+        ariaLabel="line chart"
+      />,
+    )
+    expect(screen.getByText('No data')).toBeInTheDocument()
+  })
+
+  it('plumbs ariaLabel through to the SVG when data is present', () => {
+    render(
+      <RoughLine
+        data={[
+          { x: 0, y: 1 },
+          { x: 1, y: 2 },
+        ]}
+        x={(d) => d.x}
+        y={(d) => d.y}
+        width={400}
+        height={200}
+        ariaLabel="vertical jump trend"
+      />,
+    )
+    expect(screen.getByRole('img', { name: 'vertical jump trend' })).toBeInTheDocument()
+  })
+
+  it('plumbs ariaLabelledBy to the SVG and omits aria-label in that case', () => {
+    render(
+      <>
+        <h2 id="chart-heading">Chart heading</h2>
+        <RoughLine
+          data={[{ x: 0, y: 1 }]}
+          x={(d) => d.x}
+          y={(d) => d.y}
+          width={400}
+          height={200}
+          ariaLabelledBy="chart-heading"
+        />
+      </>,
+    )
+    // role=img plus aria-labelledby resolves the accessible name from the heading.
+    expect(screen.getByRole('img', { name: 'Chart heading' })).toBeInTheDocument()
+  })
+})
+
+describe('RoughBar', () => {
+  it('renders the EmptyChart placeholder when data is empty', () => {
+    render(
+      <RoughBar
+        data={[] as Array<{ k: string; v: number }>}
+        x={(d) => d.k}
+        y={(d) => d.v}
+        width={400}
+        height={200}
+        ariaLabel="bar chart"
+        emptyMessage="No bars yet"
+      />,
+    )
+    expect(screen.getByText('No bars yet')).toBeInTheDocument()
+  })
+
+  it('plumbs ariaLabel through to the SVG when data is present', () => {
+    render(
+      <RoughBar
+        data={[
+          { k: 'A', v: 10 },
+          { k: 'B', v: 20 },
+        ]}
+        x={(d) => d.k}
+        y={(d) => d.v}
+        width={400}
+        height={200}
+        ariaLabel="HR zone distribution"
+      />,
+    )
+    expect(screen.getByRole('img', { name: 'HR zone distribution' })).toBeInTheDocument()
+  })
+})
+
+describe('RoughScatter', () => {
+  it('renders the EmptyChart placeholder when data is empty', () => {
+    render(
+      <RoughScatter
+        data={[] as Array<{ x: number; y: number }>}
+        x={(d) => d.x}
+        y={(d) => d.y}
+        width={400}
+        height={200}
+        ariaLabel="scatter chart"
+        emptyMessage="No samples yet"
+      />,
+    )
+    expect(screen.getByText('No samples yet')).toBeInTheDocument()
+  })
+
+  it('plumbs ariaLabel through to the SVG when data is present', () => {
+    render(
+      <RoughScatter
+        data={[
+          { x: 142, y: 9.8 },
+          { x: 158, y: 8.7 },
+        ]}
+        x={(d) => d.x}
+        y={(d) => d.y}
+        width={400}
+        height={200}
+        ariaLabel="pace vs heart rate"
+      />,
+    )
+    expect(screen.getByRole('img', { name: 'pace vs heart rate' })).toBeInTheDocument()
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@tailwindcss/postcss": "^4",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/d3-scale": "^4.0.9",
         "@types/node": "^20",
         "@types/react": "^19",
@@ -2178,6 +2179,20 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@tybys/wasm-util": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@tailwindcss/postcss": "^4",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/d3-scale": "^4.0.9",
     "@types/node": "^20",
     "@types/react": "^19",

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,6 +1,19 @@
 /**
- * Vitest global setup — extends `expect` with `@testing-library/jest-dom`
- * matchers (`toBeInTheDocument`, `toHaveAttribute`, etc.) so component tests
- * added in follow-up PRs read naturally without per-file imports.
+ * Vitest global setup.
+ *
+ * - Extends `expect` with `@testing-library/jest-dom` matchers
+ *   (`toBeInTheDocument`, `toHaveAttribute`, etc.) so component tests read
+ *   naturally without per-file imports.
+ * - Wires `cleanup` into `afterEach` so RTL unmounts the previous test's tree
+ *   before the next render. Without this, tests that re-render the same
+ *   component see "Found multiple elements" errors because mounted DOM leaks
+ *   across test boundaries — RTL's auto-cleanup only fires under Jest, not
+ *   Vitest.
  */
+import { afterEach } from 'vitest'
+import { cleanup } from '@testing-library/react'
 import '@testing-library/jest-dom/vitest'
+
+afterEach(() => {
+  cleanup()
+})


### PR DESCRIPTION
## Summary
Step 3 of #104. Closes out the P1/P2 component coverage from the issue checklist — 65 new tests bringing the suite to **168 across 11 files**, in ~3.5s.

### Helper exports (no behavior change)
\`TradingCard.tsx\` and \`DateFilter.tsx\` previously kept their pure helpers module-local. Promoted to named exports so they can be unit-tested directly:
- TradingCard: \`isPersonalBest\`, \`formatValue\`, \`formatCell\`, \`seasonFromDate\`
- DateFilter: \`subtractMonths\`, \`parseInputValue\`, \`toInputValue\`, \`rangeForPreset\`, \`startOfDay\`, \`endOfDay\`

### Tests added
**\`components/training-facility/shared/TradingCard.test.tsx\`** — 25 tests
- Helpers: \`isPersonalBest\` direction-awareness (higher = bigger wins, lower = smaller wins), strictly-prior comparison so a March entry doesn't lose its PB to April, \`is_complete=false\` filtering, missing-metric / no-prior-history early returns. \`formatValue\` precision + unit + rounding. \`formatCell\` integer shortcut + non-integer precision preservation. \`seasonFromDate\` quadrant table.
- Render: 4 metrics on front (with values formatted by \`formatValue\`), click toggles \`aria-pressed\`, custom \`season\` / \`playerName\` / \`playerNumber\` overrides, PB badge appears with prior history and is hidden without it, "No prior sessions" empty state, prior-session rows in the back-of-card table, notes section.

**\`components/training-facility/shared/DateFilter.test.tsx\`** — 26 tests
- Helpers: \`startOfDay\` / \`endOfDay\` time-component normalization. \`subtractMonths\` clamps Mar 31 → Feb 28 in non-leap and → Feb 29 in leap years, crosses year boundaries, handles many-month subtractions. \`toInputValue\` zero-pads. \`parseInputValue\` returns null on empty / malformed and round-trips with \`toInputValue\`. \`rangeForPreset\` invariant \`start <= end\` across every preset, ALL clamps when \`earliestDate\` is in the future. \`isInRange\` inclusive-on-both-ends.
- Render: 5 preset buttons rendered with documented labels, default preset reflected via \`aria-checked\`, preset click fires \`onChange\` with a range matching \`rangeForPreset\` (system clock frozen at April 15 2026 via \`vi.setSystemTime\`), custom date input deselects the active preset, ArrowRight / ArrowLeft / Home / End keyboard nav advances focus + selection (with wraparound at the ends).
- Uses \`vi.useFakeTimers({ shouldAdvanceTime: true })\` so userEvent's internal scheduling can advance while the system clock stays frozen — without that flag awaited userEvent calls hang under fake timers.

**\`components/training-facility/shared/charts/primitives.test.tsx\`** — 10 tests
- \`RoughLine\` / \`RoughBar\` / \`RoughScatter\` empty-data branch returns \`EmptyChart\` (renders the empty message + accessible name), \`ariaLabel\` plumbed onto the SVG \`role=img\`, \`ariaLabelledBy\` resolves the accessible name from an external heading.
- rough.js path output intentionally not asserted — visual is spot-checked on the dev/charts preview.

### Setup tweak
\`vitest.setup.ts\` adds \`afterEach(cleanup)\`. RTL's auto-cleanup is gated on Jest detection and doesn't fire under Vitest, so without this every component render leaks into the next test's DOM and produces "Found multiple elements" errors.

## Out of scope (intentional)
- Coverage threshold gate — flips on once subsequent PRs cover any remaining gaps. PR3 brings the listed Training-Facility-shared modules to high coverage but doesn't enforce a percentage.
- The \`visibilitychange\` re-anchor effect on \`DateFilter\` — exercising it requires patching \`document.visibilityState\` and provides little signal beyond \`selectPreset\`.
- API CI gating (Vercel preview check, GitHub Action) — same deferral as PR1.

## Test plan
- [ ] \`npm install && npm run test\` → 168 tests pass across 11 files in ~3.5s
- [ ] \`npm run test:coverage\` — \`TradingCard.tsx\`, \`DateFilter.tsx\`, and the three chart primitives now show coverage in the HTML report
- [ ] \`npx tsc --noEmit\` clean
- [ ] \`npx next build\` clean
- [ ] On the Vercel preview, \`/dev/charts\` and \`/dev/trading-card\` still render correctly (helper exports are additive — no runtime behavior change)

Refs #104.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suites for date filtering, training card display, and chart components.
  * Enhanced test infrastructure with improved cleanup between test runs.

* **Chores**
  * Updated testing dependencies to support user interaction testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->