### PR TITLE
feat(gym): training load chart — ATL/CTL/TSB (#78)

### DIFF
--- a/components/training-facility/gym/TrainingLoadChart.tsx
+++ b/components/training-facility/gym/TrainingLoadChart.tsx
@@ -1,0 +1,252 @@
+import type { JSX } from 'react'
+import { scaleLinear, scaleTime } from 'd3-scale'
+import {
+  Axis,
+  EmptyChart,
+  type AxisTick,
+} from '@/components/training-facility/shared/charts/axes'
+import { chartPalette } from '@/components/training-facility/shared/charts/palette'
+import {
+  drawableToPaths,
+  extent,
+  getGenerator,
+} from '@/components/training-facility/shared/charts/rough-svg'
+import {
+  resolveMargin,
+  type ChartCommonProps,
+} from '@/components/training-facility/shared/charts/types'
+import { TSB_ZONES, type TrainingLoadPoint } from '@/lib/training-facility/training-load'
+
+/** Props for {@link TrainingLoadChart}. */
+export interface TrainingLoadChartProps extends ChartCommonProps {
+  /** Pre-computed series from `computeTrainingLoad(dailyTrimpSeries(sessions))`. */
+  points: readonly TrainingLoadPoint[]
+}
+
+/** Series colors. ATL = rim-orange (acute, attention-grabbing), CTL = ink (chronic, anchoring), TSB = blue (delta line). */
+const COLORS = {
+  atl: chartPalette.rimOrange,
+  ctl: chartPalette.inkBlack,
+  tsb: '#1d4ed8',
+  zoneRed: '#fee2e2',
+  zoneYellow: '#fef9c3',
+  zoneGreen: '#dcfce7',
+} as const
+
+/**
+ * Training-load chart — three lines (ATL, CTL, TSB) with horizontal TSB zone
+ * bands behind them (PRD #78).
+ *
+ * The chart uses the existing rough.js + d3-scale stack so its hand-drawn
+ * voice matches the rest of the gym detail charts. ATL / CTL share the
+ * primary y-axis (load units); TSB lands on the same y-axis since CTL − ATL
+ * is the same scale. Zone bands paint between the documented TSB thresholds
+ * (red < −10, yellow −10..5, green 5..25) clipped to the visible plot area.
+ */
+export function TrainingLoadChart({
+  points,
+  width,
+  height,
+  margin,
+  roughness = 1.4,
+  seed = 11,
+  fontFamily = 'inherit',
+  axisColor = chartPalette.inkBlack,
+  className,
+  ariaLabel = 'Training load — ATL, CTL, and TSB over time',
+  ariaLabelledBy,
+  emptyMessage = 'No training load data in range',
+}: TrainingLoadChartProps): JSX.Element {
+  const m = resolveMargin(margin)
+  const innerW = width - m.left - m.right
+  const innerH = height - m.top - m.bottom
+
+  if (points.length === 0) {
+    return (
+      <EmptyChart
+        width={width}
+        height={height}
+        message={emptyMessage}
+        fontFamily={fontFamily}
+        className={className}
+        ariaLabel={ariaLabel}
+        ariaLabelledBy={ariaLabelledBy}
+      />
+    )
+  }
+
+  const dates = points.map((p) => p.date.getTime())
+  const [tMin, tMax] = extent(dates)
+  const xScale = scaleTime()
+    .domain([new Date(tMin), new Date(tMax)])
+    .range([0, innerW])
+
+  // y-domain spans both ATL / CTL (≥ 0) and TSB (can be negative). Pick the
+  // tightest envelope across all three series, then pad ~10% so the lines
+  // don't kiss the chart frame.
+  const allValues = points.flatMap((p) => [p.atl, p.ctl, p.tsb])
+  const [vMin, vMax] = extent(allValues)
+  const yPad = Math.max(1, (vMax - vMin) * 0.1)
+  const yScale = scaleLinear()
+    .domain([vMin - yPad, vMax + yPad])
+    .nice()
+    .range([innerH, 0])
+
+  const xTicks: AxisTick[] = xScale.ticks(5).map((tick) => ({
+    value: tick.toLocaleDateString(undefined, { month: 'short', day: 'numeric' }),
+    offset: xScale(tick),
+  }))
+  const yTicks: AxisTick[] = yScale.ticks(5).map((tick) => ({
+    value: String(Math.round(tick)),
+    offset: yScale(tick),
+  }))
+
+  const gen = getGenerator()
+
+  const atlPath = gen.linearPath(
+    points.map((p) => [xScale(p.date), yScale(p.atl)]),
+    { stroke: COLORS.atl, strokeWidth: 2, roughness, seed: seed + 1 },
+  )
+  const ctlPath = gen.linearPath(
+    points.map((p) => [xScale(p.date), yScale(p.ctl)]),
+    { stroke: COLORS.ctl, strokeWidth: 2, roughness, seed: seed + 2 },
+  )
+  const tsbPath = gen.linearPath(
+    points.map((p) => [xScale(p.date), yScale(p.tsb)]),
+    { stroke: COLORS.tsb, strokeWidth: 1.8, roughness, seed: seed + 3 },
+  )
+
+  // Zone bands: clip each TSB threshold to the visible y-domain. yScale flips
+  // (top y=0 maps to highest load), so a "red zone below −10" is the band
+  // between yScale(−10) and yScale(yDomainMin) — the lower portion of the
+  // plot. Drawn before the lines so the lines stay readable on top.
+  const yDomain = yScale.domain() as [number, number]
+  const yMinDomain = yDomain[0]
+  const yMaxDomain = yDomain[1]
+  const clamp = (v: number) => Math.max(yMinDomain, Math.min(yMaxDomain, v))
+
+  const redTop = yScale(clamp(TSB_ZONES.redMax))
+  const redBottom = yScale(yMinDomain)
+  const yellowTop = yScale(clamp(TSB_ZONES.yellowMax))
+  const yellowBottom = yScale(clamp(TSB_ZONES.redMax))
+  const greenTop = yScale(clamp(TSB_ZONES.greenMax))
+  const greenBottom = yScale(clamp(TSB_ZONES.yellowMax))
+
+  return (
+    <svg
+      width={width}
+      height={height}
+      className={className}
+      role="img"
+      aria-label={ariaLabelledBy ? undefined : ariaLabel}
+      aria-labelledby={ariaLabelledBy}
+    >
+      {ariaLabel && !ariaLabelledBy && <title>{ariaLabel}</title>}
+      <g transform={`translate(${m.left},${m.top})`}>
+        {/* Zone bands behind everything else. */}
+        {redBottom > redTop && (
+          <rect
+            x={0}
+            y={redTop}
+            width={innerW}
+            height={redBottom - redTop}
+            fill={COLORS.zoneRed}
+            opacity={0.55}
+          />
+        )}
+        {yellowBottom > yellowTop && (
+          <rect
+            x={0}
+            y={yellowTop}
+            width={innerW}
+            height={yellowBottom - yellowTop}
+            fill={COLORS.zoneYellow}
+            opacity={0.55}
+          />
+        )}
+        {greenBottom > greenTop && (
+          <rect
+            x={0}
+            y={greenTop}
+            width={innerW}
+            height={greenBottom - greenTop}
+            fill={COLORS.zoneGreen}
+            opacity={0.55}
+          />
+        )}
+
+        <Axis
+          orientation="bottom"
+          position={innerH}
+          start={0}
+          end={innerW}
+          ticks={xTicks}
+          color={axisColor}
+          fontFamily={fontFamily}
+          roughness={roughness}
+          seed={seed + 100}
+        />
+        <Axis
+          orientation="left"
+          position={0}
+          start={0}
+          end={innerH}
+          ticks={yTicks}
+          label="Load"
+          color={axisColor}
+          fontFamily={fontFamily}
+          roughness={roughness}
+          seed={seed + 200}
+        />
+
+        {drawableToPaths(ctlPath).map((p, i) => (
+          <path
+            key={`ctl-${i}`}
+            d={p.d}
+            stroke={p.stroke}
+            strokeWidth={p.strokeWidth}
+            fill="none"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        ))}
+        {drawableToPaths(atlPath).map((p, i) => (
+          <path
+            key={`atl-${i}`}
+            d={p.d}
+            stroke={p.stroke}
+            strokeWidth={p.strokeWidth}
+            fill="none"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        ))}
+        {drawableToPaths(tsbPath).map((p, i) => (
+          <path
+            key={`tsb-${i}`}
+            d={p.d}
+            stroke={p.stroke}
+            strokeWidth={p.strokeWidth}
+            fill="none"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeDasharray="4 3"
+          />
+        ))}
+
+        {/* Inline legend in the upper-right of the plot area. Static,
+            non-interactive — the goal is naming the three lines, not
+            replacing tooltip-on-hover behavior. */}
+        <g transform={`translate(${innerW - 110}, 8)`} fontFamily={fontFamily} fontSize={11}>
+          <rect x={0} y={0} width={108} height={56} fill="rgba(255,255,255,0.78)" rx={4} />
+          <line x1={6} y1={14} x2={22} y2={14} stroke={COLORS.atl} strokeWidth={2} />
+          <text x={28} y={17} fill={chartPalette.inkBlack}>ATL · acute (7d)</text>
+          <line x1={6} y1={30} x2={22} y2={30} stroke={COLORS.ctl} strokeWidth={2} />
+          <text x={28} y={33} fill={chartPalette.inkBlack}>CTL · chronic (28d)</text>
+          <line x1={6} y1={46} x2={22} y2={46} stroke={COLORS.tsb} strokeWidth={1.8} strokeDasharray="4 3" />
+          <text x={28} y={49} fill={chartPalette.inkBlack}>TSB · CTL − ATL</text>
+        </g>
+      </g>
+    </svg>
+  )
+}

--- a/components/training-facility/gym/TreadmillDetailView.tsx
+++ b/components/training-facility/gym/TreadmillDetailView.tsx
@@ -36,6 +36,12 @@ import { RoughScatter } from '@/components/training-facility/shared/charts/Rough
 import { BodyweightOverlay } from '@/components/training-facility/shared/charts/BodyweightOverlay'
 import { chartPalette } from '@/components/training-facility/shared/charts/palette'
 import { defaultMargin } from '@/components/training-facility/shared/charts/types'
+import { TrainingLoadChart } from './TrainingLoadChart'
+import {
+  computeTrainingLoad,
+  dailyTrimpSeries,
+  type TrainingLoadPoint,
+} from '@/lib/training-facility/training-load'
 
 const CHART_HEIGHT = 280
 const PACE_CHART_HEIGHT = 300
@@ -152,6 +158,25 @@ export function TreadmillDetailView(): JSX.Element {
     [runningSessions],
   )
   const paceVsHr = useMemo(() => paceAtHrPoints(runningSessions), [runningSessions])
+
+  // Training load aggregates ALL cardio activities (stair, running, walking) —
+  // TRIMP / ATL / CTL is a whole-athlete metric and excluding modalities
+  // would distort it. Pre-warm by running EMA from the earliest session in
+  // the dataset, then slice the result down to the active DateFilter window.
+  // This avoids the "zero ramp" artifact at the left edge that you get if
+  // you compute EMA only over the visible window.
+  const trainingLoad = useMemo<TrainingLoadPoint[]>(() => {
+    if (!data || data.sessions.length === 0) return []
+    const series = dailyTrimpSeries(data.sessions)
+    if (series.length === 0) return []
+    const full = computeTrainingLoad(series)
+    const fromMs = range.start.getTime()
+    const toMs = range.end.getTime()
+    return full.filter((p) => {
+      const t = p.date.getTime()
+      return t >= fromMs && t <= toMs
+    })
+  }, [data, range])
 
   // Date extent for the pace chart and bodyweight overlay must match exactly
   // so the two x-axes line up. Falls back to the active filter range when the
@@ -312,6 +337,24 @@ export function TreadmillDetailView(): JSX.Element {
                 />
               </ChartCard>
             </div>
+
+            <ChartCard
+              title="Training load"
+              helper="ATL (acute, 7d) vs. CTL (chronic, 28d) and TSB = CTL − ATL. Aggregates all cardio activities; bands shade the freshness zones."
+              wide
+            >
+              <div>
+                <TrainingLoadChart
+                  points={trainingLoad}
+                  width={paceWidth}
+                  height={PACE_CHART_HEIGHT}
+                  margin={defaultMargin}
+                  fontFamily={FONT_FAMILY}
+                  axisColor={chartPalette.inkSoft}
+                  emptyMessage="No training load in selected range"
+                />
+              </div>
+            </ChartCard>
 
             <SessionLogTable sessions={runningSessions} range={range} />
           </>

--- a/lib/training-facility/training-load.test.ts
+++ b/lib/training-facility/training-load.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect } from 'vitest'
+import {
+  ATL_ALPHA,
+  CTL_ALPHA,
+  classifyTsb,
+  computeTRIMP,
+  computeTrainingLoad,
+  dailyTrimpSeries,
+  DEFAULT_MAX_HR,
+} from './training-load'
+import type { CardioSession } from '@/types/cardio'
+
+const session = (
+  date: string,
+  extras: Partial<CardioSession> = {},
+): CardioSession => ({
+  date,
+  activity: 'running',
+  duration_seconds: 1800,
+  ...extras,
+})
+
+describe('computeTRIMP', () => {
+  it('multiplies duration_min × HR fraction × intensity weight', () => {
+    // 60 min running at 0.8 HR fraction × 1.0 weight = 48
+    const s = session('2026-04-01', { duration_seconds: 3600, avg_hr: 148 })
+    expect(computeTRIMP(s, { maxHr: 185 })).toBeCloseTo(60 * (148 / 185) * 1.0, 4)
+  })
+
+  it('applies modality weights', () => {
+    const stair: CardioSession = { date: '2026-04-01', activity: 'stair', duration_seconds: 1800, avg_hr: 148 }
+    const walk: CardioSession = { date: '2026-04-01', activity: 'walking', duration_seconds: 1800, avg_hr: 148 }
+    const stairTrimp = computeTRIMP(stair, { maxHr: 185 })
+    const walkTrimp = computeTRIMP(walk, { maxHr: 185 })
+    // stair weight 1.2; walking weight 0.5
+    expect(stairTrimp / walkTrimp).toBeCloseTo(1.2 / 0.5, 4)
+  })
+
+  it('caps HR fraction at 1 when avg_hr exceeds max_hr', () => {
+    // Sensor anomaly: avg_hr 200, max_hr 185 → HR fraction would be > 1.
+    // 60 min × 1.0 cap × 1.0 = 60
+    const s = session('2026-04-01', { duration_seconds: 3600, avg_hr: 200 })
+    expect(computeTRIMP(s, { maxHr: 185 })).toBe(60)
+  })
+
+  it('uses DEFAULT_MAX_HR when no override is supplied', () => {
+    const s = session('2026-04-01', { duration_seconds: 3600, avg_hr: 148 })
+    expect(computeTRIMP(s)).toBeCloseTo(60 * (148 / DEFAULT_MAX_HR) * 1.0, 4)
+  })
+
+  it('returns 0 when avg_hr is missing or non-positive', () => {
+    expect(computeTRIMP(session('2026-04-01'))).toBe(0)
+    expect(computeTRIMP(session('2026-04-01', { avg_hr: 0 }))).toBe(0)
+    expect(computeTRIMP(session('2026-04-01', { avg_hr: -10 }))).toBe(0)
+  })
+
+  it('returns 0 when max_hr is non-positive or non-finite', () => {
+    const s = session('2026-04-01', { avg_hr: 148, duration_seconds: 1800 })
+    expect(computeTRIMP(s, { maxHr: 0 })).toBe(0)
+    expect(computeTRIMP(s, { maxHr: Number.NaN })).toBe(0)
+    expect(computeTRIMP(s, { maxHr: -185 })).toBe(0)
+  })
+
+  it('returns 0 when duration is missing or non-positive', () => {
+    const s: CardioSession = {
+      date: '2026-04-01',
+      activity: 'running',
+      duration_seconds: 0,
+      avg_hr: 148,
+    }
+    expect(computeTRIMP(s)).toBe(0)
+  })
+})
+
+describe('dailyTrimpSeries', () => {
+  it('sums multiple sessions on the same day', () => {
+    const sessions: CardioSession[] = [
+      session('2026-04-01', { duration_seconds: 1800, avg_hr: 148 }),
+      session('2026-04-01', { duration_seconds: 1800, avg_hr: 148 }),
+    ]
+    const out = dailyTrimpSeries(sessions, { maxHr: 185 })
+    expect(out).toHaveLength(1)
+    const single = computeTRIMP(sessions[0], { maxHr: 185 })
+    expect(out[0].trimp).toBeCloseTo(single * 2, 4)
+  })
+
+  it('fills rest days with TRIMP = 0', () => {
+    const sessions: CardioSession[] = [
+      session('2026-04-01', { avg_hr: 148 }),
+      session('2026-04-04', { avg_hr: 148 }),
+    ]
+    const out = dailyTrimpSeries(sessions, { maxHr: 185 })
+    expect(out.map((p) => p.isoDate)).toEqual([
+      '2026-04-01',
+      '2026-04-02',
+      '2026-04-03',
+      '2026-04-04',
+    ])
+    expect(out.map((p) => p.trimp > 0)).toEqual([true, false, false, true])
+  })
+
+  it('returns [] for empty input', () => {
+    expect(dailyTrimpSeries([])).toEqual([])
+  })
+
+  it('respects the endDate option to extend past the last session', () => {
+    const sessions: CardioSession[] = [
+      session('2026-04-01', { avg_hr: 148 }),
+    ]
+    const out = dailyTrimpSeries(sessions, {
+      maxHr: 185,
+      endDate: new Date('2026-04-03T00:00:00'),
+    })
+    expect(out.map((p) => p.isoDate)).toEqual([
+      '2026-04-01',
+      '2026-04-02',
+      '2026-04-03',
+    ])
+    expect(out[0].trimp).toBeGreaterThan(0)
+    expect(out[1].trimp).toBe(0)
+    expect(out[2].trimp).toBe(0)
+  })
+
+  it('drops sessions with unparseable dates rather than throwing', () => {
+    const sessions: CardioSession[] = [
+      session('not-a-date', { avg_hr: 148 }),
+      session('2026-04-05', { avg_hr: 148 }),
+    ]
+    const out = dailyTrimpSeries(sessions, { maxHr: 185 })
+    expect(out.map((p) => p.isoDate)).toEqual(['2026-04-05'])
+  })
+})
+
+describe('computeTrainingLoad', () => {
+  it('returns [] for an empty series', () => {
+    expect(computeTrainingLoad([])).toEqual([])
+  })
+
+  it('first day applies α × TRIMP from a zero start', () => {
+    const out = computeTrainingLoad([
+      { date: new Date(2026, 3, 1), isoDate: '2026-04-01', trimp: 100 },
+    ])
+    expect(out).toHaveLength(1)
+    expect(out[0].atl).toBeCloseTo(ATL_ALPHA * 100, 6)
+    expect(out[0].ctl).toBeCloseTo(CTL_ALPHA * 100, 6)
+    expect(out[0].tsb).toBeCloseTo(out[0].ctl - out[0].atl, 6)
+  })
+
+  it('ATL responds faster than CTL — TSB goes negative under sustained load', () => {
+    // 30 days of TRIMP=100 every day. ATL rises faster than CTL → TSB
+    // (CTL − ATL) is negative throughout (recently loaded above chronic).
+    const series = Array.from({ length: 30 }, (_, i) => ({
+      date: new Date(2026, 3, i + 1),
+      isoDate: `2026-04-${String(i + 1).padStart(2, '0')}`,
+      trimp: 100,
+    }))
+    const out = computeTrainingLoad(series)
+    expect(out.every((p) => p.tsb <= 0)).toBe(true)
+    // ATL warms toward 100 much faster than CTL toward 100.
+    expect(out[20].atl).toBeGreaterThan(out[20].ctl)
+  })
+
+  it('TSB goes positive on rest days after a load block', () => {
+    // 14 days of TRIMP=100 then 14 days of zero. ATL drops faster than CTL,
+    // so TSB (CTL − ATL) flips positive during the rest block.
+    const loadDays = Array.from({ length: 14 }, (_, i) => ({
+      date: new Date(2026, 3, i + 1),
+      isoDate: `2026-04-${String(i + 1).padStart(2, '0')}`,
+      trimp: 100,
+    }))
+    const restDays = Array.from({ length: 14 }, (_, i) => ({
+      date: new Date(2026, 3, i + 15),
+      isoDate: `2026-04-${String(i + 15).padStart(2, '0')}`,
+      trimp: 0,
+    }))
+    const out = computeTrainingLoad([...loadDays, ...restDays])
+    expect(out[27].tsb).toBeGreaterThan(0)
+    expect(out[27].atl).toBeLessThan(out[13].atl)
+  })
+})
+
+describe('classifyTsb', () => {
+  it('partitions the value space by the documented thresholds', () => {
+    expect(classifyTsb(-15)).toBe('red')
+    expect(classifyTsb(-10)).toBe('yellow') // boundary: not red
+    expect(classifyTsb(0)).toBe('yellow')
+    expect(classifyTsb(5)).toBe('yellow') // boundary: yellow includes 5
+    expect(classifyTsb(10)).toBe('green')
+    expect(classifyTsb(25)).toBe('green') // boundary: green includes 25
+    expect(classifyTsb(30)).toBe('over')
+  })
+
+  it('non-finite TSB falls back to yellow (no signal)', () => {
+    expect(classifyTsb(Number.NaN)).toBe('yellow')
+  })
+})

--- a/lib/training-facility/training-load.ts
+++ b/lib/training-facility/training-load.ts
@@ -1,0 +1,258 @@
+/**
+ * Training-load helpers: TRIMP-based ATL / CTL / TSB.
+ *
+ * Closes #78. The math is intentionally simple — a personal-tool
+ * approximation, not a sports-science publication. Pure functions live here so
+ * the chart layer stays declarative and the math is unit-testable without RTL.
+ *
+ * **Definitions**
+ * - **TRIMP** (training impulse): per-session load score combining duration,
+ *   relative HR effort, and modality stress. Formula is
+ *   `duration_min × (avg_hr / max_hr) × intensityWeight(activity)` — the
+ *   simplest form that still tracks subjective hard-vs-easy days. Sessions
+ *   missing `avg_hr` contribute zero rather than imputing a value.
+ * - **ATL** (acute training load): 7-day exponentially weighted moving
+ *   average of daily TRIMP. Approximates "how loaded am I right now?"
+ * - **CTL** (chronic training load): 28-day EWMA of daily TRIMP. Approximates
+ *   "what's my recent baseline fitness?"
+ * - **TSB** (training stress balance): `CTL − ATL`. Positive = chronically
+ *   loaded but recently rested → fresh. Negative = recently loaded above
+ *   chronic baseline → fatigued.
+ *
+ * **EMA decay constants**
+ * Standard ATL/CTL τ = 7 / 28 days; α = `1 − exp(−1/τ)`. The series initializes
+ * at zero (no bootstrap from earliest data); early values warm up over a few τ
+ * — caller pre-warms the visible window if that's a problem (compute from the
+ * earliest session, slice the display window).
+ */
+
+import type { CardioActivity, CardioSession } from '@/types/cardio'
+
+/**
+ * Default max heart rate used when no per-athlete value is supplied. 185 BPM
+ * matches the `--max-hr` default in `scripts/import-health.mjs`. Override
+ * planned in #143 once a settings surface exists.
+ */
+export const DEFAULT_MAX_HR = 185
+
+/**
+ * Per-modality intensity weighting applied to TRIMP. Stair sessions are the
+ * most cardiovascularly demanding for a given duration and HR (vertical work
+ * recruits more muscle); running is the baseline; walking is discounted
+ * because pure HR-fraction overstates cardio stress at low ground impact.
+ */
+export const INTENSITY_WEIGHTS: Record<CardioActivity, number> = {
+  stair: 1.2,
+  running: 1.0,
+  walking: 0.5,
+}
+
+/** ATL time constant in days (acute load). */
+export const ATL_TAU_DAYS = 7
+/** CTL time constant in days (chronic load). */
+export const CTL_TAU_DAYS = 28
+/** ATL smoothing factor `α = 1 − exp(−1/τ)` ≈ 0.1331. */
+export const ATL_ALPHA = 1 - Math.exp(-1 / ATL_TAU_DAYS)
+/** CTL smoothing factor `α = 1 − exp(−1/τ)` ≈ 0.0351. */
+export const CTL_ALPHA = 1 - Math.exp(-1 / CTL_TAU_DAYS)
+
+/** Optional knobs for {@link computeTRIMP}. */
+export interface ComputeTrimpOptions {
+  /** Max heart rate, BPM. Defaults to {@link DEFAULT_MAX_HR}. */
+  maxHr?: number
+  /** Override the modality weight for tests / what-if. */
+  intensityWeights?: Record<CardioActivity, number>
+}
+
+/**
+ * Compute TRIMP for a single session.
+ *
+ * Returns `0` when:
+ * - `avg_hr` is missing or non-positive (no signal to weight by).
+ * - `max_hr` is `0` or non-finite (would divide by zero).
+ * - `duration_seconds` is missing or non-positive.
+ *
+ * Capping HR fraction at 1 prevents anomalous `avg_hr > max_hr` data (sensor
+ * spike or under-set max) from inflating load — that scenario is a data
+ * problem, not a real 1.2× effort.
+ *
+ * @param session - One `CardioSession`.
+ * @param options - See {@link ComputeTrimpOptions}.
+ */
+export function computeTRIMP(
+  session: CardioSession,
+  options: ComputeTrimpOptions = {},
+): number {
+  const maxHr = options.maxHr ?? DEFAULT_MAX_HR
+  const weights = options.intensityWeights ?? INTENSITY_WEIGHTS
+  if (!Number.isFinite(maxHr) || maxHr <= 0) return 0
+  if (typeof session.avg_hr !== 'number' || !Number.isFinite(session.avg_hr) || session.avg_hr <= 0) {
+    return 0
+  }
+  if (
+    typeof session.duration_seconds !== 'number' ||
+    !Number.isFinite(session.duration_seconds) ||
+    session.duration_seconds <= 0
+  ) {
+    return 0
+  }
+  const durationMin = session.duration_seconds / 60
+  const hrFraction = Math.min(session.avg_hr / maxHr, 1)
+  const weight = weights[session.activity] ?? 1.0
+  return durationMin * hrFraction * weight
+}
+
+/** One row in the daily TRIMP series. */
+export interface DailyTrimpPoint {
+  /** Local-midnight `Date` for the day. Used as the x-scale value. */
+  date: Date
+  /** Local `YYYY-MM-DD` for keying. */
+  isoDate: string
+  /** Total TRIMP across all sessions on this day. Zero when no session. */
+  trimp: number
+}
+
+/** Format a `Date` as `YYYY-MM-DD` in local time. */
+function localIsoDate(d: Date): string {
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  return `${y}-${m}-${day}`
+}
+
+/** Parse `YYYY-MM-DD` (local midnight) or pass an ISO timestamp through. */
+function parseLocalDate(raw: string): Date {
+  if (/^\d{4}-\d{2}-\d{2}$/.test(raw)) return new Date(`${raw}T00:00:00`)
+  return new Date(raw)
+}
+
+/**
+ * Bin sessions into a contiguous daily TRIMP series. Days without a session
+ * still appear (TRIMP = 0) so the EMA in {@link computeTrainingLoad} sees real
+ * gaps as zero-input days rather than skipping them entirely. Same-day
+ * sessions sum.
+ *
+ * The series spans from the earliest session's local-midnight day through
+ * `endDate` (default: latest session). When `sessions` is empty, returns `[]`.
+ *
+ * @param sessions - All cardio sessions; activity-agnostic.
+ * @param options - See {@link DailyTrimpSeriesOptions}.
+ */
+export interface DailyTrimpSeriesOptions {
+  /** Inclusive end-of-series date. Defaults to the latest session date. */
+  endDate?: Date
+  /** Forwarded to {@link computeTRIMP}. */
+  maxHr?: number
+  /** Forwarded to {@link computeTRIMP}. */
+  intensityWeights?: Record<CardioActivity, number>
+}
+
+export function dailyTrimpSeries(
+  sessions: readonly CardioSession[],
+  options: DailyTrimpSeriesOptions = {},
+): DailyTrimpPoint[] {
+  if (sessions.length === 0) return []
+
+  const trimpByDay = new Map<string, number>()
+  let earliestMs = Infinity
+  let latestMs = -Infinity
+
+  for (const s of sessions) {
+    const d = parseLocalDate(s.date)
+    const t = d.getTime()
+    if (!Number.isFinite(t)) continue
+    const iso = localIsoDate(d)
+    const trimp = computeTRIMP(s, {
+      maxHr: options.maxHr,
+      intensityWeights: options.intensityWeights,
+    })
+    trimpByDay.set(iso, (trimpByDay.get(iso) ?? 0) + trimp)
+    if (t < earliestMs) earliestMs = t
+    if (t > latestMs) latestMs = t
+  }
+
+  if (!Number.isFinite(earliestMs)) return []
+
+  const endMs = options.endDate ? options.endDate.getTime() : latestMs
+  const out: DailyTrimpPoint[] = []
+  // Walk by 24h ticks from earliest local midnight to end. Constructing each
+  // day via `new Date(year, month, dayN)` would be safer across DST; using
+  // ms-arithmetic is simpler and only off by an hour on DST-transition days,
+  // which doesn't change which day a session bins to since `localIsoDate`
+  // uses the date's own components.
+  const dayMs = 24 * 60 * 60 * 1000
+  for (let t = earliestMs; t <= endMs; t += dayMs) {
+    const d = new Date(t)
+    const iso = localIsoDate(d)
+    out.push({
+      date: new Date(d.getFullYear(), d.getMonth(), d.getDate()),
+      isoDate: iso,
+      trimp: trimpByDay.get(iso) ?? 0,
+    })
+  }
+  return out
+}
+
+/** One row in the training-load output series. */
+export interface TrainingLoadPoint {
+  /** Local-midnight `Date` for the day. */
+  date: Date
+  /** Total TRIMP for the day (zero on rest days). */
+  trimp: number
+  /** Acute training load — 7-day EWMA of TRIMP. */
+  atl: number
+  /** Chronic training load — 28-day EWMA of TRIMP. */
+  ctl: number
+  /** Training stress balance — `CTL − ATL`. Positive = fresh. */
+  tsb: number
+}
+
+/**
+ * Run the EMA recurrence over a daily TRIMP series and emit ATL / CTL / TSB
+ * day by day.
+ *
+ * Both EMAs initialize at zero. With no bootstrap, ATL / CTL ramp up from
+ * zero over the first few τ — visible as a "warm-up" tail at the left edge
+ * of the chart. Caller pre-warms by computing from the earliest session and
+ * slicing the display window after the fact.
+ *
+ * @param series - Daily TRIMP series from {@link dailyTrimpSeries}.
+ */
+export function computeTrainingLoad(
+  series: readonly DailyTrimpPoint[],
+): TrainingLoadPoint[] {
+  const out: TrainingLoadPoint[] = []
+  let atl = 0
+  let ctl = 0
+  for (const p of series) {
+    atl = atl + ATL_ALPHA * (p.trimp - atl)
+    ctl = ctl + CTL_ALPHA * (p.trimp - ctl)
+    out.push({ date: p.date, trimp: p.trimp, atl, ctl, tsb: ctl - atl })
+  }
+  return out
+}
+
+/** TSB zone classification thresholds (per issue #78). */
+export const TSB_ZONES = {
+  /** Below this is accumulated fatigue. */
+  redMax: -10,
+  /** Above this is functional overreach (yellow). */
+  yellowMax: 5,
+  /** Above this is optimal freshness (green). */
+  greenMax: 25,
+} as const
+
+/** TSB zone label for a single value. `'over'` is "above optimal freshness" — fresh but possibly under-loaded. */
+export type TsbZone = 'red' | 'yellow' | 'green' | 'over'
+
+/**
+ * Classify a single TSB value into a zone label. Intended for tooltips and
+ * accessible labels; the chart itself paints horizontal bands.
+ */
+export function classifyTsb(tsb: number): TsbZone {
+  if (!Number.isFinite(tsb)) return 'yellow'
+  if (tsb < TSB_ZONES.redMax) return 'red'
+  if (tsb <= TSB_ZONES.yellowMax) return 'yellow'
+  if (tsb <= TSB_ZONES.greenMax) return 'green'
+  return 'over'
+}


### PR DESCRIPTION
## Summary

Adds a TRIMP-based training-load chart to `TreadmillDetailView`, sitting between the per-activity charts and the Session Log (per #78's placement).

- **`lib/training-facility/training-load.ts`** — pure helpers (`computeTRIMP`, `dailyTrimpSeries`, `computeTrainingLoad`, `classifyTsb`) with the ATL/CTL/TSB math.
- **`components/training-facility/gym/TrainingLoadChart.tsx`** — rough.js + d3-scale chart with three lines (ATL, CTL, TSB-dashed) and horizontal TSB zone bands (red < −10, yellow −10..5, green 5..25).
- **`TreadmillDetailView.tsx`** wires it in.

The chart aggregates **all cardio activities** (stair, running, walking) because TRIMP / ATL / CTL is fundamentally a whole-athlete metric — running-only would distort it. Stair/track follow-up tracked in #142; configurable max-HR follow-up in #143.

## Math

- `TRIMP = duration_min × (avg_hr / max_hr) × intensityWeight(activity)`, capped at HR-fraction = 1 to ride out anomalous `avg_hr > max_hr` sensor data.
- Modality weights: `{ stair: 1.2, running: 1.0, walking: 0.5 }`.
- `DEFAULT_MAX_HR = 185` matches `scripts/import-health.mjs --max-hr` default. #143 will surface this through settings.
- ATL α = `1 − e⁻¹ᐟ⁷` ≈ `0.1331`; CTL α = `1 − e⁻¹ᐟ²⁸` ≈ `0.0357`. Series initializes at zero — pre-warmed by computing from the earliest session in the dataset, then sliced to the active `DateFilter` window for display, so picking `1M` doesn't show a "ramp from zero" artifact.
- Sessions missing `avg_hr` contribute 0 (no signal to weight by). Same-day sessions sum.

## Tests

`lib/training-facility/training-load.test.ts` covers:
- `computeTRIMP` — formula, modality weights, HR-cap, missing/zero/negative inputs, max-HR guard.
- `dailyTrimpSeries` — same-day sum, rest-day fill, empty input, custom `endDate`, unparseable date drop.
- `computeTrainingLoad` — empty, first-day α-multiply, ATL-leads-CTL under sustained load, TSB flips positive on rest after a load block.
- `classifyTsb` — boundary classifications + non-finite fallback.

Full suite: 351 tests across 26 files, all green.

## Test plan

- [ ] Visit `/training-facility/gym/treadmill` (with `NEXT_PUBLIC_ENABLE_TRAINING_FACILITY=true`).
- [ ] New "Training load" card appears between the cardiac-eff / pace-at-HR row and the Session Log.
- [ ] Chart renders three lines: ATL (orange, solid), CTL (black, solid), TSB (blue, dashed).
- [ ] Horizontal red / yellow / green bands shade the freshness zones behind the lines.
- [ ] Inline legend in the upper-right names the three lines.
- [ ] Date Filter pills (`1M / 3M / 6M / 1Y / All`) reslice the chart; lines smoothly continue across boundaries (no zero-ramp at the left edge thanks to pre-warm).
- [ ] Empty range / no avg-HR data: card shows the empty-state placeholder.
- [ ] Resize browser to ~375px wide — chart shrinks with the column, axes still readable.
- [ ] Stair detail view (`/training-facility/gym/stair`) is unchanged (training-load on those views is tracked in #142).

> **Preview data note:** `public/data/cardio.json` is gitignored. Run `npm run import-health -- <export.zip>` locally for real data; the Vercel preview will render empty states.

Closes #78. Refs #142, #143.