### PR TITLE
feat(combine): radar — the athletic shape (#74)

### DIFF
--- a/app/training-facility/combine/page.tsx
+++ b/app/training-facility/combine/page.tsx
@@ -11,11 +11,11 @@ import { isTrainingFacilityEnabled } from '@/lib/feature-flags'
  * Combine sub-area page (PRD §7.5 + §9). Stacks the room-level chrome
  * (back-to-court + back-to-Training-Facility nav), an eyebrow/title block,
  * the shared scoreboard summary header (PRD §9.1) plus the dev-only
- * "Log a session" entry form (PRD §7.5 view 7) and the Trading Card stat
- * block (PRD §9.2), and the side-on Combine scene SVG. Richer
- * visualizations (Silhouette, Shuttle Trace, Sprint Race, Radar) land in
- * subsequent issues and plug into the same {@link CombineDataIsland} so
- * they share live entry state.
+ * "Log a session" entry form (PRD §7.5 view 7), the Trading Card stat
+ * block (PRD §9.2), the four-axis Radar (PRD §9.7), and the side-on
+ * Combine scene SVG. The remaining visualizations (Silhouette, Shuttle
+ * Trace, Sprint Race) land in subsequent issues and plug into the same
+ * {@link CombineDataIsland} so they share live entry state.
  *
  * Gated behind {@link isTrainingFacilityEnabled} so the route stays
  * 404'd in production until the Training Facility ships publicly. The

--- a/components/training-facility/combine/CombineDataIsland.tsx
+++ b/components/training-facility/combine/CombineDataIsland.tsx
@@ -8,6 +8,7 @@ import { getMovementBenchmarks } from '@/lib/data/movement'
 import type { Benchmark } from '@/types/movement'
 
 import { CombineEntryForm } from './CombineEntryForm'
+import { CombineRadar } from './CombineRadar'
 import { CombineTradingCard } from './CombineTradingCard'
 
 /**
@@ -78,6 +79,7 @@ export function CombineDataIsland(): JSX.Element {
     <div className="flex flex-col gap-8">
       <Scoreboard cells={cells} ariaLabel="Combine scoreboard summary" />
       <CombineTradingCard entries={entries} />
+      <CombineRadar entries={entries} />
       <CombineEntryForm onSaved={handleSaved} />
     </div>
   )

--- a/components/training-facility/combine/CombineRadar.test.tsx
+++ b/components/training-facility/combine/CombineRadar.test.tsx
@@ -1,0 +1,225 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+import type { Benchmark } from '@/types/movement'
+import {
+  CombineRadar,
+  RADAR_AXIS_ORDER,
+  buildRadarShape,
+  isShapeComplete,
+  normalizeMetric,
+  projectVertex,
+  shapesEqual,
+} from './CombineRadar'
+import {
+  pickMetricBaseline,
+  pickMetricLatest,
+} from '@/components/training-facility/shared/scoreboard-utils'
+
+/**
+ * Coverage for the radar's projection math (pure functions, easy to pin
+ * with exact numbers) plus a smoke render confirming the component
+ * follows the same undefined/empty/populated pattern as the rest of the
+ * Combine surfaces.
+ */
+
+describe('normalizeMetric', () => {
+  it('maps the elite end of a higher-is-better range to 1', () => {
+    // Vertical targetRange is [16, 32], higher is better.
+    expect(normalizeMetric('vertical_in', 32)).toBe(1)
+  })
+
+  it('maps the worst end of a higher-is-better range to 0', () => {
+    expect(normalizeMetric('vertical_in', 16)).toBe(0)
+  })
+
+  it('inverts lower-is-better metrics so faster maps to 1', () => {
+    // 5-10-5 targetRange is [4.5, 6.0]; 4.5s is elite ⇒ score 1.
+    expect(normalizeMetric('shuttle_5_10_5_s', 4.5)).toBe(1)
+    expect(normalizeMetric('shuttle_5_10_5_s', 6.0)).toBe(0)
+  })
+
+  it('clamps below the elite floor and above the worst ceiling', () => {
+    // An exceptional 4.0s 5-10-5 sits past the elite floor — clamp to 1.
+    expect(normalizeMetric('shuttle_5_10_5_s', 4.0)).toBe(1)
+    // A 7.0s 5-10-5 sits past the worst ceiling — clamp to 0.
+    expect(normalizeMetric('shuttle_5_10_5_s', 7.0)).toBe(0)
+  })
+
+  it('returns null for missing or non-finite values so axes without data are distinguishable from zero', () => {
+    expect(normalizeMetric('vertical_in', undefined)).toBeNull()
+    expect(normalizeMetric('vertical_in', Number.NaN)).toBeNull()
+    expect(normalizeMetric('vertical_in', Number.POSITIVE_INFINITY)).toBeNull()
+  })
+})
+
+describe('projectVertex', () => {
+  const geo = { cx: 200, cy: 200, rim: 100 }
+
+  it('puts axis 0 (5-10-5) at 12 o\'clock when score is 1', () => {
+    const [x, y] = projectVertex(0, 1, geo)
+    expect(x).toBeCloseTo(200, 5)
+    expect(y).toBeCloseTo(100, 5)
+  })
+
+  it('puts axis 1 (Vertical) at 3 o\'clock when score is 1', () => {
+    const [x, y] = projectVertex(1, 1, geo)
+    expect(x).toBeCloseTo(300, 5)
+    expect(y).toBeCloseTo(200, 5)
+  })
+
+  it('puts axis 2 (10y sprint) at 6 o\'clock and axis 3 (Bodyweight) at 9 o\'clock', () => {
+    const [x2, y2] = projectVertex(2, 1, geo)
+    const [x3, y3] = projectVertex(3, 1, geo)
+    expect(x2).toBeCloseTo(200, 5)
+    expect(y2).toBeCloseTo(300, 5)
+    expect(x3).toBeCloseTo(100, 5)
+    expect(y3).toBeCloseTo(200, 5)
+  })
+
+  it('collapses to the center when score is 0', () => {
+    const [x, y] = projectVertex(0, 0, geo)
+    expect(x).toBeCloseTo(200, 5)
+    expect(y).toBeCloseTo(200, 5)
+  })
+})
+
+describe('buildRadarShape', () => {
+  const entries: Benchmark[] = [
+    {
+      date: '2026-01-15',
+      shuttle_5_10_5_s: 5.4,
+      vertical_in: 22,
+      sprint_10y_s: 1.95,
+      bodyweight_lbs: 230,
+    },
+    {
+      date: '2026-04-10',
+      shuttle_5_10_5_s: 5.1,
+      vertical_in: 26,
+      sprint_10y_s: 1.8,
+      bodyweight_lbs: 222,
+    },
+  ]
+
+  it('returns one vertex per axis in RADAR_AXIS_ORDER', () => {
+    const shape = buildRadarShape(entries, pickMetricLatest)
+    expect(shape.vertices.map((v) => v.metric)).toEqual([...RADAR_AXIS_ORDER])
+  })
+
+  it('uses the supplied picker — latest gives different scores than baseline', () => {
+    const latest = buildRadarShape(entries, pickMetricLatest)
+    const earliest = buildRadarShape(entries, pickMetricBaseline)
+    // The April session beats January on every axis, so latest scores ≥ earliest scores.
+    for (let i = 0; i < latest.vertices.length; i += 1) {
+      const a = latest.vertices[i].score
+      const b = earliest.vertices[i].score
+      expect(a).not.toBeNull()
+      expect(b).not.toBeNull()
+      expect(a as number).toBeGreaterThanOrEqual(b as number)
+    }
+  })
+
+  it('produces a per-axis null score when no entry covers that axis', () => {
+    const partial: Benchmark[] = [
+      { date: '2026-04-10', vertical_in: 26 }, // only vertical
+    ]
+    const shape = buildRadarShape(partial, pickMetricLatest)
+    const vertVertex = shape.vertices.find((v) => v.metric === 'vertical_in')
+    const sprintVertex = shape.vertices.find((v) => v.metric === 'sprint_10y_s')
+    expect(vertVertex?.score).not.toBeNull()
+    expect(sprintVertex?.score).toBeNull()
+  })
+})
+
+describe('isShapeComplete + shapesEqual', () => {
+  it('isShapeComplete is false when any axis is null', () => {
+    const partial: Benchmark[] = [{ date: '2026-04-10', vertical_in: 26 }]
+    const shape = buildRadarShape(partial, pickMetricLatest)
+    expect(isShapeComplete(shape)).toBe(false)
+  })
+
+  it('shapesEqual is true when latest and earliest are the same single entry', () => {
+    const single: Benchmark[] = [
+      {
+        date: '2026-04-10',
+        shuttle_5_10_5_s: 5.1,
+        vertical_in: 26,
+        sprint_10y_s: 1.8,
+        bodyweight_lbs: 222,
+      },
+    ]
+    const latest = buildRadarShape(single, pickMetricLatest)
+    const earliest = buildRadarShape(single, pickMetricBaseline)
+    expect(shapesEqual(latest, earliest)).toBe(true)
+  })
+})
+
+describe('CombineRadar', () => {
+  it('renders nothing while the initial fetch is in flight (entries undefined)', () => {
+    const { container } = render(<CombineRadar entries={undefined} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders nothing when the benchmark history is empty', () => {
+    const { container } = render(<CombineRadar entries={[]} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders nothing when no entry covers all four axes', () => {
+    const { container } = render(
+      <CombineRadar
+        entries={[{ date: '2026-04-10', vertical_in: 26 }]}
+      />,
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders the radar inside a labeled section once a complete entry arrives', () => {
+    render(
+      <CombineRadar
+        entries={[
+          {
+            date: '2026-04-10',
+            shuttle_5_10_5_s: 5.1,
+            vertical_in: 26,
+            sprint_10y_s: 1.8,
+            bodyweight_lbs: 222,
+          },
+        ]}
+      />,
+    )
+    const section = screen.getByRole('region', { name: /combine radar/i })
+    expect(section).toBeInTheDocument()
+    expect(section.querySelector('svg')).not.toBeNull()
+    // With a single complete entry, latest === earliest — the legend should
+    // hide the "Earliest" swatch.
+    expect(screen.queryByText(/earliest/i)).toBeNull()
+    expect(screen.getByText(/latest/i)).toBeInTheDocument()
+  })
+
+  it('shows both legend swatches when the history has distinct earliest and latest shapes', () => {
+    render(
+      <CombineRadar
+        entries={[
+          {
+            date: '2026-01-15',
+            shuttle_5_10_5_s: 5.4,
+            vertical_in: 22,
+            sprint_10y_s: 1.95,
+            bodyweight_lbs: 230,
+          },
+          {
+            date: '2026-04-10',
+            shuttle_5_10_5_s: 5.1,
+            vertical_in: 26,
+            sprint_10y_s: 1.8,
+            bodyweight_lbs: 222,
+          },
+        ]}
+      />,
+    )
+    expect(screen.getByText(/latest/i)).toBeInTheDocument()
+    expect(screen.getByText(/earliest/i)).toBeInTheDocument()
+  })
+})

--- a/components/training-facility/combine/CombineRadar.test.tsx
+++ b/components/training-facility/combine/CombineRadar.test.tsx
@@ -222,4 +222,33 @@ describe('CombineRadar', () => {
     expect(screen.getByText(/latest/i)).toBeInTheDocument()
     expect(screen.getByText(/earliest/i)).toBeInTheDocument()
   })
+
+  it('renders the earliest outline with stroke-dasharray (Codex P2 — rough.js strokeLineDash does not survive drawableToPaths)', () => {
+    const { container } = render(
+      <CombineRadar
+        entries={[
+          {
+            date: '2026-01-15',
+            shuttle_5_10_5_s: 5.4,
+            vertical_in: 22,
+            sprint_10y_s: 1.95,
+            bodyweight_lbs: 230,
+          },
+          {
+            date: '2026-04-10',
+            shuttle_5_10_5_s: 5.1,
+            vertical_in: 26,
+            sprint_10y_s: 1.8,
+            bodyweight_lbs: 222,
+          },
+        ]}
+      />,
+    )
+    // Bug being guarded: the rough.js `strokeLineDash` option silently
+    // drops through `drawableToPaths` (which only carries d/stroke/
+    // strokeWidth/fill), so the earliest outline previously rendered as
+    // a solid line. The dash now lives on the rendered <path> element.
+    const dashed = container.querySelectorAll('path[stroke-dasharray]')
+    expect(dashed.length).toBeGreaterThan(0)
+  })
 })

--- a/components/training-facility/combine/CombineRadar.tsx
+++ b/components/training-facility/combine/CombineRadar.tsx
@@ -250,18 +250,22 @@ export function CombineRadar({
         const drawable = gen.polygon(points, {
           stroke: chartPalette.courtLineCream,
           strokeWidth: 1.6,
-          strokeLineDash: [6, 4],
           roughness: 1.4,
           bowing: 1,
           seed: 51,
           fill: undefined,
         })
+        // `strokeDasharray` lives on the `<path>` element, not in the
+        // rough.js drawable — `drawableToPaths` only carries
+        // `d`/`stroke`/`strokeWidth`/`fill` (see `rough-svg.ts`), so a
+        // `strokeLineDash` rough option would be silently dropped.
         return drawableToPaths(drawable).map((p, i) => (
           <path
             key={`earliest-${i}`}
             d={p.d}
             stroke={p.stroke}
             strokeWidth={p.strokeWidth}
+            strokeDasharray="6 4"
             fill="none"
             strokeLinecap="round"
             strokeLinejoin="round"

--- a/components/training-facility/combine/CombineRadar.tsx
+++ b/components/training-facility/combine/CombineRadar.tsx
@@ -1,0 +1,388 @@
+'use client'
+
+import { type JSX } from 'react'
+
+import { chartPalette } from '@/components/training-facility/shared/charts/palette'
+import {
+  drawableToPaths,
+  getGenerator,
+} from '@/components/training-facility/shared/charts/rough-svg'
+import {
+  pickMetricBaseline,
+  pickMetricLatest,
+} from '@/components/training-facility/shared/scoreboard-utils'
+import { BENCHMARKS, type MetricKey } from '@/constants/benchmarks'
+import type { Benchmark } from '@/types/movement'
+
+/**
+ * Order in which axes wrap clockwise around the radar starting from 12
+ * o'clock (top). Mirrors PRD §9.7's listing — 5-10-5 → Vertical → 10y
+ * sprint → Bodyweight — and is `as const` so the four-axis assumption is
+ * encoded in the type, not just the docstring.
+ */
+export const RADAR_AXIS_ORDER: readonly MetricKey[] = [
+  'shuttle_5_10_5_s',
+  'vertical_in',
+  'sprint_10y_s',
+  'bodyweight_lbs',
+] as const
+
+/** Radius factors for the concentric reference rings (1.0 = the rim). */
+const RING_FACTORS: readonly number[] = [0.25, 0.5, 0.75, 1.0]
+
+/**
+ * Map a metric value to `[0, 1]` where `1` is the elite end of
+ * `BENCHMARKS[key].targetRange`. Direction-aware — for `'lower'` metrics
+ * (5-10-5, 10y sprint, bodyweight) a smaller raw value yields a larger
+ * score; for `'higher'` metrics (vertical) a bigger raw value does.
+ *
+ * Clamps to `[0, 1]` at both ends: an off-day value below the elite floor
+ * doesn't pierce the center, and an exceptional value above the rim
+ * doesn't blow past it. Returns `null` when `value` is missing /
+ * non-finite, so callers can render axes with no data distinct from axes
+ * scored at zero.
+ *
+ * @param key   Which Tier-1 metric the value belongs to.
+ * @param value Raw metric reading, or `undefined` if missing. NaN is treated as missing.
+ */
+export function normalizeMetric(
+  key: MetricKey,
+  value: number | undefined,
+): number | null {
+  if (value === undefined || !Number.isFinite(value)) return null
+  const spec = BENCHMARKS[key]
+  const [a, b] = spec.targetRange
+  const span = b - a
+  if (span === 0) return null
+  const raw =
+    spec.direction === 'higher' ? (value - a) / span : (b - value) / span
+  if (raw < 0) return 0
+  if (raw > 1) return 1
+  return raw
+}
+
+/** One projected vertex of the radar polygon. */
+export interface RadarVertex {
+  /** Which axis this vertex sits on. */
+  metric: MetricKey
+  /** Short-form axis label rendered at the rim (e.g. `"VERT"`, `"5-10-5"`). */
+  shortLabel: string
+  /** Normalized score in `[0, 1]`, or `null` if no qualifying entry has a value for this axis. */
+  score: number | null
+  /** Raw metric reading the score was derived from, kept for tooltips / aria text. */
+  value: number | undefined
+}
+
+/** Four-vertex radar shape — one vertex per axis in {@link RADAR_AXIS_ORDER}. */
+export interface RadarShape {
+  /** Vertices in {@link RADAR_AXIS_ORDER}, always length 4. */
+  vertices: readonly RadarVertex[]
+}
+
+/** Pick function used to resolve a metric's raw value from the benchmark history. */
+type MetricPicker = (
+  entries: readonly Benchmark[],
+  key: MetricKey,
+) => number | undefined
+
+/**
+ * Build a four-vertex radar shape from a benchmark history using a
+ * caller-supplied pick function (typically `pickMetricLatest` or
+ * `pickMetricBaseline`). Per-axis baselining matches the scoreboard's
+ * behaviour — a partial entry contributes to the axes it covers.
+ *
+ * @param entries Full benchmark history; order does not matter.
+ * @param pick    Per-metric value resolver — see `scoreboard-utils.ts`.
+ */
+export function buildRadarShape(
+  entries: readonly Benchmark[],
+  pick: MetricPicker,
+): RadarShape {
+  const vertices: RadarVertex[] = RADAR_AXIS_ORDER.map((metric) => {
+    const value = pick(entries, metric)
+    return {
+      metric,
+      shortLabel: BENCHMARKS[metric].shortLabel,
+      score: normalizeMetric(metric, value),
+      value,
+    }
+  })
+  return { vertices }
+}
+
+/** Whether a shape has a score on every axis — required for a closed polygon. */
+export function isShapeComplete(shape: RadarShape): boolean {
+  return shape.vertices.every((v) => v.score !== null)
+}
+
+/** Whether two shapes have the same score on every axis (used to skip drawing the earliest outline when it overlaps the latest exactly). */
+export function shapesEqual(a: RadarShape, b: RadarShape): boolean {
+  return RADAR_AXIS_ORDER.every(
+    (_, i) => a.vertices[i].score === b.vertices[i].score,
+  )
+}
+
+/** Geometry-only props extracted so the projection math is independently testable. */
+interface RadarGeometry {
+  /** SVG viewBox center x. */
+  cx: number
+  /** SVG viewBox center y. */
+  cy: number
+  /** Pixel radius corresponding to a normalized score of 1.0. */
+  rim: number
+}
+
+/**
+ * Project a single vertex onto SVG coordinates.
+ *
+ * Axis indices increase clockwise starting at 12 o'clock — index 0 is up,
+ * index 1 is right, index 2 is down, index 3 is left. SVG y grows
+ * downward, so the top vertex uses `-Math.PI / 2` and `sin` follows
+ * naturally.
+ *
+ * @param axisIndex Position in {@link RADAR_AXIS_ORDER}.
+ * @param score     Normalized score in `[0, 1]`. Caller is responsible for clamping.
+ * @param geo       Center + rim radius.
+ */
+export function projectVertex(
+  axisIndex: number,
+  score: number,
+  geo: RadarGeometry,
+): [number, number] {
+  const angle = -Math.PI / 2 + axisIndex * (Math.PI / 2)
+  const r = score * geo.rim
+  return [geo.cx + r * Math.cos(angle), geo.cy + r * Math.sin(angle)]
+}
+
+/** Props for {@link CombineRadar}. */
+export interface CombineRadarProps {
+  /**
+   * Benchmark history shared with the rest of the Combine page (typically
+   * fed from `CombineDataIsland`). `undefined` while the initial fetch is
+   * in flight; an empty array means no entries are logged.
+   */
+  entries: Benchmark[] | undefined
+}
+
+const VIEWBOX = 400
+const CENTER = VIEWBOX / 2
+const RIM = 140
+const LABEL_OFFSET = 22
+const GEO: RadarGeometry = { cx: CENTER, cy: CENTER, rim: RIM }
+
+/**
+ * Radar visualization (PRD §9.7) — the four Tier-1 Combine axes (5-10-5,
+ * Vertical, 10y Sprint, Bodyweight) projected onto a hand-drawn polygon
+ * so the shape grows outward as benchmarks improve.
+ *
+ * Latest entry: filled rim-orange polygon at 30% opacity. Earliest:
+ * dashed cream outline behind it. The optional scrubber timeline from
+ * the PRD is intentionally deferred.
+ *
+ * Returns `null` while the initial fetch is in flight (matches
+ * `CombineTradingCard`'s placeholder behaviour) and when the history
+ * has no entry that covers all four axes — the scoreboard already
+ * surfaces the empty state, so duplicating it here would be noise.
+ *
+ * @param props.entries Shared benchmark history. `undefined` ⇒ render nothing; `[]` ⇒ render nothing; populated ⇒ render the radar with per-axis latest + earliest shapes.
+ */
+export function CombineRadar({
+  entries,
+}: CombineRadarProps): JSX.Element | null {
+  if (!entries || entries.length === 0) return null
+
+  const latest = buildRadarShape(entries, pickMetricLatest)
+  const earliest = buildRadarShape(entries, pickMetricBaseline)
+  if (!isShapeComplete(latest)) return null
+
+  const showEarliest = isShapeComplete(earliest) && !shapesEqual(latest, earliest)
+  const gen = getGenerator()
+
+  const ringPaths = RING_FACTORS.flatMap((factor, ringIdx) => {
+    const ringPoints: [number, number][] = RADAR_AXIS_ORDER.map((_, i) =>
+      projectVertex(i, factor, GEO),
+    )
+    const ring = gen.polygon(ringPoints, {
+      stroke: chartPalette.courtLineCream,
+      strokeWidth: factor === 1 ? 1.5 : 0.8,
+      roughness: 1.6,
+      bowing: 1.2,
+      seed: 11 + ringIdx,
+      fill: undefined,
+    })
+    return drawableToPaths(ring).map((p, i) => (
+      <path
+        key={`ring-${ringIdx}-${i}`}
+        d={p.d}
+        stroke={p.stroke}
+        strokeWidth={p.strokeWidth}
+        fill="none"
+        opacity={factor === 1 ? 0.55 : 0.22}
+      />
+    ))
+  })
+
+  const axisPaths = RADAR_AXIS_ORDER.map((_, i) => {
+    const [x, y] = projectVertex(i, 1, GEO)
+    const drawable = gen.line(GEO.cx, GEO.cy, x, y, {
+      stroke: chartPalette.courtLineCream,
+      strokeWidth: 0.8,
+      roughness: 1.2,
+      seed: 31 + i,
+    })
+    return drawableToPaths(drawable).map((p, j) => (
+      <path
+        key={`axis-${i}-${j}`}
+        d={p.d}
+        stroke={p.stroke}
+        strokeWidth={p.strokeWidth}
+        fill="none"
+        opacity={0.35}
+      />
+    ))
+  })
+
+  const earliestPaths = showEarliest
+    ? (() => {
+        const points: [number, number][] = earliest.vertices.map((v, i) =>
+          projectVertex(i, v.score ?? 0, GEO),
+        )
+        const drawable = gen.polygon(points, {
+          stroke: chartPalette.courtLineCream,
+          strokeWidth: 1.6,
+          strokeLineDash: [6, 4],
+          roughness: 1.4,
+          bowing: 1,
+          seed: 51,
+          fill: undefined,
+        })
+        return drawableToPaths(drawable).map((p, i) => (
+          <path
+            key={`earliest-${i}`}
+            d={p.d}
+            stroke={p.stroke}
+            strokeWidth={p.strokeWidth}
+            fill="none"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            opacity={0.85}
+          />
+        ))
+      })()
+    : null
+
+  const latestPoints: [number, number][] = latest.vertices.map((v, i) =>
+    projectVertex(i, v.score ?? 0, GEO),
+  )
+  const latestDrawable = gen.polygon(latestPoints, {
+    stroke: chartPalette.rimOrange,
+    strokeWidth: 2.2,
+    fill: chartPalette.rimOrange,
+    fillStyle: 'solid',
+    roughness: 1.6,
+    bowing: 1.2,
+    seed: 71,
+  })
+  const latestPaths = drawableToPaths(latestDrawable).map((p, i) => (
+    <path
+      key={`latest-${i}`}
+      d={p.d}
+      stroke={p.stroke}
+      strokeWidth={p.strokeWidth}
+      fill={p.fill ?? 'none'}
+      fillOpacity={p.fill ? 0.3 : undefined}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  ))
+
+  const labels = latest.vertices.map((v, i) => {
+    const [x, y] = projectVertex(i, 1, GEO)
+    // Push label outward along the same axis so it doesn't sit on the rim
+    // line. `dx`/`dy` from center sign tells us which side to nudge to.
+    const dx = x - GEO.cx
+    const dy = y - GEO.cy
+    const norm = Math.hypot(dx, dy) || 1
+    const lx = x + (dx / norm) * LABEL_OFFSET
+    const ly = y + (dy / norm) * LABEL_OFFSET
+    const anchor: 'start' | 'middle' | 'end' =
+      dx > 0.5 ? 'start' : dx < -0.5 ? 'end' : 'middle'
+    const baseline: 'auto' | 'middle' | 'hanging' =
+      dy > 0.5 ? 'hanging' : dy < -0.5 ? 'auto' : 'middle'
+    return (
+      <text
+        key={`label-${v.metric}`}
+        x={lx}
+        y={ly}
+        textAnchor={anchor}
+        dominantBaseline={baseline}
+        fontFamily="inherit"
+        fontSize={13}
+        fontWeight={600}
+        fill={chartPalette.courtLineCream}
+        opacity={0.85}
+      >
+        {v.shortLabel}
+      </text>
+    )
+  })
+
+  const ariaSummary = latest.vertices
+    .map((v) => {
+      const spec = BENCHMARKS[v.metric]
+      const formatted =
+        typeof v.value === 'number'
+          ? `${v.value.toFixed(spec.precision)}${spec.unit}`
+          : '—'
+      return `${spec.label} ${formatted}`
+    })
+    .join(', ')
+
+  return (
+    <section
+      aria-label="Combine radar — latest vs earliest benchmark shape"
+      className="mx-auto flex w-full max-w-md flex-col items-center gap-3"
+    >
+      <svg
+        viewBox={`0 0 ${VIEWBOX} ${VIEWBOX}`}
+        role="img"
+        aria-label={`Athletic shape: ${ariaSummary}`}
+        className="h-auto w-full"
+      >
+        <title>Combine radar</title>
+        {ringPaths}
+        {axisPaths}
+        {earliestPaths}
+        {latestPaths}
+        {labels}
+      </svg>
+      <Legend showEarliest={showEarliest} />
+    </section>
+  )
+}
+
+/** Tiny key explaining what the two polygons represent — only renders the earliest swatch when an earliest shape is drawn. */
+function Legend({ showEarliest }: { showEarliest: boolean }): JSX.Element {
+  return (
+    <div className="flex flex-wrap items-center justify-center gap-x-5 gap-y-1 text-xs uppercase tracking-[0.2em] text-[#e8d5be]/80">
+      <span className="flex items-center gap-2">
+        <span
+          aria-hidden
+          className="inline-block h-3 w-5 rounded-sm"
+          style={{ backgroundColor: chartPalette.rimOrange, opacity: 0.55 }}
+        />
+        Latest
+      </span>
+      {showEarliest && (
+        <span className="flex items-center gap-2">
+          <span
+            aria-hidden
+            className="inline-block h-0 w-5 border-t border-dashed"
+            style={{ borderColor: chartPalette.courtLineCream }}
+          />
+          Earliest
+        </span>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Four-axis radar (PRD §9.7) on the Combine page: 5-10-5 → Vertical → 10y Sprint → Bodyweight, all direction-aware so the shape grows outward as benchmarks improve.
- Latest entry: filled rim-orange polygon at 30% opacity. Earliest: dashed cream outline behind it. Both rendered with rough.js so the strokes match the rest of the Training Facility's hand-drawn aesthetic, not a slick recharts default.
- Per-axis latest/earliest baselining (reuses `pickMetricLatest` / `pickMetricBaseline` from `scoreboard-utils.ts`), so partial entries contribute to the axes they cover — same rules as the scoreboard.
- Optional scrubber timeline from the PRD is **deferred** to a follow-up issue. Latest + earliest already tells the "watch it grow" story for v1.

## Implementation notes
- New `CombineRadar.tsx` plus pure helpers (`normalizeMetric`, `buildRadarShape`, `projectVertex`, `isShapeComplete`, `shapesEqual`) — all exported and unit-tested with exact-number assertions for the projection math.
- `normalizeMetric` clamps to `[0, 1]` at both ends using each metric's `targetRange`. An exceptional value doesn't blow past the rim; an off-day doesn't pierce the center.
- Renders nothing while `entries === undefined` (initial fetch in flight) or when no entry covers all four axes — matches `CombineTradingCard`'s placeholder behaviour and avoids duplicating the scoreboard's empty state.
- Wired into `CombineDataIsland` between the Trading Card and the dev-only entry form, per PRD §9 ordering.

## Test plan
- [ ] Visit `/training-facility/combine` (preview): the radar renders below the trading card with axis labels at 12/3/6/9 (5-10-5 / VERT / 10Y / WT) and the legend shows both swatches.
- [ ] The latest filled polygon sits inside the rim cleanly; the earliest dashed outline traces a smaller shape behind it.
- [ ] Resize from desktop down to mobile: SVG scales fluidly, labels stay legible, no overflow.
- [ ] Log a new session that beats every prior axis via the dev entry form (in npm run dev): the latest polygon expands with no reload while the earliest stays put.
- [ ] Log a partial entry (vertical only): the radar still uses the most recent value per axis (so missing axes fall back to prior sessions). If literally no entry covers an axis, the radar hides rather than collapses to center.
- [ ] Run npm test — all 274 tests should pass (19 new for the radar).

Closes #74.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a four-axis Radar visualization to the Combine page that reflects the latest benchmark data.
  * Optional baseline (earliest) comparison is shown only when available and meaningfully different from the latest.
  * Radar remains hidden until a complete set of axis data is present; legend updates to reflect presence/absence of baseline.

* **Tests**
  * Added comprehensive unit and DOM tests covering radar math, geometry, rendering, and conditional behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->