### PR TITLE
feat(gym): treadmill detail view (#68)

### DIFF
--- a/app/training-facility/gym/treadmill/page.tsx
+++ b/app/training-facility/gym/treadmill/page.tsx
@@ -1,0 +1,14 @@
+import { isTrainingFacilityEnabled } from '@/lib/feature-flags'
+import { TreadmillDetailView } from '@/components/training-facility/gym/TreadmillDetailView'
+import { notFound } from 'next/navigation'
+
+/**
+ * Treadmill detail view (PRD §7.4) — running-modality charts. Reachable from
+ * the treadmill click target on the Gym scene; gated behind the Training
+ * Facility feature flag for staged rollout.
+ */
+export default function TrainingFacilityGymTreadmillPage() {
+  if (!isTrainingFacilityEnabled()) notFound()
+
+  return <TreadmillDetailView />
+}

--- a/components/training-facility/gym/StairDetailView.tsx
+++ b/components/training-facility/gym/StairDetailView.tsx
@@ -54,25 +54,26 @@ export function StairDetailView(): JSX.Element {
     let cancelled = false
     getCardioData()
       .then((next) => {
-        if (!cancelled) setData(next)
-      })
-      .catch((err: unknown) => {
         if (cancelled) return
-        const message = err instanceof Error ? err.message : String(err)
-        // Treat a missing `cardio.json` (404) as "no data yet" rather than a
-        // hard error — the file is gitignored (PRD §11 open question 7), so
-        // a fresh preview deploy without an Apple Health import legitimately
-        // has no data. Other errors (network, 5xx, malformed JSON) still
-        // bubble up to the explicit error panel.
-        if (/\b404\b/.test(message)) {
-          setData({
+        // `getCardioData()` resolves to `null` on a 404 (gitignored cardio
+        // data, PRD §11 q7). Substitute an empty `CardioData` so the
+        // component progresses past the loading panel into the empty-state
+        // branch — without this, a fresh preview deploy with no
+        // `cardio.json` would sit on "Loading cardio data…" forever.
+        setData(
+          next ?? {
             imported_at: '',
             sessions: [],
             resting_hr_trend: [],
             vo2max_trend: [],
-          })
-          return
-        }
+          },
+        )
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return
+        // Real failures (network, 5xx, malformed JSON) reach this branch.
+        // 404 is handled as "empty" inside `.then` above since
+        // `getCardioData()` no longer throws on missing data.
         setLoadError(err instanceof Error ? err : new Error(String(err)))
       })
     return () => {

--- a/components/training-facility/gym/TreadmillDetailView.tsx
+++ b/components/training-facility/gym/TreadmillDetailView.tsx
@@ -1,0 +1,480 @@
+'use client'
+
+import Link from 'next/link'
+import { useEffect, useMemo, useRef, useState, type JSX } from 'react'
+import type { CardioData, CardioSession } from '@/types/cardio'
+import type { Benchmark } from '@/types/movement'
+import { getCardioData, getMovementBenchmarks } from '@/lib/data'
+import {
+  DateFilter,
+  endOfDay,
+  rangeForPreset,
+  startOfDay,
+  type DateRange,
+} from '@/components/training-facility/shared/DateFilter'
+import {
+  aggregateHrZoneSeconds,
+  formatDuration,
+  parseSessionDate,
+  perSessionAvgHr,
+} from '@/lib/training-facility/cardio-shared'
+import {
+  cardiacEfficiencyPoints,
+  filterRunningSessions,
+  formatDistanceMiles,
+  formatPacePerMile,
+  paceAtHrPoints,
+  paceTrendPoints,
+  type PaceTrendPoint,
+} from '@/lib/training-facility/running'
+import { BackToCourtButton } from '@/components/common/BackToCourtButton'
+import { HrZoneBars } from './HrZoneBars'
+import { AvgHrBars } from './AvgHrBars'
+import { RoughLine } from '@/components/training-facility/shared/charts/RoughLine'
+import { RoughScatter } from '@/components/training-facility/shared/charts/RoughScatter'
+import { BodyweightOverlay } from '@/components/training-facility/shared/charts/BodyweightOverlay'
+import { chartPalette } from '@/components/training-facility/shared/charts/palette'
+import { defaultMargin } from '@/components/training-facility/shared/charts/types'
+
+const CHART_HEIGHT = 280
+const PACE_CHART_HEIGHT = 300
+const MIN_CHART_WIDTH = 280
+const DEFAULT_CHART_WIDTH = 560
+const DEFAULT_PACE_WIDTH = 880
+const EARLIEST_FALLBACK = new Date(2024, 0, 1)
+const FONT_FAMILY = "'Patrick Hand', system-ui, sans-serif"
+
+/**
+ * Treadmill detail view (PRD §7.4) — running-modality charts over the cardio
+ * data layer, mirroring `StairDetailView` for shared concerns (HR-zone bars,
+ * per-session avg-HR, session log) and adding three running-specific views:
+ *
+ *   1. Pace trend (`RoughLine`, full-width) — wrapped in `BodyweightOverlay`
+ *      so power-to-weight context (PRD §4) sits on the same x-axis.
+ *   2. Cardiac efficiency (`RoughLine`) — meters-per-heartbeat over time.
+ *   3. Pace-at-HR scatter (`RoughScatter`) — fast-at-low-HR sessions land in
+ *      the lower-left quadrant (most efficient).
+ *
+ * Loading and error states are first-class so a missing `cardio.json` reads as
+ * "no data yet" rather than an empty chart wall.
+ */
+export function TreadmillDetailView(): JSX.Element {
+  const [data, setData] = useState<CardioData | null>(null)
+  const [benchmarks, setBenchmarks] = useState<Benchmark[]>([])
+  const [loadError, setLoadError] = useState<Error | null>(null)
+  const [range, setRange] = useState<DateRange>(() => rangeForPreset('1M', EARLIEST_FALLBACK))
+  const [chartWidth, setChartWidth] = useState(DEFAULT_CHART_WIDTH)
+  const [paceWidth, setPaceWidth] = useState(DEFAULT_PACE_WIDTH)
+  // Sentinel ref on a per-card wrapper — see StairDetailView for the rationale
+  // (observing the grid wrapper would over-report on `lg:grid-cols-2`).
+  const cardSizerRef = useRef<HTMLDivElement>(null)
+  const paceSizerRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    Promise.all([getCardioData(), getMovementBenchmarks()])
+      .then(([cardio, bench]) => {
+        if (cancelled) return
+        setData(cardio)
+        setBenchmarks(bench)
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return
+        const message = err instanceof Error ? err.message : String(err)
+        // Treat a 404 on either resource as empty rather than fatal — both
+        // files are gitignored (PRD §11 q7), so a fresh preview deploy
+        // legitimately has no data. Real failures (5xx, network, malformed
+        // JSON) still surface in the error panel.
+        if (/\b404\b/.test(message)) {
+          setData({
+            imported_at: '',
+            sessions: [],
+            resting_hr_trend: [],
+            vo2max_trend: [],
+          })
+          setBenchmarks([])
+          return
+        }
+        setLoadError(err instanceof Error ? err : new Error(String(err)))
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  useEffect(() => {
+    const node = cardSizerRef.current
+    if (!node || typeof ResizeObserver === 'undefined') return
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        const next = Math.max(MIN_CHART_WIDTH, Math.floor(entry.contentRect.width))
+        setChartWidth((prev) => (prev === next ? prev : next))
+      }
+    })
+    observer.observe(node)
+    return () => observer.disconnect()
+  }, [])
+
+  useEffect(() => {
+    const node = paceSizerRef.current
+    if (!node || typeof ResizeObserver === 'undefined') return
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        const next = Math.max(MIN_CHART_WIDTH, Math.floor(entry.contentRect.width))
+        setPaceWidth((prev) => (prev === next ? prev : next))
+      }
+    })
+    observer.observe(node)
+    return () => observer.disconnect()
+  }, [])
+
+  const earliestDate = useMemo(() => {
+    if (!data || data.sessions.length === 0) return EARLIEST_FALLBACK
+    let earliestMs = Infinity
+    for (const s of data.sessions) {
+      const ms = parseSessionDate(s.date).getTime()
+      if (Number.isFinite(ms) && ms < earliestMs) earliestMs = ms
+    }
+    return Number.isFinite(earliestMs) ? new Date(earliestMs) : EARLIEST_FALLBACK
+  }, [data])
+
+  const runningSessions = useMemo<CardioSession[]>(
+    () => (data ? filterRunningSessions(data.sessions, range) : []),
+    [data, range],
+  )
+  const buckets = useMemo(() => aggregateHrZoneSeconds(runningSessions), [runningSessions])
+  const avgHrPoints = useMemo(() => perSessionAvgHr(runningSessions), [runningSessions])
+  const paceTrend = useMemo(() => paceTrendPoints(runningSessions), [runningSessions])
+  const efficiencyTrend = useMemo(
+    () => cardiacEfficiencyPoints(runningSessions),
+    [runningSessions],
+  )
+  const paceVsHr = useMemo(() => paceAtHrPoints(runningSessions), [runningSessions])
+
+  // Date extent for the pace chart and bodyweight overlay must match exactly
+  // so the two x-axes line up. Falls back to the active filter range when the
+  // data set has fewer than two points (rough-line still renders a single dot
+  // at midpoint, and the overlay degrades to "no entries in range").
+  const paceDateExtent = useMemo<[Date, Date]>(() => {
+    if (paceTrend.length >= 2) {
+      return [paceTrend[0].date, paceTrend[paceTrend.length - 1].date]
+    }
+    if (paceTrend.length === 1) {
+      const d = paceTrend[0].date
+      return [d, d]
+    }
+    return [range.start, range.end]
+  }, [paceTrend, range])
+
+  return (
+    <div className="relative min-h-svh overflow-hidden bg-[#120d0a] text-[#f7ead9]">
+      <div
+        aria-hidden="true"
+        className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(255,255,255,0.08),transparent_28%),linear-gradient(180deg,#241811_0%,#120d0a_52%,#0b0806_100%)]"
+      />
+
+      <div className="relative z-10 mx-auto flex min-h-svh w-full max-w-5xl flex-col px-6 py-8 sm:px-8 lg:px-12">
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <BackToCourtButton />
+          <Link
+            href="/training-facility/gym"
+            className="rounded-full border border-white/15 bg-white/5 px-4 py-2 text-xs font-semibold uppercase tracking-[0.28em] text-white/80 transition hover:bg-white/10"
+          >
+            ← The Gym
+          </Link>
+        </div>
+
+        <header className="mt-12">
+          <div className="text-xs font-semibold uppercase tracking-[0.38em] text-white/60">
+            Treadmill
+          </div>
+          <h1 className="mt-3 text-4xl font-black uppercase tracking-[0.08em] text-[#fff7ec] sm:text-5xl">
+            Pace, effort, and the engine that drives both
+          </h1>
+          <p className="mt-4 max-w-2xl text-sm leading-7 text-[#e8d5be] sm:text-base">
+            Heart-rate zones, pace trend (overlaid with bodyweight per §4),
+            cardiac efficiency, and pace-at-HR — all scoped to the date range.
+            Lower-left on the scatter is the goal: fast at low effort.
+          </p>
+        </header>
+
+        <div className="mt-8">
+          <DateFilter
+            earliestDate={earliestDate}
+            defaultPreset="1M"
+            onChange={setRange}
+          />
+        </div>
+
+        {loadError ? (
+          <ErrorPanel error={loadError} />
+        ) : !data ? (
+          <LoadingPanel />
+        ) : (
+          <>
+            <div className="mt-8 grid gap-6 lg:grid-cols-2">
+              <ChartCard
+                title="Time in zone"
+                helper="Total minutes per HR zone across the filtered window."
+              >
+                <div ref={cardSizerRef}>
+                  <HrZoneBars
+                    buckets={buckets}
+                    width={chartWidth}
+                    height={CHART_HEIGHT}
+                    fontFamily={FONT_FAMILY}
+                  />
+                </div>
+              </ChartCard>
+
+              <ChartCard
+                title="Avg HR per session"
+                helper="One bar per session — y-axis padded to the visible range so trends pop."
+              >
+                <AvgHrBars
+                  points={avgHrPoints}
+                  width={chartWidth}
+                  height={CHART_HEIGHT}
+                  fontFamily={FONT_FAMILY}
+                />
+              </ChartCard>
+            </div>
+
+            <ChartCard
+              title="Pace trend"
+              helper="Pace per mile over time. Toggle the bodyweight overlay (§4) to see whether you're getting faster or just lighter."
+              wide
+            >
+              <div ref={paceSizerRef}>
+                <BodyweightOverlay
+                  benchmarks={benchmarks}
+                  dateExtent={paceDateExtent}
+                  width={paceWidth}
+                  height={PACE_CHART_HEIGHT}
+                  margin={defaultMargin}
+                  fontFamily={FONT_FAMILY}
+                  axisColor={chartPalette.inkSoft}
+                >
+                  <RoughLine<PaceTrendPoint>
+                    data={paceTrend}
+                    x={(p) => p.date}
+                    y={(p) => p.paceSecondsPerMile}
+                    width={paceWidth}
+                    height={PACE_CHART_HEIGHT}
+                    margin={defaultMargin}
+                    fontFamily={FONT_FAMILY}
+                    yLabel="Pace (min/mi)"
+                    yTickFormat={formatTickPace}
+                    ariaLabel="Pace per mile over time"
+                    emptyMessage="No pace data in range"
+                  />
+                </BodyweightOverlay>
+              </div>
+            </ChartCard>
+
+            <div className="mt-6 grid gap-6 lg:grid-cols-2">
+              <ChartCard
+                title="Cardiac efficiency"
+                helper="Meters covered per heartbeat — higher is more efficient."
+              >
+                <RoughLine
+                  data={efficiencyTrend}
+                  x={(p) => p.date}
+                  y={(p) => p.metersPerHeartbeat}
+                  width={chartWidth}
+                  height={CHART_HEIGHT}
+                  fontFamily={FONT_FAMILY}
+                  yLabel="m / heartbeat"
+                  yTickFormat={(v) => v.toFixed(2)}
+                  ariaLabel="Cardiac efficiency over time"
+                  emptyMessage="No efficiency data in range"
+                />
+              </ChartCard>
+
+              <ChartCard
+                title="Pace at heart rate"
+                helper="Each dot is one session. Lower-left = fast at low effort."
+              >
+                <RoughScatter
+                  data={paceVsHr}
+                  x={(p) => p.avgHr}
+                  y={(p) => p.paceSecondsPerMile}
+                  width={chartWidth}
+                  height={CHART_HEIGHT}
+                  fontFamily={FONT_FAMILY}
+                  xLabel="Avg HR (BPM)"
+                  yLabel="Pace (min/mi)"
+                  yTickFormat={formatTickPace}
+                  ariaLabel="Pace vs. heart rate scatter"
+                  emptyMessage="No pace + HR pairs in range"
+                />
+              </ChartCard>
+            </div>
+
+            <SessionLogTable sessions={runningSessions} range={range} />
+          </>
+        )}
+      </div>
+    </div>
+  )
+}
+
+/** Tick formatter shared by pace y-axes — `M:SS` (no `/mi` suffix to keep ticks compact). */
+function formatTickPace(secondsPerMile: number): string {
+  if (!Number.isFinite(secondsPerMile) || secondsPerMile <= 0) return ''
+  const total = Math.round(secondsPerMile)
+  const mins = Math.floor(total / 60)
+  const secs = total % 60
+  return `${mins}:${secs.toString().padStart(2, '0')}`
+}
+
+interface ChartCardProps {
+  title: string
+  helper: string
+  /** When set, the card sits full-width (used for the pace-trend row). */
+  wide?: boolean
+  children: JSX.Element
+}
+
+function ChartCard({ title, helper, wide, children }: ChartCardProps): JSX.Element {
+  return (
+    <section
+      className={`${wide ? 'mt-6 ' : ''}rounded-[1.6rem] border border-white/10 bg-[#f5f1e6] p-5 text-[#0a0a0a] shadow-[0_18px_46px_rgba(0,0,0,0.34)]`}
+    >
+      <header className="mb-2 flex items-baseline justify-between gap-3">
+        <h2 className="font-mono text-xs font-bold uppercase tracking-[0.24em] text-[#0a0a0a]">
+          {title}
+        </h2>
+      </header>
+      <p className="mb-4 text-xs leading-5 text-[#404040]">{helper}</p>
+      <div className="overflow-x-auto">{children}</div>
+    </section>
+  )
+}
+
+interface SessionLogTableProps {
+  sessions: readonly CardioSession[]
+  range: DateRange
+}
+
+function SessionLogTable({ sessions, range }: SessionLogTableProps): JSX.Element {
+  const rows = useMemo(() => sessions.slice().reverse(), [sessions])
+  const startLabel = formatRangeBound(range.start, 'start')
+  const endLabel = formatRangeBound(range.end, 'end')
+
+  return (
+    <section className="mt-8 rounded-[1.6rem] border border-white/10 bg-black/25 p-5">
+      <header className="mb-3 flex flex-wrap items-baseline justify-between gap-3">
+        <h2 className="font-mono text-xs font-bold uppercase tracking-[0.24em] text-white/80">
+          Sessions
+        </h2>
+        <p className="text-xs text-white/55">
+          {sessions.length === 0 ? 'No sessions in range' : `${sessions.length} in range`}
+          <span className="ml-2 text-white/35">
+            ({startLabel} → {endLabel})
+          </span>
+        </p>
+      </header>
+      {rows.length === 0 ? (
+        <p className="px-2 py-6 text-center text-sm text-white/55">
+          No running sessions in the selected range.
+        </p>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full min-w-[640px] border-separate border-spacing-y-1 text-left text-sm">
+            <thead className="text-xs uppercase tracking-[0.18em] text-white/55">
+              <tr>
+                <th scope="col" className="px-3 py-2 font-semibold">
+                  Date
+                </th>
+                <th scope="col" className="px-3 py-2 font-semibold">
+                  Distance
+                </th>
+                <th scope="col" className="px-3 py-2 font-semibold">
+                  Duration
+                </th>
+                <th scope="col" className="px-3 py-2 font-semibold">
+                  Pace
+                </th>
+                <th scope="col" className="px-3 py-2 font-semibold">
+                  Avg HR
+                </th>
+                <th scope="col" className="px-3 py-2 font-semibold">
+                  Max HR
+                </th>
+              </tr>
+            </thead>
+            <tbody className="text-[#f7ead9]">
+              {rows.map((s, i) => (
+                <tr
+                  key={`${s.date}-${s.duration_seconds}-${i}`}
+                  className="rounded-md bg-white/5 align-middle"
+                >
+                  <td className="rounded-l-md px-3 py-2 font-mono">{formatRowDate(s.date)}</td>
+                  <td className="px-3 py-2 font-mono">{formatDistanceMiles(s.distance_meters)}</td>
+                  <td className="px-3 py-2 font-mono">{formatDuration(s.duration_seconds)}</td>
+                  <td className="px-3 py-2 font-mono">{formatPaceCell(s.pace_seconds_per_km)}</td>
+                  <td className="px-3 py-2 font-mono">
+                    {typeof s.avg_hr === 'number' ? `${Math.round(s.avg_hr)}` : '—'}
+                  </td>
+                  <td className="rounded-r-md px-3 py-2 font-mono">
+                    {typeof s.max_hr === 'number' ? `${Math.round(s.max_hr)}` : '—'}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  )
+}
+
+const METERS_PER_MILE = 1609.344
+
+function formatPaceCell(paceSecondsPerKm: number | undefined): string {
+  if (typeof paceSecondsPerKm !== 'number' || !Number.isFinite(paceSecondsPerKm) || paceSecondsPerKm <= 0) {
+    return '—'
+  }
+  return formatPacePerMile((paceSecondsPerKm * METERS_PER_MILE) / 1000)
+}
+
+function formatRowDate(raw: string): string {
+  const d = parseSessionDate(raw)
+  if (!Number.isFinite(d.getTime())) return raw
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
+
+function formatRangeBound(d: Date, end: 'start' | 'end'): string {
+  const norm = end === 'start' ? startOfDay(d) : endOfDay(d)
+  return `${norm.getFullYear()}-${String(norm.getMonth() + 1).padStart(2, '0')}-${String(norm.getDate()).padStart(2, '0')}`
+}
+
+function LoadingPanel(): JSX.Element {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="mt-10 rounded-[1.6rem] border border-white/10 bg-black/25 p-8 text-center text-sm text-white/65"
+    >
+      Loading cardio data…
+    </div>
+  )
+}
+
+function ErrorPanel({ error }: { error: Error }): JSX.Element {
+  return (
+    <div
+      role="alert"
+      className="mt-10 rounded-[1.6rem] border border-red-400/30 bg-red-950/40 p-6 text-sm leading-6 text-red-100"
+    >
+      <p className="font-semibold uppercase tracking-[0.18em]">Could not load cardio data</p>
+      <p className="mt-2 text-red-100/80">{error.message}</p>
+      <p className="mt-4 text-xs text-red-100/60">
+        Run <code className="rounded bg-black/40 px-1.5 py-0.5">npm run import-health</code> to
+        regenerate <code className="rounded bg-black/40 px-1.5 py-0.5">public/data/cardio.json</code>{' '}
+        from a fresh Apple Health export, then redeploy.
+      </p>
+    </div>
+  )
+}

--- a/components/training-facility/gym/TreadmillDetailView.tsx
+++ b/components/training-facility/gym/TreadmillDetailView.tsx
@@ -22,6 +22,7 @@ import {
   cardiacEfficiencyPoints,
   filterRunningSessions,
   formatDistanceMiles,
+  formatPaceCellFromSecPerKm,
   formatPacePerMile,
   paceAtHrPoints,
   paceTrendPoints,
@@ -321,11 +322,8 @@ export function TreadmillDetailView(): JSX.Element {
 
 /** Tick formatter shared by pace y-axes — `M:SS` (no `/mi` suffix to keep ticks compact). */
 function formatTickPace(secondsPerMile: number): string {
-  if (!Number.isFinite(secondsPerMile) || secondsPerMile <= 0) return ''
-  const total = Math.round(secondsPerMile)
-  const mins = Math.floor(total / 60)
-  const secs = total % 60
-  return `${mins}:${secs.toString().padStart(2, '0')}`
+  const formatted = formatPacePerMile(secondsPerMile, false)
+  return formatted === '—' ? '' : formatted
 }
 
 interface ChartCardProps {
@@ -413,7 +411,7 @@ function SessionLogTable({ sessions, range }: SessionLogTableProps): JSX.Element
                   <td className="rounded-l-md px-3 py-2 font-mono">{formatRowDate(s.date)}</td>
                   <td className="px-3 py-2 font-mono">{formatDistanceMiles(s.distance_meters)}</td>
                   <td className="px-3 py-2 font-mono">{formatDuration(s.duration_seconds)}</td>
-                  <td className="px-3 py-2 font-mono">{formatPaceCell(s.pace_seconds_per_km)}</td>
+                  <td className="px-3 py-2 font-mono">{formatPaceCellFromSecPerKm(s.pace_seconds_per_km)}</td>
                   <td className="px-3 py-2 font-mono">
                     {typeof s.avg_hr === 'number' ? `${Math.round(s.avg_hr)}` : '—'}
                   </td>
@@ -428,15 +426,6 @@ function SessionLogTable({ sessions, range }: SessionLogTableProps): JSX.Element
       )}
     </section>
   )
-}
-
-const METERS_PER_MILE = 1609.344
-
-function formatPaceCell(paceSecondsPerKm: number | undefined): string {
-  if (typeof paceSecondsPerKm !== 'number' || !Number.isFinite(paceSecondsPerKm) || paceSecondsPerKm <= 0) {
-    return '—'
-  }
-  return formatPacePerMile((paceSecondsPerKm * METERS_PER_MILE) / 1000)
 }
 
 function formatRowDate(raw: string): string {

--- a/components/training-facility/gym/TreadmillDetailView.tsx
+++ b/components/training-facility/gym/TreadmillDetailView.tsx
@@ -76,26 +76,27 @@ export function TreadmillDetailView(): JSX.Element {
     Promise.all([getCardioData(), getMovementBenchmarks()])
       .then(([cardio, bench]) => {
         if (cancelled) return
-        setData(cardio)
-        setBenchmarks(bench)
-      })
-      .catch((err: unknown) => {
-        if (cancelled) return
-        const message = err instanceof Error ? err.message : String(err)
-        // Treat a 404 on either resource as empty rather than fatal — both
-        // files are gitignored (PRD §11 q7), so a fresh preview deploy
-        // legitimately has no data. Real failures (5xx, network, malformed
-        // JSON) still surface in the error panel.
-        if (/\b404\b/.test(message)) {
-          setData({
+        // `getCardioData()` resolves to `null` on a 404 (the dataset isn't
+        // produced yet — gitignored, PRD §11 q7). Substitute an empty
+        // `CardioData` so the component progresses past the loading panel
+        // and renders the empty-state branch. Without this, a fresh preview
+        // (no cardio.json yet) would sit on "Loading cardio data…" forever.
+        setData(
+          cardio ?? {
             imported_at: '',
             sessions: [],
             resting_hr_trend: [],
             vo2max_trend: [],
-          })
-          setBenchmarks([])
-          return
-        }
+          },
+        )
+        setBenchmarks(bench)
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return
+        // Real failures (network, 5xx, malformed JSON) surface the error
+        // panel. The 404-as-empty case is handled in `.then` above; this
+        // path only runs for genuine errors that `getCardioData()` /
+        // `getMovementBenchmarks()` choose to throw.
         setLoadError(err instanceof Error ? err : new Error(String(err)))
       })
     return () => {

--- a/components/training-facility/scenes/GymScene.tsx
+++ b/components/training-facility/scenes/GymScene.tsx
@@ -68,8 +68,39 @@ export function GymScene() {
       <Vo2MaxWhiteboard />
       <WallScoreboard />
 
-      {/* Foreground equipment */}
-      <Treadmill />
+      {/*
+        Treadmill group — same hover/focus pattern as the stair-climber
+        link below. Bounding rect spans from the front handlebar top
+        (y≈410) down past the deck shadow and the "treadmill" caption
+        (y≈870), wide enough to cover the cast shadow on both ends.
+      */}
+      <Link
+        href="/training-facility/gym/treadmill"
+        aria-label="Open the treadmill detail view"
+        className="group focus:outline-none"
+      >
+        <Treadmill />
+        <rect
+          x={115}
+          y={400}
+          width={365}
+          height={475}
+          fill={SCENE_PALETTE.creamBright}
+          className="opacity-0 transition-opacity group-hover:opacity-10 group-focus-visible:opacity-15"
+        />
+        <rect
+          x={115}
+          y={400}
+          width={365}
+          height={475}
+          fill="none"
+          stroke={SCENE_PALETTE.rim}
+          strokeWidth={4}
+          strokeDasharray="6 4"
+          rx={6}
+          className="opacity-0 transition-opacity group-focus-visible:opacity-100"
+        />
+      </Link>
       <SweatTowel />
 
       {/*

--- a/lib/training-facility/cardio-shared.ts
+++ b/lib/training-facility/cardio-shared.ts
@@ -1,0 +1,151 @@
+/**
+ * Shared cardio detail-view helpers (PRD §7.4).
+ *
+ * Activity-agnostic pure functions used by every Gym detail surface — stair,
+ * treadmill, track. Extracted out of `stair.ts` so the running/walking detail
+ * views can pull the same `parseSessionDate`, time-in-zone aggregation, and
+ * formatter without importing a sibling-equipment file.
+ *
+ * Activity-specific filters (`filterStairSessions`, `filterRunningSessions`,
+ * etc.) stay in their respective modules and delegate to
+ * {@link filterCardioSessionsByActivity} here so the equipment-specific public
+ * APIs continue to read naturally at call sites.
+ */
+
+import type { CardioActivity, CardioSession, HrZone } from '@/types/cardio'
+import { HR_ZONES, type HrZoneConfig } from '@/constants/hr-zones'
+import type { DateRange } from '@/components/training-facility/shared/DateFilter'
+
+/**
+ * Parse a session-date string as a local-time `Date`.
+ *
+ * Bare `YYYY-MM-DD` strings (the dominant format in `cardio.json` for
+ * non-walking sessions) are treated as local midnight so range comparisons
+ * match the `DateFilter`'s local-day bounds. Full ISO timestamps already carry
+ * an offset and pass through to `new Date()` unchanged.
+ *
+ * Exported so every layer (filters, chart projections, table row formatters)
+ * stays consistent on the local-vs-UTC interpretation of the same field.
+ *
+ * @param raw - Original `date` field from a `CardioSession`.
+ */
+export function parseSessionDate(raw: string): Date {
+  if (/^\d{4}-\d{2}-\d{2}$/.test(raw)) return new Date(`${raw}T00:00:00`)
+  return new Date(raw)
+}
+
+/**
+ * Filter `sessions` down to a single activity whose `date` falls within
+ * `range` (inclusive on both ends). Sessions with unparseable `date` strings
+ * are dropped silently — the data layer is the right place to catch malformed
+ * input, not a chart helper. Output is sorted oldest → newest so chart x-axes
+ * read left-to-right by time.
+ *
+ * @param sessions - Full session list from `getCardioData()`.
+ * @param activity - `'stair'`, `'running'`, or `'walking'`.
+ * @param range - Active range from the shared `DateFilter`.
+ */
+export function filterCardioSessionsByActivity(
+  sessions: readonly CardioSession[],
+  activity: CardioActivity,
+  range: DateRange,
+): CardioSession[] {
+  const fromMs = range.start.getTime()
+  const toMs = range.end.getTime()
+  const out: { session: CardioSession; ts: number }[] = []
+  for (const s of sessions) {
+    if (s.activity !== activity) continue
+    const ts = parseSessionDate(s.date).getTime()
+    if (!Number.isFinite(ts)) continue
+    if (ts < fromMs || ts > toMs) continue
+    out.push({ session: s, ts })
+  }
+  out.sort((a, b) => a.ts - b.ts)
+  return out.map((entry) => entry.session)
+}
+
+/** One row in the HR-zone distribution chart. */
+export interface HrZoneBucket {
+  /** Zone identifier (`Z1`–`Z5`). */
+  zone: HrZoneConfig['id']
+  /** Long zone label (e.g. "Aerobic Base"). */
+  label: string
+  /** Short axis label (e.g. "Z2"). */
+  shortLabel: string
+  /** Display color from the zone config. */
+  color: string
+  /** Total seconds spent in this zone across the filtered sessions. */
+  seconds: number
+}
+
+/**
+ * Sum the `hr_seconds_in_zone` field across a list of sessions, returning
+ * one bucket per zone (Z1–Z5) in canonical order. Sessions missing the field
+ * contribute zero — they don't drop the zone from the result, so the chart
+ * always shows all five bars regardless of data quality.
+ *
+ * @param sessions - Already-filtered session list.
+ */
+export function aggregateHrZoneSeconds(sessions: readonly CardioSession[]): HrZoneBucket[] {
+  const totals: Record<HrZone, number> = { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 }
+  for (const s of sessions) {
+    const z = s.hr_seconds_in_zone
+    if (!z) continue
+    totals[1] += z[1] ?? 0
+    totals[2] += z[2] ?? 0
+    totals[3] += z[3] ?? 0
+    totals[4] += z[4] ?? 0
+    totals[5] += z[5] ?? 0
+  }
+  return HR_ZONES.map((z, i) => ({
+    zone: z.id,
+    label: z.label,
+    shortLabel: z.shortLabel,
+    color: z.color,
+    seconds: totals[(i + 1) as HrZone],
+  }))
+}
+
+/** One point on the per-session avg-HR bar chart. */
+export interface SessionAvgHrPoint {
+  /** Original session date string (ISO or `YYYY-MM-DD`). */
+  date: string
+  /** Short label rendered on the x-axis — `M/D` in local time. */
+  label: string
+  /** Average heart rate, BPM. Sessions missing `avg_hr` are excluded upstream. */
+  avgHr: number
+}
+
+/**
+ * Project a session list to the points needed by the avg-HR bar chart.
+ * Sessions without an `avg_hr` field are excluded — there's nothing to render
+ * and a zero bar would lie about coverage. Output preserves input order, so
+ * callers pass a chronologically-sorted list to get left-to-right time
+ * ordering.
+ *
+ * @param sessions - Filtered, sorted sessions.
+ */
+export function perSessionAvgHr(sessions: readonly CardioSession[]): SessionAvgHrPoint[] {
+  const out: SessionAvgHrPoint[] = []
+  for (const s of sessions) {
+    if (typeof s.avg_hr !== 'number') continue
+    const d = parseSessionDate(s.date)
+    if (!Number.isFinite(d.getTime())) continue
+    const label = `${d.getMonth() + 1}/${d.getDate()}`
+    out.push({ date: s.date, label, avgHr: s.avg_hr })
+  }
+  return out
+}
+
+/**
+ * Format a duration in seconds as a compact `Mm Ss` string (e.g. `32m 05s`).
+ *
+ * Negative or non-finite inputs return `—` rather than `NaNm`/`-1m`, so a
+ * malformed entry doesn't pollute a table.
+ */
+export function formatDuration(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds < 0) return '—'
+  const mins = Math.floor(seconds / 60)
+  const secs = Math.floor(seconds % 60)
+  return `${mins}m ${secs.toString().padStart(2, '0')}s`
+}

--- a/lib/training-facility/running.test.ts
+++ b/lib/training-facility/running.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect } from 'vitest'
+import {
+  cardiacEfficiencyPoints,
+  filterRunningSessions,
+  formatDistanceMiles,
+  formatPacePerMile,
+  paceAtHrPoints,
+  paceTrendPoints,
+} from './running'
+import type { CardioSession } from '@/types/cardio'
+
+const range = (startIso: string, endIso: string) => ({
+  start: new Date(startIso),
+  end: new Date(endIso),
+})
+
+const run = (date: string, extras: Partial<CardioSession> = {}): CardioSession => ({
+  date,
+  activity: 'running',
+  duration_seconds: 1800,
+  ...extras,
+})
+
+describe('filterRunningSessions', () => {
+  it('keeps only running-activity sessions inside the range, sorted oldest → newest', () => {
+    const sessions: CardioSession[] = [
+      run('2026-04-10'),
+      run('2026-04-01'),
+      { date: '2026-04-05', activity: 'stair', duration_seconds: 1500 },
+      { date: '2026-04-12', activity: 'walking', duration_seconds: 2400 },
+      run('2026-03-15'),
+      run('2026-04-20'),
+    ]
+    const out = filterRunningSessions(
+      sessions,
+      range('2026-04-01T00:00:00', '2026-04-15T23:59:59.999'),
+    )
+    expect(out.map((s) => s.date)).toEqual(['2026-04-01', '2026-04-10'])
+  })
+})
+
+describe('paceTrendPoints', () => {
+  it('converts pace from sec/km to sec/mi and preserves order', () => {
+    const sessions: CardioSession[] = [
+      run('2026-04-01', { pace_seconds_per_km: 360 }),
+      run('2026-04-08', { pace_seconds_per_km: 330 }),
+    ]
+    const out = paceTrendPoints(sessions)
+    expect(out).toHaveLength(2)
+    // 360 sec/km × 1.609344 ≈ 579.36 sec/mi
+    expect(out[0].paceSecondsPerMile).toBeCloseTo(579.36, 1)
+    expect(out[0].rawDate).toBe('2026-04-01')
+    // 330 sec/km × 1.609344 ≈ 531.08 sec/mi
+    expect(out[1].paceSecondsPerMile).toBeCloseTo(531.08, 1)
+  })
+
+  it('drops sessions without a usable pace', () => {
+    const sessions: CardioSession[] = [
+      run('2026-04-01'), // no pace
+      run('2026-04-02', { pace_seconds_per_km: 0 }), // sentinel
+      run('2026-04-03', { pace_seconds_per_km: -1 }), // negative
+      run('2026-04-04', { pace_seconds_per_km: Number.NaN }),
+      run('2026-04-05', { pace_seconds_per_km: 360 }),
+    ]
+    const out = paceTrendPoints(sessions)
+    expect(out.map((p) => p.rawDate)).toEqual(['2026-04-05'])
+  })
+
+  it('drops sessions whose date is unparseable', () => {
+    const sessions: CardioSession[] = [
+      run('garbage', { pace_seconds_per_km: 360 }),
+      run('2026-04-05', { pace_seconds_per_km: 360 }),
+    ]
+    const out = paceTrendPoints(sessions)
+    expect(out.map((p) => p.rawDate)).toEqual(['2026-04-05'])
+  })
+})
+
+describe('cardiacEfficiencyPoints', () => {
+  it('keeps sessions with positive m/heartbeat, in input order', () => {
+    const sessions: CardioSession[] = [
+      run('2026-04-01', { meters_per_heartbeat: 1.42 }),
+      run('2026-04-08', { meters_per_heartbeat: 1.51 }),
+    ]
+    const out = cardiacEfficiencyPoints(sessions)
+    expect(out.map((p) => p.metersPerHeartbeat)).toEqual([1.42, 1.51])
+  })
+
+  it('drops sessions missing the field or non-positive', () => {
+    const sessions: CardioSession[] = [
+      run('2026-04-01'),
+      run('2026-04-02', { meters_per_heartbeat: 0 }),
+      run('2026-04-03', { meters_per_heartbeat: -0.5 }),
+      run('2026-04-04', { meters_per_heartbeat: 1.6 }),
+    ]
+    const out = cardiacEfficiencyPoints(sessions)
+    expect(out.map((p) => p.rawDate)).toEqual(['2026-04-04'])
+  })
+})
+
+describe('paceAtHrPoints', () => {
+  it('keeps sessions with both avg_hr and pace, converting to sec/mi', () => {
+    const sessions: CardioSession[] = [
+      run('2026-04-01', { avg_hr: 152, pace_seconds_per_km: 360 }),
+      run('2026-04-08', { avg_hr: 148, pace_seconds_per_km: 348 }),
+    ]
+    const out = paceAtHrPoints(sessions)
+    expect(out).toHaveLength(2)
+    expect(out[0].avgHr).toBe(152)
+    expect(out[0].paceSecondsPerMile).toBeCloseTo(579.36, 1)
+  })
+
+  it('drops sessions missing either coordinate', () => {
+    const sessions: CardioSession[] = [
+      run('2026-04-01', { avg_hr: 152 }), // no pace
+      run('2026-04-02', { pace_seconds_per_km: 360 }), // no HR
+      run('2026-04-03', { avg_hr: 0, pace_seconds_per_km: 360 }),
+      run('2026-04-04', { avg_hr: 152, pace_seconds_per_km: 0 }),
+      run('2026-04-05', { avg_hr: 150, pace_seconds_per_km: 350 }),
+    ]
+    const out = paceAtHrPoints(sessions)
+    expect(out.map((p) => p.rawDate)).toEqual(['2026-04-05'])
+  })
+})
+
+describe('formatPacePerMile', () => {
+  it('formats whole minutes', () => {
+    expect(formatPacePerMile(540)).toBe('9:00 /mi')
+  })
+
+  it('zero-pads seconds', () => {
+    expect(formatPacePerMile(545)).toBe('9:05 /mi')
+  })
+
+  it('handles sub-minute paces', () => {
+    expect(formatPacePerMile(45)).toBe('0:45 /mi')
+  })
+
+  it('returns an em dash for invalid input', () => {
+    expect(formatPacePerMile(Number.NaN)).toBe('—')
+    expect(formatPacePerMile(0)).toBe('—')
+    expect(formatPacePerMile(-30)).toBe('—')
+  })
+})
+
+describe('formatDistanceMiles', () => {
+  it('converts meters to miles with one decimal', () => {
+    // 5000 m / 1609.344 ≈ 3.1 mi
+    expect(formatDistanceMiles(5000)).toBe('3.1 mi')
+    // 1609.344 m → 1.0 mi exactly
+    expect(formatDistanceMiles(1609.344)).toBe('1.0 mi')
+  })
+
+  it('returns em dash when distance is missing or zero', () => {
+    expect(formatDistanceMiles(undefined)).toBe('—')
+    expect(formatDistanceMiles(0)).toBe('—')
+    expect(formatDistanceMiles(-100)).toBe('—')
+    expect(formatDistanceMiles(Number.NaN)).toBe('—')
+  })
+})

--- a/lib/training-facility/running.test.ts
+++ b/lib/training-facility/running.test.ts
@@ -3,9 +3,11 @@ import {
   cardiacEfficiencyPoints,
   filterRunningSessions,
   formatDistanceMiles,
+  formatPaceCellFromSecPerKm,
   formatPacePerMile,
   paceAtHrPoints,
   paceTrendPoints,
+  secPerKmToSecPerMile,
 } from './running'
 import type { CardioSession } from '@/types/cardio'
 
@@ -96,6 +98,38 @@ describe('cardiacEfficiencyPoints', () => {
     const out = cardiacEfficiencyPoints(sessions)
     expect(out.map((p) => p.rawDate)).toEqual(['2026-04-04'])
   })
+
+  it('drops sessions whose date is unparseable', () => {
+    const sessions: CardioSession[] = [
+      run('garbage', { meters_per_heartbeat: 1.4 }),
+      run('2026-04-05', { meters_per_heartbeat: 1.5 }),
+    ]
+    const out = cardiacEfficiencyPoints(sessions)
+    expect(out.map((p) => p.rawDate)).toEqual(['2026-04-05'])
+  })
+})
+
+describe('secPerKmToSecPerMile', () => {
+  it('multiplies by miles-per-meter then re-scales km → m', () => {
+    // 360 sec/km × 1.609344 ≈ 579.36 sec/mi
+    expect(secPerKmToSecPerMile(360)).toBeCloseTo(579.36, 1)
+    // 0 stays 0 — caller filters but the math is still well-defined.
+    expect(secPerKmToSecPerMile(0)).toBe(0)
+  })
+})
+
+describe('formatPaceCellFromSecPerKm', () => {
+  it('converts and formats with /mi suffix', () => {
+    // 360 sec/km ≈ 579 sec/mi → 9:39 /mi
+    expect(formatPaceCellFromSecPerKm(360)).toBe('9:39 /mi')
+  })
+
+  it('returns em dash when input is missing or non-positive', () => {
+    expect(formatPaceCellFromSecPerKm(undefined)).toBe('—')
+    expect(formatPaceCellFromSecPerKm(0)).toBe('—')
+    expect(formatPaceCellFromSecPerKm(-30)).toBe('—')
+    expect(formatPaceCellFromSecPerKm(Number.NaN)).toBe('—')
+  })
 })
 
 describe('paceAtHrPoints', () => {
@@ -134,6 +168,10 @@ describe('formatPacePerMile', () => {
 
   it('handles sub-minute paces', () => {
     expect(formatPacePerMile(45)).toBe('0:45 /mi')
+  })
+
+  it('omits the unit when includeUnit is false (chart tick form)', () => {
+    expect(formatPacePerMile(545, false)).toBe('9:05')
   })
 
   it('returns an em dash for invalid input', () => {

--- a/lib/training-facility/running.ts
+++ b/lib/training-facility/running.ts
@@ -1,0 +1,159 @@
+/**
+ * Treadmill / running detail-view helpers (PRD §7.4).
+ *
+ * Pure functions for the running-specific charts: pace trend (min/mi over
+ * time), cardiac efficiency (m/heartbeat over time), and pace-at-HR scatter.
+ * Activity-agnostic helpers live in {@link ./cardio-shared}.
+ */
+
+import type { CardioSession } from '@/types/cardio'
+import type { DateRange } from '@/components/training-facility/shared/DateFilter'
+import { filterCardioSessionsByActivity, parseSessionDate } from './cardio-shared'
+
+/** One mile in meters — IUPAC value, used for pace conversions. */
+const METERS_PER_MILE = 1609.344
+
+/**
+ * Filter `sessions` down to running entries inside `range`. Thin wrapper over
+ * {@link filterCardioSessionsByActivity} so the `TreadmillDetailView` call
+ * site reads as the equipment-specific verb.
+ *
+ * @param sessions - Full session list from `getCardioData()`.
+ * @param range - Active range from the shared `DateFilter`.
+ */
+export function filterRunningSessions(
+  sessions: readonly CardioSession[],
+  range: DateRange,
+): CardioSession[] {
+  return filterCardioSessionsByActivity(sessions, 'running', range)
+}
+
+/** One point on the pace-trend line chart. */
+export interface PaceTrendPoint {
+  /** Local-midnight `Date` for the session — used as the x-scale value. */
+  date: Date
+  /** Original session date string, kept for keying and table joins. */
+  rawDate: string
+  /** Pace in seconds per mile (lower = faster). Y value of the chart. */
+  paceSecondsPerMile: number
+}
+
+/**
+ * Project running sessions to pace-trend points (seconds per mile).
+ *
+ * Source data is `pace_seconds_per_km`; conversion is `× 1609.344 / 1000`.
+ * Sessions without a numeric pace, with non-positive pace (sentinel for
+ * "missing" in some Apple Health exports), or with an unparseable date are
+ * dropped — the chart renders gaps as missing points rather than zero-pace
+ * outliers that would compress the y-domain.
+ *
+ * @param sessions - Filtered, sorted running sessions.
+ */
+export function paceTrendPoints(sessions: readonly CardioSession[]): PaceTrendPoint[] {
+  const out: PaceTrendPoint[] = []
+  for (const s of sessions) {
+    const secPerKm = s.pace_seconds_per_km
+    if (typeof secPerKm !== 'number' || !Number.isFinite(secPerKm) || secPerKm <= 0) continue
+    const date = parseSessionDate(s.date)
+    if (!Number.isFinite(date.getTime())) continue
+    out.push({
+      date,
+      rawDate: s.date,
+      paceSecondsPerMile: (secPerKm * METERS_PER_MILE) / 1000,
+    })
+  }
+  return out
+}
+
+/** One point on the cardiac-efficiency line chart. */
+export interface CardiacEfficiencyPoint {
+  /** Local-midnight `Date` for the session. */
+  date: Date
+  /** Original session date string. */
+  rawDate: string
+  /** Distance covered per heartbeat, in meters. Higher = more efficient. */
+  metersPerHeartbeat: number
+}
+
+/**
+ * Project running sessions to cardiac-efficiency points (m/heartbeat over
+ * time). Sessions missing `meters_per_heartbeat`, with non-positive values,
+ * or with an unparseable date are dropped.
+ *
+ * @param sessions - Filtered, sorted running sessions.
+ */
+export function cardiacEfficiencyPoints(
+  sessions: readonly CardioSession[],
+): CardiacEfficiencyPoint[] {
+  const out: CardiacEfficiencyPoint[] = []
+  for (const s of sessions) {
+    const mph = s.meters_per_heartbeat
+    if (typeof mph !== 'number' || !Number.isFinite(mph) || mph <= 0) continue
+    const date = parseSessionDate(s.date)
+    if (!Number.isFinite(date.getTime())) continue
+    out.push({ date, rawDate: s.date, metersPerHeartbeat: mph })
+  }
+  return out
+}
+
+/** One point on the pace-at-HR scatter plot. */
+export interface PaceAtHrPoint {
+  /** Original session date string — used as a stable key. */
+  rawDate: string
+  /** Average heart rate over the session, BPM. X value of the scatter. */
+  avgHr: number
+  /** Pace in seconds per mile. Y value of the scatter (lower = faster). */
+  paceSecondsPerMile: number
+}
+
+/**
+ * Project running sessions to scatter-plot points (avg HR vs pace). Both
+ * fields must be present and positive — there's no defensible value to plot
+ * for a session that's missing either coordinate. The lower-left quadrant is
+ * "fast at low effort" (most efficient).
+ *
+ * @param sessions - Filtered, sorted running sessions.
+ */
+export function paceAtHrPoints(sessions: readonly CardioSession[]): PaceAtHrPoint[] {
+  const out: PaceAtHrPoint[] = []
+  for (const s of sessions) {
+    if (typeof s.avg_hr !== 'number' || !Number.isFinite(s.avg_hr) || s.avg_hr <= 0) continue
+    const secPerKm = s.pace_seconds_per_km
+    if (typeof secPerKm !== 'number' || !Number.isFinite(secPerKm) || secPerKm <= 0) continue
+    out.push({
+      rawDate: s.date,
+      avgHr: s.avg_hr,
+      paceSecondsPerMile: (secPerKm * METERS_PER_MILE) / 1000,
+    })
+  }
+  return out
+}
+
+/**
+ * Format a pace in seconds-per-mile as `M:SS /mi` (e.g. `9:42 /mi`).
+ *
+ * Used by tick labels on pace charts and the session log Pace column. Returns
+ * `—` for non-finite or non-positive input so a malformed point doesn't render
+ * as `NaN:NaN /mi`.
+ *
+ * @param secondsPerMile - Pace value (lower = faster).
+ */
+export function formatPacePerMile(secondsPerMile: number): string {
+  if (!Number.isFinite(secondsPerMile) || secondsPerMile <= 0) return '—'
+  const total = Math.round(secondsPerMile)
+  const mins = Math.floor(total / 60)
+  const secs = total % 60
+  return `${mins}:${secs.toString().padStart(2, '0')} /mi`
+}
+
+/**
+ * Format a distance in meters as a miles string with one decimal (e.g.
+ * `3.1 mi`). Returns `—` for non-finite, negative, or zero input — the column
+ * shows missing distance as a dash rather than `0.0 mi`.
+ *
+ * @param meters - Raw distance from `CardioSession.distance_meters`.
+ */
+export function formatDistanceMiles(meters: number | undefined): string {
+  if (typeof meters !== 'number' || !Number.isFinite(meters) || meters <= 0) return '—'
+  return `${(meters / METERS_PER_MILE).toFixed(1)} mi`
+}

--- a/lib/training-facility/running.ts
+++ b/lib/training-facility/running.ts
@@ -10,8 +10,19 @@ import type { CardioSession } from '@/types/cardio'
 import type { DateRange } from '@/components/training-facility/shared/DateFilter'
 import { filterCardioSessionsByActivity, parseSessionDate } from './cardio-shared'
 
-/** One mile in meters — IUPAC value, used for pace conversions. */
-const METERS_PER_MILE = 1609.344
+/** One mile in meters — used for pace and distance conversions. */
+export const METERS_PER_MILE = 1609.344
+
+/**
+ * Convert a pace from `sec/km` (the format `cardio.json` stores) to `sec/mi`
+ * (the format the UI renders). Exported so the data helpers and the table-row
+ * formatter share the conversion without duplicating the constant.
+ *
+ * @param secPerKm - Pace in seconds per kilometer (lower = faster).
+ */
+export function secPerKmToSecPerMile(secPerKm: number): number {
+  return (secPerKm * METERS_PER_MILE) / 1000
+}
 
 /**
  * Filter `sessions` down to running entries inside `range`. Thin wrapper over
@@ -59,7 +70,7 @@ export function paceTrendPoints(sessions: readonly CardioSession[]): PaceTrendPo
     out.push({
       date,
       rawDate: s.date,
-      paceSecondsPerMile: (secPerKm * METERS_PER_MILE) / 1000,
+      paceSecondsPerMile: secPerKmToSecPerMile(secPerKm),
     })
   }
   return out
@@ -123,27 +134,48 @@ export function paceAtHrPoints(sessions: readonly CardioSession[]): PaceAtHrPoin
     out.push({
       rawDate: s.date,
       avgHr: s.avg_hr,
-      paceSecondsPerMile: (secPerKm * METERS_PER_MILE) / 1000,
+      paceSecondsPerMile: secPerKmToSecPerMile(secPerKm),
     })
   }
   return out
 }
 
 /**
- * Format a pace in seconds-per-mile as `M:SS /mi` (e.g. `9:42 /mi`).
+ * Format a pace in seconds-per-mile as `M:SS` or `M:SS /mi`.
  *
- * Used by tick labels on pace charts and the session log Pace column. Returns
- * `—` for non-finite or non-positive input so a malformed point doesn't render
- * as `NaN:NaN /mi`.
+ * Used by tick labels on pace charts (`includeUnit: false`) and the session
+ * log Pace column (`includeUnit: true`). Returns `—` for non-finite or
+ * non-positive input so a malformed point doesn't render as `NaN:NaN`.
  *
  * @param secondsPerMile - Pace value (lower = faster).
+ * @param includeUnit - When `true`, append ` /mi`. Defaults to `true`.
  */
-export function formatPacePerMile(secondsPerMile: number): string {
+export function formatPacePerMile(secondsPerMile: number, includeUnit = true): string {
   if (!Number.isFinite(secondsPerMile) || secondsPerMile <= 0) return '—'
   const total = Math.round(secondsPerMile)
   const mins = Math.floor(total / 60)
   const secs = total % 60
-  return `${mins}:${secs.toString().padStart(2, '0')} /mi`
+  const base = `${mins}:${secs.toString().padStart(2, '0')}`
+  return includeUnit ? `${base} /mi` : base
+}
+
+/**
+ * Format a `pace_seconds_per_km` value (the on-disk format) directly as a
+ * display string. Convenience wrapper for the session-log Pace column — saves
+ * call sites from threading the conversion + formatting through two helpers.
+ *
+ * @param paceSecondsPerKm - Raw `CardioSession.pace_seconds_per_km`. Missing /
+ *   non-positive / non-finite inputs render as `—`.
+ */
+export function formatPaceCellFromSecPerKm(paceSecondsPerKm: number | undefined): string {
+  if (
+    typeof paceSecondsPerKm !== 'number' ||
+    !Number.isFinite(paceSecondsPerKm) ||
+    paceSecondsPerKm <= 0
+  ) {
+    return '—'
+  }
+  return formatPacePerMile(secPerKmToSecPerMile(paceSecondsPerKm))
 }
 
 /**

--- a/lib/training-facility/stair.ts
+++ b/lib/training-facility/stair.ts
@@ -1,42 +1,28 @@
 /**
- * Stair-climber detail-view aggregation helpers (PRD §7.4).
+ * Stair-climber detail-view helpers (PRD §7.4).
  *
- * Pure functions used by the Gym stair detail route to slice cardio sessions
- * down to the stair modality, sum time-in-zone across the visible window, and
- * project per-session points for the avg-HR bar chart. Kept separate from the
- * React components so the math is unit-testable without RTL.
+ * Stair-specific filter sits here; activity-agnostic helpers
+ * (`parseSessionDate`, HR-zone aggregation, avg-HR projection, duration
+ * formatter, related types) live in {@link ./cardio-shared} and are re-exported
+ * for backwards compatibility with the existing `StairDetailView` import path.
  */
 
-import type { CardioSession, HrZone } from '@/types/cardio'
-import { HR_ZONES, type HrZoneConfig } from '@/constants/hr-zones'
+import type { CardioSession } from '@/types/cardio'
 import type { DateRange } from '@/components/training-facility/shared/DateFilter'
+import { filterCardioSessionsByActivity } from './cardio-shared'
+
+export {
+  parseSessionDate,
+  aggregateHrZoneSeconds,
+  perSessionAvgHr,
+  formatDuration,
+} from './cardio-shared'
+export type { HrZoneBucket, SessionAvgHrPoint } from './cardio-shared'
 
 /**
- * Parse a session-date string as a local-time `Date`.
- *
- * Bare `YYYY-MM-DD` strings (the dominant format in `cardio.json` for stair
- * sessions) are treated as local midnight so range comparisons match the
- * `DateFilter`'s local-day bounds. Full ISO timestamps already carry an offset
- * and pass through to `new Date()` unchanged.
- *
- * Exported so the rendering layer (`StairDetailView`, table row formatter,
- * earliest-date scan) can stay consistent with how the aggregation layer
- * interprets the same field — single source of truth, no per-call-site
- * timezone divergence.
- *
- * @param raw - Original `date` field from a `CardioSession`.
- */
-export function parseSessionDate(raw: string): Date {
-  if (/^\d{4}-\d{2}-\d{2}$/.test(raw)) return new Date(`${raw}T00:00:00`)
-  return new Date(raw)
-}
-
-/**
- * Filter `sessions` down to stair-climbing entries whose `date` falls within
- * `range` (inclusive on both ends). Sessions with unparseable `date` strings
- * are dropped silently — the data layer is the right place to catch malformed
- * input, not a chart helper. Output is sorted oldest → newest so chart x-axes
- * read left-to-right by time.
+ * Filter `sessions` down to stair-climbing entries inside `range`. Thin
+ * wrapper over {@link filterCardioSessionsByActivity} so the call site at
+ * `StairDetailView` reads as the equipment-specific verb.
  *
  * @param sessions - Full session list from `getCardioData()`.
  * @param range - Active range from the shared `DateFilter`.
@@ -45,104 +31,5 @@ export function filterStairSessions(
   sessions: readonly CardioSession[],
   range: DateRange,
 ): CardioSession[] {
-  const fromMs = range.start.getTime()
-  const toMs = range.end.getTime()
-  const out: { session: CardioSession; ts: number }[] = []
-  for (const s of sessions) {
-    if (s.activity !== 'stair') continue
-    const ts = parseSessionDate(s.date).getTime()
-    if (!Number.isFinite(ts)) continue
-    if (ts < fromMs || ts > toMs) continue
-    out.push({ session: s, ts })
-  }
-  out.sort((a, b) => a.ts - b.ts)
-  return out.map((entry) => entry.session)
-}
-
-/** One row in the HR-zone distribution chart. */
-export interface HrZoneBucket {
-  /** Zone identifier (`Z1`–`Z5`). */
-  zone: HrZoneConfig['id']
-  /** Long zone label (e.g. "Aerobic Base"). */
-  label: string
-  /** Short axis label (e.g. "Z2"). */
-  shortLabel: string
-  /** Display color from the zone config. */
-  color: string
-  /** Total seconds spent in this zone across the filtered sessions. */
-  seconds: number
-}
-
-/**
- * Sum the `hr_seconds_in_zone` field across a list of stair sessions, returning
- * one bucket per zone (Z1–Z5) in canonical order. Sessions missing the field
- * contribute zero — they don't drop the zone from the result, so the chart
- * always shows all five bars regardless of data quality.
- *
- * @param sessions - Already-filtered session list (e.g. from `filterStairSessions`).
- */
-export function aggregateHrZoneSeconds(sessions: readonly CardioSession[]): HrZoneBucket[] {
-  const totals: Record<HrZone, number> = { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 }
-  for (const s of sessions) {
-    const z = s.hr_seconds_in_zone
-    if (!z) continue
-    totals[1] += z[1] ?? 0
-    totals[2] += z[2] ?? 0
-    totals[3] += z[3] ?? 0
-    totals[4] += z[4] ?? 0
-    totals[5] += z[5] ?? 0
-  }
-  return HR_ZONES.map((z, i) => ({
-    zone: z.id,
-    label: z.label,
-    shortLabel: z.shortLabel,
-    color: z.color,
-    seconds: totals[(i + 1) as HrZone],
-  }))
-}
-
-/** One point on the per-session avg-HR bar chart. */
-export interface SessionAvgHrPoint {
-  /** Original session date string (ISO or `YYYY-MM-DD`). */
-  date: string
-  /** Short label rendered on the x-axis — `M/D` in local time. */
-  label: string
-  /** Average heart rate, BPM. Sessions missing `avg_hr` are excluded upstream. */
-  avgHr: number
-}
-
-/**
- * Project a session list to the points needed by the avg-HR bar chart. Sessions
- * without an `avg_hr` field are excluded — there's nothing to render and a zero
- * bar would lie about coverage. The output preserves input order, so callers
- * pass a chronologically-sorted list (e.g. from `filterStairSessions`) to get
- * left-to-right time ordering.
- *
- * @param sessions - Filtered, sorted stair sessions.
- */
-export function perSessionAvgHr(sessions: readonly CardioSession[]): SessionAvgHrPoint[] {
-  const out: SessionAvgHrPoint[] = []
-  for (const s of sessions) {
-    if (typeof s.avg_hr !== 'number') continue
-    const d = parseSessionDate(s.date)
-    if (!Number.isFinite(d.getTime())) continue
-    const label = `${d.getMonth() + 1}/${d.getDate()}`
-    out.push({ date: s.date, label, avgHr: s.avg_hr })
-  }
-  return out
-}
-
-/**
- * Format a duration in seconds as a compact `Mm Ss` string (e.g. `32m 05s`).
- * Used by the session log table; kept here so the test suite can exercise the
- * formatter without spinning up RTL.
- *
- * Negative or non-finite inputs return `—` rather than `NaNm`/`-1m`, so a
- * malformed entry doesn't pollute the table.
- */
-export function formatDuration(seconds: number): string {
-  if (!Number.isFinite(seconds) || seconds < 0) return '—'
-  const mins = Math.floor(seconds / 60)
-  const secs = Math.floor(seconds % 60)
-  return `${mins}m ${secs.toString().padStart(2, '0')}s`
+  return filterCardioSessionsByActivity(sessions, 'stair', range)
 }


### PR DESCRIPTION
## Summary

Second Gym detail surface from PRD §7.4. New `/training-facility/gym/treadmill` route renders running-modality views over the cardio data layer:

- **Time in zone** + **Avg HR per session** — same `HrZoneBars` / `AvgHrBars` primitives the stair detail view uses; running-only sessions feed in.
- **Pace trend** (full-width) — `RoughLine` of pace per mile over time, wrapped in `BodyweightOverlay` so the §4 power-to-weight context (am I getting faster, or just lighter?) sits on the same x-axis. Bodyweight reads from `getMovementBenchmarks()` so the cardio layer doesn't need to know about Combine data.
- **Cardiac efficiency** — `RoughLine` of `meters_per_heartbeat` over time. Higher = more efficient.
- **Pace at heart rate** — `RoughScatter` plotting avg HR (x) vs pace (y). Lower-left quadrant = fast at low effort.
- **Session log** — Date · Distance · Duration · Pace · Avg HR · Max HR, newest first.

The treadmill in `GymScene` is now a click target (same `<Link>`-with-group-hover pattern the stair-climber uses), and the detail route is gated by `NEXT_PUBLIC_ENABLE_TRAINING_FACILITY` like every other Training Facility surface.

Pace data is stored as `pace_seconds_per_km` (metric — Apple Health output convention) and rendered as `M:SS /mi` for display, with a constant `METERS_PER_MILE = 1609.344` for conversion.

## Implementation notes

- **Shared cardio helpers extracted.** `parseSessionDate`, `aggregateHrZoneSeconds`, `perSessionAvgHr`, `formatDuration`, and the related types moved out of `lib/training-facility/stair.ts` into `lib/training-facility/cardio-shared.ts`. `stair.ts` re-exports them so `StairDetailView`'s import path stays stable, and now contains only the stair-specific filter — itself a thin wrapper over the new `filterCardioSessionsByActivity`. `running.ts` does the same. Tests still target `./stair`; the running suite covers the new running-specific projections.
- **No new chart primitives.** `RoughLine`, `RoughScatter`, `BodyweightOverlay`, `HrZoneBars`, and `AvgHrBars` already exist — treadmill view composes them. The pace y-axis uses a custom tick formatter (`M:SS`) because seconds-per-mile axes formatted as raw integers ("540", "560") are unreadable.
- **BodyweightOverlay scope mirrors stair's call.** Wired only on the pace-trend chart, not on HR-zone / efficiency / scatter. Cardio HR isn't a §4 benchmark; pace-against-bodyweight is the chart §4 actually argues for.
- **Both data fetches share a `Promise.all`** so the loading panel doesn't flash twice; a 404 on either resource degrades to the empty state (PRD §11 q7 — gitignored data files mean fresh previews legitimately have nothing to render).
- **Pace chart wide-layout** — full-width row above the cardiac-efficiency / pace-at-HR pair. Pace deserves the horizontal real-estate because the bodyweight overlay and time x-axis benefit from a wider canvas; the two-up grid below stays at the established `lg:grid-cols-2` width.

## Tests

`lib/training-facility/running.test.ts` covers:
- `filterRunningSessions` — activity filter + sorting
- `paceTrendPoints` — sec/km → sec/mi conversion, drops sessions without usable pace, drops unparseable dates
- `cardiacEfficiencyPoints` — drops missing/non-positive `meters_per_heartbeat`
- `paceAtHrPoints` — drops sessions missing either coordinate
- `formatPacePerMile` — `M:SS /mi` happy paths + invalid input
- `formatDistanceMiles` — meters → miles + missing/zero/negative

`stair.test.ts` continues to pass against the slimmed-down `stair.ts` since the public exports are unchanged.

Full suite: 261 tests across 19 files, all green.

## Test plan

- [ ] Visit `/training-facility/gym` (with `NEXT_PUBLIC_ENABLE_TRAINING_FACILITY=true`). Hover the treadmill — cream tint reveals over the asset. Tab to it — dashed focus ring appears. Click/Enter takes you to `/training-facility/gym/treadmill`.
- [ ] On the treadmill detail, the Date Filter pills (`1M / 3M / 6M / 1Y / All`) all change rendered content; custom date inputs work too.
- [ ] HR-zone chart renders five tinted bars (Z1–Z5).
- [ ] Avg-HR chart renders one bar per running session, oldest → newest.
- [ ] Pace-trend chart renders a sketchy line, y-ticks read as `M:SS` minutes-per-mile, x-ticks read as month/day.
- [ ] Bodyweight toggle (top-right of pace chart) switches the dashed bodyweight line on/off; right-side y-axis is `Bodyweight (lbs)`. With no benchmarks in range, toggle is disabled.
- [ ] Cardiac efficiency renders `m/heartbeat` to two decimal places; pace-at-HR scatter renders one dot per session in range.
- [ ] Session log table is newest-first; Distance reads `X.X mi`, Duration `Mm SSs`, Pace `M:SS /mi`, missing values render as `—`.
- [ ] Empty range: all charts render their empty-state placeholders; table reads "No running sessions in the selected range."
- [ ] Resize browser to ~375px wide — every chart shrinks with the column (ResizeObserver-driven), table scrolls horizontally.
- [ ] Header chrome — "🏀 Back to Home Court" returns to `/`, "← The Gym" returns to `/training-facility/gym`.
- [ ] With `NEXT_PUBLIC_ENABLE_TRAINING_FACILITY` unset, `/training-facility/gym/treadmill` 404s.
- [ ] Stair detail view (`/training-facility/gym/stair`) still works as before — shared helpers extracted but public API unchanged.

> **Preview data note:** `public/data/cardio.json` and `public/data/movement_benchmarks.json` are both gitignored (PRD §11 q7). The Vercel preview will render empty states until the files are force-added or the gitignore is revisited.

Closes #68.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added treadmill detail page displaying running analytics including HR zone distribution, pace trends, cardiac efficiency, and pace-versus-heart-rate metrics with filterable session logs.
  * Treadmill is now interactive in the gym view with keyboard navigation and hover/focus visual feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->