### PR TITLE
test(e2e): add Playwright route smoke coverage (#83)

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,31 @@
+name: Playwright E2E
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Run Playwright smoke suite
+        run: npm run test:e2e

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,10 @@
 
 # testing
 /coverage
+/playwright-report
+/test-results
+/.next-e2e-default
+/.next-e2e-training-facility
 
 # next.js
 /.next/

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -30,7 +30,7 @@ export default function ProjectPage() {
       {/* Page content — wrapped by the root layout's <main id="main"> landmark. */}
       <div className="flex-grow w-full">
         <SectionContainer className="pt-2 pb-1">
-          <div className="text-yellow-200 uppercase tracking-wide text-sm font-mono">
+          <div data-testid="projects-title" className="text-yellow-200 uppercase tracking-wide text-sm font-mono">
             Lucas Lawrence // Tech Stack Binder
           </div>
         </SectionContainer>

--- a/e2e/helpers/intro.ts
+++ b/e2e/helpers/intro.ts
@@ -1,0 +1,14 @@
+import type { Page } from '@playwright/test'
+
+const HAS_SEEN_INTRO_KEY = 'hasSeenIntro'
+
+/**
+ * Seeds localStorage so the home page skips the tunnel intro animation.
+ *
+ * @param page - Playwright page that should start on the post-intro court.
+ */
+export async function bypassHomeIntro(page: Page): Promise<void> {
+  await page.addInitScript(storageKey => {
+    window.localStorage.setItem(storageKey, 'true')
+  }, HAS_SEEN_INTRO_KEY)
+}

--- a/e2e/helpers/intro.ts
+++ b/e2e/helpers/intro.ts
@@ -1,5 +1,6 @@
 import type { Page } from '@playwright/test'
 
+/** LocalStorage key used to persist whether the visitor has already seen the intro. */
 const HAS_SEEN_INTRO_KEY = 'hasSeenIntro'
 
 /**

--- a/e2e/home.spec.ts
+++ b/e2e/home.spec.ts
@@ -1,0 +1,29 @@
+import { expect, test } from '@playwright/test'
+
+import { bypassHomeIntro } from './helpers/intro'
+
+test.describe('home court', () => {
+  test.beforeEach(async ({ page }) => {
+    await bypassHomeIntro(page)
+  })
+
+  test('renders the primary navigation affordances', async ({ page }) => {
+    await page.goto('/')
+
+    await expect(page.getByRole('button', { name: /view the rafters/i })).toBeVisible()
+    await expect(page.getByRole('button', { name: /enter locker room/i })).toBeVisible()
+    await expect(page.getByRole('button', { name: /view project binder/i })).toBeVisible()
+    await expect(page.getByRole('button', { name: /go to front office/i })).toBeVisible()
+  })
+
+  test('navigates from the home court into the locker room', async ({ page }) => {
+    await page.goto('/')
+
+    await page.getByRole('button', { name: /enter locker room/i }).click()
+
+    await expect(page).toHaveURL(/\/locker-room$/)
+    await expect(
+      page.getByRole('heading', { name: /locker room - select an item to get more info/i })
+    ).toBeVisible()
+  })
+})

--- a/e2e/rooms.spec.ts
+++ b/e2e/rooms.spec.ts
@@ -14,7 +14,7 @@ const roomExpectations: RoomExpectation[] = [
   },
   {
     route: '/projects',
-    locator: page => page.getByText(/tech stack binder/i),
+    locator: page => page.getByTestId('projects-title'),
     backLinkName: /back to home court/i,
   },
   {

--- a/e2e/rooms.spec.ts
+++ b/e2e/rooms.spec.ts
@@ -1,0 +1,47 @@
+import { expect, test, type Locator, type Page } from '@playwright/test'
+
+type RoomExpectation = {
+  route: string
+  locator: (page: Page) => Locator
+  backLinkName: RegExp
+}
+
+const roomExpectations: RoomExpectation[] = [
+  {
+    route: '/locker-room',
+    locator: page => page.getByRole('heading', { name: /locker room - select an item to get more info/i }),
+    backLinkName: /back to home court/i,
+  },
+  {
+    route: '/projects',
+    locator: page => page.getByText(/tech stack binder/i),
+    backLinkName: /back to home court/i,
+  },
+  {
+    route: '/contact',
+    locator: page => page.getByRole('heading', { name: /scouting inquiry/i }),
+    backLinkName: /back to home court/i,
+  },
+  {
+    route: '/banners',
+    locator: page => page.getByRole('heading', { name: /the rafters/i }),
+    backLinkName: /back to the court/i,
+  },
+]
+
+test.describe('room routes', () => {
+  for (const { route, locator, backLinkName } of roomExpectations) {
+    test(`renders ${route}`, async ({ page }) => {
+      await page.goto(route)
+
+      await expect(locator(page)).toBeVisible()
+      await expect(page.getByRole('link', { name: backLinkName })).toBeVisible()
+    })
+  }
+
+  test('contact page exposes the resume affordance', async ({ page }) => {
+    await page.goto('/contact')
+
+    await expect(page.getByRole('link', { name: /view full resume \(pdf\)/i })).toBeVisible()
+  })
+})

--- a/e2e/training-facility-disabled.spec.ts
+++ b/e2e/training-facility-disabled.spec.ts
@@ -2,6 +2,7 @@ import { expect, test } from '@playwright/test'
 
 import { bypassHomeIntro } from './helpers/intro'
 
+/** Routes that should continue to render the custom 404 while the feature flag is off. */
 const gatedRoutes = ['/training-facility', '/training-facility/gym', '/training-facility/combine']
 
 test.describe('training facility disabled', () => {

--- a/e2e/training-facility-disabled.spec.ts
+++ b/e2e/training-facility-disabled.spec.ts
@@ -1,0 +1,27 @@
+import { expect, test } from '@playwright/test'
+
+import { bypassHomeIntro } from './helpers/intro'
+
+const gatedRoutes = ['/training-facility', '/training-facility/gym', '/training-facility/combine']
+
+test.describe('training facility disabled', () => {
+  test.beforeEach(async ({ page }) => {
+    await bypassHomeIntro(page)
+  })
+
+  test('does not expose the home-court entrance when the flag is off', async ({ page }) => {
+    await page.goto('/')
+
+    await expect(page.getByRole('button', { name: /enter the training facility/i })).toHaveCount(0)
+  })
+
+  for (const route of gatedRoutes) {
+    test(`renders the custom 404 for ${route}`, async ({ page }) => {
+      await page.goto(route)
+
+      await expect(page.getByText('AIRBALL.')).toBeVisible()
+      await expect(page.getByText(route)).toBeVisible()
+      await expect(page.getByRole('link', { name: /back to home court/i })).toBeVisible()
+    })
+  }
+})

--- a/e2e/training-facility-enabled.spec.ts
+++ b/e2e/training-facility-enabled.spec.ts
@@ -1,0 +1,34 @@
+import { expect, test } from '@playwright/test'
+
+import { bypassHomeIntro } from './helpers/intro'
+
+test.describe('training facility enabled', () => {
+  test.beforeEach(async ({ page }) => {
+    await bypassHomeIntro(page)
+  })
+
+  test('shows the court-side entrance on the home page', async ({ page }) => {
+    await page.goto('/')
+
+    await expect(page.getByRole('button', { name: /enter the training facility/i })).toBeVisible()
+  })
+
+  test('renders the top-level shell route', async ({ page }) => {
+    await page.goto('/training-facility')
+
+    await expect(page.getByRole('heading', { name: /pick a door\./i })).toBeVisible()
+    await expect(page.getByRole('link', { name: /the gym/i })).toBeVisible()
+    await expect(page.getByRole('link', { name: /the combine/i })).toBeVisible()
+    await expect(page.getByRole('button', { name: /weight room/i })).toBeDisabled()
+  })
+
+  test('renders the gym and combine placeholder routes', async ({ page }) => {
+    await page.goto('/training-facility/gym')
+    await expect(page.getByRole('heading', { name: /^the gym$/i })).toBeVisible()
+    await expect(page.getByRole('link', { name: /back to training facility/i })).toBeVisible()
+
+    await page.goto('/training-facility/combine')
+    await expect(page.getByRole('heading', { name: /^the combine$/i })).toBeVisible()
+    await expect(page.getByRole('link', { name: /back to training facility/i })).toBeVisible()
+  })
+})

--- a/next.config.ts
+++ b/next.config.ts
@@ -25,7 +25,15 @@ const contentSecurityPolicyReportOnly = [
   'upgrade-insecure-requests',
 ].join('; ')
 
+/**
+ * Optional alternate build output directory used by the Playwright
+ * smoke suite so the feature-flagged and default dev servers do not
+ * share the same client bundle cache.
+ */
+const distDir = process.env.NEXT_DIST_DIR || '.next'
+
 const nextConfig: NextConfig = {
+  distDir,
   /**
    * Applies baseline security response headers to every route in the
    * app, including public assets and App Router pages.

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "zod": "^4.3.6"
       },
       "devDependencies": {
+        "@playwright/test": "^1.59.1",
         "@tailwindcss/postcss": "^4",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
@@ -30,6 +31,7 @@
         "@vitejs/plugin-react": "^6.0.1",
         "@vitest/coverage-v8": "^4.1.5",
         "autoprefixer": "^10.4.21",
+        "cross-env": "^10.1.0",
         "eslint": "9.39.2",
         "eslint-config-next": "16.1.1",
         "jsdom": "^29.0.2",
@@ -556,6 +558,13 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@epic-web/invariant": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+      "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
@@ -1514,6 +1523,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -3663,6 +3688,24 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cross-env": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
+      "integrity": "sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@epic-web/invariant": "^1.0.0",
+        "cross-spawn": "^7.0.6"
+      },
+      "bin": {
+        "cross-env": "dist/bin/cross-env.js",
+        "cross-env-shell": "dist/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -6812,6 +6855,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/points-on-curve": {

--- a/package.json
+++ b/package.json
@@ -9,9 +9,12 @@
     "lint": "next lint",
     "format": "prettier --write \"**/*.{ts,tsx}\"",
     "import-health": "node scripts/import-health.mjs",
+    "e2e:dev": "cross-env NEXT_DIST_DIR=.next-e2e-default next dev --turbopack --hostname 127.0.0.1 --port 3007",
+    "e2e:dev:training-facility": "cross-env NEXT_DIST_DIR=.next-e2e-training-facility NEXT_PUBLIC_ENABLE_TRAINING_FACILITY=true next dev --turbopack --hostname 127.0.0.1 --port 3008",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@vercel/analytics": "^1.5.0",
@@ -26,6 +29,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@tailwindcss/postcss": "^4",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
@@ -36,6 +40,7 @@
     "@vitejs/plugin-react": "^6.0.1",
     "@vitest/coverage-v8": "^4.1.5",
     "autoprefixer": "^10.4.21",
+    "cross-env": "^10.1.0",
     "eslint": "9.39.2",
     "eslint-config-next": "16.1.1",
     "jsdom": "^29.0.2",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint",
     "format": "prettier --write \"**/*.{ts,tsx}\"",
     "import-health": "node scripts/import-health.mjs",
-    "e2e:dev": "cross-env NEXT_DIST_DIR=.next-e2e-default next dev --turbopack --hostname 127.0.0.1 --port 3007",
+    "e2e:dev": "cross-env NEXT_DIST_DIR=.next-e2e-default NEXT_PUBLIC_ENABLE_TRAINING_FACILITY=false next dev --turbopack --hostname 127.0.0.1 --port 3007",
     "e2e:dev:training-facility": "cross-env NEXT_DIST_DIR=.next-e2e-training-facility NEXT_PUBLIC_ENABLE_TRAINING_FACILITY=true next dev --turbopack --hostname 127.0.0.1 --port 3008",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,7 +1,12 @@
 import { defineConfig } from '@playwright/test'
 
+/** Base URL for the default route smoke-test project. */
 const DEFAULT_BASE_URL = 'http://127.0.0.1:3007'
+
+/** Base URL for the feature-flag-enabled Training Facility smoke-test project. */
 const TRAINING_FACILITY_BASE_URL = 'http://127.0.0.1:3008'
+
+/** Whether the Playwright run is executing under CI. */
 const IS_CI = Boolean(process.env.CI)
 
 export default defineConfig({

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -9,6 +9,10 @@ const TRAINING_FACILITY_BASE_URL = 'http://127.0.0.1:3008'
 /** Whether the Playwright run is executing under CI. */
 const IS_CI = Boolean(process.env.CI)
 
+/**
+ * Playwright configuration for route smoke coverage across the default and
+ * Training Facility-enabled app states.
+ */
 export default defineConfig({
   testDir: './e2e',
   fullyParallel: true,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,55 @@
+import { defineConfig } from '@playwright/test'
+
+const DEFAULT_BASE_URL = 'http://127.0.0.1:3007'
+const TRAINING_FACILITY_BASE_URL = 'http://127.0.0.1:3008'
+const IS_CI = Boolean(process.env.CI)
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: IS_CI,
+  retries: IS_CI ? 2 : 0,
+  workers: IS_CI ? 1 : undefined,
+  reporter: IS_CI ? [['github'], ['html', { open: 'never' }]] : [['list'], ['html', { open: 'never' }]],
+  use: {
+    browserName: 'chromium',
+    headless: true,
+    screenshot: 'only-on-failure',
+    trace: 'on-first-retry',
+    video: 'retain-on-failure',
+  },
+  projects: [
+    {
+      name: 'default-routes',
+      testMatch: /(?:home|rooms|training-facility-disabled)\.spec\.ts/,
+      use: {
+        baseURL: DEFAULT_BASE_URL,
+      },
+    },
+    {
+      name: 'training-facility-enabled',
+      testMatch: /training-facility-enabled\.spec\.ts/,
+      use: {
+        baseURL: TRAINING_FACILITY_BASE_URL,
+      },
+    },
+  ],
+  webServer: [
+    {
+      command: 'npm run e2e:dev',
+      url: DEFAULT_BASE_URL,
+      timeout: 180_000,
+      reuseExistingServer: !IS_CI,
+      stdout: 'pipe',
+      stderr: 'pipe',
+    },
+    {
+      command: 'npm run e2e:dev:training-facility',
+      url: TRAINING_FACILITY_BASE_URL,
+      timeout: 180_000,
+      reuseExistingServer: !IS_CI,
+      stdout: 'pipe',
+      stderr: 'pipe',
+    },
+  ],
+})

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -7,7 +7,7 @@ const DEFAULT_BASE_URL = 'http://127.0.0.1:3007'
 const TRAINING_FACILITY_BASE_URL = 'http://127.0.0.1:3008'
 
 /** Whether the Playwright run is executing under CI. */
-const IS_CI = Boolean(process.env.CI)
+const IS_CI = /^(1|true)$/i.test(process.env.CI ?? '') || process.env.GITHUB_ACTIONS === 'true'
 
 /**
  * Playwright configuration for route smoke coverage across the default and

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,15 @@
       "@/*": ["./*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", "app/banners", "global.d.ts"],
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next-e2e-default/types/**/*.ts",
+    ".next-e2e-training-facility/types/**/*.ts",
+    "app/banners",
+    "global.d.ts"
+  ],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary
- rewrite issue #83 around the current Next.js app and ship the first Playwright slice
- add Playwright config, route smoke tests, and a minimal GitHub Actions workflow
- cover the Training Facility feature flag in both disabled and enabled states by running two isolated Next dev servers with separate `distDir`s

## What is covered
- `/` home court smoke coverage with intro bypass via `localStorage`
- room route smoke coverage for `/locker-room`, `/projects`, `/contact`, and `/banners`
- Training Facility off-state coverage: no home-court entrance and custom 404s for `/training-facility`, `/training-facility/gym`, and `/training-facility/combine`
- Training Facility on-state coverage: home-court entrance visible, shell route renders, Gym/Combine placeholder routes render

## Notes
- the previous issue body was stale (`src/`, Vite on `5173`, upload-flow assertions). This branch updates the issue and implements the repo-accurate scope.
- dual `NEXT_PUBLIC_ENABLE_TRAINING_FACILITY` coverage required isolated build output directories; otherwise the client bundle bled between the two dev servers.
- Next will warn about multiple lockfiles when this runs from a local git worktree. That is a local-worktree warning, not a CI blocker.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run test:e2e`

Closes #83.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added Playwright E2E suites for home, rooms, and training-facility (enabled/disabled); includes a helper to bypass the intro and a stable test selector for projects.
* **CI**
  * New E2E workflow runs on pull requests and main pushes to execute the smoke test suite.
* **Chores**
  * Added E2E scripts/config, alternate build output support, and ignore rules for generated E2E artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->