### PR TITLE
test(e2e): fix home.spec.ts flakes via deterministic readiness wait (#126)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -55,6 +55,7 @@ export default function HomePage() {
       ) : (
         <motion.div
           key="main"
+          data-testid="home-court"
           initial={reduce ? false : { opacity: 0 }}
           animate={{ opacity: 1 }}
           transition={{ duration }}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -55,7 +55,7 @@ export default function HomePage() {
       ) : (
         <motion.div
           key="main"
-          data-testid="home-court"
+          data-testid="home-court-root"
           initial={reduce ? false : { opacity: 0 }}
           animate={{ opacity: 1 }}
           transition={{ duration }}

--- a/e2e/helpers/intro.ts
+++ b/e2e/helpers/intro.ts
@@ -1,7 +1,13 @@
-import type { Page } from '@playwright/test'
+import { expect, type Page } from '@playwright/test'
 
 /** LocalStorage key used to persist whether the visitor has already seen the intro. */
 const HAS_SEEN_INTRO_KEY = 'hasSeenIntro'
+
+/** Test ID applied to the post-intro home-court root once it is mounted. */
+const HOME_COURT_TEST_ID = 'home-court'
+
+/** Maximum time to wait for the home court to mount, in milliseconds. */
+const HOME_COURT_READY_TIMEOUT_MS = 30_000
 
 /**
  * Seeds localStorage so the home page skips the tunnel intro animation.
@@ -12,4 +18,20 @@ export async function bypassHomeIntro(page: Page): Promise<void> {
   await page.addInitScript(storageKey => {
     window.localStorage.setItem(storageKey, 'true')
   }, HAS_SEEN_INTRO_KEY)
+}
+
+/**
+ * Navigates to `/` and waits for the post-intro home-court root to mount,
+ * absorbing dev-server compile time and the framer-motion fade-in so callers
+ * can immediately assert against rendered court affordances.
+ *
+ * Requires {@link bypassHomeIntro} to have run first (typically in `beforeEach`).
+ *
+ * @param page - Playwright page that has had the intro bypass seeded.
+ */
+export async function gotoHomeCourt(page: Page): Promise<void> {
+  await page.goto('/')
+  await expect(page.getByTestId(HOME_COURT_TEST_ID)).toBeVisible({
+    timeout: HOME_COURT_READY_TIMEOUT_MS,
+  })
 }

--- a/e2e/helpers/intro.ts
+++ b/e2e/helpers/intro.ts
@@ -4,7 +4,7 @@ import { expect, type Page } from '@playwright/test'
 const HAS_SEEN_INTRO_KEY = 'hasSeenIntro'
 
 /** Test ID applied to the post-intro home-court root once it is mounted. */
-const HOME_COURT_TEST_ID = 'home-court'
+const HOME_COURT_TEST_ID = 'home-court-root'
 
 /** Maximum time to wait for the home court to mount, in milliseconds. */
 const HOME_COURT_READY_TIMEOUT_MS = 30_000

--- a/e2e/helpers/intro.ts
+++ b/e2e/helpers/intro.ts
@@ -28,6 +28,7 @@ export async function bypassHomeIntro(page: Page): Promise<void> {
  * Requires {@link bypassHomeIntro} to have run first (typically in `beforeEach`).
  *
  * @param page - Playwright page that has had the intro bypass seeded.
+ * @throws If the home-court root is not visible within `HOME_COURT_READY_TIMEOUT_MS`.
  */
 export async function gotoHomeCourt(page: Page): Promise<void> {
   await page.goto('/')

--- a/e2e/home.spec.ts
+++ b/e2e/home.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test'
 
-import { bypassHomeIntro } from './helpers/intro'
+import { bypassHomeIntro, gotoHomeCourt } from './helpers/intro'
 
 test.describe('home court', () => {
   test.beforeEach(async ({ page }) => {
@@ -8,7 +8,7 @@ test.describe('home court', () => {
   })
 
   test('renders the primary navigation affordances', async ({ page }) => {
-    await page.goto('/')
+    await gotoHomeCourt(page)
 
     await expect(page.getByRole('button', { name: /view the rafters/i })).toBeVisible()
     await expect(page.getByRole('button', { name: /enter locker room/i })).toBeVisible()
@@ -17,7 +17,7 @@ test.describe('home court', () => {
   })
 
   test('navigates from the home court into the locker room', async ({ page }) => {
-    await page.goto('/')
+    await gotoHomeCourt(page)
 
     await page.getByRole('button', { name: /enter locker room/i }).click()
 

--- a/e2e/home.spec.ts
+++ b/e2e/home.spec.ts
@@ -10,16 +10,16 @@ test.describe('home court', () => {
   test('renders the primary navigation affordances', async ({ page }) => {
     await gotoHomeCourt(page)
 
-    await expect(page.getByRole('button', { name: /view the rafters/i })).toBeVisible()
-    await expect(page.getByRole('button', { name: /enter locker room/i })).toBeVisible()
-    await expect(page.getByRole('button', { name: /view project binder/i })).toBeVisible()
-    await expect(page.getByRole('button', { name: /go to front office/i })).toBeVisible()
+    await expect(page.getByRole('button', { name: /^rafters/i })).toBeVisible()
+    await expect(page.getByRole('button', { name: /^locker room/i })).toBeVisible()
+    await expect(page.getByRole('button', { name: /^project binder/i })).toBeVisible()
+    await expect(page.getByRole('button', { name: /^front office/i })).toBeVisible()
   })
 
   test('navigates from the home court into the locker room', async ({ page }) => {
     await gotoHomeCourt(page)
 
-    await page.getByRole('button', { name: /enter locker room/i }).click()
+    await page.getByRole('button', { name: /^locker room/i }).click()
 
     await expect(page).toHaveURL(/\/locker-room$/)
     await expect(

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -19,6 +19,7 @@ export default defineConfig({
   forbidOnly: IS_CI,
   retries: IS_CI ? 2 : 0,
   workers: IS_CI ? 1 : undefined,
+  timeout: 60_000,
   reporter: IS_CI ? [['github'], ['html', { open: 'never' }]] : [['list'], ['html', { open: 'never' }]],
   use: {
     browserName: 'chromium',


### PR DESCRIPTION
## Summary

The two `e2e/home.spec.ts` smoke tests fail on CI for **two reasons**, both addressed here:

1. **Broken accessible-name selectors (primary cause).** The court's four entry buttons (`ZoneEntryButton`) set `aria-label` to a long description (e.g. `"Rafters — career highlights and accolades"`), which overrides the visible text (`"View The Rafters"`) for the accessible name. `getByRole('button', { name: /view the rafters/i })` therefore never matched anything — the tests have been broken since they were written, not flaky. Selectors are now anchored regexes against the actual `aria-label` prefix (`/^rafters/i`, `/^locker room/i`, `/^project binder/i`, `/^front office/i`).

2. **Non-deterministic mount race (secondary).** Even with correct selectors, the assertions still raced framer-motion's intro→court fade and Turbopack's first-compile against a 5s default visibility timeout. Added a `data-testid="home-court-root"` to the post-intro wrapper, a `gotoHomeCourt(page)` helper that navigates to `/` and waits for that node, and bumped the per-test timeout to 60s so the helper's 30s wait can fail with a clean error rather than colliding with the test deadline.

### Files

- `app/page.tsx` — `data-testid="home-court-root"` on the post-intro `<motion.div>`. No prod behavior change.
- `e2e/helpers/intro.ts` — new `gotoHomeCourt(page)` helper. `bypassHomeIntro` keeps its narrow `beforeEach` job.
- `e2e/home.spec.ts` — selectors aligned with aria-labels; tests use `gotoHomeCourt`.
- `playwright.config.ts` — `timeout: 60_000` so test deadline gives helper room to fail cleanly.

`rooms.spec.ts` and `training-facility-disabled.spec.ts` aren't touched — they don't pass through the home intro.

## Test plan

- [ ] CI run on this PR: `Playwright E2E` → `default-routes` project goes green.
- [ ] Both `home court › renders the primary navigation affordances` and `home court › navigates from the home court into the locker room` pass on the first attempt (no Playwright retry consumed).
- [ ] After merge, re-run `Playwright E2E` on `main` HEAD and confirm green.
- [ ] Spot-check the Vercel preview homepage — the intro→court transition still renders normally for a fresh visitor (no `hasSeenIntro` cookie), and the `data-testid` doesn't break any styling.

Closes #126.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * More reliable home-page end-to-end flows via a new navigation helper and stronger element matching to reduce flaky UI tests.
  * Added a stable test identifier on the main page to improve automated query reliability and speed up test synchronization.

* **Chores**
  * Introduced a global test timeout to ensure consistent and predictable automated test execution across suites.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->