### PR TITLE
feat(gym): stair climber detail view (#62)

### DIFF
--- a/app/training-facility/gym/page.tsx
+++ b/app/training-facility/gym/page.tsx
@@ -14,6 +14,15 @@ export default function TrainingFacilityGymPage() {
       title="The Gym"
       description="This is where the cardio side of the Training Facility takes shape: the migrated stair-climber dashboard, running and walking views, and the stat wall that pulls the metrics into one room."
       accentClassName="bg-gradient-to-r from-amber-300 via-orange-400 to-amber-500"
+      // Temporary CTA — surfaces the first Gym detail view (PRD §7.4) before
+      // the Gym scene SVG (#61) lands and wires the click directly on the
+      // stair-climber group. Goes away with the placeholder shell once #61 merges.
+      cta={{
+        href: '/training-facility/gym/stair',
+        label: 'Open stair climber',
+        helper:
+          'First Gym detail surface — HR zone bars, per-session avg HR, and the session log.',
+      }}
       nextSteps={[
         'Build the Gym scene art and equipment entry points.',
         'Wire cardio.json into the room-level visualizations.',

--- a/app/training-facility/gym/stair/page.tsx
+++ b/app/training-facility/gym/stair/page.tsx
@@ -1,0 +1,15 @@
+import { isTrainingFacilityEnabled } from '@/lib/feature-flags'
+import { StairDetailView } from '@/components/training-facility/gym/StairDetailView'
+import { notFound } from 'next/navigation'
+
+/**
+ * Renders the Stair Climber detail view (PRD §7.4) — the first Gym detail
+ * surface. Click-from-scene wiring lands once issue #61 (Gym scene SVG) is in.
+ * Until then the route is reachable directly and via a temporary CTA on
+ * `/training-facility/gym`.
+ */
+export default function TrainingFacilityGymStairPage() {
+  if (!isTrainingFacilityEnabled()) notFound()
+
+  return <StairDetailView />
+}

--- a/components/training-facility/TrainingFacilitySubareaShell.tsx
+++ b/components/training-facility/TrainingFacilitySubareaShell.tsx
@@ -3,6 +3,20 @@ import Link from 'next/link'
 import { BackToCourtButton } from '@/components/common/BackToCourtButton'
 
 /**
+ * Optional call-to-action rendered below the placeholder copy. Used while the
+ * sub-area is still a placeholder but already has at least one real interior
+ * route worth navigating to (e.g. the Stair Climber detail view).
+ */
+export type TrainingFacilitySubareaCta = {
+  /** Internal Next.js path the CTA links to. */
+  href: string
+  /** Visible button text. */
+  label: string
+  /** Sub-line shown under the CTA button — short context for the destination. */
+  helper?: string
+}
+
+/**
  * Props for the placeholder Training Facility sub-area shell used by Gym and Combine.
  */
 type TrainingFacilitySubareaShellProps = {
@@ -30,6 +44,15 @@ type TrainingFacilitySubareaShellProps = {
    * Concrete next-phase items that make the placeholder route useful today.
    */
   nextSteps: string[]
+
+  /**
+   * Optional CTA rendered after the description. Bridge while a sub-area still
+   * uses the placeholder shell but already has at least one real interior
+   * route worth surfacing — e.g. the Gym placeholder linking to the Stair
+   * Climber detail view before the Gym scene SVG lands. Goes away once the
+   * scene replaces this shell entirely.
+   */
+  cta?: TrainingFacilitySubareaCta
 }
 
 /**
@@ -43,6 +66,8 @@ type TrainingFacilitySubareaShellProps = {
  * @param props.description - Short explanation of what the finished sub-area will contain.
  * @param props.accentClassName - Tailwind class string used for the room's accent bar.
  * @param props.nextSteps - Ordered list of follow-up implementation items for the sub-area.
+ * @param props.cta - Optional CTA rendered after the description. Used to surface a real interior
+ *   route (e.g. the Stair Climber detail view) while the placeholder shell is still in place.
  */
 export function TrainingFacilitySubareaShell({
   eyebrow,
@@ -50,6 +75,7 @@ export function TrainingFacilitySubareaShell({
   description,
   accentClassName,
   nextSteps,
+  cta,
 }: TrainingFacilitySubareaShellProps) {
   return (
     <div className="relative min-h-svh overflow-hidden bg-[#120d0a] text-[#f7ead9]">
@@ -81,6 +107,21 @@ export function TrainingFacilitySubareaShell({
             <p className="mt-5 max-w-3xl text-base leading-7 text-[#e8d5be] sm:text-lg">
               {description}
             </p>
+
+            {cta && (
+              <div className="mt-7 flex flex-wrap items-center gap-4">
+                <Link
+                  href={cta.href}
+                  className="inline-flex items-center gap-2 rounded-full bg-orange-500 px-5 py-2.5 text-xs font-bold uppercase tracking-[0.28em] text-[#1a0d05] shadow-[0_12px_30px_rgba(234,88,12,0.45)] transition hover:bg-orange-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-300 focus-visible:ring-offset-2 focus-visible:ring-offset-[#120d0a]"
+                >
+                  {cta.label}
+                  <span aria-hidden="true">→</span>
+                </Link>
+                {cta.helper && (
+                  <p className="max-w-md text-xs leading-5 text-white/55">{cta.helper}</p>
+                )}
+              </div>
+            )}
 
             <div className="mt-10 grid gap-6 lg:grid-cols-[1.35fr_0.9fr]">
               <div className="rounded-[1.6rem] border border-white/10 bg-black/25 p-6">

--- a/components/training-facility/gym/AvgHrBars.tsx
+++ b/components/training-facility/gym/AvgHrBars.tsx
@@ -1,0 +1,161 @@
+import type { JSX } from 'react'
+import { scaleBand, scaleLinear } from 'd3-scale'
+import {
+  Axis,
+  EmptyChart,
+  type AxisTick,
+} from '@/components/training-facility/shared/charts/axes'
+import { chartPalette } from '@/components/training-facility/shared/charts/palette'
+import {
+  drawableToPaths,
+  extent,
+  getGenerator,
+} from '@/components/training-facility/shared/charts/rough-svg'
+import {
+  resolveMargin,
+  type ChartCommonProps,
+} from '@/components/training-facility/shared/charts/types'
+import type { SessionAvgHrPoint } from '@/lib/training-facility/stair'
+
+/** Props for {@link AvgHrBars}. */
+export interface AvgHrBarsProps extends ChartCommonProps {
+  /** Per-session avg-HR points, oldest → newest. */
+  points: readonly SessionAvgHrPoint[]
+  /** Inner padding between bars (0–1). Defaults to 0.3. */
+  padding?: number
+}
+
+/**
+ * Per-session average heart-rate bar chart for the stair detail view.
+ *
+ * Why this lives outside `RoughBar`: avg-HR values typically cluster in a
+ * narrow 130–170 BPM band. With `RoughBar`'s default `[0, yMax]` domain, every
+ * bar fills ~85–99% of the chart and the trend disappears. This view auto-pads
+ * the domain around the actual range so a 12-BPM week-over-week swing reads as
+ * a meaningful step rather than a 1px nudge.
+ */
+export function AvgHrBars({
+  points,
+  width,
+  height,
+  margin,
+  padding = 0.3,
+  roughness = 1.4,
+  seed = 8,
+  fontFamily = 'inherit',
+  axisColor = chartPalette.inkBlack,
+  className,
+  ariaLabel = 'Average heart rate per session',
+  ariaLabelledBy,
+  emptyMessage = 'No avg-HR sessions in range',
+}: AvgHrBarsProps): JSX.Element {
+  const m = resolveMargin(margin)
+  const innerW = width - m.left - m.right
+  const innerH = height - m.top - m.bottom
+
+  if (points.length === 0) {
+    return (
+      <EmptyChart
+        width={width}
+        height={height}
+        message={emptyMessage}
+        fontFamily={fontFamily}
+        className={className}
+        ariaLabel={ariaLabel}
+        ariaLabelledBy={ariaLabelledBy}
+      />
+    )
+  }
+
+  const labels = points.map((p) => p.label)
+  const xScale = scaleBand<string>().domain(labels).range([0, innerW]).padding(padding)
+
+  const values = points.map((p) => p.avgHr)
+  const [vMin, vMax] = extent(values)
+  // Pad the domain by ~15% of the observed range (or ±5 BPM if every session
+  // had the same avg HR) so adjacent bars read as different heights instead of
+  // collapsing to a single visual step. Lower bound stays >= 0.
+  const span = vMax - vMin
+  const pad = span > 0 ? span * 0.15 : 5
+  const yDomainMin = Math.max(0, Math.floor(vMin - pad))
+  const yDomainMax = Math.ceil(vMax + pad)
+  const yScale = scaleLinear().domain([yDomainMin, yDomainMax]).nice().range([innerH, 0])
+
+  const gen = getGenerator()
+
+  const xTicks: AxisTick[] = labels.map((l) => ({
+    value: l,
+    offset: (xScale(l) ?? 0) + xScale.bandwidth() / 2,
+  }))
+
+  const yTicks: AxisTick[] = yScale.ticks(5).map((tick) => ({
+    value: String(tick),
+    offset: yScale(tick),
+  }))
+
+  return (
+    <svg
+      width={width}
+      height={height}
+      className={className}
+      role="img"
+      aria-label={ariaLabelledBy ? undefined : ariaLabel}
+      aria-labelledby={ariaLabelledBy}
+    >
+      {ariaLabel && !ariaLabelledBy && <title>{ariaLabel}</title>}
+      <g transform={`translate(${m.left},${m.top})`}>
+        <Axis
+          orientation="bottom"
+          position={innerH}
+          start={0}
+          end={innerW}
+          ticks={xTicks}
+          label="Session"
+          color={axisColor}
+          fontFamily={fontFamily}
+          roughness={roughness}
+          seed={seed + 100}
+        />
+        <Axis
+          orientation="left"
+          position={0}
+          start={0}
+          end={innerH}
+          ticks={yTicks}
+          label="Avg HR (BPM)"
+          color={axisColor}
+          fontFamily={fontFamily}
+          roughness={roughness}
+          seed={seed + 200}
+        />
+        {points.map((p, i) => {
+          const bx = xScale(p.label) ?? 0
+          const bw = xScale.bandwidth()
+          const bh = Math.max(innerH - yScale(p.avgHr), 1)
+          const by = innerH - bh
+          const rect = gen.rectangle(bx, by, bw, bh, {
+            fill: chartPalette.rimOrange,
+            fillStyle: 'hachure',
+            fillWeight: 2,
+            hachureGap: 5,
+            stroke: chartPalette.inkBlack,
+            strokeWidth: 1.5,
+            roughness,
+            seed: seed + 1000 + i,
+          })
+          return drawableToPaths(rect).map((path, j) => (
+            <path
+              key={`avghr-${i}-${j}`}
+              d={path.d}
+              stroke={path.stroke}
+              strokeWidth={path.strokeWidth}
+              fill={path.fill ?? 'none'}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          ))
+        })}
+      </g>
+    </svg>
+  )
+}

--- a/components/training-facility/gym/AvgHrBars.tsx
+++ b/components/training-facility/gym/AvgHrBars.tsx
@@ -67,8 +67,12 @@ export function AvgHrBars({
     )
   }
 
-  const labels = points.map((p) => p.label)
-  const xScale = scaleBand<string>().domain(labels).range([0, innerW]).padding(padding)
+  // Key the band scale by index, not by `label`. Two sessions on the same
+  // calendar day (or the same M/D across years) share a `label` value but
+  // are genuinely distinct points — a string-keyed domain would collapse
+  // them onto a single x position. Tick text still shows the M/D label.
+  const indices = points.map((_, i) => i)
+  const xScale = scaleBand<number>().domain(indices).range([0, innerW]).padding(padding)
 
   const values = points.map((p) => p.avgHr)
   const [vMin, vMax] = extent(values)
@@ -83,9 +87,9 @@ export function AvgHrBars({
 
   const gen = getGenerator()
 
-  const xTicks: AxisTick[] = labels.map((l) => ({
-    value: l,
-    offset: (xScale(l) ?? 0) + xScale.bandwidth() / 2,
+  const xTicks: AxisTick[] = points.map((p, i) => ({
+    value: p.label,
+    offset: (xScale(i) ?? 0) + xScale.bandwidth() / 2,
   }))
 
   const yTicks: AxisTick[] = yScale.ticks(5).map((tick) => ({
@@ -129,7 +133,7 @@ export function AvgHrBars({
           seed={seed + 200}
         />
         {points.map((p, i) => {
-          const bx = xScale(p.label) ?? 0
+          const bx = xScale(i) ?? 0
           const bw = xScale.bandwidth()
           const bh = Math.max(innerH - yScale(p.avgHr), 1)
           const by = innerH - bh

--- a/components/training-facility/gym/HrZoneBars.tsx
+++ b/components/training-facility/gym/HrZoneBars.tsx
@@ -83,8 +83,20 @@ export function HrZoneBars({
     offset: (xScale(b.shortLabel) ?? 0) + xScale.bandwidth() / 2,
   }))
 
+  // Switch the y-axis units when the largest bar is under two minutes —
+  // rounding 20s / 40s / 60s straight to whole minutes produces duplicate
+  // 0m / 1m / 1m ticks that misrepresent the data. The threshold (120s)
+  // is chosen so a typical stair session (≥25 min) always reads in minutes
+  // while short windows (one short session, or single-zone time) read in
+  // seconds.
+  const showSeconds = yMaxSeconds < 120
+  const formatYTick = showSeconds
+    ? (tick: number) => `${Math.round(tick)}s`
+    : (tick: number) => `${Math.round(tick / 60)}m`
+  const yAxisLabel = showSeconds ? 'Seconds' : 'Minutes'
+
   const yTicks: AxisTick[] = yScale.ticks(5).map((tick) => ({
-    value: `${Math.round(tick / 60)}m`,
+    value: formatYTick(tick),
     offset: yScale(tick),
   }))
 
@@ -117,7 +129,7 @@ export function HrZoneBars({
           start={0}
           end={innerH}
           ticks={yTicks}
-          label="Minutes"
+          label={yAxisLabel}
           color={axisColor}
           fontFamily={fontFamily}
           roughness={roughness}

--- a/components/training-facility/gym/HrZoneBars.tsx
+++ b/components/training-facility/gym/HrZoneBars.tsx
@@ -11,7 +11,6 @@ import {
   getGenerator,
 } from '@/components/training-facility/shared/charts/rough-svg'
 import {
-  defaultMargin,
   resolveMargin,
   type ChartCommonProps,
 } from '@/components/training-facility/shared/charts/types'
@@ -158,6 +157,3 @@ export function HrZoneBars({
     </svg>
   )
 }
-
-/** Re-export the shared default margin so callers don't have to dig for it. */
-export const hrZoneBarsDefaultMargin = defaultMargin

--- a/components/training-facility/gym/HrZoneBars.tsx
+++ b/components/training-facility/gym/HrZoneBars.tsx
@@ -1,0 +1,163 @@
+import type { JSX } from 'react'
+import { scaleBand, scaleLinear } from 'd3-scale'
+import {
+  Axis,
+  EmptyChart,
+  type AxisTick,
+} from '@/components/training-facility/shared/charts/axes'
+import { chartPalette } from '@/components/training-facility/shared/charts/palette'
+import {
+  drawableToPaths,
+  getGenerator,
+} from '@/components/training-facility/shared/charts/rough-svg'
+import {
+  defaultMargin,
+  resolveMargin,
+  type ChartCommonProps,
+} from '@/components/training-facility/shared/charts/types'
+import type { HrZoneBucket } from '@/lib/training-facility/stair'
+
+/** Props for {@link HrZoneBars}. */
+export interface HrZoneBarsProps extends ChartCommonProps {
+  /** Pre-aggregated zone buckets (Z1–Z5, in canonical order). */
+  buckets: readonly HrZoneBucket[]
+  /** Inner padding between bars (0–1). Defaults to 0.25. */
+  padding?: number
+}
+
+/**
+ * Time-in-zone bar chart for the Gym detail views — five bars (Z1–Z5), each
+ * tinted with the zone's display color, heights driven by total seconds in
+ * that zone across the filtered window.
+ *
+ * The shared `RoughBar` primitive only accepts a single `fill`, so this view
+ * inlines a small custom renderer that asks rough.js for one rectangle per
+ * bucket using `bucket.color` directly. Y-axis ticks are formatted as whole
+ * minutes for legibility.
+ */
+export function HrZoneBars({
+  buckets,
+  width,
+  height,
+  margin,
+  padding = 0.25,
+  roughness = 1.4,
+  seed = 4,
+  fontFamily = 'inherit',
+  axisColor = chartPalette.inkBlack,
+  className,
+  ariaLabel = 'Time in heart-rate zone',
+  ariaLabelledBy,
+  emptyMessage = 'No HR-zone data in range',
+}: HrZoneBarsProps): JSX.Element {
+  const m = resolveMargin(margin)
+  const innerW = width - m.left - m.right
+  const innerH = height - m.top - m.bottom
+
+  const totalSeconds = buckets.reduce((acc, b) => acc + b.seconds, 0)
+  if (totalSeconds === 0) {
+    return (
+      <EmptyChart
+        width={width}
+        height={height}
+        message={emptyMessage}
+        fontFamily={fontFamily}
+        className={className}
+        ariaLabel={ariaLabel}
+        ariaLabelledBy={ariaLabelledBy}
+      />
+    )
+  }
+
+  const xScale = scaleBand<string>()
+    .domain(buckets.map((b) => b.shortLabel))
+    .range([0, innerW])
+    .padding(padding)
+
+  const yMaxSeconds = Math.max(0, ...buckets.map((b) => b.seconds))
+  const yScale = scaleLinear().domain([0, yMaxSeconds]).nice().range([innerH, 0])
+
+  const gen = getGenerator()
+
+  const xTicks: AxisTick[] = buckets.map((b) => ({
+    value: b.shortLabel,
+    offset: (xScale(b.shortLabel) ?? 0) + xScale.bandwidth() / 2,
+  }))
+
+  const yTicks: AxisTick[] = yScale.ticks(5).map((tick) => ({
+    value: `${Math.round(tick / 60)}m`,
+    offset: yScale(tick),
+  }))
+
+  return (
+    <svg
+      width={width}
+      height={height}
+      className={className}
+      role="img"
+      aria-label={ariaLabelledBy ? undefined : ariaLabel}
+      aria-labelledby={ariaLabelledBy}
+    >
+      {ariaLabel && !ariaLabelledBy && <title>{ariaLabel}</title>}
+      <g transform={`translate(${m.left},${m.top})`}>
+        <Axis
+          orientation="bottom"
+          position={innerH}
+          start={0}
+          end={innerW}
+          ticks={xTicks}
+          label="Zone"
+          color={axisColor}
+          fontFamily={fontFamily}
+          roughness={roughness}
+          seed={seed + 100}
+        />
+        <Axis
+          orientation="left"
+          position={0}
+          start={0}
+          end={innerH}
+          ticks={yTicks}
+          label="Minutes"
+          color={axisColor}
+          fontFamily={fontFamily}
+          roughness={roughness}
+          seed={seed + 200}
+        />
+        {buckets.map((b, i) => {
+          const bx = xScale(b.shortLabel) ?? 0
+          const bw = xScale.bandwidth()
+          // Render zero buckets as a 1px baseline so the zone stays visible
+          // on the axis even when no time was logged in it during the window.
+          const bh = b.seconds > 0 ? Math.max(innerH - yScale(b.seconds), 1) : 0
+          if (bh === 0) return null
+          const by = innerH - bh
+          const rect = gen.rectangle(bx, by, bw, bh, {
+            fill: b.color,
+            fillStyle: 'hachure',
+            fillWeight: 2,
+            hachureGap: 5,
+            stroke: chartPalette.inkBlack,
+            strokeWidth: 1.5,
+            roughness,
+            seed: seed + 1000 + i,
+          })
+          return drawableToPaths(rect).map((p, j) => (
+            <path
+              key={`hrzone-${b.zone}-${j}`}
+              d={p.d}
+              stroke={p.stroke}
+              strokeWidth={p.strokeWidth}
+              fill={p.fill ?? 'none'}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          ))
+        })}
+      </g>
+    </svg>
+  )
+}
+
+/** Re-export the shared default margin so callers don't have to dig for it. */
+export const hrZoneBarsDefaultMargin = defaultMargin

--- a/components/training-facility/gym/StairDetailView.tsx
+++ b/components/training-facility/gym/StairDetailView.tsx
@@ -1,0 +1,332 @@
+'use client'
+
+import Link from 'next/link'
+import { useEffect, useMemo, useRef, useState, type JSX } from 'react'
+import type { CardioData, CardioSession } from '@/types/cardio'
+import { getCardioData } from '@/lib/data'
+import {
+  DateFilter,
+  endOfDay,
+  rangeForPreset,
+  startOfDay,
+  type DateRange,
+} from '@/components/training-facility/shared/DateFilter'
+import {
+  aggregateHrZoneSeconds,
+  filterStairSessions,
+  formatDuration,
+  parseSessionDate,
+  perSessionAvgHr,
+} from '@/lib/training-facility/stair'
+import { BackToCourtButton } from '@/components/common/BackToCourtButton'
+import { HrZoneBars } from './HrZoneBars'
+import { AvgHrBars } from './AvgHrBars'
+
+const CHART_HEIGHT = 280
+const MIN_CHART_WIDTH = 280
+const DEFAULT_CHART_WIDTH = 560
+const EARLIEST_FALLBACK = new Date(2024, 0, 1)
+
+/**
+ * Stair-climber detail view (PRD §7.4) — the first Gym detail surface.
+ *
+ * Composes three views fed by `getCardioData()` and a shared `DateFilter`:
+ *   1. Time-in-zone bars (`HrZoneBars`) — total seconds per Z1–Z5, summed
+ *      across the filtered window.
+ *   2. Per-session avg-HR bars (`AvgHrBars`) — one bar per session in range.
+ *   3. Session log table — one row per session, oldest → newest.
+ *
+ * Loading and error are surfaced explicitly so a missing `cardio.json` (or a
+ * future API outage) reads as "no data yet" instead of an empty chart trio.
+ */
+export function StairDetailView(): JSX.Element {
+  const [data, setData] = useState<CardioData | null>(null)
+  const [loadError, setLoadError] = useState<Error | null>(null)
+  const [range, setRange] = useState<DateRange>(() => rangeForPreset('1M', EARLIEST_FALLBACK))
+  const [chartWidth, setChartWidth] = useState(DEFAULT_CHART_WIDTH)
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    getCardioData()
+      .then((next) => {
+        if (!cancelled) setData(next)
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return
+        setLoadError(err instanceof Error ? err : new Error(String(err)))
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  // Track the cards' rendered width so the SVG charts shrink with the column
+  // on mobile rather than overflowing the viewport. The shared chart
+  // primitives don't accept a fluid width — we measure here and pass.
+  useEffect(() => {
+    const node = containerRef.current
+    if (!node || typeof ResizeObserver === 'undefined') return
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        const next = Math.max(MIN_CHART_WIDTH, Math.floor(entry.contentRect.width))
+        setChartWidth((prev) => (prev === next ? prev : next))
+      }
+    })
+    observer.observe(node)
+    return () => observer.disconnect()
+  }, [])
+
+  // Earliest cardio date in the dataset — drives the `All` preset bound. Falls
+  // back to a fixed date so the picker is functional before any data loads.
+  // Uses `parseSessionDate` so the local-day interpretation matches what
+  // `filterStairSessions` will compare against later.
+  const earliestDate = useMemo(() => {
+    if (!data || data.sessions.length === 0) return EARLIEST_FALLBACK
+    let earliestMs = Infinity
+    for (const s of data.sessions) {
+      const ms = parseSessionDate(s.date).getTime()
+      if (Number.isFinite(ms) && ms < earliestMs) earliestMs = ms
+    }
+    return Number.isFinite(earliestMs) ? new Date(earliestMs) : EARLIEST_FALLBACK
+  }, [data])
+
+  // Re-anchor the active range to the dataset's earliest date once the data
+  // arrives — otherwise an `All` preset locked to the fallback date wouldn't
+  // include the real data when it's older. Only fires for the initial 1M
+  // preset; user-selected ranges aren't overwritten.
+  const anchoredRef = useRef(false)
+  useEffect(() => {
+    if (!data || anchoredRef.current) return
+    setRange((prev) => {
+      const next = rangeForPreset('1M', earliestDate)
+      return prev.start.getTime() === next.start.getTime() &&
+        prev.end.getTime() === next.end.getTime()
+        ? prev
+        : next
+    })
+    anchoredRef.current = true
+  }, [data, earliestDate])
+
+  const stairSessions = useMemo<CardioSession[]>(
+    () => (data ? filterStairSessions(data.sessions, range) : []),
+    [data, range],
+  )
+  const buckets = useMemo(() => aggregateHrZoneSeconds(stairSessions), [stairSessions])
+  const avgHrPoints = useMemo(() => perSessionAvgHr(stairSessions), [stairSessions])
+
+  return (
+    <div className="relative min-h-svh overflow-hidden bg-[#120d0a] text-[#f7ead9]">
+      <div
+        aria-hidden="true"
+        className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(255,255,255,0.08),transparent_28%),linear-gradient(180deg,#241811_0%,#120d0a_52%,#0b0806_100%)]"
+      />
+
+      <div className="relative z-10 mx-auto flex min-h-svh w-full max-w-5xl flex-col px-6 py-8 sm:px-8 lg:px-12">
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <BackToCourtButton />
+          <Link
+            href="/training-facility/gym"
+            className="rounded-full border border-white/15 bg-white/5 px-4 py-2 text-xs font-semibold uppercase tracking-[0.28em] text-white/80 transition hover:bg-white/10"
+          >
+            ← The Gym
+          </Link>
+        </div>
+
+        <header className="mt-12">
+          <div className="text-xs font-semibold uppercase tracking-[0.38em] text-white/60">
+            Stair climber
+          </div>
+          <h1 className="mt-3 text-4xl font-black uppercase tracking-[0.08em] text-[#fff7ec] sm:text-5xl">
+            Where the engine gets built
+          </h1>
+          <p className="mt-4 max-w-2xl text-sm leading-7 text-[#e8d5be] sm:text-base">
+            Time-in-zone, per-session average heart rate, and the session log — all
+            scoped to the date range. The stair climber is the primary Gym surface
+            (PRD §7.4); treadmill and track detail views follow in Phase 3.
+          </p>
+        </header>
+
+        <div className="mt-8">
+          <DateFilter
+            earliestDate={earliestDate}
+            defaultPreset="1M"
+            onChange={setRange}
+          />
+        </div>
+
+        {loadError ? (
+          <ErrorPanel error={loadError} />
+        ) : !data ? (
+          <LoadingPanel />
+        ) : (
+          <>
+            <div ref={containerRef} className="mt-8 grid gap-6 lg:grid-cols-2">
+              <ChartCard
+                title="Time in zone"
+                helper="Total minutes per HR zone across the filtered window."
+              >
+                <HrZoneBars
+                  buckets={buckets}
+                  width={chartWidth}
+                  height={CHART_HEIGHT}
+                  fontFamily="'Patrick Hand', system-ui, sans-serif"
+                />
+              </ChartCard>
+
+              <ChartCard
+                title="Avg HR per session"
+                helper="One bar per session — y-axis padded to the visible range so trends pop."
+              >
+                <AvgHrBars
+                  points={avgHrPoints}
+                  width={chartWidth}
+                  height={CHART_HEIGHT}
+                  fontFamily="'Patrick Hand', system-ui, sans-serif"
+                />
+              </ChartCard>
+            </div>
+
+            <SessionLogTable sessions={stairSessions} range={range} />
+          </>
+        )}
+      </div>
+    </div>
+  )
+}
+
+interface ChartCardProps {
+  title: string
+  helper: string
+  children: JSX.Element
+}
+
+function ChartCard({ title, helper, children }: ChartCardProps): JSX.Element {
+  return (
+    <section
+      className="rounded-[1.6rem] border border-white/10 bg-[#f5f1e6] p-5 text-[#0a0a0a] shadow-[0_18px_46px_rgba(0,0,0,0.34)]"
+    >
+      <header className="mb-2 flex items-baseline justify-between gap-3">
+        <h2 className="font-mono text-xs font-bold uppercase tracking-[0.24em] text-[#0a0a0a]">
+          {title}
+        </h2>
+      </header>
+      <p className="mb-4 text-xs leading-5 text-[#404040]">{helper}</p>
+      <div className="overflow-x-auto">{children}</div>
+    </section>
+  )
+}
+
+interface SessionLogTableProps {
+  sessions: readonly CardioSession[]
+  range: DateRange
+}
+
+function SessionLogTable({ sessions, range }: SessionLogTableProps): JSX.Element {
+  // Show newest first in the table — opposite of charts. Tabular reading
+  // convention is "what happened most recently?" at the top.
+  const rows = useMemo(() => sessions.slice().reverse(), [sessions])
+  const startLabel = formatRangeBound(range.start, 'start')
+  const endLabel = formatRangeBound(range.end, 'end')
+
+  return (
+    <section className="mt-8 rounded-[1.6rem] border border-white/10 bg-black/25 p-5">
+      <header className="mb-3 flex flex-wrap items-baseline justify-between gap-3">
+        <h2 className="font-mono text-xs font-bold uppercase tracking-[0.24em] text-white/80">
+          Sessions
+        </h2>
+        <p className="text-xs text-white/55">
+          {sessions.length === 0 ? 'No sessions in range' : `${sessions.length} in range`}
+          <span className="ml-2 text-white/35">
+            ({startLabel} → {endLabel})
+          </span>
+        </p>
+      </header>
+      {rows.length === 0 ? (
+        <p className="px-2 py-6 text-center text-sm text-white/55">
+          No stair sessions in the selected range.
+        </p>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full min-w-[480px] border-separate border-spacing-y-1 text-left text-sm">
+            <thead className="text-xs uppercase tracking-[0.18em] text-white/55">
+              <tr>
+                <th scope="col" className="px-3 py-2 font-semibold">
+                  Date
+                </th>
+                <th scope="col" className="px-3 py-2 font-semibold">
+                  Duration
+                </th>
+                <th scope="col" className="px-3 py-2 font-semibold">
+                  Avg HR
+                </th>
+                <th scope="col" className="px-3 py-2 font-semibold">
+                  Max HR
+                </th>
+              </tr>
+            </thead>
+            <tbody className="text-[#f7ead9]">
+              {rows.map((s) => (
+                <tr
+                  key={`${s.date}-${s.duration_seconds}`}
+                  className="rounded-md bg-white/5 align-middle"
+                >
+                  <td className="rounded-l-md px-3 py-2 font-mono">{formatRowDate(s.date)}</td>
+                  <td className="px-3 py-2 font-mono">{formatDuration(s.duration_seconds)}</td>
+                  <td className="px-3 py-2 font-mono">
+                    {typeof s.avg_hr === 'number' ? `${Math.round(s.avg_hr)}` : '—'}
+                  </td>
+                  <td className="rounded-r-md px-3 py-2 font-mono">
+                    {typeof s.max_hr === 'number' ? `${Math.round(s.max_hr)}` : '—'}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  )
+}
+
+function formatRowDate(raw: string): string {
+  const d = parseSessionDate(raw)
+  if (!Number.isFinite(d.getTime())) return raw
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
+
+function formatRangeBound(d: Date, end: 'start' | 'end'): string {
+  // Normalize to the same boundary the filter advertises so the readout
+  // matches the picker's value, regardless of when the user clicked.
+  const norm = end === 'start' ? startOfDay(d) : endOfDay(d)
+  return `${norm.getFullYear()}-${String(norm.getMonth() + 1).padStart(2, '0')}-${String(norm.getDate()).padStart(2, '0')}`
+}
+
+function LoadingPanel(): JSX.Element {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="mt-10 rounded-[1.6rem] border border-white/10 bg-black/25 p-8 text-center text-sm text-white/65"
+    >
+      Loading cardio data…
+    </div>
+  )
+}
+
+function ErrorPanel({ error }: { error: Error }): JSX.Element {
+  return (
+    <div
+      role="alert"
+      className="mt-10 rounded-[1.6rem] border border-red-400/30 bg-red-950/40 p-6 text-sm leading-6 text-red-100"
+    >
+      <p className="font-semibold uppercase tracking-[0.18em]">Could not load cardio data</p>
+      <p className="mt-2 text-red-100/80">{error.message}</p>
+      <p className="mt-4 text-xs text-red-100/60">
+        Run <code className="rounded bg-black/40 px-1.5 py-0.5">npm run import-health</code> to
+        regenerate <code className="rounded bg-black/40 px-1.5 py-0.5">public/data/cardio.json</code>{' '}
+        from a fresh Apple Health export, then redeploy.
+      </p>
+    </div>
+  )
+}

--- a/components/training-facility/gym/StairDetailView.tsx
+++ b/components/training-facility/gym/StairDetailView.tsx
@@ -266,9 +266,13 @@ function SessionLogTable({ sessions, range }: SessionLogTableProps): JSX.Element
               </tr>
             </thead>
             <tbody className="text-[#f7ead9]">
-              {rows.map((s) => (
+              {rows.map((s, i) => (
                 <tr
-                  key={`${s.date}-${s.duration_seconds}`}
+                  // Append the row index to disambiguate the rare case of two
+                  // sessions sharing both a date and an exact duration_seconds
+                  // (back-to-back stair sessions). Stable as long as the
+                  // reverse-sorted row order is.
+                  key={`${s.date}-${s.duration_seconds}-${i}`}
                   className="rounded-md bg-white/5 align-middle"
                 >
                   <td className="rounded-l-md px-3 py-2 font-mono">{formatRowDate(s.date)}</td>

--- a/components/training-facility/gym/StairDetailView.tsx
+++ b/components/training-facility/gym/StairDetailView.tsx
@@ -44,7 +44,11 @@ export function StairDetailView(): JSX.Element {
   const [loadError, setLoadError] = useState<Error | null>(null)
   const [range, setRange] = useState<DateRange>(() => rangeForPreset('1M', EARLIEST_FALLBACK))
   const [chartWidth, setChartWidth] = useState(DEFAULT_CHART_WIDTH)
-  const containerRef = useRef<HTMLDivElement>(null)
+  // Sentinel ref placed on a per-card wrapper, NOT on the two-column grid.
+  // The grid wrapper would report the combined width on `lg:grid-cols-2`, so
+  // each chart would render at ~2× its column footprint and overflow. The
+  // two cards are equal width by grid contract, so observing one is enough.
+  const cardSizerRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
     let cancelled = false
@@ -54,6 +58,21 @@ export function StairDetailView(): JSX.Element {
       })
       .catch((err: unknown) => {
         if (cancelled) return
+        const message = err instanceof Error ? err.message : String(err)
+        // Treat a missing `cardio.json` (404) as "no data yet" rather than a
+        // hard error — the file is gitignored (PRD §11 open question 7), so
+        // a fresh preview deploy without an Apple Health import legitimately
+        // has no data. Other errors (network, 5xx, malformed JSON) still
+        // bubble up to the explicit error panel.
+        if (/\b404\b/.test(message)) {
+          setData({
+            imported_at: '',
+            sessions: [],
+            resting_hr_trend: [],
+            vo2max_trend: [],
+          })
+          return
+        }
         setLoadError(err instanceof Error ? err : new Error(String(err)))
       })
     return () => {
@@ -61,11 +80,13 @@ export function StairDetailView(): JSX.Element {
     }
   }, [])
 
-  // Track the cards' rendered width so the SVG charts shrink with the column
-  // on mobile rather than overflowing the viewport. The shared chart
-  // primitives don't accept a fluid width — we measure here and pass.
+  // Track per-card width so the SVG charts shrink with the column on mobile
+  // rather than overflowing the viewport. The shared chart primitives don't
+  // accept a fluid width — we measure the sentinel and pass. The sentinel
+  // sits inside the chart's content area (no card padding) so its width is
+  // exactly what the SVG should render at.
   useEffect(() => {
-    const node = containerRef.current
+    const node = cardSizerRef.current
     if (!node || typeof ResizeObserver === 'undefined') return
     const observer = new ResizeObserver((entries) => {
       for (const entry of entries) {
@@ -91,22 +112,12 @@ export function StairDetailView(): JSX.Element {
     return Number.isFinite(earliestMs) ? new Date(earliestMs) : EARLIEST_FALLBACK
   }, [data])
 
-  // Re-anchor the active range to the dataset's earliest date once the data
-  // arrives — otherwise an `All` preset locked to the fallback date wouldn't
-  // include the real data when it's older. Only fires for the initial 1M
-  // preset; user-selected ranges aren't overwritten.
-  const anchoredRef = useRef(false)
-  useEffect(() => {
-    if (!data || anchoredRef.current) return
-    setRange((prev) => {
-      const next = rangeForPreset('1M', earliestDate)
-      return prev.start.getTime() === next.start.getTime() &&
-        prev.end.getTime() === next.end.getTime()
-        ? prev
-        : next
-    })
-    anchoredRef.current = true
-  }, [data, earliestDate])
+  // No re-anchor effect: the `1M` preset is computed from "today" and is
+  // independent of `earliestDate`, so the initial range value is already
+  // correct before data loads. When the user clicks `All`, `DateFilter`
+  // reads the latest `earliestDate` prop and computes the right span on
+  // the spot — no need to overwrite the range from this side, which would
+  // also clobber a filter the user picked while the fetch was in flight.
 
   const stairSessions = useMemo<CardioSession[]>(
     () => (data ? filterStairSessions(data.sessions, range) : []),
@@ -161,17 +172,19 @@ export function StairDetailView(): JSX.Element {
           <LoadingPanel />
         ) : (
           <>
-            <div ref={containerRef} className="mt-8 grid gap-6 lg:grid-cols-2">
+            <div className="mt-8 grid gap-6 lg:grid-cols-2">
               <ChartCard
                 title="Time in zone"
                 helper="Total minutes per HR zone across the filtered window."
               >
-                <HrZoneBars
-                  buckets={buckets}
-                  width={chartWidth}
-                  height={CHART_HEIGHT}
-                  fontFamily="'Patrick Hand', system-ui, sans-serif"
-                />
+                <div ref={cardSizerRef}>
+                  <HrZoneBars
+                    buckets={buckets}
+                    width={chartWidth}
+                    height={CHART_HEIGHT}
+                    fontFamily="'Patrick Hand', system-ui, sans-serif"
+                  />
+                </div>
               </ChartCard>
 
               <ChartCard

--- a/lib/training-facility/stair.test.ts
+++ b/lib/training-facility/stair.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from 'vitest'
+import {
+  aggregateHrZoneSeconds,
+  filterStairSessions,
+  formatDuration,
+  perSessionAvgHr,
+} from './stair'
+import type { CardioSession } from '@/types/cardio'
+
+const range = (startIso: string, endIso: string) => ({
+  start: new Date(startIso),
+  end: new Date(endIso),
+})
+
+const stair = (
+  date: string,
+  extras: Partial<CardioSession> = {},
+): CardioSession => ({
+  date,
+  activity: 'stair',
+  duration_seconds: 1800,
+  ...extras,
+})
+
+describe('filterStairSessions', () => {
+  it('keeps only stair-activity sessions inside the range, sorted oldest → newest', () => {
+    const sessions: CardioSession[] = [
+      stair('2026-04-10'),
+      stair('2026-04-01'),
+      { date: '2026-04-05', activity: 'running', duration_seconds: 1500 },
+      stair('2026-03-15'),
+      stair('2026-04-20'),
+    ]
+    const out = filterStairSessions(
+      sessions,
+      range('2026-04-01T00:00:00', '2026-04-15T23:59:59.999'),
+    )
+    expect(out.map((s) => s.date)).toEqual(['2026-04-01', '2026-04-10'])
+  })
+
+  it('is inclusive on both ends', () => {
+    const sessions: CardioSession[] = [
+      stair('2026-04-01'),
+      stair('2026-04-15'),
+      stair('2026-03-31'),
+      stair('2026-04-16'),
+    ]
+    const out = filterStairSessions(
+      sessions,
+      range('2026-04-01T00:00:00', '2026-04-15T23:59:59.999'),
+    )
+    expect(out.map((s) => s.date)).toEqual(['2026-04-01', '2026-04-15'])
+  })
+
+  it('drops sessions with unparseable date strings rather than throwing', () => {
+    const sessions: CardioSession[] = [
+      stair('not-a-date'),
+      stair('2026-04-10'),
+    ]
+    const out = filterStairSessions(
+      sessions,
+      range('2026-01-01T00:00:00', '2026-12-31T23:59:59.999'),
+    )
+    expect(out.map((s) => s.date)).toEqual(['2026-04-10'])
+  })
+})
+
+describe('aggregateHrZoneSeconds', () => {
+  it('sums time-in-zone across sessions in canonical Z1–Z5 order', () => {
+    const sessions: CardioSession[] = [
+      stair('2026-04-01', {
+        hr_seconds_in_zone: { 1: 30, 2: 400, 3: 600, 4: 400, 5: 100 },
+      }),
+      stair('2026-04-08', {
+        hr_seconds_in_zone: { 1: 20, 2: 380, 3: 720, 4: 540, 5: 140 },
+      }),
+    ]
+    const out = aggregateHrZoneSeconds(sessions)
+    expect(out.map((b) => b.seconds)).toEqual([50, 780, 1320, 940, 240])
+    expect(out.map((b) => b.zone)).toEqual(['Z1', 'Z2', 'Z3', 'Z4', 'Z5'])
+  })
+
+  it('returns five zero buckets when no session carries a zone breakdown', () => {
+    const sessions: CardioSession[] = [stair('2026-04-01'), stair('2026-04-08')]
+    const out = aggregateHrZoneSeconds(sessions)
+    expect(out).toHaveLength(5)
+    expect(out.every((b) => b.seconds === 0)).toBe(true)
+  })
+
+  it('returns five zero buckets when given no sessions', () => {
+    const out = aggregateHrZoneSeconds([])
+    expect(out.map((b) => b.zone)).toEqual(['Z1', 'Z2', 'Z3', 'Z4', 'Z5'])
+    expect(out.every((b) => b.seconds === 0)).toBe(true)
+  })
+})
+
+describe('perSessionAvgHr', () => {
+  it('keeps avg-HR-bearing sessions and projects M/D labels', () => {
+    const sessions: CardioSession[] = [
+      stair('2026-04-01', { avg_hr: 142 }),
+      stair('2026-04-08'), // no avg_hr
+      stair('2026-04-15', { avg_hr: 156 }),
+    ]
+    const out = perSessionAvgHr(sessions)
+    expect(out).toEqual([
+      { date: '2026-04-01', label: '4/1', avgHr: 142 },
+      { date: '2026-04-15', label: '4/15', avgHr: 156 },
+    ])
+  })
+
+  it('skips sessions whose date string cannot be parsed', () => {
+    const sessions: CardioSession[] = [
+      stair('garbage', { avg_hr: 140 }),
+      stair('2026-04-10', { avg_hr: 150 }),
+    ]
+    const out = perSessionAvgHr(sessions)
+    expect(out.map((p) => p.avgHr)).toEqual([150])
+  })
+})
+
+describe('formatDuration', () => {
+  it('formats whole minutes', () => {
+    expect(formatDuration(1800)).toBe('30m 00s')
+  })
+
+  it('zero-pads seconds', () => {
+    expect(formatDuration(1505)).toBe('25m 05s')
+  })
+
+  it('handles sub-minute durations', () => {
+    expect(formatDuration(45)).toBe('0m 45s')
+  })
+
+  it('returns an em dash for invalid input', () => {
+    expect(formatDuration(Number.NaN)).toBe('—')
+    expect(formatDuration(-12)).toBe('—')
+  })
+})

--- a/lib/training-facility/stair.ts
+++ b/lib/training-facility/stair.ts
@@ -1,0 +1,148 @@
+/**
+ * Stair-climber detail-view aggregation helpers (PRD §7.4).
+ *
+ * Pure functions used by the Gym stair detail route to slice cardio sessions
+ * down to the stair modality, sum time-in-zone across the visible window, and
+ * project per-session points for the avg-HR bar chart. Kept separate from the
+ * React components so the math is unit-testable without RTL.
+ */
+
+import type { CardioSession, HrZone } from '@/types/cardio'
+import { HR_ZONES, type HrZoneConfig } from '@/constants/hr-zones'
+import type { DateRange } from '@/components/training-facility/shared/DateFilter'
+
+/**
+ * Parse a session-date string as a local-time `Date`.
+ *
+ * Bare `YYYY-MM-DD` strings (the dominant format in `cardio.json` for stair
+ * sessions) are treated as local midnight so range comparisons match the
+ * `DateFilter`'s local-day bounds. Full ISO timestamps already carry an offset
+ * and pass through to `new Date()` unchanged.
+ *
+ * Exported so the rendering layer (`StairDetailView`, table row formatter,
+ * earliest-date scan) can stay consistent with how the aggregation layer
+ * interprets the same field — single source of truth, no per-call-site
+ * timezone divergence.
+ *
+ * @param raw - Original `date` field from a `CardioSession`.
+ */
+export function parseSessionDate(raw: string): Date {
+  if (/^\d{4}-\d{2}-\d{2}$/.test(raw)) return new Date(`${raw}T00:00:00`)
+  return new Date(raw)
+}
+
+/**
+ * Filter `sessions` down to stair-climbing entries whose `date` falls within
+ * `range` (inclusive on both ends). Sessions with unparseable `date` strings
+ * are dropped silently — the data layer is the right place to catch malformed
+ * input, not a chart helper. Output is sorted oldest → newest so chart x-axes
+ * read left-to-right by time.
+ *
+ * @param sessions - Full session list from `getCardioData()`.
+ * @param range - Active range from the shared `DateFilter`.
+ */
+export function filterStairSessions(
+  sessions: readonly CardioSession[],
+  range: DateRange,
+): CardioSession[] {
+  const fromMs = range.start.getTime()
+  const toMs = range.end.getTime()
+  const out: { session: CardioSession; ts: number }[] = []
+  for (const s of sessions) {
+    if (s.activity !== 'stair') continue
+    const ts = parseSessionDate(s.date).getTime()
+    if (!Number.isFinite(ts)) continue
+    if (ts < fromMs || ts > toMs) continue
+    out.push({ session: s, ts })
+  }
+  out.sort((a, b) => a.ts - b.ts)
+  return out.map((entry) => entry.session)
+}
+
+/** One row in the HR-zone distribution chart. */
+export interface HrZoneBucket {
+  /** Zone identifier (`Z1`–`Z5`). */
+  zone: HrZoneConfig['id']
+  /** Long zone label (e.g. "Aerobic Base"). */
+  label: string
+  /** Short axis label (e.g. "Z2"). */
+  shortLabel: string
+  /** Display color from the zone config. */
+  color: string
+  /** Total seconds spent in this zone across the filtered sessions. */
+  seconds: number
+}
+
+/**
+ * Sum the `hr_seconds_in_zone` field across a list of stair sessions, returning
+ * one bucket per zone (Z1–Z5) in canonical order. Sessions missing the field
+ * contribute zero — they don't drop the zone from the result, so the chart
+ * always shows all five bars regardless of data quality.
+ *
+ * @param sessions - Already-filtered session list (e.g. from `filterStairSessions`).
+ */
+export function aggregateHrZoneSeconds(sessions: readonly CardioSession[]): HrZoneBucket[] {
+  const totals: Record<HrZone, number> = { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 }
+  for (const s of sessions) {
+    const z = s.hr_seconds_in_zone
+    if (!z) continue
+    totals[1] += z[1] ?? 0
+    totals[2] += z[2] ?? 0
+    totals[3] += z[3] ?? 0
+    totals[4] += z[4] ?? 0
+    totals[5] += z[5] ?? 0
+  }
+  return HR_ZONES.map((z, i) => ({
+    zone: z.id,
+    label: z.label,
+    shortLabel: z.shortLabel,
+    color: z.color,
+    seconds: totals[(i + 1) as HrZone],
+  }))
+}
+
+/** One point on the per-session avg-HR bar chart. */
+export interface SessionAvgHrPoint {
+  /** Original session date string (ISO or `YYYY-MM-DD`). */
+  date: string
+  /** Short label rendered on the x-axis — `M/D` in local time. */
+  label: string
+  /** Average heart rate, BPM. Sessions missing `avg_hr` are excluded upstream. */
+  avgHr: number
+}
+
+/**
+ * Project a session list to the points needed by the avg-HR bar chart. Sessions
+ * without an `avg_hr` field are excluded — there's nothing to render and a zero
+ * bar would lie about coverage. The output preserves input order, so callers
+ * pass a chronologically-sorted list (e.g. from `filterStairSessions`) to get
+ * left-to-right time ordering.
+ *
+ * @param sessions - Filtered, sorted stair sessions.
+ */
+export function perSessionAvgHr(sessions: readonly CardioSession[]): SessionAvgHrPoint[] {
+  const out: SessionAvgHrPoint[] = []
+  for (const s of sessions) {
+    if (typeof s.avg_hr !== 'number') continue
+    const d = parseSessionDate(s.date)
+    if (!Number.isFinite(d.getTime())) continue
+    const label = `${d.getMonth() + 1}/${d.getDate()}`
+    out.push({ date: s.date, label, avgHr: s.avg_hr })
+  }
+  return out
+}
+
+/**
+ * Format a duration in seconds as a compact `Mm Ss` string (e.g. `32m 05s`).
+ * Used by the session log table; kept here so the test suite can exercise the
+ * formatter without spinning up RTL.
+ *
+ * Negative or non-finite inputs return `—` rather than `NaNm`/`-1m`, so a
+ * malformed entry doesn't pollute the table.
+ */
+export function formatDuration(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds < 0) return '—'
+  const mins = Math.floor(seconds / 60)
+  const secs = Math.floor(seconds % 60)
+  return `${mins}m ${secs.toString().padStart(2, '0')}s`
+}


### PR DESCRIPTION
## Summary

First Gym detail surface from PRD §7.4. New `/training-facility/gym/stair` route renders three views over the cardio data layer:

- **Time-in-zone bars** — five bars (Z1–Z5), each tinted with the zone's display color from `constants/hr-zones.ts`. Heights are total minutes spent in each zone across the filtered window.
- **Per-session avg-HR bars** — one bar per stair session in range. Y-domain auto-pads ±15% around the observed range so a 12-BPM week-over-week swing reads as a real step instead of a 1px nudge (the default `[0, yMax]` of `RoughBar` flattens 130–170 BPM data into visually-identical bars).
- **Session log table** — Date · Duration · Avg HR · Max HR, newest first.

All three views read through `lib/data/cardio.ts` (PRD §7.10 — no direct JSON imports in components) and are driven by the shared `DateFilter` (`1M` default). Loading and error states are first-class so a missing `cardio.json` reads as "no data yet" instead of an empty chart trio.

The Gym placeholder gets a temporary "Open stair climber" CTA into the route. Once #61 (Gym scene SVG) lands, the click moves onto the stair-climber group in the scene and the placeholder shell — including this CTA — goes away. The CTA path is documented in code as a Phase 2 bridge.

## Implementation notes

- Charts use the existing rough.js primitives (`Axis`, palette, `getGenerator`/`drawableToPaths`) — no new dependency. PRD §7.14 lists rough.js as the right pick for the hand-drawn Gym aesthetic.
- The HR-zone bar chart is custom-rendered (`HrZoneBars`) rather than going through `RoughBar`: the shared primitive only accepts a single `fill`, and we need per-zone colors. The avg-HR chart (`AvgHrBars`) is similarly custom so the y-domain can be padded around the visible range.
- Date strings in `cardio.json` (`YYYY-MM-DD`) are parsed as **local midnight** via `parseSessionDate` so range filtering matches the local-day bounds the shared `DateFilter` produces. Without this, a session on `2026-04-01` falls outside an "April 1 → April 15" range in any non-UTC timezone.
- `BodyweightOverlay` is intentionally _not_ wired in here — it reads from `movement_benchmarks.json` (Combine), and a stair session's avg HR isn't a "benchmark" in the §4 sense. Worth a follow-up if power-to-weight context becomes useful for cardio later.

## Tests

`lib/training-facility/stair.test.ts` covers:
- `filterStairSessions` — activity filter + range inclusivity + unparseable dates
- `aggregateHrZoneSeconds` — Z1–Z5 sum, missing breakdowns, empty input
- `perSessionAvgHr` — avg-HR-only filter + M/D label projection + bad-date handling
- `formatDuration` — happy paths + invalid input fallback

`stair.ts` lands at 100% line coverage; full suite goes to 225 / 16 files.

## Test plan

- [ ] Visit `/training-facility/gym` (with `NEXT_PUBLIC_ENABLE_TRAINING_FACILITY=true`) — see "Open stair climber" CTA. Click it, land on the stair detail.
- [ ] On the stair detail, the date filter pills (`1M / 3M / 6M / 1Y / All`) all change the rendered content. Custom date inputs work too.
- [ ] Time-in-zone chart renders five bars (Z1–Z5) tinted green → red. Hover/tab — accessible role/label is present.
- [ ] Avg-HR chart renders one bar per session, oldest → newest left-to-right, y-axis BPM ticks readable.
- [ ] Session log table is in newest-first order; Duration formatted as `Mm SSs`; missing avg/max HR reads as `—`.
- [ ] Empty range (e.g. set custom start = end on a date with no sessions) — all three views show their empty-state placeholder, table reads "No stair sessions in the selected range."
- [ ] Resize browser to ~375px wide — charts shrink with the column (ResizeObserver-driven), table scrolls horizontally without breaking the page layout.
- [ ] Header chrome — "🏀 Back to Home Court" returns to `/`, "← The Gym" returns to `/training-facility/gym`.
- [ ] With `NEXT_PUBLIC_ENABLE_TRAINING_FACILITY` unset / `false`, `/training-facility/gym/stair` 404s.

> **Preview data note:** `public/data/cardio.json` is gitignored (PRD §11 open question 7 — visitor exposure of personal data). The Vercel preview will render empty states until the file is force-added or the gitignore is revisited.

Closes #62.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added stair climber detail page with interactive heart-rate visualizations and date-range filtering.
  * Added CTA link to the stair climber from the gym area.
  * Added heart-rate zone and average-heart-rate charts (responsive) and a session history table showing duration and HR metrics.
* **Tests**
  * Added unit tests covering stair-session filtering, HR-zone aggregation, per-session avg HR, and duration formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->