### PR TITLE
test(e2e): match unified BackToCourtButton text in room + 404 specs (#136)

### DIFF
--- a/.claude/commands/ship-issue.md
+++ b/.claude/commands/ship-issue.md
@@ -22,10 +22,13 @@ Take the GitHub issue at `$ARGUMENTS` from open to PR-ready in one shot. Argumen
 1. Pick a `<slug>` — 2–4 words from the issue title in kebab-case (e.g. `data-layer`, `trading-card`). Reuse this same slug for the worktree name and the remote branch in Phase 3.
 2. `EnterWorktree` named `issue-<number>-<slug>`.
 3. Implement against the issue's "Done when" criteria. Don't scope-creep. If a step fails (build error, test failure), fix and retry; if you can't, surface to the user.
-4. Verify locally:
+4. **Audit tests that the change may have invalidated.** If you touched user-facing copy, ARIA labels/roles, route shapes, public function signatures, exported types, or test IDs, grep `e2e/` and co-located `*.test.ts(x)` for assertions on the old shape and update them in the same commit. A test left asserting on yesterday's behavior is a regression you've shipped to `main` — even if it was green when the PR merged, the next push will go red. Don't gate the merge on the test "deserving" an update; if reality changed, the assertion changes too.
+5. Verify locally:
    - `npx tsc --noEmit` — must be clean.
    - `npx next build` — must compile.
-5. Commit using a conventional message:
+   - `npm test` — vitest unit suite must pass.
+   - `npm run test:e2e` — only if you touched routes, page DOM, or anything else under Playwright coverage. Skip for pure-internal refactors. (Suite takes ~30–60s.)
+6. Commit using a conventional message:
    ```
    <type>(<scope>): <one-line summary>
 

--- a/e2e/rooms.spec.ts
+++ b/e2e/rooms.spec.ts
@@ -3,39 +3,40 @@ import { expect, test, type Locator, type Page } from '@playwright/test'
 type RoomExpectation = {
   route: string
   locator: (page: Page) => Locator
-  backLinkName: RegExp
 }
+
+/**
+ * Every non-home room renders the shared `BackToCourtButton`, whose link text is
+ * "🏀 Home Court". A single regex covers all four routes.
+ */
+const BACK_LINK_NAME = /home court/i
 
 const roomExpectations: RoomExpectation[] = [
   {
     route: '/locker-room',
     locator: page => page.getByRole('heading', { name: /locker room - select an item to get more info/i }),
-    backLinkName: /back to home court/i,
   },
   {
     route: '/projects',
     locator: page => page.getByTestId('projects-title'),
-    backLinkName: /back to home court/i,
   },
   {
     route: '/contact',
     locator: page => page.getByRole('heading', { name: /scouting inquiry/i }),
-    backLinkName: /back to home court/i,
   },
   {
     route: '/banners',
     locator: page => page.getByRole('heading', { name: /the rafters/i }),
-    backLinkName: /back to the court/i,
   },
 ]
 
 test.describe('room routes', () => {
-  for (const { route, locator, backLinkName } of roomExpectations) {
+  for (const { route, locator } of roomExpectations) {
     test(`renders ${route}`, async ({ page }) => {
       await page.goto(route)
 
       await expect(locator(page)).toBeVisible()
-      await expect(page.getByRole('link', { name: backLinkName })).toBeVisible()
+      await expect(page.getByRole('link', { name: BACK_LINK_NAME })).toBeVisible()
     })
   }
 

--- a/e2e/training-facility-disabled.spec.ts
+++ b/e2e/training-facility-disabled.spec.ts
@@ -22,7 +22,7 @@ test.describe('training facility disabled', () => {
 
       await expect(page.getByText('AIRBALL.')).toBeVisible()
       await expect(page.getByText(route)).toBeVisible()
-      await expect(page.getByRole('link', { name: /back to home court/i })).toBeVisible()
+      await expect(page.getByRole('link', { name: /home court/i })).toBeVisible()
     })
   }
 })


### PR DESCRIPTION
## Summary

- Update \`e2e/rooms.spec.ts\` and \`e2e/training-facility-disabled.spec.ts\` to assert on \`/home court/i\` instead of the old \`/back to home court/i\` and \`/back to the court/i\` regexes.
- PR #116 unified all per-room back-links onto \`BackToCourtButton\` (renders "🏀 Home Court"); the specs were not updated alongside the implementation, which broke Playwright E2E on every push to \`main\` since #129.
- Simplify \`rooms.spec.ts\`: drop the per-route \`backLinkName\` field — every room shares the same back button now.

## Test plan

- [x] \`npm run test:e2e\` — 14/14 passing locally
- [ ] CI \`Playwright E2E\` workflow green on this PR
- [ ] CI \`Playwright E2E\` green on the resulting \`main\` commit after merge

Closes #136.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Consolidated E2E test assertions for room route navigation links.
  * Updated home navigation link label verification in disabled feature scenarios.

* **Refactor**
  * Simplified room route test data structure for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->