### PR TITLE
feat(seo): inter-room "Next stop" chip nav on every non-home room (#44)

### DIFF
--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -35,14 +35,12 @@ export default function ContactPage() {
               <ZoneContact />
             </FrontOfficeZone>
           ),
-          'back-to-court': (
-            <FrontOfficeZone x={1320} y={980} width={340} height={70}>
-              <BackToCourtButton />
-            </FrontOfficeZone>
-          ),
           'next-stop-nav': (
-            <FrontOfficeZone x={40} y={950} width={1260} height={80}>
-              <NextStopNav current="contact" />
+            <FrontOfficeZone x={20} y={950} width={1516} height={80}>
+              <div className="flex h-full items-center justify-end gap-3 pr-2">
+                <NextStopNav current="contact" />
+                <BackToCourtButton />
+              </div>
             </FrontOfficeZone>
           ),
           resume: (

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { BackToCourtButton } from '@/components/common/BackToCourtButton'
+import { NextStopNav } from '@/components/common/NextStopNav'
 import { FrontOfficeSvg } from '@/components/contact/FrontOfficeSvg'
 import { FrontOfficeZone } from '@/components/contact/FrontOfficeZone'
 import { LosAngelesPictureSvg } from '@/components/contact/LosAngelesPictureSvg'
@@ -37,6 +38,11 @@ export default function ContactPage() {
           'back-to-court': (
             <FrontOfficeZone x={1320} y={980} width={340} height={70}>
               <BackToCourtButton />
+            </FrontOfficeZone>
+          ),
+          'next-stop-nav': (
+            <FrontOfficeZone x={40} y={950} width={1260} height={80}>
+              <NextStopNav current="contact" />
             </FrontOfficeZone>
           ),
           resume: (

--- a/app/locker-room/page.tsx
+++ b/app/locker-room/page.tsx
@@ -20,6 +20,7 @@ import { StrawHatSvg } from '@/components/locker-room/assets/StrawHatSvg'
 import { JerseysSVG } from '@/components/locker-room/assets/JerseysSvg'
 import { LaptopSvg } from '@/components/locker-room/assets/LaptopSvg'
 import { BackToCourtButton } from '@/components/common/BackToCourtButton'
+import { NextStopNav } from '@/components/common/NextStopNav'
 import { LockerInfo } from '@/components/locker-room/LockerInfo'
 import { SvgLayoutContainer } from '@/components/common/SvgLayoutContainer'
 import { Yellow4Jersey } from '@/components/locker-room/assets/Yellow4Jersey'
@@ -360,6 +361,11 @@ export default function LockerRoomPage() {
           'back-to-court': (
             <LockerZone x={1220} y={970} width={340} height={70}>
               <BackToCourtButton />
+            </LockerZone>
+          ),
+          'next-stop-nav': (
+            <LockerZone x={40} y={950} width={1160} height={80}>
+              <NextStopNav current="locker-room" />
             </LockerZone>
           ),
           'locker-info': (

--- a/app/locker-room/page.tsx
+++ b/app/locker-room/page.tsx
@@ -358,14 +358,12 @@ export default function LockerRoomPage() {
               <PS5ControllerSVG />
             </LockerZone>
           ),
-          'back-to-court': (
-            <LockerZone x={1220} y={970} width={340} height={70}>
-              <BackToCourtButton />
-            </LockerZone>
-          ),
           'next-stop-nav': (
-            <LockerZone x={40} y={950} width={1160} height={80}>
-              <NextStopNav current="locker-room" />
+            <LockerZone x={20} y={950} width={1516} height={80}>
+              <div className="flex h-full items-center justify-end gap-3 pr-2">
+                <NextStopNav current="locker-room" />
+                <BackToCourtButton />
+              </div>
             </LockerZone>
           ),
           'locker-info': (

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -19,11 +19,12 @@ export default function ProjectPage() {
     <div className="bg-[url('/textures/binder-leather.png')] bg-center bg-cover bg-no-repeat min-h-screen flex flex-col relative">
       <h1 className="sr-only">Project Binder — Lucas Lawrence</h1>
       {/* Header Controls */}
-      <SectionContainer className="pt-4 pb-2 z-10 flex justify-between">
+      <SectionContainer className="pt-4 pb-2 z-10 flex flex-wrap items-center justify-between gap-3">
         <div className="text-xs bg-black/30 text-white px-3 py-1 font-mono rounded-tr-md">
           Page 1
         </div>
-        <div className="text-xs bg-black/30 text-white px-3 py-1 font-mono rounded-tr-md">
+        <div className="flex flex-wrap items-center gap-3">
+          <NextStopNav current="projects" />
           <BackToCourtButton />
         </div>
       </SectionContainer>
@@ -44,10 +45,6 @@ export default function ProjectPage() {
 
         <ProjectGallery />
       </div>
-
-      <SectionContainer className="pb-6 pt-4">
-        <NextStopNav current="projects" />
-      </SectionContainer>
     </div>
   )
 }

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { BackToCourtButton } from '@/components/common/BackToCourtButton'
+import { NextStopNav } from '@/components/common/NextStopNav'
 import { SectionContainer } from '@/components/common/SectionContainer'
 import React from 'react'
 import { ProjectGallery } from '@/components/project-binder/ProjectGallery'
@@ -43,6 +44,10 @@ export default function ProjectPage() {
 
         <ProjectGallery />
       </div>
+
+      <SectionContainer className="pb-6 pt-4">
+        <NextStopNav current="projects" />
+      </SectionContainer>
     </div>
   )
 }

--- a/components/banners/BannersView.tsx
+++ b/components/banners/BannersView.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link'
 import { motion } from 'framer-motion'
 import { BannerCard, BannerProps } from '@/components/common/BannerCard'
+import { NextStopNav } from '@/components/common/NextStopNav'
 
 export type BannerSection = {
   label: string
@@ -41,7 +42,8 @@ export function BannersView({ sections }: { sections: BannerSection[] }) {
             </div>
           ))}
 
-          <div className="mt-20">
+          <div className="mt-20 flex flex-col items-center gap-6">
+            <NextStopNav current="rafters" className="justify-center" />
             <Link href="/" className="text-orange-300 underline hover:text-orange-100">
               Back to the Court
             </Link>

--- a/components/banners/BannersView.tsx
+++ b/components/banners/BannersView.tsx
@@ -42,8 +42,8 @@ export function BannersView({ sections }: { sections: BannerSection[] }) {
             </div>
           ))}
 
-          <div className="mt-20 flex flex-col items-center gap-6">
-            <NextStopNav current="rafters" className="justify-center" />
+          <div className="mt-20 flex flex-wrap items-center justify-center gap-x-4 gap-y-3">
+            <NextStopNav current="rafters" />
             <Link href="/" className="text-orange-300 underline hover:text-orange-100">
               Back to the Court
             </Link>

--- a/components/banners/BannersView.tsx
+++ b/components/banners/BannersView.tsx
@@ -1,9 +1,9 @@
 ﻿'use client'
 
-import Link from 'next/link'
 import { motion } from 'framer-motion'
 import { BannerCard, BannerProps } from '@/components/common/BannerCard'
 import { NextStopNav } from '@/components/common/NextStopNav'
+import { BackToCourtButton } from '@/components/common/BackToCourtButton'
 
 export type BannerSection = {
   label: string
@@ -42,11 +42,9 @@ export function BannersView({ sections }: { sections: BannerSection[] }) {
             </div>
           ))}
 
-          <div className="mt-20 flex flex-wrap items-center justify-center gap-x-4 gap-y-3">
+          <div className="mt-20 flex flex-wrap items-center justify-center gap-3">
             <NextStopNav current="rafters" />
-            <Link href="/" className="text-orange-300 underline hover:text-orange-100">
-              Back to the Court
-            </Link>
+            <BackToCourtButton />
           </div>
         </div>
       </div>

--- a/components/common/BackToCourtButton.tsx
+++ b/components/common/BackToCourtButton.tsx
@@ -9,7 +9,7 @@ export function BackToCourtButton() {
   return (
     <Link
       href="/"
-      className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs sm:text-sm rounded-full border border-white/20 bg-black/85 text-white hover:border-orange-300 hover:bg-orange-500 transition shadow-sm whitespace-nowrap cursor-pointer"
+      className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs sm:text-sm rounded-full border border-white/40 bg-white/10 backdrop-blur-sm text-white hover:border-orange-300 hover:bg-orange-500 transition shadow-sm whitespace-nowrap cursor-pointer"
     >
       🏀 Home Court
     </Link>

--- a/components/common/BackToCourtButton.tsx
+++ b/components/common/BackToCourtButton.tsx
@@ -9,9 +9,9 @@ export function BackToCourtButton() {
   return (
     <Link
       href="/"
-      className="px-3 py-1.5 text-xs sm:text-sm rounded-full bg-black text-white hover:bg-orange-500 transition shadow-sm whitespace-nowrap cursor-pointer"
+      className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs sm:text-sm rounded-full border border-white/20 bg-black/85 text-white hover:border-orange-300 hover:bg-orange-500 transition shadow-sm whitespace-nowrap cursor-pointer"
     >
-      🏀 Back to Home Court
+      🏀 Home Court
     </Link>
   )
 }

--- a/components/common/NextStopNav.tsx
+++ b/components/common/NextStopNav.tsx
@@ -72,7 +72,7 @@ export function NextStopNav({ current, className }: NextStopNavProps) {
           <Link
             key={key}
             href={room.href}
-            className="inline-flex items-center gap-1.5 whitespace-nowrap rounded-full bg-black/70 px-3 py-1.5 text-xs font-medium text-white shadow-sm transition hover:bg-orange-500 sm:text-sm"
+            className="inline-flex items-center gap-1.5 whitespace-nowrap rounded-full border border-white/20 bg-black/85 px-3 py-1.5 text-xs font-medium text-white shadow-sm transition hover:border-orange-300 hover:bg-orange-500 sm:text-sm"
           >
             <span aria-hidden="true">{room.icon}</span>
             <span>{room.label}</span>

--- a/components/common/NextStopNav.tsx
+++ b/components/common/NextStopNav.tsx
@@ -1,0 +1,84 @@
+'use client'
+
+import Link from 'next/link'
+
+/**
+ * Stable identifier for each non-home room participating in the inter-room
+ * "Next stop" navigation. The home court itself is reached via
+ * {@link BackToCourtButton}, so it is intentionally absent from this set.
+ */
+export type RoomKey = 'rafters' | 'locker-room' | 'projects' | 'contact'
+
+/**
+ * Display metadata for a sibling room chip. Icons mirror the home court's
+ * existing entry buttons (`useZoneContent`) so the inter-room link graph
+ * reads as the same vocabulary the visitor saw on the court.
+ */
+type RoomMeta = {
+  /** Internal route, consumed by `next/link`. */
+  href: string
+  /** Emoji glyph rendered before the label; decorative only (`aria-hidden`). */
+  icon: string
+  /** Visible chip label and accessible name for the link. */
+  label: string
+}
+
+const ROOMS: Record<RoomKey, RoomMeta> = {
+  rafters: { href: '/banners', icon: '🏟️', label: 'Rafters' },
+  'locker-room': { href: '/locker-room', icon: '🧳', label: 'Locker Room' },
+  projects: { href: '/projects', icon: '🎨', label: 'Project Binder' },
+  contact: { href: '/contact', icon: '📫', label: 'Front Office' },
+}
+
+/**
+ * Stable display order — siblings are rendered in this order with the
+ * `current` room filtered out, so each room's chip strip reads consistently
+ * regardless of which room the visitor is on.
+ */
+const ORDER: readonly RoomKey[] = ['rafters', 'locker-room', 'projects', 'contact']
+
+export interface NextStopNavProps {
+  /** The room currently being rendered. Filtered out of the chip list. */
+  current: RoomKey
+  /** Optional Tailwind classes appended to the root `<nav>` element. */
+  className?: string
+}
+
+/**
+ * Renders a horizontal "Next stop" chip strip linking to the other rooms in
+ * the site. Each non-home room embeds this nav so visitors can hop directly
+ * between rooms without bouncing through the court, and so the internal link
+ * graph fans out symmetrically for SEO.
+ *
+ * Uses `next/link` for client-side navigation and crawler-friendly `<a>`
+ * tags. The `<nav>` element carries `aria-label="Other rooms"` so assistive
+ * tech can distinguish this strip from the existing "Back to Home Court"
+ * button it sits alongside.
+ */
+export function NextStopNav({ current, className }: NextStopNavProps) {
+  const siblings = ORDER.filter(key => key !== current)
+
+  return (
+    <nav
+      aria-label="Other rooms"
+      className={`flex flex-wrap items-center gap-2 ${className ?? ''}`}
+    >
+      <span className="text-[10px] font-mono uppercase tracking-widest text-white/70">
+        Next stop
+      </span>
+      {siblings.map(key => {
+        const room = ROOMS[key]
+        return (
+          <Link
+            key={key}
+            href={room.href}
+            className="inline-flex items-center gap-1.5 whitespace-nowrap rounded-full bg-black/70 px-3 py-1.5 text-xs font-medium text-white shadow-sm transition hover:bg-orange-500 sm:text-sm"
+          >
+            <span aria-hidden="true">{room.icon}</span>
+            <span>{room.label}</span>
+          </Link>
+        )
+      })}
+    </nav>
+  )
+}

--- a/components/common/NextStopNav.tsx
+++ b/components/common/NextStopNav.tsx
@@ -72,7 +72,7 @@ export function NextStopNav({ current, className }: NextStopNavProps) {
           <Link
             key={key}
             href={room.href}
-            className="inline-flex items-center gap-1.5 whitespace-nowrap rounded-full border border-white/20 bg-black/85 px-3 py-1.5 text-xs font-medium text-white shadow-sm transition hover:border-orange-300 hover:bg-orange-500 sm:text-sm"
+            className="inline-flex items-center gap-1.5 whitespace-nowrap rounded-full border border-white/40 bg-white/10 px-3 py-1.5 text-xs font-medium text-white shadow-sm backdrop-blur-sm transition hover:border-orange-300 hover:bg-orange-500 sm:text-sm"
           >
             <span aria-hidden="true">{room.icon}</span>
             <span>{room.label}</span>

--- a/components/locker-room/types.ts
+++ b/components/locker-room/types.ts
@@ -27,4 +27,9 @@ export type LockerZoneId =
   | 'snap-shoes'
   | 'ghost-logo-jersey'
 
-export type LockerContentKey = LockerZoneId | 'title' | 'back-to-court' | 'locker-info'
+export type LockerContentKey =
+  | LockerZoneId
+  | 'title'
+  | 'back-to-court'
+  | 'locker-info'
+  | 'next-stop-nav'


### PR DESCRIPTION
## Summary

Each non-home room (Locker Room, Front Office, Project Binder, Rafters) now carries a small footer "Next stop" chip strip linking to the other three rooms via `next/link`. Visitors can hop directly between rooms without bouncing through the court, and crawlers see a symmetric inter-room link graph for SEO.

A shared `NextStopNav` component encodes the four-room set in one place and renders the three siblings appropriate to whichever room is current. Each chip uses the same emoji vocabulary the home court already uses for the room entry buttons (🏟️ Rafters, 🧳 Locker Room, 🎨 Project Binder, 📫 Front Office), so the cross-room nav reads as the same language visitors saw on the court.

The chip strip sits inside a `<nav aria-label="Other rooms">` and renders alongside the existing "Back to Home Court" affordance — both are still present on every room.

## Test plan

- [ ] Open `/locker-room` — confirm a "Next stop" chip strip appears at the bottom-left with chips for Rafters, Project Binder, Front Office. The existing "Back to Home Court" button is still present at the bottom-right.
- [ ] Click each chip — navigates to the right room.
- [ ] Repeat on `/contact` — chips for Rafters, Locker Room, Project Binder.
- [ ] Repeat on `/projects` — chips for Rafters, Locker Room, Front Office at the bottom of the page (below the gallery).
- [ ] Repeat on `/banners` — chips for Locker Room, Project Binder, Front Office, with the existing "Back to the Court" link below them.
- [ ] Inspect the rendered DOM in any one of these pages: chip links use `<a href="/...">` (real anchors via `next/link`), not button onClicks. Confirms the SEO link-graph payoff.
- [ ] Resize to mobile portrait (~390px) — chip strip wraps cleanly to multiple rows; chips remain tappable.
- [ ] On `/locker-room` and `/contact`, confirm the chip strip does not regress the existing item interactions (locker zones still clickable, contact form still works).

Closes #44.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Next Stop" navigation component across multiple pages, allowing users to quickly navigate between different sections (Contact, Locker Room, Projects, and Banners areas).
  * Displays section-specific navigation links with icons and labels in a new bottom navigation area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->