### PR TITLE
feat(data): getCardioData returns null on 404 (#120)

### DIFF
--- a/lib/data/cardio.test.ts
+++ b/lib/data/cardio.test.ts
@@ -2,11 +2,10 @@ import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest'
 import { getCardioData } from './cardio'
 
 /**
- * `getCardioData` is a thin fetch wrapper. Issue #104's checklist says it
- * should "return [] on 404, throw on other failures" but the current
- * implementation throws on all non-OK responses (and `CardioData` is an
- * object — `[]` wouldn't typecheck). These tests pin current behavior; the
- * `[]`-on-404 refactor is its own concern outside this PR's scope.
+ * `getCardioData` is a thin fetch wrapper that mirrors the empty-state
+ * behavior of `getMovementBenchmarks`: 404 → return a sentinel (here `null`,
+ * since `CardioData` is an object and `[]` wouldn't typecheck), other non-OK
+ * responses → throw.
  */
 
 let fetchMock: ReturnType<typeof vi.fn>
@@ -40,9 +39,9 @@ describe('getCardioData', () => {
     expect(url).toBe('/data/cardio.json')
   })
 
-  it('throws on 404 (current behavior — no empty-state shortcut)', async () => {
+  it('returns null on 404 (pre-baseline empty state, no cardio.json yet)', async () => {
     fetchMock.mockResolvedValueOnce(new Response(null, { status: 404, statusText: 'Not Found' }))
-    await expect(getCardioData()).rejects.toThrow(/Failed to load cardio data: 404/)
+    await expect(getCardioData()).resolves.toBeNull()
   })
 
   it('throws on 500 with status code in the message', async () => {

--- a/lib/data/cardio.ts
+++ b/lib/data/cardio.ts
@@ -7,10 +7,16 @@ import { DATA_BASE_URL } from './config';
  * Today this is a static asset; a future migration to a hosted API only changes
  * the URL inside this function — callers don't need to know.
  *
- * @throws if the fetch fails or the response status is not OK.
+ * Returns `null` if the dataset doesn't exist yet (typical pre-baseline state,
+ * before `scripts/preprocess-health.py` has produced `cardio.json`). Callers
+ * should render an empty state in that case rather than treating it as an error.
+ * `null` rather than an empty array because `CardioData` is an object.
+ *
+ * @throws on non-404 fetch failures.
  */
-export async function getCardioData(): Promise<CardioData> {
+export async function getCardioData(): Promise<CardioData | null> {
   const res = await fetch(`${DATA_BASE_URL}/cardio.json`);
+  if (res.status === 404) return null;
   if (!res.ok) {
     throw new Error(`Failed to load cardio data: ${res.status} ${res.statusText}`);
   }

--- a/lib/data/cardio.ts
+++ b/lib/data/cardio.ts
@@ -12,7 +12,8 @@ import { DATA_BASE_URL } from './config';
  * should render an empty state in that case rather than treating it as an error.
  * `null` rather than an empty array because `CardioData` is an object.
  *
- * @throws on non-404 fetch failures.
+ * @throws {Error} on non-404 fetch failures (status not 200 OK).
+ * @throws {SyntaxError} if the response body is not valid JSON.
  */
 export async function getCardioData(): Promise<CardioData | null> {
   const res = await fetch(`${DATA_BASE_URL}/cardio.json`);


### PR DESCRIPTION
## Summary
Adopt Option A from #120: `getCardioData` now returns `null` on a 404 (pre-baseline empty state, no `public/data/cardio.json` yet) instead of throwing. Other non-OK statuses still throw, matching the pattern already used by `getMovementBenchmarks`.

This unblocks the Gym detail views (#62, #68, #69) — they can render an empty state when there's no dataset yet rather than a hard error. There are no consumers of `getCardioData` on `main` today, so the return-type widening to `CardioData | null` is safe.

## Why null instead of an empty sentinel object
`CardioData` is a struct, not an array, so `[]` doesn't typecheck. A sentinel like `{ imported_at: '', sessions: [], … }` would lie about `imported_at` (which the wall display reads), so `null` is the truthful option. Branching cost for consumers is one `if (!data) return <EmptyState />`.

## Test plan
`lib/data/cardio.test.ts` is updated to pin the new contract:
- [x] 200 with valid body → returns parsed data (unchanged)
- [x] 404 → resolves to `null` (new — was: throws)
- [x] 500 → still throws (unchanged)
- [x] 200 with malformed JSON → still throws (unchanged)

Local verification:
- [x] `npx vitest run lib/data/cardio.test.ts` — 4/4 passing
- [x] `npx tsc --noEmit` — clean
- [x] `npx next build` — compiles

Closes #120.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing cardio data—the system now gracefully returns `null` instead of throwing an error when data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->