### PR TITLE
feat(gym): wire TrainingLoadChart into stair + track detail views (#142)

### DIFF
--- a/components/training-facility/gym/StairDetailView.tsx
+++ b/components/training-facility/gym/StairDetailView.tsx
@@ -26,11 +26,22 @@ import {
 } from '@/components/training-facility/shared/CardioStatsCards'
 import { HrZoneBars } from './HrZoneBars'
 import { AvgHrBars } from './AvgHrBars'
+import { TrainingLoadChart } from './TrainingLoadChart'
+import {
+  computeTrainingLoad,
+  dailyTrimpSeries,
+  type TrainingLoadPoint,
+} from '@/lib/training-facility/training-load'
+import { chartPalette } from '@/components/training-facility/shared/charts/palette'
+import { defaultMargin } from '@/components/training-facility/shared/charts/types'
 
 const CHART_HEIGHT = 280
+const TRAINING_LOAD_HEIGHT = 300
 const MIN_CHART_WIDTH = 280
 const DEFAULT_CHART_WIDTH = 560
+const DEFAULT_WIDE_WIDTH = 880
 const EARLIEST_FALLBACK = new Date(2024, 0, 1)
+const FONT_FAMILY = "'Patrick Hand', system-ui, sans-serif"
 
 /**
  * Compact total-time label that promotes to `Hh Mm` once we cross an
@@ -138,25 +149,34 @@ const STAIR_STATS: ReadonlyArray<CardioStatCard> = [
 /**
  * Stair-climber detail view (PRD §7.4) — the first Gym detail surface.
  *
- * Composes three views fed by `getCardioData()` and a shared `DateFilter`:
+ * Composes four views fed by `getCardioData()` and a shared `DateFilter`:
  *   1. Time-in-zone bars (`HrZoneBars`) — total seconds per Z1–Z5, summed
- *      across the filtered window.
- *   2. Per-session avg-HR bars (`AvgHrBars`) — one bar per session in range.
- *   3. Session log table — one row per session, oldest → newest.
+ *      across the filtered window (filter scope: stair sessions).
+ *   2. Per-session avg-HR bars (`AvgHrBars`) — one bar per stair session in
+ *      range.
+ *   3. Training load (`TrainingLoadChart`) — ATL/CTL/TSB across ALL cardio
+ *      activities (not just stair). TRIMP is a whole-athlete metric, so the
+ *      chart respects the active `DateFilter` window but aggregates across
+ *      modalities (PRD #78).
+ *   4. Session log table — one row per stair session, newest → oldest.
  *
  * Loading and error are surfaced explicitly so a missing `cardio.json` (or a
- * future API outage) reads as "no data yet" instead of an empty chart trio.
+ * future API outage) reads as "no data yet" instead of an empty chart wall.
  */
 export function StairDetailView(): JSX.Element {
   const [data, setData] = useState<CardioData | null>(null)
   const [loadError, setLoadError] = useState<Error | null>(null)
   const [range, setRange] = useState<DateRange>(() => rangeForPreset('1M', EARLIEST_FALLBACK))
   const [chartWidth, setChartWidth] = useState(DEFAULT_CHART_WIDTH)
+  const [wideWidth, setWideWidth] = useState(DEFAULT_WIDE_WIDTH)
   // Sentinel ref placed on a per-card wrapper, NOT on the two-column grid.
   // The grid wrapper would report the combined width on `lg:grid-cols-2`, so
   // each chart would render at ~2× its column footprint and overflow. The
   // two cards are equal width by grid contract, so observing one is enough.
   const cardSizerRef = useRef<HTMLDivElement>(null)
+  // Separate sentinel for the full-width training-load card. Its content area
+  // spans the whole container instead of one column, so it needs its own width.
+  const wideSizerRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
     let cancelled = false
@@ -207,6 +227,19 @@ export function StairDetailView(): JSX.Element {
     return () => observer.disconnect()
   }, [])
 
+  useEffect(() => {
+    const node = wideSizerRef.current
+    if (!node || typeof ResizeObserver === 'undefined') return
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        const next = Math.max(MIN_CHART_WIDTH, Math.floor(entry.contentRect.width))
+        setWideWidth((prev) => (prev === next ? prev : next))
+      }
+    })
+    observer.observe(node)
+    return () => observer.disconnect()
+  }, [])
+
   // Earliest cardio date in the dataset — drives the `All` preset bound. Falls
   // back to a fixed date so the picker is functional before any data loads.
   // Uses `parseSessionDate` so the local-day interpretation matches what
@@ -242,6 +275,24 @@ export function StairDetailView(): JSX.Element {
   )
   const buckets = useMemo(() => aggregateHrZoneSeconds(stairSessions), [stairSessions])
   const avgHrPoints = useMemo(() => perSessionAvgHr(stairSessions), [stairSessions])
+
+  // Training load aggregates ALL cardio activities (stair, running, walking) —
+  // TRIMP / ATL / CTL is a whole-athlete metric and excluding modalities would
+  // distort it. Pre-warm the EMA from the earliest session in the dataset,
+  // then slice the result to the active DateFilter window so the left edge
+  // doesn't show a synthetic zero ramp.
+  const trainingLoad = useMemo<TrainingLoadPoint[]>(() => {
+    if (!data || data.sessions.length === 0) return []
+    const series = dailyTrimpSeries(data.sessions)
+    if (series.length === 0) return []
+    const full = computeTrainingLoad(series)
+    const fromMs = range.start.getTime()
+    const toMs = range.end.getTime()
+    return full.filter((p) => {
+      const t = p.date.getTime()
+      return t >= fromMs && t <= toMs
+    })
+  }, [data, range])
 
   return (
     <div className="relative min-h-svh overflow-hidden bg-[#120d0a] text-[#f7ead9]">
@@ -306,7 +357,7 @@ export function StairDetailView(): JSX.Element {
                     buckets={buckets}
                     width={chartWidth}
                     height={CHART_HEIGHT}
-                    fontFamily="'Patrick Hand', system-ui, sans-serif"
+                    fontFamily={FONT_FAMILY}
                   />
                 </div>
               </ChartCard>
@@ -319,10 +370,28 @@ export function StairDetailView(): JSX.Element {
                   points={avgHrPoints}
                   width={chartWidth}
                   height={CHART_HEIGHT}
-                  fontFamily="'Patrick Hand', system-ui, sans-serif"
+                  fontFamily={FONT_FAMILY}
                 />
               </ChartCard>
             </div>
+
+            <ChartCard
+              title="Training load"
+              helper="ATL (acute, 7d) vs. CTL (chronic, 28d) and TSB = CTL − ATL. Aggregates all cardio activities; bands shade the freshness zones."
+              wide
+            >
+              <div ref={wideSizerRef}>
+                <TrainingLoadChart
+                  points={trainingLoad}
+                  width={wideWidth}
+                  height={TRAINING_LOAD_HEIGHT}
+                  margin={defaultMargin}
+                  fontFamily={FONT_FAMILY}
+                  axisColor={chartPalette.inkSoft}
+                  emptyMessage="No training load in selected range"
+                />
+              </div>
+            </ChartCard>
 
             <SessionLogTable sessions={stairSessions} range={range} />
           </>
@@ -335,13 +404,15 @@ export function StairDetailView(): JSX.Element {
 interface ChartCardProps {
   title: string
   helper: string
+  /** When set, the card sits full-width (used for the training-load row). */
+  wide?: boolean
   children: JSX.Element
 }
 
-function ChartCard({ title, helper, children }: ChartCardProps): JSX.Element {
+function ChartCard({ title, helper, wide, children }: ChartCardProps): JSX.Element {
   return (
     <section
-      className="rounded-[1.6rem] border border-white/10 bg-[#f5f1e6] p-5 text-[#0a0a0a] shadow-[0_18px_46px_rgba(0,0,0,0.34)]"
+      className={`${wide ? 'mt-6 ' : ''}rounded-[1.6rem] border border-white/10 bg-[#f5f1e6] p-5 text-[#0a0a0a] shadow-[0_18px_46px_rgba(0,0,0,0.34)]`}
     >
       <header className="mb-2 flex items-baseline justify-between gap-3">
         <h2 className="font-mono text-xs font-bold uppercase tracking-[0.24em] text-[#0a0a0a]">

--- a/components/training-facility/gym/StairDetailView.tsx
+++ b/components/training-facility/gym/StairDetailView.tsx
@@ -28,8 +28,7 @@ import { HrZoneBars } from './HrZoneBars'
 import { AvgHrBars } from './AvgHrBars'
 import { TrainingLoadChart } from './TrainingLoadChart'
 import {
-  computeTrainingLoad,
-  dailyTrimpSeries,
+  trainingLoadInRange,
   type TrainingLoadPoint,
 } from '@/lib/training-facility/training-load'
 import { chartPalette } from '@/components/training-facility/shared/charts/palette'
@@ -278,21 +277,13 @@ export function StairDetailView(): JSX.Element {
 
   // Training load aggregates ALL cardio activities (stair, running, walking) —
   // TRIMP / ATL / CTL is a whole-athlete metric and excluding modalities would
-  // distort it. Pre-warm the EMA from the earliest session in the dataset,
-  // then slice the result to the active DateFilter window so the left edge
-  // doesn't show a synthetic zero ramp.
-  const trainingLoad = useMemo<TrainingLoadPoint[]>(() => {
-    if (!data || data.sessions.length === 0) return []
-    const series = dailyTrimpSeries(data.sessions)
-    if (series.length === 0) return []
-    const full = computeTrainingLoad(series)
-    const fromMs = range.start.getTime()
-    const toMs = range.end.getTime()
-    return full.filter((p) => {
-      const t = p.date.getTime()
-      return t >= fromMs && t <= toMs
-    })
-  }, [data, range])
+  // distort it. The helper pre-warms the EMA from the earliest session, then
+  // clips to the active DateFilter window so the left edge doesn't show a
+  // synthetic zero ramp.
+  const trainingLoad = useMemo<TrainingLoadPoint[]>(
+    () => (data ? trainingLoadInRange(data.sessions, range) : []),
+    [data, range],
+  )
 
   return (
     <div className="relative min-h-svh overflow-hidden bg-[#120d0a] text-[#f7ead9]">

--- a/components/training-facility/gym/TrackDetailView.tsx
+++ b/components/training-facility/gym/TrackDetailView.tsx
@@ -38,8 +38,7 @@ import { chartPalette } from '@/components/training-facility/shared/charts/palet
 import { defaultMargin } from '@/components/training-facility/shared/charts/types'
 import { TrainingLoadChart } from './TrainingLoadChart'
 import {
-  computeTrainingLoad,
-  dailyTrimpSeries,
+  trainingLoadInRange,
   type TrainingLoadPoint,
 } from '@/lib/training-facility/training-load'
 
@@ -161,21 +160,13 @@ export function TrackDetailView(): JSX.Element {
 
   // Training load aggregates ALL cardio activities (stair, running, walking) —
   // TRIMP / ATL / CTL is a whole-athlete metric and excluding modalities would
-  // distort it. Pre-warm the EMA from the earliest session in the dataset,
-  // then slice the result to the active DateFilter window so the left edge
-  // doesn't show a synthetic zero ramp.
-  const trainingLoad = useMemo<TrainingLoadPoint[]>(() => {
-    if (!data || data.sessions.length === 0) return []
-    const series = dailyTrimpSeries(data.sessions)
-    if (series.length === 0) return []
-    const full = computeTrainingLoad(series)
-    const fromMs = range.start.getTime()
-    const toMs = range.end.getTime()
-    return full.filter((p) => {
-      const t = p.date.getTime()
-      return t >= fromMs && t <= toMs
-    })
-  }, [data, range])
+  // distort it. The helper pre-warms the EMA from the earliest session, then
+  // clips to the active DateFilter window so the left edge doesn't show a
+  // synthetic zero ramp.
+  const trainingLoad = useMemo<TrainingLoadPoint[]>(
+    () => (data ? trainingLoadInRange(data.sessions, range) : []),
+    [data, range],
+  )
 
   // Date extent for the pace chart and bodyweight overlay must match exactly
   // so the two x-axes line up. Falls back to the active filter range when the

--- a/components/training-facility/gym/TrackDetailView.tsx
+++ b/components/training-facility/gym/TrackDetailView.tsx
@@ -36,6 +36,12 @@ import { RoughScatter } from '@/components/training-facility/shared/charts/Rough
 import { BodyweightOverlay } from '@/components/training-facility/shared/charts/BodyweightOverlay'
 import { chartPalette } from '@/components/training-facility/shared/charts/palette'
 import { defaultMargin } from '@/components/training-facility/shared/charts/types'
+import { TrainingLoadChart } from './TrainingLoadChart'
+import {
+  computeTrainingLoad,
+  dailyTrimpSeries,
+  type TrainingLoadPoint,
+} from '@/lib/training-facility/training-load'
 
 const CHART_HEIGHT = 280
 const PACE_CHART_HEIGHT = 300
@@ -49,9 +55,14 @@ const FONT_FAMILY = "'Patrick Hand', system-ui, sans-serif"
  * Track detail view (PRD §7.4) — walking-modality charts over the cardio
  * data layer. Mirrors `TreadmillDetailView` for shared concerns (HR-zone bars,
  * per-session avg-HR, session log, pace trend with bodyweight overlay,
- * cardiac efficiency, pace-at-HR scatter) — the only differences are the
- * walking-only filter and the equipment-specific copy framing walking as
- * recovery / aerobic-base work rather than the speed work treadmill is for.
+ * cardiac efficiency, pace-at-HR scatter, training load) — the only
+ * differences are the walking-only filter and the equipment-specific copy
+ * framing walking as recovery / aerobic-base work rather than the speed work
+ * treadmill is for.
+ *
+ * Note: the training-load chart aggregates ALL cardio activities (TRIMP is a
+ * whole-athlete metric — PRD #78), so its scope is wider than the rest of the
+ * charts on this page.
  *
  * Shares pace projection helpers with running (see {@link ./running}) since
  * those are activity-agnostic; only the activity filter is walking-specific.
@@ -147,6 +158,24 @@ export function TrackDetailView(): JSX.Element {
     [walkingSessions],
   )
   const paceVsHr = useMemo(() => paceAtHrPoints(walkingSessions), [walkingSessions])
+
+  // Training load aggregates ALL cardio activities (stair, running, walking) —
+  // TRIMP / ATL / CTL is a whole-athlete metric and excluding modalities would
+  // distort it. Pre-warm the EMA from the earliest session in the dataset,
+  // then slice the result to the active DateFilter window so the left edge
+  // doesn't show a synthetic zero ramp.
+  const trainingLoad = useMemo<TrainingLoadPoint[]>(() => {
+    if (!data || data.sessions.length === 0) return []
+    const series = dailyTrimpSeries(data.sessions)
+    if (series.length === 0) return []
+    const full = computeTrainingLoad(series)
+    const fromMs = range.start.getTime()
+    const toMs = range.end.getTime()
+    return full.filter((p) => {
+      const t = p.date.getTime()
+      return t >= fromMs && t <= toMs
+    })
+  }, [data, range])
 
   // Date extent for the pace chart and bodyweight overlay must match exactly
   // so the two x-axes line up. Falls back to the active filter range when the
@@ -308,6 +337,24 @@ export function TrackDetailView(): JSX.Element {
                 />
               </ChartCard>
             </div>
+
+            <ChartCard
+              title="Training load"
+              helper="ATL (acute, 7d) vs. CTL (chronic, 28d) and TSB = CTL − ATL. Aggregates all cardio activities; bands shade the freshness zones."
+              wide
+            >
+              <div>
+                <TrainingLoadChart
+                  points={trainingLoad}
+                  width={paceWidth}
+                  height={PACE_CHART_HEIGHT}
+                  margin={defaultMargin}
+                  fontFamily={FONT_FAMILY}
+                  axisColor={chartPalette.inkSoft}
+                  emptyMessage="No training load in selected range"
+                />
+              </div>
+            </ChartCard>
 
             <SessionLogTable sessions={walkingSessions} range={range} />
           </>

--- a/components/training-facility/gym/TreadmillDetailView.tsx
+++ b/components/training-facility/gym/TreadmillDetailView.tsx
@@ -38,8 +38,7 @@ import { chartPalette } from '@/components/training-facility/shared/charts/palet
 import { defaultMargin } from '@/components/training-facility/shared/charts/types'
 import { TrainingLoadChart } from './TrainingLoadChart'
 import {
-  computeTrainingLoad,
-  dailyTrimpSeries,
+  trainingLoadInRange,
   type TrainingLoadPoint,
 } from '@/lib/training-facility/training-load'
 
@@ -160,23 +159,14 @@ export function TreadmillDetailView(): JSX.Element {
   const paceVsHr = useMemo(() => paceAtHrPoints(runningSessions), [runningSessions])
 
   // Training load aggregates ALL cardio activities (stair, running, walking) —
-  // TRIMP / ATL / CTL is a whole-athlete metric and excluding modalities
-  // would distort it. Pre-warm by running EMA from the earliest session in
-  // the dataset, then slice the result down to the active DateFilter window.
-  // This avoids the "zero ramp" artifact at the left edge that you get if
-  // you compute EMA only over the visible window.
-  const trainingLoad = useMemo<TrainingLoadPoint[]>(() => {
-    if (!data || data.sessions.length === 0) return []
-    const series = dailyTrimpSeries(data.sessions)
-    if (series.length === 0) return []
-    const full = computeTrainingLoad(series)
-    const fromMs = range.start.getTime()
-    const toMs = range.end.getTime()
-    return full.filter((p) => {
-      const t = p.date.getTime()
-      return t >= fromMs && t <= toMs
-    })
-  }, [data, range])
+  // TRIMP / ATL / CTL is a whole-athlete metric and excluding modalities would
+  // distort it. The helper pre-warms the EMA from the earliest session, then
+  // clips to the active DateFilter window so the left edge doesn't show a
+  // synthetic zero ramp.
+  const trainingLoad = useMemo<TrainingLoadPoint[]>(
+    () => (data ? trainingLoadInRange(data.sessions, range) : []),
+    [data, range],
+  )
 
   // Date extent for the pace chart and bodyweight overlay must match exactly
   // so the two x-axes line up. Falls back to the active filter range when the

--- a/lib/training-facility/training-load.test.ts
+++ b/lib/training-facility/training-load.test.ts
@@ -7,8 +7,10 @@ import {
   computeTrainingLoad,
   dailyTrimpSeries,
   DEFAULT_MAX_HR,
+  trainingLoadInRange,
 } from './training-load'
 import type { CardioSession } from '@/types/cardio'
+import type { DateRange } from '@/components/training-facility/shared/DateFilter'
 
 const session = (
   date: string,
@@ -192,5 +194,48 @@ describe('classifyTsb', () => {
 
   it('non-finite TSB falls back to yellow (no signal)', () => {
     expect(classifyTsb(Number.NaN)).toBe('yellow')
+  })
+})
+
+describe('trainingLoadInRange', () => {
+  const range = (start: string, end: string): DateRange => ({
+    start: new Date(start),
+    end: new Date(end),
+  })
+
+  it('returns [] for an empty session set', () => {
+    expect(trainingLoadInRange([], range('2026-01-01', '2026-12-31'))).toEqual([])
+  })
+
+  it('clips the prewarmed series to the range, preserving EMA continuity', () => {
+    // Three sessions across two months. Build the full series first so we
+    // can assert that the in-range slice equals the same slice taken from
+    // the unclipped series — i.e., clipping doesn't mutate values.
+    const sessions: CardioSession[] = [
+      { date: '2026-02-01', activity: 'running', duration_seconds: 3600, avg_hr: 148 },
+      { date: '2026-03-15', activity: 'stair', duration_seconds: 1800, avg_hr: 160 },
+      { date: '2026-04-10', activity: 'walking', duration_seconds: 2400, avg_hr: 110 },
+    ]
+    const window = range('2026-04-01', '2026-04-30')
+    const clipped = trainingLoadInRange(sessions, window)
+
+    // Every returned point sits inside the window.
+    for (const p of clipped) {
+      expect(p.date.getTime()).toBeGreaterThanOrEqual(window.start.getTime())
+      expect(p.date.getTime()).toBeLessThanOrEqual(window.end.getTime())
+    }
+
+    // Pre-warming holds: the leftmost point's CTL is non-zero because
+    // earlier sessions seeded the EMA. A naive in-window-only computation
+    // would start CTL at 0 here.
+    expect(clipped.length).toBeGreaterThan(0)
+    expect(clipped[0].ctl).toBeGreaterThan(0)
+  })
+
+  it('returns [] when no session lands in the window', () => {
+    const sessions: CardioSession[] = [
+      { date: '2026-02-01', activity: 'running', duration_seconds: 3600, avg_hr: 148 },
+    ]
+    expect(trainingLoadInRange(sessions, range('2026-05-01', '2026-05-31'))).toEqual([])
   })
 })

--- a/lib/training-facility/training-load.ts
+++ b/lib/training-facility/training-load.ts
@@ -27,6 +27,7 @@
  */
 
 import type { CardioActivity, CardioSession } from '@/types/cardio'
+import type { DateRange } from '@/components/training-facility/shared/DateFilter'
 
 /**
  * Default max heart rate used when no per-athlete value is supplied. 185 BPM
@@ -230,6 +231,35 @@ export function computeTrainingLoad(
     out.push({ date: p.date, trimp: p.trimp, atl, ctl, tsb: ctl - atl })
   }
   return out
+}
+
+/**
+ * One-shot helper for view containers: build the EMA-prewarmed training-load
+ * series from the full session set, then clip to a `DateFilter` window.
+ *
+ * Pre-warming the EMA from the earliest session avoids the synthetic zero
+ * ramp at the left edge of the visible window. Each detail view (Treadmill,
+ * Stair, Track) wraps this in `useMemo` keyed on `[data, range]`.
+ *
+ * @param sessions all cardio sessions (modality-agnostic — TRIMP is a
+ *   whole-athlete metric, so callers should not pre-filter to one activity).
+ * @param range the active `DateFilter` window; both endpoints are inclusive
+ *   in millisecond comparisons.
+ */
+export function trainingLoadInRange(
+  sessions: readonly CardioSession[],
+  range: DateRange,
+): TrainingLoadPoint[] {
+  if (sessions.length === 0) return []
+  const series = dailyTrimpSeries(sessions)
+  if (series.length === 0) return []
+  const full = computeTrainingLoad(series)
+  const fromMs = range.start.getTime()
+  const toMs = range.end.getTime()
+  return full.filter((p) => {
+    const t = p.date.getTime()
+    return t >= fromMs && t <= toMs
+  })
 }
 
 /** TSB zone classification thresholds (per issue #78). */


### PR DESCRIPTION
## Summary
- Renders `<TrainingLoadChart />` between the per-activity charts and the Session Log on both `StairDetailView` and `TrackDetailView` — same placement and behavior as the treadmill detail (#78).
- Computes ATL/CTL/TSB across **all** cardio sessions and slices to the active `DateFilter` window. TRIMP is a whole-athlete metric, so excluding stair / track from the chart on those pages would actively mislead.
- Bodyweight overlay is intentionally not paired with this chart — TRIMP isn't a §4 power-to-weight metric.
- StairDetailView gains a `wide` variant on its local `ChartCard` plus a second `ResizeObserver` sentinel for the full-width card (the existing column-width sentinel would under-report).

Closes #142.

## Test plan
- [ ] `/training-facility/gym/stair` — Training load card renders below the two-column row, above the Session log.
- [ ] `/training-facility/gym/track` — same placement; helper copy mirrors the treadmill view.
- [ ] Switching `DateFilter` (1W / 1M / 3M / 6M / 1Y / All) resizes the line series and TSB bands on both pages without a flicker or off-by-one at the right edge.
- [ ] EMA pre-warming holds: the leftmost ATL/CTL points on a 1M view sit at sensible non-zero values, not a synthetic ramp from zero.
- [ ] Mobile (`390×844`) — the wide chart shrinks with the container, no horizontal overflow on either page.
- [ ] Empty state — with no sessions in the chosen range, the chart shows "No training load in selected range" rather than rendering a blank axis.
- [ ] Treadmill view (`/training-facility/gym/treadmill`) — chart still renders identically to before; this PR only adds new mounts, no shared state changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a full-width "Training load" chart to gym dashboards, showing TRIMP-derived ATL/CTL/TSB across all cardio sessions in the selected date range.

* **Refactor**
  * Consolidated training-load generation into a single range-aware utility reused by multiple views.

* **Style**
  * Standardized chart typography and improved spacing for the wide training-load card.

* **Tests**
  * Added tests for range clipping and continuity of training-load results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->