### PR TITLE
feat(combine): admin sign-out affordance in entry form panel (#151)

### DIFF
--- a/components/training-facility/combine/CombineEntryForm.test.tsx
+++ b/components/training-facility/combine/CombineEntryForm.test.tsx
@@ -83,6 +83,35 @@ describe('CombineEntryForm — admin-session gate', () => {
   })
 })
 
+describe('CombineEntryForm — sign-out affordance (#151)', () => {
+  it('renders a "Sign out" button when the viewer is admin', () => {
+    render(<CombineEntryForm onSaved={() => {}} />)
+    expect(screen.getByRole('button', { name: /sign out/i })).toBeInTheDocument()
+  })
+
+  it('does NOT render the sign-out button when the viewer is not admin', () => {
+    adminSessionMock.mockReturnValue({ isAdmin: false, isLoading: false, email: null })
+    render(<CombineEntryForm onSaved={() => {}} />)
+    expect(screen.queryByRole('button', { name: /sign out/i })).not.toBeInTheDocument()
+  })
+
+  it('wraps the sign-out button in a form posting to /auth/sign-out', () => {
+    render(<CombineEntryForm onSaved={() => {}} />)
+    const button = screen.getByRole('button', { name: /sign out/i })
+    const form = button.closest('form')
+    expect(form).not.toBeNull()
+    // jsdom normalizes the `action` to a fully-qualified URL on the
+    // property, so use the raw attribute to assert the literal value
+    // emitted by the component.
+    expect(form?.getAttribute('action')).toBe('/auth/sign-out')
+    expect(form?.getAttribute('method')?.toLowerCase()).toBe('post')
+    // Same form must NOT also be the entry-form (which has its own
+    // `onSubmit` for logBenchmark) — i.e., the sign-out button isn't
+    // accidentally nested inside the data form.
+    expect(form?.querySelector('input[type="number"]')).toBeNull()
+  })
+})
+
 describe('CombineEntryForm — collapsing panel', () => {
   it('starts collapsed (no form fields visible)', () => {
     render(<CombineEntryForm onSaved={() => {}} />)

--- a/components/training-facility/combine/CombineEntryForm.test.tsx
+++ b/components/training-facility/combine/CombineEntryForm.test.tsx
@@ -105,10 +105,34 @@ describe('CombineEntryForm — sign-out affordance (#151)', () => {
     // emitted by the component.
     expect(form?.getAttribute('action')).toBe('/auth/sign-out')
     expect(form?.getAttribute('method')?.toLowerCase()).toBe('post')
-    // Same form must NOT also be the entry-form (which has its own
-    // `onSubmit` for logBenchmark) — i.e., the sign-out button isn't
-    // accidentally nested inside the data form.
-    expect(form?.querySelector('input[type="number"]')).toBeNull()
+  })
+
+  it('keeps the sign-out form separate from the data form when the panel is expanded (edit mode)', () => {
+    // Edit mode auto-opens the panel, so the data form (the one with
+    // `onSubmit={handleSubmit(onSubmit)}` and the numeric inputs) is
+    // mounted. Nested <form> elements are invalid HTML and would route
+    // a sign-out submit through RHF's `onSubmit`, calling logBenchmark
+    // instead of POSTing to /auth/sign-out. Pin the boundary.
+    const ENTRY: Benchmark = { date: '2026-03-10', bodyweight_lbs: 230 }
+    render(
+      <CombineEntryForm
+        onSaved={() => {}}
+        editingEntry={ENTRY}
+        onCancelEdit={() => {}}
+      />,
+    )
+    const signOutForm = screen.getByRole('button', { name: /sign out/i }).closest('form')
+    expect(signOutForm).not.toBeNull()
+    expect(signOutForm?.querySelector('input[type="number"]')).toBeNull()
+    // And conversely: the data form (identified by its numeric inputs)
+    // must not contain the sign-out button.
+    const bw = screen.getByLabelText(/bodyweight/i) as HTMLInputElement
+    const dataForm = bw.closest('form')
+    expect(dataForm).not.toBeNull()
+    expect(dataForm).not.toBe(signOutForm)
+    expect(dataForm?.querySelector('button[type="submit"]')?.textContent).not.toMatch(
+      /sign out/i,
+    )
   })
 })
 

--- a/components/training-facility/combine/CombineEntryForm.tsx
+++ b/components/training-facility/combine/CombineEntryForm.tsx
@@ -352,7 +352,7 @@ function CombineEntryFormImpl({
             navigation without any client-side JS. The browser follows
             the redirect with GET, the next page render sees no Supabase
             session, and the admin gate flips back to non-admin. */}
-          <form action="/auth/sign-out" method="POST">
+          <form action="/auth/sign-out" method="POST" aria-label="Sign out admin session">
             <button
               type="submit"
               className="rounded px-1 font-mono text-[11px] uppercase tracking-[0.28em] text-amber-200/80 transition-colors hover:text-rose-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-300"

--- a/components/training-facility/combine/CombineEntryForm.tsx
+++ b/components/training-facility/combine/CombineEntryForm.tsx
@@ -186,6 +186,10 @@ const PANEL_BUTTON_LABEL_EDITING = 'Cancel edit'
  * ({@link useAdminSession}). Returning `null` during the initial
  * session-check avoids a frame of "Log a session" UI flickering at
  * unauthenticated visitors before the panel disappears.
+ *
+ * The panel header also exposes a "Sign out" affordance — a native
+ * `<form>` POST to `/auth/sign-out` so the route's 303 redirect drives
+ * the navigation without any client-side fetch logic.
  */
 export function CombineEntryForm({
   onSaved,
@@ -343,26 +347,40 @@ function CombineEntryFormImpl({
         >
           {isEditing ? `Admin · Edit session for ${editingEntry.date}` : 'Admin · Log a session'}
         </h2>
-        <button
-          type="button"
-          onClick={() => {
-            if (isEditing) {
-              handleCancelEdit()
-              return
-            }
-            setServerError(null)
-            setSavedDate(null)
-            setIsOpen((v) => !v)
-          }}
-          aria-expanded={isOpen}
-          className="rounded border border-amber-300/40 px-3 py-1.5 font-mono text-[11px] uppercase tracking-[0.2em] text-amber-200 hover:bg-amber-300/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-300"
-        >
-          {isEditing
-            ? PANEL_BUTTON_LABEL_EDITING
-            : isOpen
-              ? PANEL_BUTTON_LABEL_OPEN
-              : PANEL_BUTTON_LABEL_CLOSED}
-        </button>
+        <div className="flex items-center gap-3">
+          {/* Native form POST so the route's 303 redirect drives the
+            navigation without any client-side JS. The browser follows
+            the redirect with GET, the next page render sees no Supabase
+            session, and the admin gate flips back to non-admin. */}
+          <form action="/auth/sign-out" method="POST">
+            <button
+              type="submit"
+              className="rounded px-1 font-mono text-[11px] uppercase tracking-[0.28em] text-amber-200/80 transition-colors hover:text-rose-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-300"
+            >
+              Sign out
+            </button>
+          </form>
+          <button
+            type="button"
+            onClick={() => {
+              if (isEditing) {
+                handleCancelEdit()
+                return
+              }
+              setServerError(null)
+              setSavedDate(null)
+              setIsOpen((v) => !v)
+            }}
+            aria-expanded={isOpen}
+            className="rounded border border-amber-300/40 px-3 py-1.5 font-mono text-[11px] uppercase tracking-[0.2em] text-amber-200 hover:bg-amber-300/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-300"
+          >
+            {isEditing
+              ? PANEL_BUTTON_LABEL_EDITING
+              : isOpen
+                ? PANEL_BUTTON_LABEL_OPEN
+                : PANEL_BUTTON_LABEL_CLOSED}
+          </button>
+        </div>
       </header>
 
       {isOpen && (


### PR DESCRIPTION
## Summary

- Adds a "Sign out" affordance to the Combine entry form panel header. Visible only when `useAdminSession().isAdmin` is true (same gate as the panel itself).
- Implementation is a native `<form action="/auth/sign-out" method="POST">` — the route already returns 303, so the browser follows the redirect with GET, the next render sees no Supabase session, and the admin gate flips back to non-admin without any client-side fetch / reload plumbing.
- Style hint from the issue: small uppercase tracked label, `rose-300` hover, `amber-300` focus-visible ring.
- New unit tests cover: button visible for admin, hidden for non-admin, button is wrapped in a form posting to the right path/method.

> **Base branch:** this PR targets `feat/131-supabase-admin-writes` (PR #144) since #151 depends on the `useAdminSession()` hook and the `/auth/sign-out` route introduced there. Re-target to `main` after #144 lands, or it'll fold in cleanly on top.

## Test plan

- [ ] Sign in via `/admin/login` → land on `/training-facility/combine` → "Admin · Log a session" panel shows a "Sign out" link to the left of "Log a session".
- [ ] Click "Sign out" → page navigates to `/` with no entry form visible (admin gate flipped to non-admin).
- [ ] Tab to the "Sign out" button → `amber-300` focus ring is visible.
- [ ] Hover "Sign out" → text turns `rose-300`.
- [ ] In edit mode (click ✏️ on a row), the panel header shows "Sign out" + "Cancel edit" — both keyboard-accessible, neither overflows.
- [ ] Sign out while in edit mode → still navigates to `/` cleanly, no stuck-edit-state warnings.
- [ ] Logged-out (incognito) viewer of `/training-facility/combine` does NOT see "Sign out" or any panel UI.

Closes #151.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a sign-out button to the training facility panel header, allowing users to sign out directly from the panel.

* **Tests**
  * Added test coverage for sign-out button visibility, form submission routing, and proper form isolation during panel editing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->