### PR TITLE
feat(gym): All Cardio overview / stats wall (#73)

### DIFF
--- a/app/training-facility/gym/overview/page.tsx
+++ b/app/training-facility/gym/overview/page.tsx
@@ -1,0 +1,14 @@
+import { isTrainingFacilityEnabled } from '@/lib/feature-flags'
+import { AllCardioOverview } from '@/components/training-facility/gym/AllCardioOverview'
+import { notFound } from 'next/navigation'
+
+/**
+ * Renders the All Cardio overview / stats wall (PRD §7.4) — the cross-activity
+ * Gym surface. Reachable from the Gym scene's wall scoreboard and from a
+ * `View all cardio →` pill on `/training-facility/gym`.
+ */
+export default function TrainingFacilityGymOverviewPage() {
+  if (!isTrainingFacilityEnabled()) notFound()
+
+  return <AllCardioOverview />
+}

--- a/app/training-facility/gym/page.tsx
+++ b/app/training-facility/gym/page.tsx
@@ -3,26 +3,19 @@ import { notFound } from 'next/navigation'
 
 import { BackToCourtButton } from '@/components/common/BackToCourtButton'
 import { GymScene } from '@/components/training-facility/scenes/GymScene'
-import { getCardioDataFromDisk } from '@/lib/data/cardio-server'
 import { isTrainingFacilityEnabled } from '@/lib/feature-flags'
 
 /**
  * `/training-facility/gym` route — the cardio sub-area scene.
  *
- * Server-reads `cardio.json` from disk so the wall fixtures (HR monitor,
- * VO2max whiteboard, wall scoreboard — PRD §7.4) hydrate with live data
- * on the first paint. Uses {@link getCardioDataFromDisk} rather than the
- * browser-facing `getCardioData()` because relative-URL fetches have no
- * base URL when run in a Next server component. Before any Apple Health
- * import has landed the read returns `null` and the fixtures fall back
- * to painted placeholder values. Gated behind the same Training Facility
- * flag as the parent shell so the route family stays in sync.
+ * Phase 1: scene-only. Equipment renders identifiably but is not yet
+ * clickable; the only navigation inside the scene is the back door to the
+ * Combine. Detail views, signature visualizations, and equipment
+ * interactivity ship in later issues. Gated behind the same Training
+ * Facility flag as the parent shell so the route family stays in sync.
  */
-export default async function TrainingFacilityGymPage() {
+export default function TrainingFacilityGymPage() {
   if (!isTrainingFacilityEnabled()) notFound()
-  // Catch transient read errors so a flaky disk read doesn't 500 the
-  // whole page — the fixtures gracefully fall back to placeholders.
-  const cardioData = await getCardioDataFromDisk().catch(() => null)
 
   return (
     <div className="relative min-h-svh overflow-hidden bg-[#120d0a] text-[#f7ead9]">
@@ -51,14 +44,22 @@ export default async function TrainingFacilityGymPage() {
           </h1>
           <p className="mx-auto mt-4 max-w-2xl text-sm leading-6 text-[#e8d5be] sm:text-base sm:leading-7">
             Stair climber dead center, treadmill on the left, indoor track
-            curving along the back wall. Tap a piece of equipment in a later
-            phase — for now, walk through the back door to The Combine.
+            curving along the back wall. Tap a piece of equipment for its
+            detail view, or zoom out to the stats wall.
           </p>
+          <div className="mt-5 flex justify-center">
+            <Link
+              href="/training-facility/gym/overview"
+              className="rounded-full border border-amber-200/30 bg-amber-200/10 px-5 py-2 text-xs font-semibold uppercase tracking-[0.32em] text-amber-100 transition hover:bg-amber-200/20"
+            >
+              View all cardio →
+            </Link>
+          </div>
         </div>
 
         <div className="mt-8 flex-1 sm:mt-10">
           <div className="mx-auto w-full max-w-6xl rounded-[1.6rem] border border-white/10 bg-black/35 p-3 shadow-[0_28px_70px_rgba(0,0,0,0.4)] sm:p-5">
-            <GymScene cardioData={cardioData} />
+            <GymScene />
           </div>
         </div>
       </div>

--- a/app/training-facility/gym/page.tsx
+++ b/app/training-facility/gym/page.tsx
@@ -3,19 +3,26 @@ import { notFound } from 'next/navigation'
 
 import { BackToCourtButton } from '@/components/common/BackToCourtButton'
 import { GymScene } from '@/components/training-facility/scenes/GymScene'
+import { getCardioDataFromDisk } from '@/lib/data/cardio-server'
 import { isTrainingFacilityEnabled } from '@/lib/feature-flags'
 
 /**
  * `/training-facility/gym` route — the cardio sub-area scene.
  *
- * Phase 1: scene-only. Equipment renders identifiably but is not yet
- * clickable; the only navigation inside the scene is the back door to the
- * Combine. Detail views, signature visualizations, and equipment
- * interactivity ship in later issues. Gated behind the same Training
- * Facility flag as the parent shell so the route family stays in sync.
+ * Server-reads `cardio.json` from disk so the wall fixtures (HR monitor,
+ * VO2max whiteboard, wall scoreboard — PRD §7.4) hydrate with live data
+ * on the first paint. Uses {@link getCardioDataFromDisk} rather than the
+ * browser-facing `getCardioData()` because relative-URL fetches have no
+ * base URL when run in a Next server component. Before any Apple Health
+ * import has landed the read returns `null` and the fixtures fall back
+ * to painted placeholder values. Gated behind the same Training Facility
+ * flag as the parent shell so the route family stays in sync.
  */
-export default function TrainingFacilityGymPage() {
+export default async function TrainingFacilityGymPage() {
   if (!isTrainingFacilityEnabled()) notFound()
+  // Catch transient read errors so a flaky disk read doesn't 500 the
+  // whole page — the fixtures gracefully fall back to placeholders.
+  const cardioData = await getCardioDataFromDisk().catch(() => null)
 
   return (
     <div className="relative min-h-svh overflow-hidden bg-[#120d0a] text-[#f7ead9]">
@@ -59,7 +66,7 @@ export default function TrainingFacilityGymPage() {
 
         <div className="mt-8 flex-1 sm:mt-10">
           <div className="mx-auto w-full max-w-6xl rounded-[1.6rem] border border-white/10 bg-black/35 p-3 shadow-[0_28px_70px_rgba(0,0,0,0.4)] sm:p-5">
-            <GymScene />
+            <GymScene cardioData={cardioData} />
           </div>
         </div>
       </div>

--- a/components/training-facility/gym/AllCardioOverview.tsx
+++ b/components/training-facility/gym/AllCardioOverview.tsx
@@ -16,7 +16,11 @@ import {
   formatDuration,
   parseSessionDate,
 } from '@/lib/training-facility/cardio-shared'
-import { formatDistanceMiles, formatPaceCellFromSecPerKm } from '@/lib/training-facility/running'
+import {
+  METERS_PER_MILE,
+  formatDistanceMiles,
+  formatPaceCellFromSecPerKm,
+} from '@/lib/training-facility/running'
 import {
   ACTIVITY_VISUALS,
   countByActivity,
@@ -62,7 +66,7 @@ function formatTotalDuration(seconds: number): string {
 /** Format a meters value as miles with one decimal — `—` for zero/missing. */
 function formatTotalMiles(meters: number): string {
   if (!Number.isFinite(meters) || meters <= 0) return '—'
-  return `${(meters / 1609.344).toFixed(1)} mi`
+  return `${(meters / METERS_PER_MILE).toFixed(1)} mi`
 }
 
 /**

--- a/components/training-facility/gym/AllCardioOverview.tsx
+++ b/components/training-facility/gym/AllCardioOverview.tsx
@@ -1,0 +1,577 @@
+'use client'
+
+import Link from 'next/link'
+import { useEffect, useMemo, useRef, useState, type JSX } from 'react'
+import type { CardioData, CardioSession } from '@/types/cardio'
+import { getCardioData } from '@/lib/data'
+import {
+  DateFilter,
+  endOfDay,
+  rangeForPreset,
+  startOfDay,
+  type DateRange,
+} from '@/components/training-facility/shared/DateFilter'
+import {
+  aggregateHrZoneSeconds,
+  formatDuration,
+  parseSessionDate,
+} from '@/lib/training-facility/cardio-shared'
+import { formatDistanceMiles, formatPaceCellFromSecPerKm } from '@/lib/training-facility/running'
+import {
+  ACTIVITY_VISUALS,
+  countByActivity,
+  filterAllCardioSessions,
+  perSessionAvgHrByActivity,
+  summarizeAllCardio,
+  type ActivityCount,
+} from '@/lib/training-facility/all-cardio'
+import {
+  computeTrainingLoad,
+  dailyTrimpSeries,
+  type TrainingLoadPoint,
+} from '@/lib/training-facility/training-load'
+import { BackToCourtButton } from '@/components/common/BackToCourtButton'
+import { HrZoneBars } from './HrZoneBars'
+import { ActivityLegend, AvgHrBarsByActivity } from './AvgHrBarsByActivity'
+import { TrainingLoadChart } from './TrainingLoadChart'
+import { chartPalette } from '@/components/training-facility/shared/charts/palette'
+import { defaultMargin } from '@/components/training-facility/shared/charts/types'
+
+const CHART_HEIGHT = 280
+const WIDE_CHART_HEIGHT = 300
+const MIN_CHART_WIDTH = 280
+const DEFAULT_CHART_WIDTH = 560
+const DEFAULT_WIDE_WIDTH = 880
+const EARLIEST_FALLBACK = new Date(2024, 0, 1)
+const FONT_FAMILY = "'Patrick Hand', system-ui, sans-serif"
+
+/**
+ * Format a duration in seconds as a compact `Hh MMm` once it crosses an hour,
+ * `Mm` below. Used for the stats-wall total/avg cards where hours-of-work is
+ * the right granularity (a stair-heavy month is 6h 18m, not 378m).
+ */
+function formatTotalDuration(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds < 0) return '—'
+  const mins = Math.floor(seconds / 60)
+  if (mins < 60) return `${mins}m`
+  const hours = Math.floor(mins / 60)
+  const remMins = mins % 60
+  return `${hours}h ${remMins.toString().padStart(2, '0')}m`
+}
+
+/** Format a meters value as miles with one decimal — `—` for zero/missing. */
+function formatTotalMiles(meters: number): string {
+  if (!Number.isFinite(meters) || meters <= 0) return '—'
+  return `${(meters / 1609.344).toFixed(1)} mi`
+}
+
+/**
+ * All-cardio overview (PRD §7.4) — the "stats wall" view that aggregates stair,
+ * running, and walking sessions into a single page. Sits at
+ * `/training-facility/gym/overview` and is the only Gym surface that crosses
+ * activity boundaries; the per-equipment detail views (Stair, Treadmill, Track)
+ * stay single-activity by design.
+ *
+ * Composition:
+ *   1. Stats summary row — sessions / total time / total distance / avg
+ *      duration across all activities in the filtered window.
+ *   2. Time-in-zone bars — combined HR-zone seconds across activities.
+ *   3. Avg HR per session — bars colored by activity (legend below).
+ *   4. Training load — ATL / CTL / TSB. Already pan-activity; lifted up.
+ *   5. Activity mix — small breakdown row (sessions + total time per activity).
+ *   6. Session log — every session in range with an activity column.
+ *
+ * Skips the pace and cardiac-efficiency charts — combining walking and running
+ * paces on one axis is misleading, and stair sessions don't have pace at all.
+ */
+export function AllCardioOverview(): JSX.Element {
+  const [data, setData] = useState<CardioData | null>(null)
+  const [loadError, setLoadError] = useState<Error | null>(null)
+  const [range, setRange] = useState<DateRange>(() => rangeForPreset('1M', EARLIEST_FALLBACK))
+  const [chartWidth, setChartWidth] = useState(DEFAULT_CHART_WIDTH)
+  const [wideWidth, setWideWidth] = useState(DEFAULT_WIDE_WIDTH)
+  const cardSizerRef = useRef<HTMLDivElement>(null)
+  const wideSizerRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    getCardioData()
+      .then((next) => {
+        if (cancelled) return
+        // Same empty-shape substitution as Stair/Treadmill/Track — `null`
+        // means a 404 on `cardio.json` (not produced yet, gitignored). Render
+        // the empty-state branch instead of sitting on the loading panel.
+        setData(
+          next ?? {
+            imported_at: '',
+            sessions: [],
+            resting_hr_trend: [],
+            vo2max_trend: [],
+          },
+        )
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return
+        setLoadError(err instanceof Error ? err : new Error(String(err)))
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  useEffect(() => {
+    const node = cardSizerRef.current
+    if (!node || typeof ResizeObserver === 'undefined') return
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        const next = Math.max(MIN_CHART_WIDTH, Math.floor(entry.contentRect.width))
+        setChartWidth((prev) => (prev === next ? prev : next))
+      }
+    })
+    observer.observe(node)
+    return () => observer.disconnect()
+  }, [])
+
+  useEffect(() => {
+    const node = wideSizerRef.current
+    if (!node || typeof ResizeObserver === 'undefined') return
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        const next = Math.max(MIN_CHART_WIDTH, Math.floor(entry.contentRect.width))
+        setWideWidth((prev) => (prev === next ? prev : next))
+      }
+    })
+    observer.observe(node)
+    return () => observer.disconnect()
+  }, [])
+
+  const earliestDate = useMemo(() => {
+    if (!data || data.sessions.length === 0) return EARLIEST_FALLBACK
+    let earliestMs = Infinity
+    for (const s of data.sessions) {
+      const ms = parseSessionDate(s.date).getTime()
+      if (Number.isFinite(ms) && ms < earliestMs) earliestMs = ms
+    }
+    return Number.isFinite(earliestMs) ? new Date(earliestMs) : EARLIEST_FALLBACK
+  }, [data])
+
+  const sessions = useMemo<CardioSession[]>(
+    () => (data ? filterAllCardioSessions(data.sessions, range) : []),
+    [data, range],
+  )
+  const summary = useMemo(() => summarizeAllCardio(sessions), [sessions])
+  const buckets = useMemo(() => aggregateHrZoneSeconds(sessions), [sessions])
+  const avgHrByActivity = useMemo(() => perSessionAvgHrByActivity(sessions), [sessions])
+  const activityCounts = useMemo(() => countByActivity(sessions), [sessions])
+
+  // Training load aggregates ALL cardio activities — same pre-warm trick as
+  // TreadmillDetailView so the EMA doesn't ramp from zero at the visible
+  // window's left edge. Compute over the full dataset, then slice down.
+  const trainingLoad = useMemo<TrainingLoadPoint[]>(() => {
+    if (!data || data.sessions.length === 0) return []
+    const series = dailyTrimpSeries(data.sessions)
+    if (series.length === 0) return []
+    const full = computeTrainingLoad(series)
+    const fromMs = range.start.getTime()
+    const toMs = range.end.getTime()
+    return full.filter((p) => {
+      const t = p.date.getTime()
+      return t >= fromMs && t <= toMs
+    })
+  }, [data, range])
+
+  return (
+    <div className="relative min-h-svh overflow-hidden bg-[#120d0a] text-[#f7ead9]">
+      <div
+        aria-hidden="true"
+        className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(255,255,255,0.08),transparent_28%),linear-gradient(180deg,#241811_0%,#120d0a_52%,#0b0806_100%)]"
+      />
+
+      <div className="relative z-10 mx-auto flex min-h-svh w-full max-w-5xl flex-col px-6 py-8 sm:px-8 lg:px-12">
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <BackToCourtButton />
+          <Link
+            href="/training-facility/gym"
+            className="rounded-full border border-white/15 bg-white/5 px-4 py-2 text-xs font-semibold uppercase tracking-[0.28em] text-white/80 transition hover:bg-white/10"
+          >
+            ← The Gym
+          </Link>
+        </div>
+
+        <header className="mt-12">
+          <div className="text-xs font-semibold uppercase tracking-[0.38em] text-white/60">
+            Coach&rsquo;s clipboard
+          </div>
+          <h1 className="mt-3 text-4xl font-black uppercase tracking-[0.08em] text-[#fff7ec] sm:text-5xl">
+            All cardio — the stats wall
+          </h1>
+          <p className="mt-4 max-w-2xl text-sm leading-7 text-[#e8d5be] sm:text-base">
+            Stair, run, walk — every cardio session in the window aggregated.
+            Time in zone is summed across activities; per-session avg HR is
+            color-coded so the activity mix is legible at a glance; training
+            load is whole-athlete (ATL / CTL / TSB don&rsquo;t care which
+            equipment you used).
+          </p>
+        </header>
+
+        <div className="mt-8">
+          <DateFilter
+            earliestDate={earliestDate}
+            defaultPreset="1M"
+            onChange={setRange}
+          />
+        </div>
+
+        {loadError ? (
+          <ErrorPanel error={loadError} />
+        ) : !data ? (
+          <LoadingPanel />
+        ) : (
+          <>
+            <SummaryRow summary={summary} />
+
+            <div className="mt-8 grid gap-6 lg:grid-cols-2">
+              <ChartCard
+                title="Time in zone"
+                helper="Total minutes per HR zone, summed across stair, run, and walk."
+              >
+                <div ref={cardSizerRef}>
+                  <HrZoneBars
+                    buckets={buckets}
+                    width={chartWidth}
+                    height={CHART_HEIGHT}
+                    fontFamily={FONT_FAMILY}
+                  />
+                </div>
+              </ChartCard>
+
+              <ChartCard
+                title="Avg HR per session"
+                helper="One bar per session — color is the activity. Legend below."
+                footer={<ActivityLegend className="mt-3" />}
+              >
+                <AvgHrBarsByActivity
+                  points={avgHrByActivity}
+                  width={chartWidth}
+                  height={CHART_HEIGHT}
+                  fontFamily={FONT_FAMILY}
+                />
+              </ChartCard>
+            </div>
+
+            <ChartCard
+              title="Training load"
+              helper="ATL (acute, 7d) vs. CTL (chronic, 28d) and TSB = CTL − ATL. Whole-athlete metric — every cardio modality contributes."
+              wide
+            >
+              <div ref={wideSizerRef}>
+                <TrainingLoadChart
+                  points={trainingLoad}
+                  width={wideWidth}
+                  height={WIDE_CHART_HEIGHT}
+                  margin={defaultMargin}
+                  fontFamily={FONT_FAMILY}
+                  axisColor={chartPalette.inkSoft}
+                  emptyMessage="No training load in selected range"
+                />
+              </div>
+            </ChartCard>
+
+            <ActivityMix counts={activityCounts} />
+
+            <SessionLogTable sessions={sessions} range={range} />
+          </>
+        )}
+      </div>
+    </div>
+  )
+}
+
+interface SummaryRowProps {
+  summary: ReturnType<typeof summarizeAllCardio>
+}
+
+/**
+ * Stats-wall summary row — four big-number cards that read across the top of
+ * the overview. Static (no period comparison) on purpose: this view's job is
+ * "what did I do across all activities," not "vs. last month." The per-
+ * equipment views are where deltas live (#77).
+ */
+function SummaryRow({ summary }: SummaryRowProps): JSX.Element {
+  const cards: Array<{ key: string; label: string; value: string; unit?: string }> = [
+    {
+      key: 'sessions',
+      label: 'Sessions',
+      value: String(summary.sessionCount),
+    },
+    {
+      key: 'time',
+      label: 'Total time',
+      value: formatTotalDuration(summary.totalDurationSeconds),
+    },
+    {
+      key: 'distance',
+      label: 'Total distance',
+      value: formatTotalMiles(summary.totalDistanceMeters),
+    },
+    {
+      key: 'avg',
+      label: 'Avg duration',
+      value:
+        summary.avgDurationSeconds === null ? '—' : formatDuration(summary.avgDurationSeconds),
+    },
+  ]
+  return (
+    <section
+      aria-label="All-cardio totals"
+      className="mt-8 grid gap-3 sm:grid-cols-2 lg:grid-cols-4"
+    >
+      {cards.map((c) => (
+        <article
+          key={c.key}
+          data-testid={`overview-stat-${c.key}`}
+          className="rounded-[1.2rem] border border-white/10 bg-[#f5f1e6] p-4 text-[#0a0a0a] shadow-[0_12px_32px_rgba(0,0,0,0.28)]"
+        >
+          <h3 className="font-mono text-[10px] font-bold uppercase tracking-[0.22em] text-[#0a0a0a]/70">
+            {c.label}
+          </h3>
+          <p className="mt-2 font-mono text-2xl font-semibold tabular-nums text-[#0a0a0a]">
+            {c.value}
+          </p>
+        </article>
+      ))}
+    </section>
+  )
+}
+
+interface ChartCardProps {
+  title: string
+  helper: string
+  /** When set, the card sits full-width (used for the training-load row). */
+  wide?: boolean
+  /** Optional content rendered after the chart body — e.g. a legend. */
+  footer?: JSX.Element
+  children: JSX.Element
+}
+
+function ChartCard({ title, helper, wide, footer, children }: ChartCardProps): JSX.Element {
+  return (
+    <section
+      className={`${wide ? 'mt-6 ' : ''}rounded-[1.6rem] border border-white/10 bg-[#f5f1e6] p-5 text-[#0a0a0a] shadow-[0_18px_46px_rgba(0,0,0,0.34)]`}
+    >
+      <header className="mb-2 flex items-baseline justify-between gap-3">
+        <h2 className="font-mono text-xs font-bold uppercase tracking-[0.24em] text-[#0a0a0a]">
+          {title}
+        </h2>
+      </header>
+      <p className="mb-4 text-xs leading-5 text-[#404040]">{helper}</p>
+      <div className="overflow-x-auto">{children}</div>
+      {footer}
+    </section>
+  )
+}
+
+interface ActivityMixProps {
+  counts: readonly ActivityCount[]
+}
+
+/**
+ * Compact per-activity breakdown — one card per activity showing session count
+ * and total time. Sits below the training-load chart so the "and what was the
+ * mix?" question is answered without forcing the user to read the avg-HR
+ * legend and count bars.
+ */
+function ActivityMix({ counts }: ActivityMixProps): JSX.Element {
+  const totalDurationAll = counts.reduce((acc, c) => acc + c.totalDurationSeconds, 0)
+  return (
+    <section
+      aria-label="Activity mix"
+      className="mt-8 rounded-[1.6rem] border border-white/10 bg-black/25 p-5"
+    >
+      <header className="mb-3">
+        <h2 className="font-mono text-xs font-bold uppercase tracking-[0.24em] text-white/80">
+          Activity mix
+        </h2>
+        <p className="mt-1 text-xs text-white/55">
+          Sessions and total time per activity in the selected range.
+        </p>
+      </header>
+      <ul className="grid gap-3 sm:grid-cols-3">
+        {counts.map((row) => {
+          const visual = ACTIVITY_VISUALS[row.activity]
+          const sharePct =
+            totalDurationAll > 0
+              ? Math.round((row.totalDurationSeconds / totalDurationAll) * 100)
+              : 0
+          return (
+            <li
+              key={row.activity}
+              data-testid={`activity-mix-${row.activity}`}
+              className="rounded-[1.1rem] border border-white/10 bg-white/5 p-4"
+            >
+              <div className="flex items-center gap-2">
+                <span
+                  aria-hidden="true"
+                  className="inline-block h-2.5 w-2.5 rounded-full"
+                  style={{ backgroundColor: visual.color }}
+                />
+                <span className="font-mono text-[11px] uppercase tracking-[0.2em] text-white/70">
+                  {visual.label}
+                </span>
+              </div>
+              <p className="mt-2 font-mono text-xl font-semibold tabular-nums text-[#fff7ec]">
+                {row.sessionCount}
+              </p>
+              <p className="mt-1 text-xs text-white/55">
+                {formatTotalDuration(row.totalDurationSeconds)}
+                {row.sessionCount > 0 && totalDurationAll > 0 ? (
+                  <span className="ml-2 text-white/35">({sharePct}%)</span>
+                ) : null}
+              </p>
+            </li>
+          )
+        })}
+      </ul>
+    </section>
+  )
+}
+
+interface SessionLogTableProps {
+  sessions: readonly CardioSession[]
+  range: DateRange
+}
+
+function SessionLogTable({ sessions, range }: SessionLogTableProps): JSX.Element {
+  const rows = useMemo(() => sessions.slice().reverse(), [sessions])
+  const startLabel = formatRangeBound(range.start, 'start')
+  const endLabel = formatRangeBound(range.end, 'end')
+
+  return (
+    <section className="mt-8 rounded-[1.6rem] border border-white/10 bg-black/25 p-5">
+      <header className="mb-3 flex flex-wrap items-baseline justify-between gap-3">
+        <h2 className="font-mono text-xs font-bold uppercase tracking-[0.24em] text-white/80">
+          Sessions
+        </h2>
+        <p className="text-xs text-white/55">
+          {sessions.length === 0 ? 'No sessions in range' : `${sessions.length} in range`}
+          <span className="ml-2 text-white/35">
+            ({startLabel} → {endLabel})
+          </span>
+        </p>
+      </header>
+      {rows.length === 0 ? (
+        <p className="px-2 py-6 text-center text-sm text-white/55">
+          No cardio sessions in the selected range.
+        </p>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full min-w-[680px] border-separate border-spacing-y-1 text-left text-sm">
+            <thead className="text-xs uppercase tracking-[0.18em] text-white/55">
+              <tr>
+                <th scope="col" className="px-3 py-2 font-semibold">
+                  Date
+                </th>
+                <th scope="col" className="px-3 py-2 font-semibold">
+                  Activity
+                </th>
+                <th scope="col" className="px-3 py-2 font-semibold">
+                  Distance
+                </th>
+                <th scope="col" className="px-3 py-2 font-semibold">
+                  Duration
+                </th>
+                <th scope="col" className="px-3 py-2 font-semibold">
+                  Pace
+                </th>
+                <th scope="col" className="px-3 py-2 font-semibold">
+                  Avg HR
+                </th>
+                <th scope="col" className="px-3 py-2 font-semibold">
+                  Max HR
+                </th>
+              </tr>
+            </thead>
+            <tbody className="text-[#f7ead9]">
+              {rows.map((s, i) => {
+                const visual = ACTIVITY_VISUALS[s.activity]
+                return (
+                  <tr
+                    key={`${s.date}-${s.activity}-${s.duration_seconds}-${i}`}
+                    className="rounded-md bg-white/5 align-middle"
+                  >
+                    <td className="rounded-l-md px-3 py-2 font-mono">
+                      {formatRowDate(s.date)}
+                    </td>
+                    <td className="px-3 py-2 font-mono">
+                      <span className="inline-flex items-center gap-1.5">
+                        <span
+                          aria-hidden="true"
+                          className="inline-block h-2 w-2 rounded-full"
+                          style={{ backgroundColor: visual.color }}
+                        />
+                        {visual.label}
+                      </span>
+                    </td>
+                    <td className="px-3 py-2 font-mono">
+                      {formatDistanceMiles(s.distance_meters)}
+                    </td>
+                    <td className="px-3 py-2 font-mono">{formatDuration(s.duration_seconds)}</td>
+                    <td className="px-3 py-2 font-mono">
+                      {formatPaceCellFromSecPerKm(s.pace_seconds_per_km)}
+                    </td>
+                    <td className="px-3 py-2 font-mono">
+                      {typeof s.avg_hr === 'number' ? `${Math.round(s.avg_hr)}` : '—'}
+                    </td>
+                    <td className="rounded-r-md px-3 py-2 font-mono">
+                      {typeof s.max_hr === 'number' ? `${Math.round(s.max_hr)}` : '—'}
+                    </td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  )
+}
+
+function formatRowDate(raw: string): string {
+  const d = parseSessionDate(raw)
+  if (!Number.isFinite(d.getTime())) return raw
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
+
+function formatRangeBound(d: Date, end: 'start' | 'end'): string {
+  const norm = end === 'start' ? startOfDay(d) : endOfDay(d)
+  return `${norm.getFullYear()}-${String(norm.getMonth() + 1).padStart(2, '0')}-${String(norm.getDate()).padStart(2, '0')}`
+}
+
+function LoadingPanel(): JSX.Element {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="mt-10 rounded-[1.6rem] border border-white/10 bg-black/25 p-8 text-center text-sm text-white/65"
+    >
+      Loading cardio data…
+    </div>
+  )
+}
+
+function ErrorPanel({ error }: { error: Error }): JSX.Element {
+  return (
+    <div
+      role="alert"
+      className="mt-10 rounded-[1.6rem] border border-red-400/30 bg-red-950/40 p-6 text-sm leading-6 text-red-100"
+    >
+      <p className="font-semibold uppercase tracking-[0.18em]">Could not load cardio data</p>
+      <p className="mt-2 text-red-100/80">{error.message}</p>
+      <p className="mt-4 text-xs text-red-100/60">
+        Run <code className="rounded bg-black/40 px-1.5 py-0.5">npm run import-health</code> to
+        regenerate <code className="rounded bg-black/40 px-1.5 py-0.5">public/data/cardio.json</code>{' '}
+        from a fresh Apple Health export, then redeploy.
+      </p>
+    </div>
+  )
+}

--- a/components/training-facility/gym/AvgHrBarsByActivity.tsx
+++ b/components/training-facility/gym/AvgHrBarsByActivity.tsx
@@ -1,0 +1,206 @@
+import type { JSX } from 'react'
+import { scaleBand, scaleLinear } from 'd3-scale'
+import {
+  Axis,
+  EmptyChart,
+  type AxisTick,
+} from '@/components/training-facility/shared/charts/axes'
+import { chartPalette } from '@/components/training-facility/shared/charts/palette'
+import {
+  drawableToPaths,
+  extent,
+  getGenerator,
+} from '@/components/training-facility/shared/charts/rough-svg'
+import {
+  resolveMargin,
+  type ChartCommonProps,
+} from '@/components/training-facility/shared/charts/types'
+import {
+  ACTIVITY_ORDER,
+  ACTIVITY_VISUALS,
+  type SessionAvgHrByActivityPoint,
+} from '@/lib/training-facility/all-cardio'
+
+/** Props for {@link AvgHrBarsByActivity}. */
+export interface AvgHrBarsByActivityProps extends ChartCommonProps {
+  /** Per-session avg-HR points (oldest → newest), each tagged with its activity. */
+  points: readonly SessionAvgHrByActivityPoint[]
+  /** Inner padding between bars (0–1). Defaults to 0.3. */
+  padding?: number
+}
+
+/**
+ * Activity-tinted variant of {@link ./AvgHrBars} for the All-Cardio overview
+ * (PRD §7.4). Each bar is filled with the originating activity's color from
+ * {@link ACTIVITY_VISUALS} so the chart simultaneously communicates the
+ * avg-HR trend and the activity mix across the filtered window.
+ *
+ * Lives separately from `AvgHrBars` because the per-equipment detail views
+ * intentionally render single-activity data in a single tint — adding an
+ * `activity` axis to the shared component would push concerns from the
+ * overview down into views that don't need it.
+ *
+ * The y-axis auto-pads around the observed range (same heuristic as the base
+ * component) so a 12-BPM swing reads as a meaningful step rather than a 1px
+ * nudge in a `[0, max]` domain.
+ */
+export function AvgHrBarsByActivity({
+  points,
+  width,
+  height,
+  margin,
+  padding = 0.3,
+  roughness = 1.4,
+  seed = 12,
+  fontFamily = 'inherit',
+  axisColor = chartPalette.inkBlack,
+  className,
+  ariaLabel = 'Average heart rate per session, colored by activity',
+  ariaLabelledBy,
+  emptyMessage = 'No avg-HR sessions in range',
+}: AvgHrBarsByActivityProps): JSX.Element {
+  const m = resolveMargin(margin)
+  const innerW = width - m.left - m.right
+  const innerH = height - m.top - m.bottom
+
+  if (points.length === 0) {
+    return (
+      <EmptyChart
+        width={width}
+        height={height}
+        message={emptyMessage}
+        fontFamily={fontFamily}
+        className={className}
+        ariaLabel={ariaLabel}
+        ariaLabelledBy={ariaLabelledBy}
+      />
+    )
+  }
+
+  // Key by index — two sessions on the same calendar day (or the same M/D
+  // across years) share a `label` value but are genuinely distinct points.
+  const indices = points.map((_, i) => i)
+  const xScale = scaleBand<number>().domain(indices).range([0, innerW]).padding(padding)
+
+  const values = points.map((p) => p.avgHr)
+  const [vMin, vMax] = extent(values)
+  const span = vMax - vMin
+  const pad = span > 0 ? span * 0.15 : 5
+  const yDomainMin = Math.max(0, Math.floor(vMin - pad))
+  const yDomainMax = Math.ceil(vMax + pad)
+  const yScale = scaleLinear().domain([yDomainMin, yDomainMax]).nice().range([innerH, 0])
+
+  const gen = getGenerator()
+
+  const xTicks: AxisTick[] = points.map((p, i) => ({
+    value: p.label,
+    offset: (xScale(i) ?? 0) + xScale.bandwidth() / 2,
+  }))
+
+  const yTicks: AxisTick[] = yScale.ticks(5).map((tick) => ({
+    value: String(tick),
+    offset: yScale(tick),
+  }))
+
+  return (
+    <svg
+      width={width}
+      height={height}
+      className={className}
+      role="img"
+      aria-label={ariaLabelledBy ? undefined : ariaLabel}
+      aria-labelledby={ariaLabelledBy}
+    >
+      {ariaLabel && !ariaLabelledBy && <title>{ariaLabel}</title>}
+      <g transform={`translate(${m.left},${m.top})`}>
+        <Axis
+          orientation="bottom"
+          position={innerH}
+          start={0}
+          end={innerW}
+          ticks={xTicks}
+          label="Session"
+          color={axisColor}
+          fontFamily={fontFamily}
+          roughness={roughness}
+          seed={seed + 100}
+        />
+        <Axis
+          orientation="left"
+          position={0}
+          start={0}
+          end={innerH}
+          ticks={yTicks}
+          label="Avg HR (BPM)"
+          color={axisColor}
+          fontFamily={fontFamily}
+          roughness={roughness}
+          seed={seed + 200}
+        />
+        {points.map((p, i) => {
+          const bx = xScale(i) ?? 0
+          const bw = xScale.bandwidth()
+          const bh = Math.max(innerH - yScale(p.avgHr), 1)
+          const by = innerH - bh
+          const fill = ACTIVITY_VISUALS[p.activity]?.color ?? chartPalette.rimOrange
+          const rect = gen.rectangle(bx, by, bw, bh, {
+            fill,
+            fillStyle: 'hachure',
+            fillWeight: 2,
+            hachureGap: 5,
+            stroke: chartPalette.inkBlack,
+            strokeWidth: 1.5,
+            roughness,
+            seed: seed + 1000 + i,
+          })
+          return drawableToPaths(rect).map((path, j) => (
+            <path
+              key={`avghr-act-${i}-${j}`}
+              d={path.d}
+              stroke={path.stroke}
+              strokeWidth={path.strokeWidth}
+              fill={path.fill ?? 'none'}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          ))
+        })}
+      </g>
+    </svg>
+  )
+}
+
+/** Props for {@link ActivityLegend}. */
+export interface ActivityLegendProps {
+  /** Tailwind classes appended to the legend wrapper. */
+  className?: string
+}
+
+/**
+ * Three-dot legend mapping the activity colors used by
+ * {@link AvgHrBarsByActivity} to their labels. Pure presentation — pulls
+ * directly from {@link ACTIVITY_VISUALS} so a future palette change ripples
+ * through both the chart bars and the legend without manual sync.
+ */
+export function ActivityLegend({ className = '' }: ActivityLegendProps): JSX.Element {
+  return (
+    <ul
+      className={`flex flex-wrap items-center gap-x-4 gap-y-1 text-[11px] uppercase tracking-[0.18em] text-[#0a0a0a]/65 ${className}`}
+      aria-label="Activity color legend"
+    >
+      {ACTIVITY_ORDER.map((activity) => {
+        const visual = ACTIVITY_VISUALS[activity]
+        return (
+          <li key={activity} className="flex items-center gap-1.5 font-mono">
+            <span
+              aria-hidden="true"
+              className="inline-block h-2.5 w-2.5 rounded-full"
+              style={{ backgroundColor: visual.color }}
+            />
+            {visual.label}
+          </li>
+        )
+      })}
+    </ul>
+  )
+}

--- a/components/training-facility/scenes/assets/gym-fixtures.tsx
+++ b/components/training-facility/scenes/assets/gym-fixtures.tsx
@@ -420,6 +420,10 @@ const WALL_FALLBACK = {
  * (a region of three labeled cells), painted to live in-scene rather
  * than reusing the HTML component verbatim.
  *
+ * Wrapped in a `<Link>` to the All Cardio overview (PRD §7.4 stats-wall
+ * view): the totals it advertises *are* the page underneath, so tapping
+ * the scoreboard opens the full breakdown.
+ *
  * All three values default to placeholders so the static scene reads as a
  * populated room when `cardio.json` doesn't exist yet.
  */
@@ -435,7 +439,11 @@ export function WallScoreboard({
   ]
 
   return (
-    <g>
+    <Link
+      href="/training-facility/gym/overview"
+      aria-label="Open the all-cardio overview / stats wall"
+      className="group focus:outline-none"
+    >
       {/* Panel */}
       <RoughRect
         x={820}
@@ -511,9 +519,31 @@ export function WallScoreboard({
         fontFamily={HANDWRITING_FONT}
         fontSize={18}
       >
-        wall scoreboard
+        wall scoreboard → all cardio
       </text>
-    </g>
+      {/* Hover/focus tint over the panel footprint */}
+      <rect
+        x={820}
+        y={68}
+        width={400}
+        height={222}
+        fill={SCENE_PALETTE.banner}
+        className="opacity-0 transition-opacity group-hover:opacity-10 group-focus-visible:opacity-15"
+      />
+      {/* Focus ring — visible only when the Link is keyboard-focused */}
+      <rect
+        x={814}
+        y={62}
+        width={412}
+        height={234}
+        fill="none"
+        stroke={SCENE_PALETTE.rim}
+        strokeWidth={4}
+        strokeDasharray="6 4"
+        rx={4}
+        className="opacity-0 transition-opacity group-focus-visible:opacity-100"
+      />
+    </Link>
   )
 }
 

--- a/lib/training-facility/all-cardio.test.ts
+++ b/lib/training-facility/all-cardio.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from 'vitest'
+import type { CardioSession } from '@/types/cardio'
+import {
+  ACTIVITY_ORDER,
+  ACTIVITY_VISUALS,
+  countByActivity,
+  filterAllCardioSessions,
+  perSessionAvgHrByActivity,
+  summarizeAllCardio,
+} from './all-cardio'
+
+const range = (startIso: string, endIso: string) => ({
+  start: new Date(startIso),
+  end: new Date(endIso),
+})
+
+const session = (
+  date: string,
+  activity: CardioSession['activity'],
+  extras: Partial<CardioSession> = {},
+): CardioSession => ({
+  date,
+  activity,
+  duration_seconds: 1800,
+  ...extras,
+})
+
+describe('filterAllCardioSessions', () => {
+  it('keeps sessions of every activity inside the range, sorted oldest → newest', () => {
+    const sessions: CardioSession[] = [
+      session('2026-04-10', 'stair'),
+      session('2026-04-01', 'running'),
+      session('2026-04-05', 'walking'),
+      session('2026-03-15', 'stair'),
+      session('2026-04-20', 'running'),
+    ]
+    const out = filterAllCardioSessions(
+      sessions,
+      range('2026-04-01T00:00:00', '2026-04-15T23:59:59.999'),
+    )
+    expect(out.map((s) => s.date)).toEqual(['2026-04-01', '2026-04-05', '2026-04-10'])
+    expect(out.map((s) => s.activity)).toEqual(['running', 'walking', 'stair'])
+  })
+
+  it('is inclusive on both ends', () => {
+    const sessions: CardioSession[] = [
+      session('2026-04-01', 'stair'),
+      session('2026-04-15', 'walking'),
+      session('2026-03-31', 'stair'),
+      session('2026-04-16', 'running'),
+    ]
+    const out = filterAllCardioSessions(
+      sessions,
+      range('2026-04-01T00:00:00', '2026-04-15T23:59:59.999'),
+    )
+    expect(out.map((s) => s.date)).toEqual(['2026-04-01', '2026-04-15'])
+  })
+
+  it('drops sessions with unparseable date strings rather than throwing', () => {
+    const sessions: CardioSession[] = [
+      session('not-a-date', 'stair'),
+      session('2026-04-10', 'running'),
+    ]
+    const out = filterAllCardioSessions(
+      sessions,
+      range('2026-01-01T00:00:00', '2026-12-31T23:59:59.999'),
+    )
+    expect(out.map((s) => s.date)).toEqual(['2026-04-10'])
+  })
+})
+
+describe('summarizeAllCardio', () => {
+  it('sums duration and distance across all activities and reports avg duration', () => {
+    const sessions: CardioSession[] = [
+      session('2026-04-01', 'stair', { duration_seconds: 1500 }),
+      session('2026-04-02', 'running', { duration_seconds: 1800, distance_meters: 5000 }),
+      session('2026-04-03', 'walking', { duration_seconds: 2400, distance_meters: 3200 }),
+    ]
+    const out = summarizeAllCardio(sessions)
+    expect(out.sessionCount).toBe(3)
+    expect(out.totalDurationSeconds).toBe(5700)
+    expect(out.totalDistanceMeters).toBe(8200)
+    expect(out.avgDurationSeconds).toBeCloseTo(1900)
+  })
+
+  it('returns zeroed totals and a null avg when given no sessions', () => {
+    const out = summarizeAllCardio([])
+    expect(out).toEqual({
+      sessionCount: 0,
+      totalDurationSeconds: 0,
+      totalDistanceMeters: 0,
+      avgDurationSeconds: null,
+    })
+  })
+
+  it('treats sessions without distance as zero contribution', () => {
+    const sessions: CardioSession[] = [
+      session('2026-04-01', 'stair'),
+      session('2026-04-02', 'running', { distance_meters: 4800 }),
+    ]
+    const out = summarizeAllCardio(sessions)
+    expect(out.totalDistanceMeters).toBe(4800)
+  })
+})
+
+describe('countByActivity', () => {
+  it('groups by activity in canonical order, including zero rows for missing activities', () => {
+    const sessions: CardioSession[] = [
+      session('2026-04-01', 'stair', { duration_seconds: 1800 }),
+      session('2026-04-02', 'stair', { duration_seconds: 1500 }),
+      session('2026-04-03', 'walking', { duration_seconds: 2400 }),
+    ]
+    const out = countByActivity(sessions)
+    expect(out.map((row) => row.activity)).toEqual(ACTIVITY_ORDER)
+    expect(out).toEqual([
+      { activity: 'stair', sessionCount: 2, totalDurationSeconds: 3300 },
+      { activity: 'running', sessionCount: 0, totalDurationSeconds: 0 },
+      { activity: 'walking', sessionCount: 1, totalDurationSeconds: 2400 },
+    ])
+  })
+
+  it('returns three zero rows for an empty input', () => {
+    const out = countByActivity([])
+    expect(out.map((r) => r.activity)).toEqual(ACTIVITY_ORDER)
+    expect(out.every((r) => r.sessionCount === 0 && r.totalDurationSeconds === 0)).toBe(true)
+  })
+})
+
+describe('perSessionAvgHrByActivity', () => {
+  it('keeps avg-HR-bearing sessions, threads activity through, projects M/D labels', () => {
+    const sessions: CardioSession[] = [
+      session('2026-04-01', 'stair', { avg_hr: 142 }),
+      session('2026-04-08', 'running'), // no avg_hr — dropped
+      session('2026-04-15', 'walking', { avg_hr: 118 }),
+    ]
+    const out = perSessionAvgHrByActivity(sessions)
+    expect(out).toEqual([
+      { date: '2026-04-01', label: '4/1', avgHr: 142, activity: 'stair' },
+      { date: '2026-04-15', label: '4/15', avgHr: 118, activity: 'walking' },
+    ])
+  })
+
+  it('skips sessions whose date string cannot be parsed', () => {
+    const sessions: CardioSession[] = [
+      session('garbage', 'stair', { avg_hr: 140 }),
+      session('2026-04-10', 'running', { avg_hr: 150 }),
+    ]
+    const out = perSessionAvgHrByActivity(sessions)
+    expect(out.map((p) => p.avgHr)).toEqual([150])
+  })
+})
+
+describe('ACTIVITY_VISUALS', () => {
+  it('defines a visual entry for every CardioActivity', () => {
+    for (const a of ACTIVITY_ORDER) {
+      expect(ACTIVITY_VISUALS[a]).toBeDefined()
+      expect(ACTIVITY_VISUALS[a].activity).toBe(a)
+    }
+  })
+})

--- a/lib/training-facility/all-cardio.ts
+++ b/lib/training-facility/all-cardio.ts
@@ -1,0 +1,178 @@
+/**
+ * All-cardio overview helpers (PRD §7.4 — "All Cardio" view).
+ *
+ * Activity-agnostic filter and projection helpers that aggregate stair, running,
+ * and walking sessions into a single overview. Pairs with `AllCardioOverview`
+ * (the stats-wall page) and a per-activity-tinted `AvgHrBarsByActivity` variant.
+ *
+ * Activity-specific filters (`filterStairSessions`, `filterRunningSessions`,
+ * `filterWalkingSessions`) stay in their respective modules. This module is the
+ * only place where the cross-activity aggregations live so per-equipment views
+ * don't accidentally start computing combined totals.
+ */
+
+import type { CardioActivity, CardioSession } from '@/types/cardio'
+import type { DateRange } from '@/components/training-facility/shared/DateFilter'
+import { parseSessionDate, type SessionAvgHrPoint } from './cardio-shared'
+
+/**
+ * Filter `sessions` to entries whose `date` falls within `range` (inclusive
+ * on both ends), regardless of activity. Sessions with unparseable dates are
+ * dropped silently — same contract as {@link filterCardioSessionsByActivity}.
+ * Output is sorted oldest → newest so chart x-axes read left-to-right by time.
+ *
+ * @param sessions - Full session list from `getCardioData()`.
+ * @param range - Active range from the shared `DateFilter`.
+ */
+export function filterAllCardioSessions(
+  sessions: readonly CardioSession[],
+  range: DateRange,
+): CardioSession[] {
+  const fromMs = range.start.getTime()
+  const toMs = range.end.getTime()
+  const out: { session: CardioSession; ts: number }[] = []
+  for (const s of sessions) {
+    const ts = parseSessionDate(s.date).getTime()
+    if (!Number.isFinite(ts)) continue
+    if (ts < fromMs || ts > toMs) continue
+    out.push({ session: s, ts })
+  }
+  out.sort((a, b) => a.ts - b.ts)
+  return out.map((entry) => entry.session)
+}
+
+/** Summary totals across the filtered session list (PRD §7.4 stats-wall row). */
+export interface AllCardioSummary {
+  /** Number of sessions in the filtered window. */
+  sessionCount: number
+  /** Sum of `duration_seconds` across the window. */
+  totalDurationSeconds: number
+  /** Sum of `distance_meters` across the window — stair sessions contribute zero. */
+  totalDistanceMeters: number
+  /** Average `duration_seconds` per session, or `null` when the window is empty. */
+  avgDurationSeconds: number | null
+}
+
+/**
+ * Aggregate session-count, total time, total distance, and avg duration over
+ * a pre-filtered session list. Used by the All-Cardio overview's summary row
+ * and by the wall-scoreboard "this week" totals once those wire up to real
+ * data. Pure — does no date math or activity filtering itself; the caller is
+ * responsible for passing the right slice of sessions.
+ *
+ * @param sessions - Already-filtered session list.
+ */
+export function summarizeAllCardio(sessions: readonly CardioSession[]): AllCardioSummary {
+  let totalDurationSeconds = 0
+  let totalDistanceMeters = 0
+  for (const s of sessions) {
+    if (Number.isFinite(s.duration_seconds)) totalDurationSeconds += s.duration_seconds
+    if (typeof s.distance_meters === 'number' && Number.isFinite(s.distance_meters)) {
+      totalDistanceMeters += s.distance_meters
+    }
+  }
+  const sessionCount = sessions.length
+  const avgDurationSeconds = sessionCount === 0 ? null : totalDurationSeconds / sessionCount
+  return {
+    sessionCount,
+    totalDurationSeconds,
+    totalDistanceMeters,
+    avgDurationSeconds,
+  }
+}
+
+/** One row in the activity-mix breakdown — sessions and total time per activity. */
+export interface ActivityCount {
+  /** Activity identifier (`stair` | `running` | `walking`). */
+  activity: CardioActivity
+  /** Number of sessions of this activity in the filtered window. */
+  sessionCount: number
+  /** Sum of `duration_seconds` across this activity's sessions. */
+  totalDurationSeconds: number
+}
+
+/** Canonical activity ordering used across the overview surfaces. */
+export const ACTIVITY_ORDER: readonly CardioActivity[] = ['stair', 'running', 'walking']
+
+/**
+ * Group `sessions` by activity and return one row per activity in canonical
+ * order — even activities with zero sessions show up so the breakdown reads
+ * as a stable shape regardless of which activities the window covers. Used by
+ * the activity-mix legend below the avg-HR-by-activity chart.
+ *
+ * @param sessions - Already-filtered session list.
+ */
+export function countByActivity(sessions: readonly CardioSession[]): ActivityCount[] {
+  const totals: Record<CardioActivity, ActivityCount> = {
+    stair: { activity: 'stair', sessionCount: 0, totalDurationSeconds: 0 },
+    running: { activity: 'running', sessionCount: 0, totalDurationSeconds: 0 },
+    walking: { activity: 'walking', sessionCount: 0, totalDurationSeconds: 0 },
+  }
+  for (const s of sessions) {
+    const bucket = totals[s.activity]
+    if (!bucket) continue
+    bucket.sessionCount += 1
+    if (Number.isFinite(s.duration_seconds)) {
+      bucket.totalDurationSeconds += s.duration_seconds
+    }
+  }
+  return ACTIVITY_ORDER.map((a) => totals[a])
+}
+
+/**
+ * One point on the activity-tinted avg-HR chart. Extends the activity-agnostic
+ * {@link SessionAvgHrPoint} with the originating activity so the bar chart can
+ * pick a per-bar color from {@link ACTIVITY_VISUALS}.
+ */
+export interface SessionAvgHrByActivityPoint extends SessionAvgHrPoint {
+  /** Activity that produced this session — drives the bar tint. */
+  activity: CardioActivity
+}
+
+/**
+ * Project a session list to the points needed by the activity-tinted avg-HR
+ * bar chart. Same contract as {@link perSessionAvgHr} (drops sessions missing
+ * `avg_hr` or with unparseable dates) but threads the activity through so the
+ * caller can color bars without joining back to the original session list.
+ *
+ * @param sessions - Filtered, sorted sessions.
+ */
+export function perSessionAvgHrByActivity(
+  sessions: readonly CardioSession[],
+): SessionAvgHrByActivityPoint[] {
+  const out: SessionAvgHrByActivityPoint[] = []
+  for (const s of sessions) {
+    if (typeof s.avg_hr !== 'number') continue
+    const d = parseSessionDate(s.date)
+    if (!Number.isFinite(d.getTime())) continue
+    const label = `${d.getMonth() + 1}/${d.getDate()}`
+    out.push({ date: s.date, label, avgHr: s.avg_hr, activity: s.activity })
+  }
+  return out
+}
+
+/** Display copy + tint for an activity — single source of truth for the overview surfaces. */
+export interface ActivityVisual {
+  /** Activity identifier. */
+  activity: CardioActivity
+  /** Title-cased label (e.g. `"Stair"`). */
+  label: string
+  /** Hex fill color used for activity-tinted chart bars and legend dots. */
+  color: string
+}
+
+/**
+ * Per-activity visual config. Picked to be visually distinct and consistent
+ * with the `chartPalette` family (rim-orange, hardwood-tan, ink-black) so the
+ * overview reads as part of the same room as the per-equipment detail views.
+ *
+ * - **Stair**: rim-orange — primary modality (PRD §7.4: "front-and-center").
+ * - **Running**: hardwood-tan — warm secondary, contrasts orange.
+ * - **Walking**: cool indigo — distinct from the warm pair without resorting
+ *   to neon (PRD §8: no neon, no Chart.js defaults).
+ */
+export const ACTIVITY_VISUALS: Readonly<Record<CardioActivity, ActivityVisual>> = {
+  stair: { activity: 'stair', label: 'Stair', color: '#EA580C' },
+  running: { activity: 'running', label: 'Running', color: '#C9A268' },
+  walking: { activity: 'walking', label: 'Walking', color: '#4F6D8E' },
+}


### PR DESCRIPTION
## Summary
- Cross-activity Gym surface at `/training-facility/gym/overview` — stair, run, and walk aggregated into a coach's-clipboard view.
- Composition: totals row → combined HR-zone bars → activity-tinted avg-HR bars (with legend) → training load (whole-athlete) → activity mix → session log with activity column.
- Reachable from two places in the scene: the wall scoreboard (now a `<Link>` to the overview — the totals it advertises *are* the page underneath) and a `View all cardio →` pill on the Gym page header.
- New `lib/training-facility/all-cardio.ts` owns the cross-activity aggregations (filter / summary / per-activity counts / activity-tagged avg-HR points). Per-equipment views stay single-activity by design.
- New `AvgHrBarsByActivity` chart variant — separate from `AvgHrBars` so the Stair/Treadmill/Track views don't pick up an activity axis they don't need.
- Skips pace and cardiac-efficiency charts: combining walking+running paces is misleading, and stair has no pace at all.

Per PRD §7.4 ("All Cardio overview" — last open Phase 4 milestone item).

## Test plan
- [ ] Visit `/training-facility/gym` → confirm the new `View all cardio →` pill renders below the existing "The Gym" intro paragraph.
- [ ] In the Gym scene, hover and tab into the wall scoreboard → confirm the hover tint + dashed focus ring appear and Enter navigates to `/training-facility/gym/overview`.
- [ ] Visit `/training-facility/gym/overview` directly → header reads "Coach's clipboard / All cardio — the stats wall."
- [ ] Date filter works: 1M / 3M / 6M / 1Y / All change the totals row, charts, activity mix, and session log together.
- [ ] Stats summary row shows sessions, total time, total distance, avg duration. Distance shows a dash if no sessions in range have distance.
- [ ] Time-in-zone bars render with five Z1–Z5 buckets, summing across activities.
- [ ] Avg HR per session bars render with stair = rim-orange, running = hardwood-tan, walking = cool indigo. Legend below the chart matches.
- [ ] Training load chart renders with ATL / CTL / TSB curves. EMA pre-warmed from earliest session (no zero-ramp at the visible left edge).
- [ ] Activity mix shows three cards (stair / running / walking), with session count + total time + share-percent. Activities with zero sessions show "0 / —" and no percent.
- [ ] Session log shows newest-first, activity column with colored dot, every column populated where data exists.
- [ ] Empty state: with `cardio.json` missing or no sessions in range, the page shows the "No cardio sessions in the selected range" message rather than blank charts.
- [ ] `/training-facility/gym/overview` with `NEXT_PUBLIC_ENABLE_TRAINING_FACILITY=false` → 404.
- [ ] Mobile (390px wide): summary row stacks 2-up, then 1-up; charts shrink to fit; legend wraps cleanly; session log scrolls horizontally inside its card.

Closes #73.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a full "All Cardio" overview with stats wall, charts, activity mix, and session log; includes a date-range filter and responsive chart sizing.
  * Added per-activity average HR bars with legend and empty-state messaging.
  * Updated gym page copy and added a centered "View all cardio →" navigation CTA.
  * Made the wall scoreboard an interactive link with improved focus/hover affordances.

* **Tests**
  * Added unit tests covering filtering, summaries, activity counts, and HR projections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->