### PR TITLE
feat(gym): period-comparison stat row on Stair detail view (#77)

### DIFF
--- a/components/training-facility/gym/StairDetailView.tsx
+++ b/components/training-facility/gym/StairDetailView.tsx
@@ -18,7 +18,12 @@ import {
   parseSessionDate,
   perSessionAvgHr,
 } from '@/lib/training-facility/stair'
+import { computePreviousRange } from '@/lib/training-facility/period-comparison'
 import { BackToCourtButton } from '@/components/common/BackToCourtButton'
+import {
+  CardioStatsCards,
+  type CardioStatCard,
+} from '@/components/training-facility/shared/CardioStatsCards'
 import { HrZoneBars } from './HrZoneBars'
 import { AvgHrBars } from './AvgHrBars'
 
@@ -26,6 +31,109 @@ const CHART_HEIGHT = 280
 const MIN_CHART_WIDTH = 280
 const DEFAULT_CHART_WIDTH = 560
 const EARLIEST_FALLBACK = new Date(2024, 0, 1)
+
+/**
+ * Compact total-time label that promotes to `Hh Mm` once we cross an
+ * hour. Keeps the stat-card row scannable for monthly totals (e.g. a
+ * stair-heavy month is hours, not 300+ minutes). Fractional seconds and
+ * sub-minute remainders are dropped — the rounding loss is invisible at
+ * the row's display fidelity.
+ */
+function formatTotalDuration(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds < 0) return '—'
+  const mins = Math.floor(seconds / 60)
+  if (mins < 60) return `${mins}m`
+  const hours = Math.floor(mins / 60)
+  const remMins = mins % 60
+  return `${hours}h ${remMins.toString().padStart(2, '0')}m`
+}
+
+/** Sum a numeric per-session field, skipping sessions where the field is missing. */
+function sumOf(
+  sessions: readonly CardioSession[],
+  pick: (s: CardioSession) => number | undefined,
+): number {
+  let total = 0
+  for (const s of sessions) {
+    const v = pick(s)
+    if (typeof v === 'number') total += v
+  }
+  return total
+}
+
+/** Average a numeric per-session field, returning `null` when no session has the field. */
+function avgOf(
+  sessions: readonly CardioSession[],
+  pick: (s: CardioSession) => number | undefined,
+): number | null {
+  let total = 0
+  let count = 0
+  for (const s of sessions) {
+    const v = pick(s)
+    if (typeof v === 'number') {
+      total += v
+      count += 1
+    }
+  }
+  return count === 0 ? null : total / count
+}
+
+/**
+ * Period-comparison metrics surfaced above the Stair charts (#77).
+ * Module-scope so the array reference stays stable across renders —
+ * `<CardioStatsCards>` memoizes on identity.
+ *
+ * Direction: sessions / total time / avg duration are higher-is-better
+ * (more work logged = improvement); avg/max HR are neutral because
+ * "improvement" depends on which zone the session was targeting.
+ */
+const STAIR_STATS: ReadonlyArray<CardioStatCard> = [
+  {
+    key: 'sessions',
+    label: 'Sessions',
+    compute: (s) => s.length,
+    formatValue: (v) => String(v),
+    direction: 'higher-is-better',
+  },
+  {
+    key: 'total_time',
+    label: 'Total time',
+    compute: (s) => sumOf(s, (x) => x.duration_seconds),
+    formatValue: formatTotalDuration,
+    formatDelta: (delta) => {
+      const sign = delta > 0 ? '+' : delta < 0 ? '−' : '±'
+      return `${sign}${formatTotalDuration(Math.abs(delta))}`
+    },
+    direction: 'higher-is-better',
+  },
+  {
+    key: 'avg_duration',
+    label: 'Avg duration',
+    compute: (s) => avgOf(s, (x) => x.duration_seconds),
+    formatValue: formatDuration,
+    formatDelta: (delta) => {
+      const sign = delta > 0 ? '+' : delta < 0 ? '−' : '±'
+      return `${sign}${formatDuration(Math.abs(delta))}`
+    },
+    direction: 'higher-is-better',
+  },
+  {
+    key: 'avg_hr',
+    label: 'Avg HR',
+    compute: (s) => avgOf(s, (x) => x.avg_hr),
+    formatValue: (v) => String(Math.round(v)),
+    unit: 'BPM',
+    direction: 'neutral',
+  },
+  {
+    key: 'avg_max_hr',
+    label: 'Avg max HR',
+    compute: (s) => avgOf(s, (x) => x.max_hr),
+    formatValue: (v) => String(Math.round(v)),
+    unit: 'BPM',
+    direction: 'neutral',
+  },
+]
 
 /**
  * Stair-climber detail view (PRD §7.4) — the first Gym detail surface.
@@ -124,6 +232,14 @@ export function StairDetailView(): JSX.Element {
     () => (data ? filterStairSessions(data.sessions, range) : []),
     [data, range],
   )
+  // Previous period of equal length, ending the day before `range.start`.
+  // Computed alongside the current-range filter so both use the same
+  // `data` snapshot — `<CardioStatsCards>` then memoizes off both arrays.
+  const previousRange = useMemo(() => computePreviousRange(range), [range])
+  const previousStairSessions = useMemo<CardioSession[]>(
+    () => (data ? filterStairSessions(data.sessions, previousRange) : []),
+    [data, previousRange],
+  )
   const buckets = useMemo(() => aggregateHrZoneSeconds(stairSessions), [stairSessions])
   const avgHrPoints = useMemo(() => perSessionAvgHr(stairSessions), [stairSessions])
 
@@ -173,6 +289,13 @@ export function StairDetailView(): JSX.Element {
           <LoadingPanel />
         ) : (
           <>
+            <CardioStatsCards
+              className="mt-8"
+              current={stairSessions}
+              previous={previousStairSessions}
+              metrics={STAIR_STATS}
+            />
+
             <div className="mt-8 grid gap-6 lg:grid-cols-2">
               <ChartCard
                 title="Time in zone"

--- a/components/training-facility/shared/CardioStatsCards.test.tsx
+++ b/components/training-facility/shared/CardioStatsCards.test.tsx
@@ -1,0 +1,220 @@
+import { describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import type { CardioSession } from '@/types/cardio'
+import { CardioStatsCards, type CardioStatCard } from './CardioStatsCards'
+
+/**
+ * Helper — build a CardioSession with sane defaults. Override only what
+ * the case under test needs.
+ */
+const session = (overrides: Partial<CardioSession> = {}): CardioSession => ({
+  date: '2026-01-01',
+  activity: 'stair',
+  duration_seconds: 1800,
+  avg_hr: 140,
+  ...overrides,
+})
+
+const sessionsCountMetric: CardioStatCard = {
+  key: 'sessions',
+  label: 'Sessions',
+  compute: (s) => s.length,
+  formatValue: (v) => String(v),
+  direction: 'higher-is-better',
+}
+
+const avgHrMetric: CardioStatCard = {
+  key: 'avg_hr',
+  label: 'Avg HR',
+  compute: (s) => {
+    const vals = s.map((x) => x.avg_hr).filter((v): v is number => typeof v === 'number')
+    if (vals.length === 0) return null
+    return vals.reduce((a, b) => a + b, 0) / vals.length
+  },
+  formatValue: (v) => Math.round(v).toString(),
+  unit: 'BPM',
+  direction: 'neutral',
+}
+
+describe('CardioStatsCards', () => {
+  it('renders one card per metric with current values', () => {
+    render(
+      <CardioStatsCards
+        current={[session(), session(), session()]}
+        previous={[]}
+        metrics={[sessionsCountMetric, avgHrMetric]}
+      />,
+    )
+    const sessionsCard = screen.getByTestId('stat-card-sessions')
+    expect(sessionsCard).toHaveTextContent('Sessions')
+    expect(sessionsCard).toHaveTextContent('3')
+    const hrCard = screen.getByTestId('stat-card-avg_hr')
+    expect(hrCard).toHaveTextContent('Avg HR')
+    expect(hrCard).toHaveTextContent('140')
+    expect(hrCard).toHaveTextContent('BPM')
+  })
+
+  it('hides the delta line when previous has fewer than the threshold sessions', () => {
+    render(
+      <CardioStatsCards
+        current={[session(), session()]}
+        previous={[session(), session(), session()]}
+        metrics={[sessionsCountMetric]}
+      />,
+    )
+    expect(screen.getByTestId('stat-card-sessions-no-delta')).toBeInTheDocument()
+    expect(screen.getByTestId('stat-card-sessions-no-delta')).toHaveTextContent(
+      /no prior comparison/i,
+    )
+  })
+
+  it('renders delta arrow, signed absolute, and percent when previous meets the threshold', () => {
+    render(
+      <CardioStatsCards
+        current={[session(), session(), session(), session(), session(), session()]}
+        previous={[session(), session(), session(), session()]}
+        metrics={[sessionsCountMetric]}
+      />,
+    )
+    const card = screen.getByTestId('stat-card-sessions')
+    expect(card).toHaveTextContent('▲')
+    expect(card).toHaveTextContent('+2')
+    expect(card).toHaveTextContent('+50.0%')
+    expect(screen.queryByTestId('stat-card-sessions-no-delta')).not.toBeInTheDocument()
+  })
+
+  it('uses the down arrow and a negative absolute when current < previous', () => {
+    render(
+      <CardioStatsCards
+        current={[session(), session()]}
+        previous={[session(), session(), session(), session(), session()]}
+        metrics={[sessionsCountMetric]}
+      />,
+    )
+    const card = screen.getByTestId('stat-card-sessions')
+    expect(card).toHaveTextContent('▼')
+    expect(card).toHaveTextContent('−3')
+  })
+
+  it('renders an em-dash when the current value is null', () => {
+    const nullableMetric: CardioStatCard = {
+      key: 'always_null',
+      label: 'Nothing',
+      compute: () => null,
+      formatValue: (v) => String(v),
+      direction: 'neutral',
+    }
+    render(
+      <CardioStatsCards
+        current={[session()]}
+        previous={Array.from({ length: 4 }, () => session())}
+        metrics={[nullableMetric]}
+      />,
+    )
+    expect(screen.getByTestId('stat-card-always_null')).toHaveTextContent('—')
+    expect(screen.getByTestId('stat-card-always_null-no-delta')).toBeInTheDocument()
+  })
+
+  it('paints higher-is-better up-changes in green and down-changes in red', () => {
+    const greenUp = render(
+      <CardioStatsCards
+        current={Array.from({ length: 6 }, () => session())}
+        previous={Array.from({ length: 4 }, () => session())}
+        metrics={[sessionsCountMetric]}
+      />,
+    )
+    expect(
+      greenUp.getByTestId('stat-card-sessions').querySelector('.text-emerald-700'),
+    ).not.toBeNull()
+    greenUp.unmount()
+
+    const redDown = render(
+      <CardioStatsCards
+        current={Array.from({ length: 4 }, () => session())}
+        previous={Array.from({ length: 6 }, () => session())}
+        metrics={[sessionsCountMetric]}
+      />,
+    )
+    expect(
+      redDown.getByTestId('stat-card-sessions').querySelector('.text-red-700'),
+    ).not.toBeNull()
+  })
+
+  it('paints lower-is-better down-changes in green', () => {
+    const lowerIsBetter: CardioStatCard = {
+      ...sessionsCountMetric,
+      key: 'rhr',
+      label: 'RHR',
+      direction: 'lower-is-better',
+    }
+    render(
+      <CardioStatsCards
+        current={[session(), session()]}
+        previous={Array.from({ length: 5 }, () => session())}
+        metrics={[lowerIsBetter]}
+      />,
+    )
+    expect(screen.getByTestId('stat-card-rhr').querySelector('.text-emerald-700')).not.toBeNull()
+  })
+
+  it('uses neutral coloring for direction="neutral" regardless of change', () => {
+    render(
+      <CardioStatsCards
+        current={Array.from({ length: 4 }, () => session({ avg_hr: 150 }))}
+        previous={Array.from({ length: 4 }, () => session({ avg_hr: 100 }))}
+        metrics={[avgHrMetric]}
+      />,
+    )
+    const card = screen.getByTestId('stat-card-avg_hr')
+    expect(card.querySelector('.text-emerald-700')).toBeNull()
+    expect(card.querySelector('.text-red-700')).toBeNull()
+    // Sanity: the up arrow is still rendered, just not colored.
+    expect(card).toHaveTextContent('▲')
+  })
+
+  it('honors a custom formatDelta for unit-bearing metrics', () => {
+    const durationMetric: CardioStatCard = {
+      key: 'duration',
+      label: 'Avg duration',
+      compute: (s) =>
+        s.length === 0
+          ? null
+          : s.reduce((acc, x) => acc + x.duration_seconds, 0) / s.length,
+      formatValue: (v) => `${Math.round(v)}s`,
+      formatDelta: (d) => `${d > 0 ? '+' : d < 0 ? '−' : '±'}${Math.abs(Math.round(d))}s`,
+      direction: 'higher-is-better',
+    }
+    render(
+      <CardioStatsCards
+        current={Array.from({ length: 5 }, () => session({ duration_seconds: 2400 }))}
+        previous={Array.from({ length: 5 }, () => session({ duration_seconds: 1800 }))}
+        metrics={[durationMetric]}
+      />,
+    )
+    const card = screen.getByTestId('stat-card-duration')
+    expect(card).toHaveTextContent('+600s')
+  })
+
+  it('omits the percent label when previous value is 0', () => {
+    const zeroPrev: CardioStatCard = {
+      ...sessionsCountMetric,
+      key: 'distance',
+      label: 'Total distance',
+      compute: (s) =>
+        s.reduce((acc, x) => acc + (x.distance_meters ?? 0), 0),
+      formatValue: (v) => `${v}m`,
+    }
+    // Previous has 4 sessions but all distance_meters undefined → metric value 0.
+    render(
+      <CardioStatsCards
+        current={[session({ distance_meters: 500 })]}
+        previous={Array.from({ length: 4 }, () => session())}
+        metrics={[zeroPrev]}
+      />,
+    )
+    const card = screen.getByTestId('stat-card-distance')
+    expect(card).toHaveTextContent('+500m')
+    // Percent must not render — would be "(+Infinity%)" otherwise.
+    expect(card).not.toHaveTextContent('%')
+  })
+})

--- a/components/training-facility/shared/CardioStatsCards.tsx
+++ b/components/training-facility/shared/CardioStatsCards.tsx
@@ -1,0 +1,190 @@
+'use client'
+
+import { useMemo, type JSX } from 'react'
+import type { CardioSession } from '@/types/cardio'
+import {
+  MIN_PREVIOUS_SESSIONS_FOR_DELTA,
+  computeDelta,
+  type DeltaDirection,
+  type PeriodDelta,
+} from '@/lib/training-facility/period-comparison'
+
+/**
+ * Direction semantics for a stat card's delta. Drives the color of the
+ * delta arrow:
+ *
+ * - `higher-is-better` — `up` is green, `down` is red
+ * - `lower-is-better` — `up` is red, `down` is green
+ * - `neutral` — both directions render in muted gray (the metric has
+ *   no inherent improvement direction; e.g. average HR is good or bad
+ *   only relative to the zone the user was targeting)
+ */
+export type CardioStatCardDirection = 'higher-is-better' | 'lower-is-better' | 'neutral'
+
+/**
+ * Definition of a single stat card. The card row is parameterized so
+ * the Stair, Treadmill, and Track detail views can each supply their
+ * own metric set without forking the component.
+ */
+export interface CardioStatCard {
+  /** Stable React key and `data-testid` suffix. */
+  key: string
+  /** Card title (e.g. `"Avg HR"`, `"Total time"`). */
+  label: string
+  /**
+   * Project a session list to a single scalar value, or `null` when the
+   * metric isn't computable for the period (e.g. avg-HR with no
+   * sessions carrying `avg_hr`). Pure function — receives the already-
+   * filtered session list for the relevant period.
+   */
+  compute: (sessions: readonly CardioSession[]) => number | null
+  /** Format the scalar value for the card body (e.g. `"32m 05s"`, `"148"`). */
+  formatValue: (value: number) => string
+  /**
+   * Format the absolute delta for the delta line (e.g. `"+2m 15s"`,
+   * `"−4"`). Should include the sign. Defaults to a signed call to
+   * {@link CardioStatCard.formatValue}.
+   */
+  formatDelta?: (delta: number) => string
+  /** Optional small unit string rendered next to the value (e.g. `"BPM"`). */
+  unit?: string
+  /** Direction semantics — drives the color of the delta arrow. */
+  direction: CardioStatCardDirection
+}
+
+/** Props for {@link CardioStatsCards}. */
+export interface CardioStatsCardsProps {
+  /** Sessions filtered to the current period. */
+  current: readonly CardioSession[]
+  /** Sessions filtered to the previous (equal-length) period. */
+  previous: readonly CardioSession[]
+  /** Metric definitions, in display order. */
+  metrics: ReadonlyArray<CardioStatCard>
+  /** Tailwind classes appended to the outer grid wrapper. */
+  className?: string
+}
+
+/**
+ * `CardioStatsCards` — period-comparison stat row for Gym detail views (#77).
+ *
+ * Renders one card per metric in `metrics`, each showing the current
+ * value and a delta line against the previous period. The card is
+ * data-shape-driven via {@link CardioStatCard.compute}, so a Stair view
+ * can supply different metrics from a Track view without a fork.
+ *
+ * Deltas are suppressed when the previous period contains fewer than
+ * {@link MIN_PREVIOUS_SESSIONS_FOR_DELTA} sessions — a small-sample
+ * comparison would advertise a misleading 100 %-style swing. The card
+ * still renders the current value in that case; only the delta line
+ * collapses to a "No prior comparison" placeholder.
+ */
+export function CardioStatsCards({
+  current,
+  previous,
+  metrics,
+  className = '',
+}: CardioStatsCardsProps): JSX.Element {
+  const cells = useMemo(() => {
+    return metrics.map((metric) => {
+      const currentValue = metric.compute(current)
+      const previousValue = metric.compute(previous)
+      const delta = computeDelta(currentValue, previousValue)
+      const showDelta =
+        previous.length >= MIN_PREVIOUS_SESSIONS_FOR_DELTA && delta !== null
+      return { metric, currentValue, delta, showDelta }
+    })
+  }, [current, previous, metrics])
+
+  return (
+    <section
+      aria-label="Period comparison summary"
+      className={`grid gap-3 sm:grid-cols-2 lg:grid-cols-5 ${className}`}
+    >
+      {cells.map(({ metric, currentValue, delta, showDelta }) => (
+        <article
+          key={metric.key}
+          data-testid={`stat-card-${metric.key}`}
+          className="rounded-[1.2rem] border border-white/10 bg-[#f5f1e6] p-4 text-[#0a0a0a] shadow-[0_12px_32px_rgba(0,0,0,0.28)]"
+        >
+          <h3 className="font-mono text-[10px] font-bold uppercase tracking-[0.22em] text-[#0a0a0a]/70">
+            {metric.label}
+          </h3>
+          <p className="mt-2 flex items-baseline gap-1.5">
+            <span className="font-mono text-2xl font-semibold tabular-nums text-[#0a0a0a]">
+              {currentValue === null ? '—' : metric.formatValue(currentValue)}
+            </span>
+            {metric.unit && (
+              <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-[#0a0a0a]/55">
+                {metric.unit}
+              </span>
+            )}
+          </p>
+          {showDelta && delta !== null ? (
+            <DeltaLine
+              delta={delta}
+              direction={metric.direction}
+              format={metric.formatDelta ?? defaultDeltaFormatter(metric.formatValue)}
+            />
+          ) : (
+            <p
+              data-testid={`stat-card-${metric.key}-no-delta`}
+              className="mt-2 font-mono text-[10px] uppercase tracking-[0.18em] text-[#0a0a0a]/45"
+            >
+              No prior comparison
+            </p>
+          )}
+        </article>
+      ))}
+    </section>
+  )
+}
+
+interface DeltaLineProps {
+  delta: PeriodDelta
+  direction: CardioStatCardDirection
+  format: (delta: number) => string
+}
+
+function DeltaLine({ delta, direction, format }: DeltaLineProps): JSX.Element {
+  const arrow = delta.direction === 'up' ? '▲' : delta.direction === 'down' ? '▼' : '±'
+  const colorClass = deltaColorClass(direction, delta.direction)
+  const percentLabel =
+    delta.percent === null
+      ? ''
+      : ` (${delta.percent > 0 ? '+' : ''}${delta.percent.toFixed(1)}%)`
+  return (
+    <p
+      className={`mt-2 flex items-baseline gap-1 font-mono text-[11px] tabular-nums ${colorClass}`}
+    >
+      <span aria-hidden="true">{arrow}</span>
+      <span>
+        {format(delta.absolute)}
+        {percentLabel}
+      </span>
+    </p>
+  )
+}
+
+/** Map (semantic direction, observed change) → tailwind text-color class. */
+function deltaColorClass(
+  direction: CardioStatCardDirection,
+  change: DeltaDirection,
+): string {
+  if (direction === 'neutral' || change === 'same') return 'text-[#0a0a0a]/55'
+  if (direction === 'higher-is-better') {
+    return change === 'up' ? 'text-emerald-700' : 'text-red-700'
+  }
+  // direction === 'lower-is-better'
+  return change === 'down' ? 'text-emerald-700' : 'text-red-700'
+}
+
+/** Default delta formatter — signed `formatValue` over the absolute change. */
+function defaultDeltaFormatter(
+  formatValue: (n: number) => string,
+): (delta: number) => string {
+  return (delta) => {
+    const abs = Math.abs(delta)
+    const sign = delta > 0 ? '+' : delta < 0 ? '−' : '±'
+    return `${sign}${formatValue(abs)}`
+  }
+}

--- a/lib/training-facility/period-comparison.test.ts
+++ b/lib/training-facility/period-comparison.test.ts
@@ -9,13 +9,24 @@ import {
 const MS_PER_DAY = 24 * 60 * 60 * 1000
 
 /**
- * Calendar-day count for a `DateRange` whose bounds are start- and
- * end-of-day. `Math.floor` + 1 because the range is inclusive on both
- * ends (Mar 1 00:00 → Mar 31 23:59:59.999 is 31 days, not 32, even
- * though `(end - start) / day ≈ 30.999`).
+ * Calendar-day count via UTC midnights of each bound's local date —
+ * same approach as the source-of-truth helper inside
+ * `period-comparison.ts`. UTC arithmetic neutralizes DST drift; a
+ * naive `(end - start) / day` would over- or under-count fall-back
+ * and spring-forward windows by a day.
  */
 function calendarDayCount(range: DateRange): number {
-  return Math.floor((range.end.getTime() - range.start.getTime()) / MS_PER_DAY) + 1
+  const startUtcMid = Date.UTC(
+    range.start.getFullYear(),
+    range.start.getMonth(),
+    range.start.getDate(),
+  )
+  const endUtcMid = Date.UTC(
+    range.end.getFullYear(),
+    range.end.getMonth(),
+    range.end.getDate(),
+  )
+  return Math.round((endUtcMid - startUtcMid) / MS_PER_DAY) + 1
 }
 
 describe('computePreviousRange', () => {
@@ -53,6 +64,36 @@ describe('computePreviousRange', () => {
     const previous = computePreviousRange(current)
     expect(previous.start.getFullYear()).toBe(2025)
     expect(previous.end).toEqual(new Date(2025, 11, 31, 23, 59, 59, 999))
+  })
+
+  it('preserves calendar-day count across a fall-back DST window (Nov 1 → Nov 30 = 30 days, not 31)', () => {
+    // In US/Eastern, Nov 2 is the DST transition (EDT → EST). A naive
+    // ms-based previous-range derivation would compute Oct 1 → Oct 31
+    // (31 days) here because the fall-back gives the current window an
+    // extra hour of ms. This regression test pins the calendar-day
+    // contract: 30 in → 30 out.
+    const current: DateRange = {
+      start: new Date(2025, 10, 1, 0, 0, 0, 0),
+      end: new Date(2025, 10, 30, 23, 59, 59, 999),
+    }
+    const previous = computePreviousRange(current)
+    expect(calendarDayCount(current)).toBe(30)
+    expect(calendarDayCount(previous)).toBe(30)
+    expect(previous.start).toEqual(new Date(2025, 9, 2, 0, 0, 0, 0))
+    expect(previous.end).toEqual(new Date(2025, 9, 31, 23, 59, 59, 999))
+  })
+
+  it('preserves calendar-day count across a spring-forward DST window (Mar 1 → Mar 31 = 31 days)', () => {
+    // Companion to the fall-back case. Spring-forward subtracts an
+    // hour, which an ms-based derivation would otherwise round in the
+    // opposite direction.
+    const current: DateRange = {
+      start: new Date(2026, 2, 1, 0, 0, 0, 0),
+      end: new Date(2026, 2, 31, 23, 59, 59, 999),
+    }
+    const previous = computePreviousRange(current)
+    expect(calendarDayCount(current)).toBe(31)
+    expect(calendarDayCount(previous)).toBe(31)
   })
 
   it('end-of-previous is strictly before start-of-current', () => {

--- a/lib/training-facility/period-comparison.test.ts
+++ b/lib/training-facility/period-comparison.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest'
+import type { DateRange } from '@/components/training-facility/shared/DateFilter'
+import {
+  MIN_PREVIOUS_SESSIONS_FOR_DELTA,
+  computeDelta,
+  computePreviousRange,
+} from './period-comparison'
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000
+
+/**
+ * Calendar-day count for a `DateRange` whose bounds are start- and
+ * end-of-day. `Math.floor` + 1 because the range is inclusive on both
+ * ends (Mar 1 00:00 → Mar 31 23:59:59.999 is 31 days, not 32, even
+ * though `(end - start) / day ≈ 30.999`).
+ */
+function calendarDayCount(range: DateRange): number {
+  return Math.floor((range.end.getTime() - range.start.getTime()) / MS_PER_DAY) + 1
+}
+
+describe('computePreviousRange', () => {
+  it('returns a previous range covering the same calendar-day count, ending the day before range.start', () => {
+    // Mar 1 → Mar 31 spans 31 calendar days. Previous of equal length
+    // therefore ends Feb 28 (day before Mar 1) and starts Jan 29.
+    // The ms-duration may differ by an hour across this boundary
+    // because DST springs forward in March; calendar-day count is the
+    // user-facing invariant.
+    const current: DateRange = {
+      start: new Date(2026, 2, 1, 0, 0, 0, 0),
+      end: new Date(2026, 2, 31, 23, 59, 59, 999),
+    }
+    const previous = computePreviousRange(current)
+    expect(previous.start).toEqual(new Date(2026, 0, 29, 0, 0, 0, 0))
+    expect(previous.end).toEqual(new Date(2026, 1, 28, 23, 59, 59, 999))
+    expect(calendarDayCount(previous)).toBe(calendarDayCount(current))
+  })
+
+  it('handles a single-day range', () => {
+    const current: DateRange = {
+      start: new Date(2026, 2, 15, 0, 0, 0, 0),
+      end: new Date(2026, 2, 15, 23, 59, 59, 999),
+    }
+    const previous = computePreviousRange(current)
+    expect(previous.start).toEqual(new Date(2026, 2, 14, 0, 0, 0, 0))
+    expect(previous.end).toEqual(new Date(2026, 2, 14, 23, 59, 59, 999))
+  })
+
+  it('handles a range crossing a year boundary', () => {
+    const current: DateRange = {
+      start: new Date(2026, 0, 1, 0, 0, 0, 0),
+      end: new Date(2026, 0, 31, 23, 59, 59, 999),
+    }
+    const previous = computePreviousRange(current)
+    expect(previous.start.getFullYear()).toBe(2025)
+    expect(previous.end).toEqual(new Date(2025, 11, 31, 23, 59, 59, 999))
+  })
+
+  it('end-of-previous is strictly before start-of-current', () => {
+    const current: DateRange = {
+      start: new Date(2026, 5, 1, 0, 0, 0, 0),
+      end: new Date(2026, 5, 30, 23, 59, 59, 999),
+    }
+    const previous = computePreviousRange(current)
+    expect(previous.end.getTime()).toBeLessThan(current.start.getTime())
+  })
+})
+
+describe('computeDelta', () => {
+  it('returns up when current > previous', () => {
+    expect(computeDelta(120, 100)).toEqual({ absolute: 20, percent: 20, direction: 'up' })
+  })
+
+  it('returns down when current < previous', () => {
+    expect(computeDelta(80, 100)).toEqual({ absolute: -20, percent: -20, direction: 'down' })
+  })
+
+  it('returns same when current === previous', () => {
+    expect(computeDelta(100, 100)).toEqual({ absolute: 0, percent: 0, direction: 'same' })
+  })
+
+  it('returns null percent when previous is 0 but still reports absolute and direction', () => {
+    expect(computeDelta(50, 0)).toEqual({ absolute: 50, percent: null, direction: 'up' })
+  })
+
+  it('returns null when current is null', () => {
+    expect(computeDelta(null, 100)).toBeNull()
+  })
+
+  it('returns null when previous is null', () => {
+    expect(computeDelta(100, null)).toBeNull()
+  })
+
+  it('returns null when both are null', () => {
+    expect(computeDelta(null, null)).toBeNull()
+  })
+})
+
+describe('MIN_PREVIOUS_SESSIONS_FOR_DELTA', () => {
+  it('matches the spec threshold of >3 prior sessions', () => {
+    expect(MIN_PREVIOUS_SESSIONS_FOR_DELTA).toBe(4)
+  })
+})

--- a/lib/training-facility/period-comparison.ts
+++ b/lib/training-facility/period-comparison.ts
@@ -53,31 +53,78 @@ export interface PeriodDelta {
 }
 
 /**
- * Compute a previous period of equal length to `range`, ending one
- * millisecond before `range.start`. The returned range's bounds are
+ * Number of milliseconds in a day. Used only inside
+ * {@link calendarDayCount}, where the operands have already been
+ * snapped to UTC midnight so the divisor is exact.
+ */
+const MS_PER_DAY = 86_400_000
+
+/**
+ * Calendar-day count of `range` (inclusive on both ends).
+ *
+ * Counts via UTC midnights of each bound's local date so DST
+ * transitions don't drift the result by ±1. A direct subtraction of
+ * the local timestamps would yield 30 days, 22 h 59 m 59.999 s for a
+ * spring-forward window (off by an hour) and 30 days, 0 h 59 m 59.999 s
+ * for a fall-back window — both round to the wrong day count.
+ *
+ * @internal Intentionally private — call sites that need calendar-day
+ *   arithmetic should call {@link computePreviousRange}, which embeds
+ *   this helper.
+ */
+function calendarDayCount(range: DateRange): number {
+  const startUtcMid = Date.UTC(
+    range.start.getFullYear(),
+    range.start.getMonth(),
+    range.start.getDate(),
+  )
+  const endUtcMid = Date.UTC(
+    range.end.getFullYear(),
+    range.end.getMonth(),
+    range.end.getDate(),
+  )
+  return Math.round((endUtcMid - startUtcMid) / MS_PER_DAY) + 1
+}
+
+/**
+ * Compute a previous period of equal calendar-day count to `range`,
+ * ending the day before `range.start`. The returned range's bounds are
  * day-normalized (start- and end-of-day) so downstream session filters
  * that compare against day-aligned bounds behave the same way as for
  * the current range.
  *
- * Equal length, not "the previous calendar month" — for a current
- * `Mar 1 → Mar 31` (31 days) the previous range is `Jan 29 → Feb 28`
- * (also 31 days), not Feb 1 → Feb 28 (28 days). This keeps "total
- * distance" and "total time" comparable rather than penalizing a
- * 31-day current period against a 28-day previous.
+ * Equal length means **same number of calendar days**, not equal
+ * milliseconds — DST fall-back/spring-forward transitions add or
+ * remove an hour from the ms duration, but the user-facing intent is
+ * "comparable windows". For a current `Mar 1 → Mar 31` (31 days) the
+ * previous range is `Jan 29 → Feb 28` (also 31 days), not Feb 1 → Feb
+ * 28 (28 days). Likewise for `Nov 1 → Nov 30` (30 days, fall-back
+ * window) the previous range is `Oct 2 → Oct 31` (also 30 days), not
+ * Oct 1 → Oct 31 (31 days).
  *
- * @param range - The current `DateRange`. Duration is computed in
- *   milliseconds from `range.start` to `range.end`; the previous range
- *   spans the same duration ending the day before `range.start`.
+ * @param range - The current `DateRange`. The previous range spans
+ *   the same number of calendar days, ending the day before
+ *   `range.start`.
  */
 export function computePreviousRange(range: DateRange): DateRange {
-  const durationMs = range.end.getTime() - range.start.getTime()
-  // End of previous range = the day before `range.start`. Snap to
-  // end-of-day so downstream filters that compare against
-  // `parseSessionDate(s.date).getTime()` (local midnight) include
-  // every session on that day.
-  const previousEnd = endOfDay(new Date(range.start.getTime() - 1))
-  const previousStart = startOfDay(new Date(previousEnd.getTime() - durationMs))
-  return { start: previousStart, end: previousEnd }
+  // Use local-date setDate arithmetic so day subtraction is immune to
+  // DST drift (ms-subtraction would over- or under-count by 1 day
+  // when the current range straddles a transition).
+  const previousEndAnchor = new Date(
+    range.start.getFullYear(),
+    range.start.getMonth(),
+    range.start.getDate() - 1,
+  )
+  const dayCount = calendarDayCount(range)
+  const previousStartAnchor = new Date(
+    previousEndAnchor.getFullYear(),
+    previousEndAnchor.getMonth(),
+    previousEndAnchor.getDate() - (dayCount - 1),
+  )
+  return {
+    start: startOfDay(previousStartAnchor),
+    end: endOfDay(previousEndAnchor),
+  }
 }
 
 /**

--- a/lib/training-facility/period-comparison.ts
+++ b/lib/training-facility/period-comparison.ts
@@ -1,0 +1,105 @@
+/**
+ * Period-comparison helpers for date-range-driven Training Facility surfaces (issue #77).
+ *
+ * Lets a Gym detail view (Stair, Treadmill, Track) compute a "previous
+ * period of equal length, ending where the current range starts" and
+ * project a delta between scalar metric values across the two periods.
+ *
+ * Range derivation lives here (date math); metric computation lives at
+ * each call site (the metrics differ per detail view). The component
+ * `<CardioStatsCards>` consumes the output to render side-by-side stat
+ * cards with delta arrows.
+ */
+
+import {
+  endOfDay,
+  startOfDay,
+  type DateRange,
+} from '@/components/training-facility/shared/DateFilter'
+
+/**
+ * Minimum sessions in the previous period required before a delta is
+ * shown. Below this, the card renders the current value but suppresses
+ * the delta line — small samples produce misleading swings.
+ *
+ * Set to `4` to match the issue spec ("only show deltas when the
+ * previous period has >3 sessions").
+ */
+export const MIN_PREVIOUS_SESSIONS_FOR_DELTA = 4
+
+/**
+ * Direction of change between current and previous scalar values.
+ *
+ * - `up` — current is strictly greater than previous
+ * - `down` — current is strictly less than previous
+ * - `same` — current equals previous (or both are zero)
+ */
+export type DeltaDirection = 'up' | 'down' | 'same'
+
+/** Result of comparing current and previous scalar values for one metric. */
+export interface PeriodDelta {
+  /** Signed absolute change (`current - previous`). */
+  absolute: number
+  /**
+   * Percentage change relative to the previous value, e.g. `+25` for a
+   * 25 % increase. `null` when the previous value is `0` (the percentage
+   * is undefined — division by zero is a meaningless infinity). Callers
+   * should fall back to {@link PeriodDelta.absolute} for display in
+   * that case.
+   */
+  percent: number | null
+  /** Direction of change. See {@link DeltaDirection}. */
+  direction: DeltaDirection
+}
+
+/**
+ * Compute a previous period of equal length to `range`, ending one
+ * millisecond before `range.start`. The returned range's bounds are
+ * day-normalized (start- and end-of-day) so downstream session filters
+ * that compare against day-aligned bounds behave the same way as for
+ * the current range.
+ *
+ * Equal length, not "the previous calendar month" — for a current
+ * `Mar 1 → Mar 31` (31 days) the previous range is `Jan 29 → Feb 28`
+ * (also 31 days), not Feb 1 → Feb 28 (28 days). This keeps "total
+ * distance" and "total time" comparable rather than penalizing a
+ * 31-day current period against a 28-day previous.
+ *
+ * @param range - The current `DateRange`. Duration is computed in
+ *   milliseconds from `range.start` to `range.end`; the previous range
+ *   spans the same duration ending the day before `range.start`.
+ */
+export function computePreviousRange(range: DateRange): DateRange {
+  const durationMs = range.end.getTime() - range.start.getTime()
+  // End of previous range = the day before `range.start`. Snap to
+  // end-of-day so downstream filters that compare against
+  // `parseSessionDate(s.date).getTime()` (local midnight) include
+  // every session on that day.
+  const previousEnd = endOfDay(new Date(range.start.getTime() - 1))
+  const previousStart = startOfDay(new Date(previousEnd.getTime() - durationMs))
+  return { start: previousStart, end: previousEnd }
+}
+
+/**
+ * Compute a {@link PeriodDelta} between two scalar values.
+ *
+ * Both inputs may be `null` when the underlying metric is not
+ * computable for the period (e.g. an avg-HR metric when the period has
+ * no sessions with `avg_hr`). When either side is `null` this function
+ * returns `null` — the caller should hide the delta line entirely.
+ * When `previous` is `0`, `percent` is `null` (undefined ratio) but the
+ * absolute delta and direction are still reported.
+ *
+ * @param current - Metric value for the current period.
+ * @param previous - Metric value for the previous period.
+ */
+export function computeDelta(
+  current: number | null,
+  previous: number | null,
+): PeriodDelta | null {
+  if (current === null || previous === null) return null
+  const absolute = current - previous
+  const direction: DeltaDirection = absolute > 0 ? 'up' : absolute < 0 ? 'down' : 'same'
+  const percent = previous === 0 ? null : (absolute / previous) * 100
+  return { absolute, percent, direction }
+}


### PR DESCRIPTION
## Summary

- Adds a five-card stats row above the Stair charts: **Sessions**, **Total time**, **Avg duration**, **Avg HR**, **Avg max HR**.
- Each card compares the active `DateFilter` range against a **previous period of equal calendar length, ending the day before `range.start`** — e.g. a current `Mar 1 → Mar 31` window compares against `Jan 29 → Feb 28`.
- Deltas are **suppressed when the previous period has fewer than 4 sessions** (issue's `>3` rule) to avoid small-sample swings advertising a 100%-style change.
- HR metrics render with **neutral coloring** because "improvement" depends on which zone you were targeting; sessions / total time / avg duration use the higher-is-better green/red palette.

Lifts the range + delta math into `lib/training-facility/period-comparison.ts` and the renderer into a generic, metric-spec-driven `CardioStatsCards` so Treadmill (#68) and Track (#69) can pick it up later with their own metric arrays.

## Test plan

- [x] `npm test` — vitest unit suite, 355/355 passing (22 new for this feature)
- [x] `npx tsc --noEmit` — clean
- [x] `npx next build` — clean
- [x] `npm run test:e2e` — Playwright 14/14 (no e2e specs touch the Stair view, but ran for safety)
- [ ] Open `/training-facility/gym/stair` on the Vercel preview, confirm the card row renders between the date filter and the chart grid
- [ ] Switch presets (1M / 3M / 6M / 1Y / All) — current values update, deltas update or collapse to "No prior comparison" when the previous window has ≤3 sessions
- [ ] Edit the custom date inputs — same behavior
- [ ] Mobile width (390 px): cards wrap to 2 cols, then 1
- [ ] No regressions on the existing chart grid or session log table below

Closes #77.

🤖 Generated with [Claude Code](https://claude.com/claude-code)