### PR TITLE
feat(gym): Supabase-backed cardio data — migrate from cardio.json (#152)

### DIFF
--- a/docs/training-facility-prd.md
+++ b/docs/training-facility-prd.md
@@ -334,7 +334,7 @@ Even in single-user mode, users (Lucas) need to fix mistakes. Typos happen. Some
 
 **Data layer:** `updateBenchmark()` and `deleteBenchmark()` in `lib/data/movement.ts` (per 7.10). Both are dev-only writes via the same Next.js API route gated behind `NODE_ENV === 'development'`, same as `logBenchmark()`.
 
-**Cardio data parity:** the Python preprocessor is the source of truth for cardio data — re-running it produces a fresh `cardio.json`. Editing individual cardio entries isn't supported in v1 (you'd re-export Apple Health and re-process). If a workout was logged incorrectly in HealthKit itself, fix it there and re-import. Adding edit-cardio capability is post-v1.
+**Cardio data parity:** Supabase is the source of truth for cardio data (#152). The Python preprocessor still parses Apple Health into an intermediate `public/data/cardio.json`, then `npm run import-health` upserts those rows into the three `cardio_*` tables via the service-role key — idempotent, so re-running after a fresh export overwrites the same primary keys instead of duplicating. Editing individual cardio entries from the UI isn't supported in v1: if a workout was logged incorrectly in HealthKit, fix it there and re-import. (Unlike Combine benchmarks in 7.10/7.11, no `/api/admin/cardio` write routes exist — adding edit-cardio is post-v1.)
 
 ### 7.12 Admin section — what's needed (and not) at each stage
 

--- a/lib/data/cardio.test.ts
+++ b/lib/data/cardio.test.ts
@@ -1,64 +1,253 @@
 import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest'
+
 import { getCardioData } from './cardio'
 
 /**
- * `getCardioData` is a thin fetch wrapper that mirrors the empty-state
- * behavior of `getMovementBenchmarks`: 404 → return a sentinel (here `null`,
- * since `CardioData` is an object and `[]` wouldn't typecheck), other non-OK
- * responses → throw.
+ * Tests for the cardio data-access wrapper after the Supabase migration
+ * (#152). Reads now hit three tables in parallel — the test mocks
+ * `getBrowserSupabaseClient` and tracks which table each chained call
+ * targets so each assertion can stub a per-table result independently.
+ *
+ * Sibling pattern: `lib/data/movement.test.ts`.
  */
 
-let fetchMock: ReturnType<typeof vi.fn>
+interface FakeQuery {
+  select: ReturnType<typeof vi.fn>
+  order: ReturnType<typeof vi.fn>
+}
+
+const queriesByTable: Record<string, FakeQuery> = {}
+const fromMock = vi.fn((table: string): FakeQuery => {
+  if (!queriesByTable[table]) {
+    const query: FakeQuery = {
+      select: vi.fn(),
+      order: vi.fn(),
+    }
+    query.select.mockReturnValue(query)
+    query.order.mockResolvedValue({ data: [], error: null })
+    queriesByTable[table] = query
+  }
+  return queriesByTable[table]
+})
+const browserClientMock = { from: fromMock }
+
+vi.mock('@/lib/supabase/browser', () => ({
+  getBrowserSupabaseClient: () => browserClientMock,
+}))
 
 beforeEach(() => {
-  fetchMock = vi.fn()
-  vi.stubGlobal('fetch', fetchMock)
+  for (const key of Object.keys(queriesByTable)) {
+    delete queriesByTable[key]
+  }
+  fromMock.mockClear()
 })
 
 afterEach(() => {
   vi.unstubAllGlobals()
 })
 
+/** Pre-stub a query result for one of the three cardio tables. */
+function stubTable(table: string, data: Array<Record<string, unknown>> | null, error: unknown = null): void {
+  const query = fromMock(table)
+  query.order.mockReset()
+  query.order.mockResolvedValue({ data, error })
+}
+
 describe('getCardioData', () => {
-  it('fetches /data/cardio.json by default', async () => {
-    const payload = {
-      imported_at: '2026-04-26T00:00:00Z',
-      sessions: [],
-      resting_hr_trend: [],
-      vo2max_trend: [],
-    }
-    fetchMock.mockResolvedValueOnce(
-      new Response(JSON.stringify(payload), {
-        status: 200,
-        headers: { 'content-type': 'application/json' },
-      }),
-    )
-    await expect(getCardioData()).resolves.toEqual(payload)
-
-    const [url] = fetchMock.mock.calls[0]
-    expect(url).toBe('/data/cardio.json')
-  })
-
-  it('returns null on 404 (pre-baseline empty state, no cardio.json yet)', async () => {
-    fetchMock.mockResolvedValueOnce(new Response(null, { status: 404, statusText: 'Not Found' }))
+  it('returns null when all three cardio tables are empty', async () => {
+    stubTable('cardio_sessions', [])
+    stubTable('cardio_resting_hr', [])
+    stubTable('cardio_vo2max', [])
     await expect(getCardioData()).resolves.toBeNull()
+
+    // Verify it queried all three tables in parallel.
+    expect(fromMock).toHaveBeenCalledWith('cardio_sessions')
+    expect(fromMock).toHaveBeenCalledWith('cardio_resting_hr')
+    expect(fromMock).toHaveBeenCalledWith('cardio_vo2max')
   })
 
-  it('throws on 500 with status code in the message', async () => {
-    fetchMock.mockResolvedValueOnce(
-      new Response(null, { status: 500, statusText: 'Internal Server Error' }),
-    )
-    await expect(getCardioData()).rejects.toThrow(/500/)
+  it('orders sessions by started_at ascending and trends by date ascending', async () => {
+    stubTable('cardio_sessions', [])
+    stubTable('cardio_resting_hr', [])
+    stubTable('cardio_vo2max', [])
+    await getCardioData()
+
+    expect(queriesByTable.cardio_sessions.order).toHaveBeenCalledWith('started_at', {
+      ascending: true,
+    })
+    expect(queriesByTable.cardio_resting_hr.order).toHaveBeenCalledWith('date', {
+      ascending: true,
+    })
+    expect(queriesByTable.cardio_vo2max.order).toHaveBeenCalledWith('date', {
+      ascending: true,
+    })
   })
 
-  it('throws when the response is OK but the body is invalid JSON', async () => {
-    // Response.json() rejects on bad JSON — getCardioData lets that bubble up.
-    fetchMock.mockResolvedValueOnce(
-      new Response('not valid json', {
-        status: 200,
-        headers: { 'content-type': 'application/json' },
-      }),
+  it('assembles the legacy CardioData shape and reconstructs hr_seconds_in_zone', async () => {
+    stubTable(
+      'cardio_sessions',
+      [
+        {
+          started_at: '2026-04-26T08:00:00Z',
+          activity: 'stair',
+          duration_seconds: 1980,
+          distance_meters: null,
+          avg_hr: 158,
+          max_hr: 178,
+          pace_seconds_per_km: null,
+          zone1_seconds: 10,
+          zone2_seconds: 280,
+          zone3_seconds: 740,
+          zone4_seconds: 680,
+          zone5_seconds: 270,
+          meters_per_heartbeat: null,
+          created_at: '2026-04-26T08:30:00Z',
+        },
+      ],
     )
-    await expect(getCardioData()).rejects.toThrow()
+    stubTable(
+      'cardio_resting_hr',
+      [{ date: '2026-04-26', value: 57, created_at: '2026-04-26T08:30:00Z' }],
+    )
+    stubTable(
+      'cardio_vo2max',
+      [{ date: '2026-04-26', value: 43.4, created_at: '2026-04-26T08:30:00Z' }],
+    )
+
+    const data = await getCardioData()
+    expect(data).toEqual({
+      imported_at: '2026-04-26T08:30:00Z',
+      sessions: [
+        {
+          date: '2026-04-26T08:00:00Z',
+          activity: 'stair',
+          duration_seconds: 1980,
+          avg_hr: 158,
+          max_hr: 178,
+          hr_seconds_in_zone: { 1: 10, 2: 280, 3: 740, 4: 680, 5: 270 },
+        },
+      ],
+      resting_hr_trend: [{ date: '2026-04-26', value: 57 }],
+      vo2max_trend: [{ date: '2026-04-26', value: 43.4 }],
+    })
+  })
+
+  it('omits hr_seconds_in_zone when every zone column is null (Apple Watch off)', async () => {
+    stubTable(
+      'cardio_sessions',
+      [
+        {
+          started_at: '2026-04-21T07:00:00Z',
+          activity: 'walking',
+          duration_seconds: 1800,
+          distance_meters: 2400,
+          avg_hr: null,
+          max_hr: null,
+          pace_seconds_per_km: 750,
+          zone1_seconds: null,
+          zone2_seconds: null,
+          zone3_seconds: null,
+          zone4_seconds: null,
+          zone5_seconds: null,
+          meters_per_heartbeat: null,
+          created_at: '2026-04-21T07:30:00Z',
+        },
+      ],
+    )
+    stubTable('cardio_resting_hr', [])
+    stubTable('cardio_vo2max', [])
+
+    const data = await getCardioData()
+    expect(data?.sessions[0]).not.toHaveProperty('hr_seconds_in_zone')
+    expect(data?.sessions[0]).toEqual({
+      date: '2026-04-21T07:00:00Z',
+      activity: 'walking',
+      duration_seconds: 1800,
+      distance_meters: 2400,
+      pace_seconds_per_km: 750,
+    })
+  })
+
+  it('takes imported_at from the latest created_at across all three tables', async () => {
+    stubTable(
+      'cardio_sessions',
+      [
+        {
+          started_at: '2026-02-08T08:00:00Z',
+          activity: 'stair',
+          duration_seconds: 1440,
+          distance_meters: null,
+          avg_hr: null,
+          max_hr: null,
+          pace_seconds_per_km: null,
+          zone1_seconds: null,
+          zone2_seconds: null,
+          zone3_seconds: null,
+          zone4_seconds: null,
+          zone5_seconds: null,
+          meters_per_heartbeat: null,
+          created_at: '2026-02-08T09:00:00Z',
+        },
+      ],
+    )
+    stubTable(
+      'cardio_resting_hr',
+      [{ date: '2026-04-26', value: 57, created_at: '2026-04-26T08:30:00Z' }],
+    )
+    stubTable(
+      'cardio_vo2max',
+      [{ date: '2026-03-01', value: 42, created_at: '2026-03-01T09:00:00Z' }],
+    )
+
+    const data = await getCardioData()
+    expect(data?.imported_at).toBe('2026-04-26T08:30:00Z')
+  })
+
+  it('throws a descriptive error when the sessions query fails', async () => {
+    stubTable('cardio_sessions', null, { message: 'JWT expired' })
+    stubTable('cardio_resting_hr', [])
+    stubTable('cardio_vo2max', [])
+    await expect(getCardioData()).rejects.toThrow(/JWT expired/)
+  })
+
+  it('throws a descriptive error when the resting-HR query fails', async () => {
+    stubTable('cardio_sessions', [])
+    stubTable('cardio_resting_hr', null, { message: 'permission denied' })
+    stubTable('cardio_vo2max', [])
+    await expect(getCardioData()).rejects.toThrow(/permission denied/)
+  })
+
+  it('throws a descriptive error when the VO2max query fails', async () => {
+    stubTable('cardio_sessions', [])
+    stubTable('cardio_resting_hr', [])
+    stubTable('cardio_vo2max', null, { message: 'connection reset' })
+    await expect(getCardioData()).rejects.toThrow(/connection reset/)
+  })
+
+  it('throws when a row fails schema validation (e.g. unknown activity)', async () => {
+    stubTable(
+      'cardio_sessions',
+      [
+        {
+          started_at: '2026-04-26T08:00:00Z',
+          activity: 'cycling', // not in the enum — Zod rejects.
+          duration_seconds: 1200,
+          distance_meters: null,
+          avg_hr: null,
+          max_hr: null,
+          pace_seconds_per_km: null,
+          zone1_seconds: null,
+          zone2_seconds: null,
+          zone3_seconds: null,
+          zone4_seconds: null,
+          zone5_seconds: null,
+          meters_per_heartbeat: null,
+          created_at: '2026-04-26T08:30:00Z',
+        },
+      ],
+    )
+    stubTable('cardio_resting_hr', [])
+    stubTable('cardio_vo2max', [])
+    await expect(getCardioData()).rejects.toThrow(/cardio_sessions failed schema validation/)
   })
 })

--- a/lib/data/cardio.ts
+++ b/lib/data/cardio.ts
@@ -1,25 +1,170 @@
-import type { CardioData } from '@/types/cardio';
-import { DATA_BASE_URL } from './config';
+import { z } from 'zod'
+
+import {
+  CardioSessionRowSchema,
+  CardioTrendRowSchema,
+  sessionRowToCardioSession,
+  trendRowToTimePoint,
+} from '@/lib/schemas/cardio'
+import { getBrowserSupabaseClient } from '@/lib/supabase/browser'
+import type { CardioData } from '@/types/cardio'
+
+/** Supabase tables backing the cardio dataset (#152, PRD §7.4). */
+const SESSIONS_TABLE = 'cardio_sessions'
+const RESTING_HR_TABLE = 'cardio_resting_hr'
+const VO2MAX_TABLE = 'cardio_vo2max'
 
 /**
- * Fetches the full cardio dataset (`public/data/cardio.json`).
+ * Whitelisted column lists for each cardio table. Mirror the
+ * row-shape Zod schemas in `lib/schemas/cardio.ts` so a column added
+ * to the DB without a corresponding schema/type update doesn't
+ * silently leak through to the dashboard.
+ */
+const SESSIONS_COLUMNS =
+  'started_at, activity, duration_seconds, distance_meters, avg_hr, max_hr, ' +
+  'pace_seconds_per_km, zone1_seconds, zone2_seconds, zone3_seconds, ' +
+  'zone4_seconds, zone5_seconds, meters_per_heartbeat, created_at'
+const TREND_COLUMNS = 'date, value, created_at'
+
+/**
+ * Validate an array of `cardio_sessions` rows after `null` → omitted
+ * normalization. A schema-drift (column added without type update,
+ * or hand-edited malformed row) surfaces here as a loud error rather
+ * than as a confused render downstream.
+ */
+const CardioSessionRowsSchema = z.array(CardioSessionRowSchema)
+
+/** Same idea as {@link CardioSessionRowsSchema} for the trend tables. */
+const CardioTrendRowsSchema = z.array(CardioTrendRowSchema)
+
+/**
+ * Fetch the full cardio dataset from Supabase.
  *
- * Today this is a static asset; a future migration to a hosted API only changes
- * the URL inside this function — callers don't need to know.
+ * Queries the three cardio tables in parallel, normalizes Postgres
+ * `null` to absent (matching the legacy JSON shape's "absent key"
+ * convention), validates each table's rows against the row-shape
+ * schemas in `lib/schemas/cardio.ts`, and assembles them into the
+ * legacy {@link CardioData} shape that components consume.
  *
- * Returns `null` if the dataset doesn't exist yet (typical pre-baseline state,
- * before `scripts/preprocess-health.py` has produced `cardio.json`). Callers
- * should render an empty state in that case rather than treating it as an error.
- * `null` rather than an empty array because `CardioData` is an object.
+ * Returns `null` when all three tables are empty — preserves the
+ * pre-Supabase contract where a missing dataset triggered the dashboard
+ * empty-state branch. Components substitute an empty `CardioData`
+ * fallback in that case.
  *
- * @throws {Error} on non-404 fetch failures (status not 200 OK).
- * @throws {SyntaxError} if the response body is not valid JSON.
+ * `imported_at` is computed as the latest `created_at` across the three
+ * tables. It's surfaced for backwards-compatibility with the legacy
+ * JSON shape, but no v1 view actually displays it (the detail views
+ * default it to `''` when null).
+ *
+ * @throws when any of the three Supabase queries fail (network /
+ *   misconfigured env / RLS regression) or when row-shape validation
+ *   fails. Callers usually downgrade this to an empty render — see
+ *   `StairDetailView` / `TreadmillDetailView` / `TrackDetailView`.
  */
 export async function getCardioData(): Promise<CardioData | null> {
-  const res = await fetch(`${DATA_BASE_URL}/cardio.json`);
-  if (res.status === 404) return null;
-  if (!res.ok) {
-    throw new Error(`Failed to load cardio data: ${res.status} ${res.statusText}`);
+  const supabase = getBrowserSupabaseClient()
+  const [sessionsRes, restingRes, vo2Res] = await Promise.all([
+    supabase.from(SESSIONS_TABLE).select(SESSIONS_COLUMNS).order('started_at', { ascending: true }),
+    supabase.from(RESTING_HR_TABLE).select(TREND_COLUMNS).order('date', { ascending: true }),
+    supabase.from(VO2MAX_TABLE).select(TREND_COLUMNS).order('date', { ascending: true }),
+  ])
+
+  if (sessionsRes.error) {
+    throw new Error(`Failed to load cardio sessions: ${sessionsRes.error.message}`)
   }
-  return res.json();
+  if (restingRes.error) {
+    throw new Error(`Failed to load resting HR trend: ${restingRes.error.message}`)
+  }
+  if (vo2Res.error) {
+    throw new Error(`Failed to load VO2max trend: ${vo2Res.error.message}`)
+  }
+
+  const sessionsRaw = (sessionsRes.data ?? []) as unknown as Array<Record<string, unknown>>
+  const restingRaw = (restingRes.data ?? []) as unknown as Array<Record<string, unknown>>
+  const vo2Raw = (vo2Res.data ?? []) as unknown as Array<Record<string, unknown>>
+
+  // Compute imported_at before `created_at` is stripped — it lives on
+  // every row but isn't part of the row-shape schema.
+  const importedAt = computeImportedAt([sessionsRaw, restingRaw, vo2Raw])
+
+  if (sessionsRaw.length === 0 && restingRaw.length === 0 && vo2Raw.length === 0) {
+    // Preserves the pre-Supabase null-on-empty contract that detail
+    // views already handle via `?? { imported_at: '', sessions: [], ... }`.
+    return null
+  }
+
+  const sessionsParsed = CardioSessionRowsSchema.safeParse(
+    sessionsRaw.map(stripNulls).map(stripCreatedAt),
+  )
+  if (!sessionsParsed.success) {
+    throw new Error(
+      `cardio_sessions failed schema validation: ${sessionsParsed.error.message}`,
+    )
+  }
+  const restingParsed = CardioTrendRowsSchema.safeParse(
+    restingRaw.map(stripNulls).map(stripCreatedAt),
+  )
+  if (!restingParsed.success) {
+    throw new Error(
+      `cardio_resting_hr failed schema validation: ${restingParsed.error.message}`,
+    )
+  }
+  const vo2Parsed = CardioTrendRowsSchema.safeParse(
+    vo2Raw.map(stripNulls).map(stripCreatedAt),
+  )
+  if (!vo2Parsed.success) {
+    throw new Error(`cardio_vo2max failed schema validation: ${vo2Parsed.error.message}`)
+  }
+
+  return {
+    imported_at: importedAt,
+    sessions: sessionsParsed.data.map(sessionRowToCardioSession),
+    resting_hr_trend: restingParsed.data.map(trendRowToTimePoint),
+    vo2max_trend: vo2Parsed.data.map(trendRowToTimePoint),
+  }
+}
+
+/**
+ * Postgres returns `null` for omitted optional columns, but the row
+ * Zod schemas declare optional fields with `.optional()` (no
+ * `.nullable()`). Map `null` → absent so Zod parses Supabase rows the
+ * same way it parses freshly-imported JSON (which used absent keys,
+ * never `null`).
+ */
+function stripNulls(row: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(row)) {
+    if (value !== null) out[key] = value
+  }
+  return out
+}
+
+/**
+ * Drop the `created_at` audit column before Zod-parsing. The row
+ * schemas use `.strict()`, which would otherwise reject the column —
+ * but we still need it on the raw row to compute `imported_at`, so
+ * the caller pulls it off the un-stripped row first.
+ */
+function stripCreatedAt(row: Record<string, unknown>): Record<string, unknown> {
+  if (!('created_at' in row)) return row
+  const { created_at: _ignored, ...rest } = row
+  return rest
+}
+
+/**
+ * Determine `imported_at` from the latest `created_at` across the three
+ * cardio tables. Returns `''` when no rows have a `created_at` value —
+ * matches the fallback components already use for the "no data yet" state.
+ */
+function computeImportedAt(rowGroups: Array<Array<Record<string, unknown>>>): string {
+  let latest = ''
+  for (const rows of rowGroups) {
+    for (const row of rows) {
+      const value = row.created_at
+      if (typeof value === 'string' && value > latest) {
+        latest = value
+      }
+    }
+  }
+  return latest
 }

--- a/lib/schemas/cardio.test.ts
+++ b/lib/schemas/cardio.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect } from 'vitest'
+
+import {
+  CardioSessionRowSchema,
+  CardioTrendRowSchema,
+  cardioSessionToRow,
+  sessionRowToCardioSession,
+  trendRowToTimePoint,
+} from './cardio'
+
+/**
+ * Tests for the Zod schemas and bidirectional transforms that bridge
+ * the legacy `CardioData` JSON shape (nested `hr_seconds_in_zone` map)
+ * and the Supabase row shape (5 explicit zone columns) introduced in
+ * #152.
+ */
+
+describe('CardioSessionRowSchema', () => {
+  it('accepts a fully-populated session row', () => {
+    const row = {
+      started_at: '2026-04-26T08:00:00Z',
+      activity: 'stair' as const,
+      duration_seconds: 1980,
+      avg_hr: 158,
+      max_hr: 178,
+      zone1_seconds: 10,
+      zone2_seconds: 280,
+      zone3_seconds: 740,
+      zone4_seconds: 680,
+      zone5_seconds: 270,
+    }
+    expect(CardioSessionRowSchema.safeParse(row).success).toBe(true)
+  })
+
+  it('accepts a session row with only required fields', () => {
+    const row = {
+      started_at: '2026-04-26T08:00:00Z',
+      activity: 'walking' as const,
+      duration_seconds: 1800,
+    }
+    expect(CardioSessionRowSchema.safeParse(row).success).toBe(true)
+  })
+
+  it('rejects an unknown activity value', () => {
+    const row = {
+      started_at: '2026-04-26T08:00:00Z',
+      activity: 'cycling',
+      duration_seconds: 1200,
+    }
+    const result = CardioSessionRowSchema.safeParse(row)
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects a negative duration', () => {
+    const row = {
+      started_at: '2026-04-26T08:00:00Z',
+      activity: 'stair' as const,
+      duration_seconds: -1,
+    }
+    expect(CardioSessionRowSchema.safeParse(row).success).toBe(false)
+  })
+
+  it('rejects unknown columns (strict)', () => {
+    const row = {
+      started_at: '2026-04-26T08:00:00Z',
+      activity: 'stair' as const,
+      duration_seconds: 1200,
+      // Typo / drift — schema should reject so a stale write doesn't
+      // silently land in the DB.
+      bogus_column: 42,
+    }
+    expect(CardioSessionRowSchema.safeParse(row).success).toBe(false)
+  })
+})
+
+describe('CardioTrendRowSchema', () => {
+  it('accepts a YYYY-MM-DD date and numeric value', () => {
+    expect(
+      CardioTrendRowSchema.safeParse({ date: '2026-04-26', value: 57 }).success,
+    ).toBe(true)
+  })
+
+  it('rejects an ISO timestamp in the date field', () => {
+    expect(
+      CardioTrendRowSchema.safeParse({
+        date: '2026-04-26T08:00:00Z',
+        value: 57,
+      }).success,
+    ).toBe(false)
+  })
+})
+
+describe('sessionRowToCardioSession', () => {
+  it('reconstructs the nested hr_seconds_in_zone map from 5 columns', () => {
+    const row = {
+      started_at: '2026-04-26T08:00:00Z',
+      activity: 'stair' as const,
+      duration_seconds: 1980,
+      avg_hr: 158,
+      max_hr: 178,
+      zone1_seconds: 10,
+      zone2_seconds: 280,
+      zone3_seconds: 740,
+      zone4_seconds: 680,
+      zone5_seconds: 270,
+    }
+    expect(sessionRowToCardioSession(row)).toEqual({
+      date: '2026-04-26T08:00:00Z',
+      activity: 'stair',
+      duration_seconds: 1980,
+      avg_hr: 158,
+      max_hr: 178,
+      hr_seconds_in_zone: { 1: 10, 2: 280, 3: 740, 4: 680, 5: 270 },
+    })
+  })
+
+  it('omits hr_seconds_in_zone when every zone column is undefined', () => {
+    const session = sessionRowToCardioSession({
+      started_at: '2026-04-21T07:00:00Z',
+      activity: 'walking',
+      duration_seconds: 1800,
+      distance_meters: 2400,
+      pace_seconds_per_km: 750,
+    })
+    expect(session).not.toHaveProperty('hr_seconds_in_zone')
+    expect(session).toEqual({
+      date: '2026-04-21T07:00:00Z',
+      activity: 'walking',
+      duration_seconds: 1800,
+      distance_meters: 2400,
+      pace_seconds_per_km: 750,
+    })
+  })
+
+  it('fills missing zones with 0 when at least one zone is present', () => {
+    // A glitched session where Apple Watch only logged time in Z3 — the
+    // dashboard should still see explicit zeros for the other four
+    // zones so the bar chart renders four empty bars rather than
+    // collapsing to one.
+    const session = sessionRowToCardioSession({
+      started_at: '2026-04-26T08:00:00Z',
+      activity: 'stair',
+      duration_seconds: 1980,
+      zone3_seconds: 740,
+    })
+    expect(session.hr_seconds_in_zone).toEqual({ 1: 0, 2: 0, 3: 740, 4: 0, 5: 0 })
+  })
+})
+
+describe('cardioSessionToRow', () => {
+  it('flattens hr_seconds_in_zone into 5 explicit columns', () => {
+    const row = cardioSessionToRow({
+      date: '2026-04-26T08:00:00Z',
+      activity: 'stair',
+      duration_seconds: 1980,
+      avg_hr: 158,
+      max_hr: 178,
+      hr_seconds_in_zone: { '1': 10, '2': 280, '3': 740, '4': 680, '5': 270 },
+    })
+    expect(row).toMatchObject({
+      started_at: '2026-04-26T08:00:00Z',
+      activity: 'stair',
+      duration_seconds: 1980,
+      avg_hr: 158,
+      max_hr: 178,
+      zone1_seconds: 10,
+      zone2_seconds: 280,
+      zone3_seconds: 740,
+      zone4_seconds: 680,
+      zone5_seconds: 270,
+    })
+  })
+
+  it('emits null for absent zone fields so re-imports clear stale values', () => {
+    const row = cardioSessionToRow({
+      date: '2026-04-21T07:00:00Z',
+      activity: 'walking',
+      duration_seconds: 1800,
+      distance_meters: 2400,
+      pace_seconds_per_km: 750,
+    })
+    // hr_seconds_in_zone absent → all 5 zone columns serialize to null,
+    // so a re-upsert of a session whose Apple Watch data was later
+    // removed clears the old zone values rather than leaving stale
+    // numbers behind.
+    expect(row).toMatchObject({
+      zone1_seconds: null,
+      zone2_seconds: null,
+      zone3_seconds: null,
+      zone4_seconds: null,
+      zone5_seconds: null,
+      avg_hr: null,
+      max_hr: null,
+    })
+  })
+
+  it('round-trips a session through cardioSessionToRow → sessionRowToCardioSession', () => {
+    const original = {
+      date: '2026-04-26T08:00:00Z',
+      activity: 'stair' as const,
+      duration_seconds: 1980,
+      avg_hr: 158,
+      max_hr: 178,
+      hr_seconds_in_zone: { '1': 10, '2': 280, '3': 740, '4': 680, '5': 270 },
+    }
+    const row = cardioSessionToRow(original)
+    // Strip nulls to mirror the data layer's `stripNulls()` step before
+    // Zod validation.
+    const stripped: Record<string, unknown> = {}
+    for (const [k, v] of Object.entries(row)) {
+      if (v !== null) stripped[k] = v
+    }
+    const parsed = CardioSessionRowSchema.parse(stripped)
+    const session = sessionRowToCardioSession(parsed)
+    expect(session).toEqual({
+      date: '2026-04-26T08:00:00Z',
+      activity: 'stair',
+      duration_seconds: 1980,
+      avg_hr: 158,
+      max_hr: 178,
+      hr_seconds_in_zone: { 1: 10, 2: 280, 3: 740, 4: 680, 5: 270 },
+    })
+  })
+})
+
+describe('trendRowToTimePoint', () => {
+  it('passes through the typed shape', () => {
+    expect(trendRowToTimePoint({ date: '2026-04-26', value: 57 })).toEqual({
+      date: '2026-04-26',
+      value: 57,
+    })
+  })
+})

--- a/lib/schemas/cardio.ts
+++ b/lib/schemas/cardio.ts
@@ -1,0 +1,185 @@
+/**
+ * Pure (isomorphic) Zod schemas for the cardio Supabase row contract.
+ *
+ * Three tables back the cardio dashboard (PRD §7.4):
+ *   * `cardio_sessions`   — one row per workout
+ *   * `cardio_resting_hr` — one row per measurement day
+ *   * `cardio_vo2max`     — one row per measurement day
+ *
+ * The Zod schemas here are the single source of truth for what the
+ * data layer (`lib/data/cardio.ts`) and the import script
+ * (`scripts/import-health.mjs`) accept. The static `CardioData` /
+ * `CardioSession` / `CardioTimePoint` types in `types/cardio.ts` mirror
+ * them for IDE ergonomics — when the schema changes, update the static
+ * type so component-side `Cmd+hover` stays accurate.
+ *
+ * Sibling pattern: `lib/schemas/movement.ts`.
+ */
+
+import { z } from 'zod'
+
+import type {
+  CardioActivity,
+  CardioSession,
+  CardioTimePoint,
+  HrZone,
+} from '@/types/cardio'
+
+/** ISO calendar date in `YYYY-MM-DD` form. Used by the resting-HR and VO2max trend rows. */
+export const DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/
+
+/** Cardio activity types tracked by the v1 Gym surfaces. Must match the `activity` CHECK constraint on `cardio_sessions`. */
+export const CardioActivitySchema = z.enum(['stair', 'running', 'walking'])
+
+/**
+ * Zod schema for one row of `public.cardio_sessions`. Mirrors the table
+ * definition in `supabase/migrations/20260430120000_cardio_tables.sql`.
+ *
+ * - `started_at` is the session start as ISO 8601 timestamp; it is the
+ *   primary key, so two sessions starting at the exact same instant
+ *   would collide (vanishingly rare with second-precision timestamps).
+ * - HR-zone seconds are five explicit columns rather than JSONB so a
+ *   "time in Z3 over months" query stays a plain `select`.
+ * - Optional fields use `.optional()` (not `.nullable()`) — Postgres
+ *   `NULL` is mapped to absent before validation by `stripNulls()` in
+ *   the data layer, which keeps this schema usable from both the read
+ *   path (DB → undefined) and the import-script write path (caller
+ *   passes undefined → Supabase serializes as null).
+ */
+export const CardioSessionRowSchema = z
+  .object({
+    started_at: z.string().min(1, 'started_at must be an ISO timestamp'),
+    activity: CardioActivitySchema,
+    duration_seconds: z.number().nonnegative(),
+    distance_meters: z.number().nonnegative().optional(),
+    avg_hr: z.number().nonnegative().optional(),
+    max_hr: z.number().nonnegative().optional(),
+    pace_seconds_per_km: z.number().nonnegative().optional(),
+    zone1_seconds: z.number().nonnegative().optional(),
+    zone2_seconds: z.number().nonnegative().optional(),
+    zone3_seconds: z.number().nonnegative().optional(),
+    zone4_seconds: z.number().nonnegative().optional(),
+    zone5_seconds: z.number().nonnegative().optional(),
+    meters_per_heartbeat: z.number().nonnegative().optional(),
+  })
+  .strict()
+
+/** Validated `cardio_sessions` row inferred from {@link CardioSessionRowSchema}. */
+export type CardioSessionRow = z.infer<typeof CardioSessionRowSchema>
+
+/**
+ * Zod schema for one row of `public.cardio_resting_hr` /
+ * `public.cardio_vo2max`. Both tables share the shape `(date, value)`,
+ * keyed by calendar date so a re-import overwrites rather than
+ * duplicates the same day's measurement.
+ */
+export const CardioTrendRowSchema = z
+  .object({
+    date: z.string().regex(DATE_REGEX, 'date must be YYYY-MM-DD'),
+    value: z.number(),
+  })
+  .strict()
+
+/** Validated `cardio_resting_hr` / `cardio_vo2max` row inferred from {@link CardioTrendRowSchema}. */
+export type CardioTrendRow = z.infer<typeof CardioTrendRowSchema>
+
+/**
+ * Translate a validated `cardio_sessions` row (snake_case zone columns)
+ * into the legacy `CardioSession` shape (`hr_seconds_in_zone` nested
+ * map) that components consume today. Applied by the data layer on
+ * read so existing visualizations don't change after the
+ * Supabase migration.
+ *
+ * A session with no HR data (Apple Watch off) leaves every zone column
+ * null; in that case `hr_seconds_in_zone` is omitted entirely rather
+ * than emitted as a map of five zeros, which would render as "all
+ * zones at zero" in the dashboard instead of empty.
+ */
+export function sessionRowToCardioSession(row: CardioSessionRow): CardioSession {
+  const session: CardioSession = {
+    date: row.started_at,
+    activity: row.activity as CardioActivity,
+    duration_seconds: row.duration_seconds,
+  }
+  if (row.distance_meters !== undefined) session.distance_meters = row.distance_meters
+  if (row.avg_hr !== undefined) session.avg_hr = row.avg_hr
+  if (row.max_hr !== undefined) session.max_hr = row.max_hr
+  if (row.pace_seconds_per_km !== undefined) {
+    session.pace_seconds_per_km = row.pace_seconds_per_km
+  }
+  if (row.meters_per_heartbeat !== undefined) {
+    session.meters_per_heartbeat = row.meters_per_heartbeat
+  }
+  const zones: Record<HrZone, number | undefined> = {
+    1: row.zone1_seconds,
+    2: row.zone2_seconds,
+    3: row.zone3_seconds,
+    4: row.zone4_seconds,
+    5: row.zone5_seconds,
+  }
+  if ((Object.values(zones) as Array<number | undefined>).some((v) => v !== undefined)) {
+    session.hr_seconds_in_zone = {
+      1: zones[1] ?? 0,
+      2: zones[2] ?? 0,
+      3: zones[3] ?? 0,
+      4: zones[4] ?? 0,
+      5: zones[5] ?? 0,
+    }
+  }
+  return session
+}
+
+/**
+ * Translate a legacy `CardioSession` (the shape produced by
+ * `scripts/preprocess-health.py` and matching `types/cardio.ts`) into
+ * the snake_case row payload accepted by `cardio_sessions.upsert(...)`.
+ *
+ * Used by the import script (`scripts/import-health.mjs`) and the
+ * one-shot backfill (`scripts/backfill-cardio.mjs`). Maps absent /
+ * `null` legacy fields to explicit `null`s so an upsert that re-imports
+ * a session whose HR data has since been removed clears the old zone
+ * values instead of leaving stale numbers behind.
+ *
+ * @param session Legacy session object (e.g. parsed from
+ *   `public/data/cardio.json`). The Python preprocessor emits some
+ *   fields as `null` when missing — those map to `null` in Postgres.
+ */
+export function cardioSessionToRow(session: {
+  date: string
+  activity: string
+  duration_seconds: number
+  distance_meters?: number | null
+  avg_hr?: number | null
+  max_hr?: number | null
+  pace_seconds_per_km?: number | null
+  hr_seconds_in_zone?: Record<string, number> | null
+  meters_per_heartbeat?: number | null
+}): Record<string, unknown> {
+  const zones = session.hr_seconds_in_zone ?? null
+  return {
+    started_at: session.date,
+    activity: session.activity,
+    duration_seconds: session.duration_seconds,
+    distance_meters: session.distance_meters ?? null,
+    avg_hr: session.avg_hr ?? null,
+    max_hr: session.max_hr ?? null,
+    pace_seconds_per_km: session.pace_seconds_per_km ?? null,
+    zone1_seconds: zones?.['1'] ?? null,
+    zone2_seconds: zones?.['2'] ?? null,
+    zone3_seconds: zones?.['3'] ?? null,
+    zone4_seconds: zones?.['4'] ?? null,
+    zone5_seconds: zones?.['5'] ?? null,
+    meters_per_heartbeat: session.meters_per_heartbeat ?? null,
+  }
+}
+
+/**
+ * Translate a validated trend row into the legacy
+ * {@link CardioTimePoint} shape. The DB row already matches the
+ * legacy shape (`{ date, value }`), so this is a typed pass-through —
+ * present mostly for symmetry with `sessionRowToCardioSession` and to
+ * give the data layer a single import surface.
+ */
+export function trendRowToTimePoint(row: CardioTrendRow): CardioTimePoint {
+  return { date: row.date, value: row.value }
+}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint",
     "format": "prettier --write \"**/*.{ts,tsx}\"",
     "import-health": "node scripts/import-health.mjs",
+    "cardio:backfill": "node scripts/backfill-cardio.mjs",
     "e2e:dev": "cross-env NEXT_DIST_DIR=.next-e2e-default NEXT_PUBLIC_ENABLE_TRAINING_FACILITY=false next dev --turbopack --hostname 127.0.0.1 --port 3007",
     "e2e:dev:training-facility": "cross-env NEXT_DIST_DIR=.next-e2e-training-facility NEXT_PUBLIC_ENABLE_TRAINING_FACILITY=true next dev --turbopack --hostname 127.0.0.1 --port 3008",
     "test": "vitest run",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -4,32 +4,50 @@
 
 `npm run import-health -- path/to/export.zip`
 
-Reads an Apple Health `export.zip` (the file you get from Health → Profile → Export All Health Data on iOS) and writes `public/data/cardio.json` — the dataset the Gym detail views consume via `getCardioData()` (`lib/data/cardio.ts`).
+Reads an Apple Health `export.zip` (the file you get from Health → Profile → Export All Health Data on iOS) and writes the cardio data into Supabase — the dataset the Gym detail views consume via `getCardioData()` (`lib/data/cardio.ts`).
 
-The wrapper does two things:
+The wrapper does three things:
 
-1. Spawns `python scripts/preprocess-health.py <export.zip> public/data/cardio.json` to produce the JSON.
+1. Spawns `python scripts/preprocess-health.py <export.zip> public/data/cardio.json` to produce an intermediate JSON file.
 2. Validates the result against a Zod mirror of `CardioData` (`types/cardio.ts`) so any drift between the Python script and the TypeScript type fails loudly here, not at runtime in the dashboard.
+3. Upserts every session, resting-HR point, and VO2max point into the three `cardio_*` Supabase tables via the service-role key. Idempotent — re-running the import after a fresh Apple Health export overwrites the same primary keys (`started_at` for sessions, `date` for trends) instead of duplicating rows.
 
 ### Optional flags
 
 - `--max-hr=185` — your max heart rate (BPM), used to bucket samples into the five Z1–Z5 zones. Defaults to 185 (matches `DEFAULT_MAX_HR` in `constants/hr-zones.ts`). Pass a measured max from a treadmill test if you have one.
+- `--from-json=<path>` — skip the Python preprocess and re-upsert from an already-produced JSON file. Useful for retrying just the Supabase write after a transient connection failure.
 
-### What lands in `cardio.json`
+### Required env vars
 
-Just the three things `CardioData` defines:
+The script reads the same Supabase env vars as the rest of the app (`.env.local`, see `.env.example`):
 
-- `sessions` — stair / running / walking workouts with avg HR, max HR, time-in-zone breakdown, and cardiac efficiency aggregated from the raw HR sample stream
-- `resting_hr_trend` — one point per measurement
-- `vo2max_trend` — one point per measurement
+- `NEXT_PUBLIC_SUPABASE_URL`
+- `SUPABASE_SERVICE_ROLE_KEY` — service-role key. **Server/local only.** Never check it in.
+
+### What lands in Supabase
+
+Three tables (PRD §7.4, migration in `supabase/migrations/20260430120000_cardio_tables.sql`):
+
+- `cardio_sessions` — stair / running / walking workouts with avg HR, max HR, time-in-zone breakdown (5 explicit columns), and cardiac efficiency aggregated from the raw HR sample stream.
+- `cardio_resting_hr` — one row per measurement day.
+- `cardio_vo2max` — one row per measurement day.
 
 Everything else from the Apple Health export (HRV, walking HR average, body mass, step counts, sleep, active energy, plus non-tracked workout types like cycling and rowing) is dropped. Bring fields back when a chart consumes them.
 
 ### Privacy
 
-`public/data/cardio.json` is **gitignored** because Apple Health exports include personal medical metrics. The empty `public/data/.gitkeep` keeps the directory in the repo without committing the data. Re-run the import on each deploy (or commit a sanitized fixture for previews if you want one).
+The intermediate `public/data/cardio.json` is **gitignored** because Apple Health exports include personal medical metrics. Supabase rows are also private — RLS on `cardio_*` tables allows `select` from `anon`/`authenticated` for the read path, but the actual data is whatever the dev machine pushed up. Re-run the import after a fresh export to keep the dashboard current.
 
 ### Requirements
 
 - Python 3.9+ on `PATH` (override with `PYTHON=…` if needed)
-- The repo's `node_modules` (zod is used by the validator)
+- The repo's `node_modules` (zod + `@supabase/supabase-js`)
+- `.env.local` populated with the Supabase service-role credentials
+
+## `cardio:backfill`
+
+`npm run cardio:backfill`
+
+One-shot importer for the legacy `public/data/cardio.json` from the pre-Supabase architecture. Reads the JSON sitting at `public/data/cardio.json` (or a custom path: `npm run cardio:backfill -- ./fixtures/cardio.json`), validates it against the same `CardioData` schema as `import-health`, and upserts every row into Supabase.
+
+Idempotent (same upsert path as `import-health`), so re-running is harmless. After the backfill succeeds the JSON can be left on disk as a debug artifact or deleted — Supabase is now the source of truth.

--- a/scripts/backfill-cardio.mjs
+++ b/scripts/backfill-cardio.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+/**
+ * `npm run cardio:backfill` — one-shot import of the legacy
+ * `public/data/cardio.json` into Supabase (#152).
+ *
+ * The cardio dashboard previously read a static JSON file produced by
+ * the Apple Health preprocessor. After #152 the source of truth moves
+ * to Supabase; this script seeds the new tables from whatever JSON is
+ * sitting on disk so existing local data doesn't have to be re-derived
+ * from a fresh Apple Health export.
+ *
+ * Idempotent — uses the same upsert helpers as `import-health.mjs`,
+ * so re-running is harmless.
+ *
+ * Usage:
+ *   npm run cardio:backfill
+ *   npm run cardio:backfill -- ./path/to/cardio.json   (override path)
+ *
+ * Exits non-zero on any failure (missing file, schema mismatch,
+ * Supabase error). After the backfill succeeds the JSON file can be
+ * left in place as a debug artifact (it stays gitignored) or deleted.
+ */
+
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+
+import {
+  CardioDataSchema,
+  createServiceRoleClient,
+  loadEnv,
+  upsertCardioData,
+} from './lib/cardio-supabase.mjs'
+
+const DEFAULT_JSON_PATH = path.join('public', 'data', 'cardio.json')
+
+async function main() {
+  const argv = process.argv.slice(2)
+  const jsonPath = argv[0] ?? DEFAULT_JSON_PATH
+
+  loadEnv()
+  const supabase = createServiceRoleClient()
+
+  console.log(`  Reading ${jsonPath}...`)
+  const raw = await readFile(jsonPath, 'utf8')
+  const parsed = JSON.parse(raw)
+  const result = CardioDataSchema.safeParse(parsed)
+  if (!result.success) {
+    console.error('\n✗ Backfill source failed CardioData validation:')
+    for (const issue of result.error.issues) {
+      console.error(`  - ${issue.path.join('.') || '<root>'}: ${issue.message}`)
+    }
+    throw new Error('Schema mismatch — fix the JSON or re-run the import to regenerate it.')
+  }
+
+  const counts = await upsertCardioData(supabase, result.data)
+  console.log(
+    `✓ Backfilled to Supabase: ${counts.sessions} sessions, ` +
+      `${counts.restingHr} resting-HR points, ${counts.vo2max} VO2max points.`,
+  )
+}
+
+main().catch((err) => {
+  console.error(err.message ?? err)
+  process.exit(1)
+})

--- a/scripts/import-health.mjs
+++ b/scripts/import-health.mjs
@@ -1,73 +1,41 @@
 #!/usr/bin/env node
 /**
- * `npm run import-health -- <export.zip>` wrapper around
- * `scripts/preprocess-health.py` (PRD §7.3).
+ * `npm run import-health -- <export.zip>` — Apple Health → Supabase
+ * cardio pipeline (PRD §7.3, #152).
  *
- * 1. Spawns Python to read the Apple Health export and emit
- *    `public/data/cardio.json`.
- * 2. Validates the emitted JSON against a Zod mirror of `CardioData`
- *    (`types/cardio.ts`). Drift between the Python output shape and
- *    the TypeScript type fails loudly here instead of silently
- *    breaking the dashboard at runtime.
+ * 1. Spawns Python (`scripts/preprocess-health.py`) to read the Apple
+ *    Health export and emit an intermediate JSON file
+ *    (`public/data/cardio.json`, gitignored).
+ * 2. Validates the JSON against a Zod mirror of `CardioData`. Drift
+ *    between the Python output shape and the TypeScript type fails
+ *    loudly here instead of silently breaking the dashboard at runtime.
+ * 3. Upserts every session, resting-HR point, and VO2max point into
+ *    Supabase via the service-role key. Idempotent — re-running after
+ *    a fresh Apple Health export overwrites the same primary keys
+ *    rather than duplicating rows.
  *
  * Exits non-zero on any failure (Python error, missing file, schema
- * mismatch). Stdout/stderr from Python is forwarded to the user so
- * they see the parse log.
+ * mismatch, Supabase error). Stdout/stderr from Python is forwarded
+ * to the user so they see the parse log.
+ *
+ * Skip the Python step (re-upsert from an already-produced JSON) with
+ * `--from-json=<path>` — useful for retrying just the Supabase write
+ * after a transient connection failure.
  */
 
 import { spawn } from 'node:child_process'
 import { readFile } from 'node:fs/promises'
 import path from 'node:path'
-import { z } from 'zod'
+
+import {
+  CardioDataSchema,
+  createServiceRoleClient,
+  loadEnv,
+  upsertCardioData,
+} from './lib/cardio-supabase.mjs'
 
 const PYTHON_SCRIPT = path.join('scripts', 'preprocess-health.py')
-const OUTPUT_PATH = path.join('public', 'data', 'cardio.json')
-
-/**
- * Zod mirror of `CardioData` from `types/cardio.ts`. Kept in sync
- * manually — when the TS type changes, update this and the Python
- * script. The wrapper's whole reason to exist is to catch the case
- * where you forgot one of the two.
- */
-const HrZoneSecondsSchema = z
-  .object({
-    '1': z.number().nonnegative(),
-    '2': z.number().nonnegative(),
-    '3': z.number().nonnegative(),
-    '4': z.number().nonnegative(),
-    '5': z.number().nonnegative(),
-  })
-  .strict()
-
-const CardioSessionSchema = z
-  .object({
-    date: z.string().min(1),
-    activity: z.enum(['stair', 'running', 'walking']),
-    duration_seconds: z.number().nonnegative(),
-    distance_meters: z.number().nonnegative().nullable().optional(),
-    avg_hr: z.number().nonnegative().nullable().optional(),
-    max_hr: z.number().nonnegative().nullable().optional(),
-    pace_seconds_per_km: z.number().nonnegative().nullable().optional(),
-    hr_seconds_in_zone: HrZoneSecondsSchema.nullable().optional(),
-    meters_per_heartbeat: z.number().nonnegative().nullable().optional(),
-  })
-  .strict()
-
-const CardioTimePointSchema = z
-  .object({
-    date: z.string().min(1),
-    value: z.number(),
-  })
-  .strict()
-
-const CardioDataSchema = z
-  .object({
-    imported_at: z.string().min(1),
-    sessions: z.array(CardioSessionSchema),
-    resting_hr_trend: z.array(CardioTimePointSchema),
-    vo2max_trend: z.array(CardioTimePointSchema),
-  })
-  .strict()
+const DEFAULT_OUTPUT_PATH = path.join('public', 'data', 'cardio.json')
 
 /**
  * Pick the right Python interpreter. `python` is more universal; falls
@@ -78,7 +46,9 @@ function pythonExecutable() {
 }
 
 function usage() {
-  console.error('Usage: npm run import-health -- <export.zip|export.xml> [--max-hr=185]')
+  console.error(
+    'Usage: npm run import-health -- <export.zip|export.xml> [--max-hr=185] [--from-json=<path>]',
+  )
   process.exit(1)
 }
 
@@ -93,8 +63,8 @@ async function runPython(args) {
   })
 }
 
-async function validateOutput() {
-  const raw = await readFile(OUTPUT_PATH, 'utf8')
+async function validateJson(jsonPath) {
+  const raw = await readFile(jsonPath, 'utf8')
   const parsed = JSON.parse(raw)
   const result = CardioDataSchema.safeParse(parsed)
   if (!result.success) {
@@ -111,12 +81,34 @@ async function main() {
   const argv = process.argv.slice(2)
   if (argv.length === 0) usage()
 
-  await runPython([argv[0], OUTPUT_PATH, ...argv.slice(1)])
-  const data = await validateOutput()
+  let fromJson
+  const passthrough = []
+  for (const arg of argv) {
+    if (arg.startsWith('--from-json=')) {
+      fromJson = arg.slice('--from-json='.length)
+    } else {
+      passthrough.push(arg)
+    }
+  }
+
+  loadEnv()
+  const supabase = createServiceRoleClient()
+
+  let jsonPath
+  if (fromJson) {
+    jsonPath = fromJson
+    console.log(`  Skipping Python preprocess; reading ${jsonPath}`)
+  } else {
+    if (passthrough.length === 0) usage()
+    jsonPath = DEFAULT_OUTPUT_PATH
+    await runPython([passthrough[0], jsonPath, ...passthrough.slice(1)])
+  }
+
+  const data = await validateJson(jsonPath)
+  const counts = await upsertCardioData(supabase, data)
   console.log(
-    `✓ ${OUTPUT_PATH} validates as CardioData ` +
-      `(${data.sessions.length} sessions, ${data.resting_hr_trend.length} resting-HR points, ` +
-      `${data.vo2max_trend.length} VO2max points).`,
+    `✓ Upserted to Supabase: ${counts.sessions} sessions, ` +
+      `${counts.restingHr} resting-HR points, ${counts.vo2max} VO2max points.`,
   )
 }
 

--- a/scripts/lib/cardio-supabase.mjs
+++ b/scripts/lib/cardio-supabase.mjs
@@ -1,0 +1,191 @@
+/**
+ * Shared Supabase write helpers for cardio import scripts (#152).
+ *
+ * Used by both `scripts/import-health.mjs` (the regular Apple Health
+ * → Supabase pipeline) and `scripts/backfill-cardio.mjs` (the one-shot
+ * legacy `public/data/cardio.json` import). Keeping the upsert logic
+ * here means a future schema tweak only changes one place.
+ *
+ * Loaded as ESM from `.mjs` callers — no TypeScript transpile step.
+ */
+
+import nextEnv from '@next/env'
+import { createClient } from '@supabase/supabase-js'
+import { z } from 'zod'
+
+const { loadEnvConfig } = nextEnv
+
+/**
+ * Load `.env*` files into `process.env` the same way Next.js does
+ * (`.env.local` overrides `.env`, etc.). Call once before reading
+ * `SUPABASE_SERVICE_ROLE_KEY` so the import script picks up local
+ * dev credentials without an extra `dotenv` dependency.
+ */
+export function loadEnv() {
+  loadEnvConfig(process.cwd())
+}
+
+/**
+ * Build a service-role Supabase client. Service-role bypasses RLS, so
+ * this client must NEVER reach the browser — it's only used by the
+ * local import / backfill scripts on the dev machine. The script never
+ * runs in production; the key lives only in `.env.local`.
+ *
+ * @throws Error when `NEXT_PUBLIC_SUPABASE_URL` or
+ *   `SUPABASE_SERVICE_ROLE_KEY` is missing. Both must be set before
+ *   the script runs (see `.env.example`).
+ */
+export function createServiceRoleClient() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL?.trim()
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY?.trim()
+  if (!url) {
+    throw new Error('NEXT_PUBLIC_SUPABASE_URL is not set. Add it to .env.local before running.')
+  }
+  if (!serviceRoleKey) {
+    throw new Error(
+      'SUPABASE_SERVICE_ROLE_KEY is not set. Grab it from Supabase dashboard → Project Settings → API and add to .env.local.',
+    )
+  }
+  return createClient(url, serviceRoleKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  })
+}
+
+/**
+ * Zod schema for the legacy `CardioData` shape (`types/cardio.ts`,
+ * also the on-disk `public/data/cardio.json` shape). Mirrors the
+ * row-shape schemas in `lib/schemas/cardio.ts` but accepts the
+ * legacy nested `hr_seconds_in_zone` map and tolerates `null` on
+ * optional fields (the Python preprocessor emits null for "absent").
+ *
+ * Drift between this and the TypeScript type `CardioData` is the
+ * whole reason the import wrapper exists — a missing field here vs.
+ * `types/cardio.ts` fails loudly at import time instead of silently
+ * breaking the dashboard at runtime.
+ */
+const HrZoneSecondsSchema = z
+  .object({
+    1: z.number().nonnegative(),
+    2: z.number().nonnegative(),
+    3: z.number().nonnegative(),
+    4: z.number().nonnegative(),
+    5: z.number().nonnegative(),
+  })
+  .strict()
+
+const CardioSessionSchema = z
+  .object({
+    date: z.string().min(1),
+    activity: z.enum(['stair', 'running', 'walking']),
+    duration_seconds: z.number().nonnegative(),
+    distance_meters: z.number().nonnegative().nullable().optional(),
+    avg_hr: z.number().nonnegative().nullable().optional(),
+    max_hr: z.number().nonnegative().nullable().optional(),
+    pace_seconds_per_km: z.number().nonnegative().nullable().optional(),
+    hr_seconds_in_zone: HrZoneSecondsSchema.nullable().optional(),
+    meters_per_heartbeat: z.number().nonnegative().nullable().optional(),
+  })
+  .strict()
+
+const CardioTimePointSchema = z
+  .object({
+    date: z.string().min(1),
+    value: z.number(),
+  })
+  .strict()
+
+export const CardioDataSchema = z
+  .object({
+    imported_at: z.string().min(1),
+    sessions: z.array(CardioSessionSchema),
+    resting_hr_trend: z.array(CardioTimePointSchema),
+    vo2max_trend: z.array(CardioTimePointSchema),
+  })
+  .strict()
+
+/**
+ * Translate a legacy `CardioSession` from the JSON shape into the
+ * `cardio_sessions` row payload (snake_case zone columns). Sibling
+ * of `cardioSessionToRow()` in `lib/schemas/cardio.ts`; duplicated
+ * here only because `.mjs` scripts can't import `.ts` modules
+ * directly without a build step.
+ */
+function sessionToRow(session) {
+  const zones = session.hr_seconds_in_zone ?? null
+  return {
+    started_at: session.date,
+    activity: session.activity,
+    duration_seconds: session.duration_seconds,
+    distance_meters: session.distance_meters ?? null,
+    avg_hr: session.avg_hr ?? null,
+    max_hr: session.max_hr ?? null,
+    pace_seconds_per_km: session.pace_seconds_per_km ?? null,
+    zone1_seconds: zones?.[1] ?? null,
+    zone2_seconds: zones?.[2] ?? null,
+    zone3_seconds: zones?.[3] ?? null,
+    zone4_seconds: zones?.[4] ?? null,
+    zone5_seconds: zones?.[5] ?? null,
+    meters_per_heartbeat: session.meters_per_heartbeat ?? null,
+  }
+}
+
+/**
+ * Upsert the entire validated `CardioData` payload into Supabase.
+ * Idempotent — re-running the import after a fresh Apple Health
+ * export overwrites the same primary keys (`started_at` for sessions,
+ * `date` for trends) instead of duplicating rows.
+ *
+ * Trend rows also get an explicit `updated_at = now()` so re-importing
+ * the same day's resting-HR after a HealthKit correction reflects the
+ * change in the audit column.
+ *
+ * @param {ReturnType<createServiceRoleClient>} supabase Service-role
+ *   client; must bypass RLS to write.
+ * @param {z.infer<typeof CardioDataSchema>} data Validated payload.
+ * @returns {Promise<{ sessions: number, restingHr: number, vo2max: number }>}
+ *   Per-table row counts, surfaced in the script's success log.
+ */
+export async function upsertCardioData(supabase, data) {
+  const sessionRows = data.sessions.map(sessionToRow)
+  const restingRows = data.resting_hr_trend.map((point) => ({
+    date: point.date,
+    value: point.value,
+    updated_at: new Date().toISOString(),
+  }))
+  const vo2Rows = data.vo2max_trend.map((point) => ({
+    date: point.date,
+    value: point.value,
+    updated_at: new Date().toISOString(),
+  }))
+
+  if (sessionRows.length > 0) {
+    const { error } = await supabase
+      .from('cardio_sessions')
+      .upsert(sessionRows, { onConflict: 'started_at' })
+    if (error) {
+      throw new Error(`Failed to upsert cardio_sessions: ${error.message}`)
+    }
+  }
+  if (restingRows.length > 0) {
+    const { error } = await supabase
+      .from('cardio_resting_hr')
+      .upsert(restingRows, { onConflict: 'date' })
+    if (error) {
+      throw new Error(`Failed to upsert cardio_resting_hr: ${error.message}`)
+    }
+  }
+  if (vo2Rows.length > 0) {
+    const { error } = await supabase
+      .from('cardio_vo2max')
+      .upsert(vo2Rows, { onConflict: 'date' })
+    if (error) {
+      throw new Error(`Failed to upsert cardio_vo2max: ${error.message}`)
+    }
+  }
+
+  return {
+    sessions: sessionRows.length,
+    restingHr: restingRows.length,
+    vo2max: vo2Rows.length,
+  }
+}

--- a/supabase/migrations/20260430120000_cardio_tables.sql
+++ b/supabase/migrations/20260430120000_cardio_tables.sql
@@ -1,0 +1,89 @@
+-- Cardio data tables (PRD §7.4) — Supabase migration of cardio.json (#152, builds on #131).
+--
+-- Three tables mirror the three top-level arrays in the legacy `CardioData`
+-- shape (`types/cardio.ts`):
+--   * cardio_sessions   — one row per workout (stair/running/walking)
+--   * cardio_resting_hr — one row per measurement day (resting-HR trend)
+--   * cardio_vo2max     — one row per measurement day (VO2max trend)
+--
+-- Granularity: session-level only. Per-second HR samples stay in HealthKit
+-- as the system of record. HR-zone seconds are stored as 5 explicit
+-- columns on cardio_sessions (zone1_seconds … zone5_seconds) so a future
+-- "time in Z3 over months" chart can query them without unpacking JSONB.
+--
+-- RLS mirrors movement_benchmarks: anon + authenticated SELECT only.
+-- Writes go through the service-role key (the import script runs locally
+-- with SUPABASE_SERVICE_ROLE_KEY and bypasses RLS); no write API routes
+-- exist for cardio because PRD §7.11 keeps cardio entries non-editable
+-- from the UI — fix in HealthKit and re-import.
+--
+-- This file is the canonical record of the migration; it has already been
+-- applied to the `court-vision` Supabase project (`ryxbnvhxxkrmsrmocume`).
+
+create table public.cardio_sessions (
+  started_at timestamptz primary key,
+  activity text not null check (activity in ('stair', 'running', 'walking')),
+  duration_seconds numeric not null check (duration_seconds >= 0),
+  distance_meters numeric check (distance_meters is null or distance_meters >= 0),
+  avg_hr numeric check (avg_hr is null or avg_hr >= 0),
+  max_hr numeric check (max_hr is null or max_hr >= 0),
+  pace_seconds_per_km numeric check (pace_seconds_per_km is null or pace_seconds_per_km >= 0),
+  zone1_seconds numeric check (zone1_seconds is null or zone1_seconds >= 0),
+  zone2_seconds numeric check (zone2_seconds is null or zone2_seconds >= 0),
+  zone3_seconds numeric check (zone3_seconds is null or zone3_seconds >= 0),
+  zone4_seconds numeric check (zone4_seconds is null or zone4_seconds >= 0),
+  zone5_seconds numeric check (zone5_seconds is null or zone5_seconds >= 0),
+  meters_per_heartbeat numeric check (meters_per_heartbeat is null or meters_per_heartbeat >= 0),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+comment on table public.cardio_sessions is
+  'Cardio workout sessions (stair / running / walking) — PRD §7.4. One row per session, keyed by started_at. HR-zone seconds stored as five explicit columns so individual zones are queryable without JSONB unpacking. Writes happen via the import script (service-role) — no admin write API.';
+
+create index cardio_sessions_activity_started_at_idx
+  on public.cardio_sessions (activity, started_at desc);
+
+alter table public.cardio_sessions enable row level security;
+
+create policy "anon and authenticated can read cardio sessions"
+  on public.cardio_sessions
+  for select
+  to anon, authenticated
+  using (true);
+
+create table public.cardio_resting_hr (
+  date date primary key,
+  value numeric not null check (value > 0),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+comment on table public.cardio_resting_hr is
+  'Resting heart-rate trend (PRD §7.4). One row per calendar day; primary key is the calendar date so re-imports overwrite the same day''s value rather than duplicate it.';
+
+alter table public.cardio_resting_hr enable row level security;
+
+create policy "anon and authenticated can read resting hr"
+  on public.cardio_resting_hr
+  for select
+  to anon, authenticated
+  using (true);
+
+create table public.cardio_vo2max (
+  date date primary key,
+  value numeric not null check (value > 0),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+comment on table public.cardio_vo2max is
+  'VO2max trend (PRD §7.4). One row per measurement day; primary key is the calendar date.';
+
+alter table public.cardio_vo2max enable row level security;
+
+create policy "anon and authenticated can read vo2max"
+  on public.cardio_vo2max
+  for select
+  to anon, authenticated
+  using (true);


### PR DESCRIPTION
## Summary

Cardio reads now hit three Supabase tables (`cardio_sessions`, `cardio_resting_hr`, `cardio_vo2max`) instead of the static `public/data/cardio.json` the Python preprocessor used to write directly. The legacy `CardioData` shape is preserved on the read side, so the Trading Card, Stair / Treadmill / Track detail views, and overview stats wall render unchanged.

## Schema choices

- **3 tables** matching the 3 sections of `CardioData`. HR-zone seconds are 5 explicit columns on `cardio_sessions` (`zone1_seconds` … `zone5_seconds`) so a "time in Z3 over months" query stays a plain `select`.
- **Session-level granularity only.** Per-second HR samples stay in HealthKit as the system of record. Per-minute aggregates are deferred until a chart consumes them.
- **No `/api/admin/cardio` routes.** PRD §7.11 keeps cardio entries non-editable from the UI (fix in HealthKit, re-import). Writes go via the import script using `SUPABASE_SERVICE_ROLE_KEY` locally.

## What changed

- **DB:** new `cardio_sessions`, `cardio_resting_hr`, `cardio_vo2max` tables on the `court-vision` Supabase project (`ryxbnvhxxkrmsrmocume`). RLS allows anon/authenticated SELECT; writes only via service-role. Migration SQL checked in at `supabase/migrations/20260430120000_cardio_tables.sql` and already applied to the live DB.
- **Schemas:** `lib/schemas/cardio.ts` is the single source of truth for the row shape + bidirectional transforms (legacy nested `hr_seconds_in_zone` ↔ 5 explicit columns).
- **Data layer:** `lib/data/cardio.ts` queries all three tables in parallel via the browser Supabase client, validates each through the row schemas, and assembles the legacy `CardioData` shape. Preserves the pre-Supabase `null`-on-empty contract (detail views already substitute an empty-state fallback).
- **Import script:** `scripts/import-health.mjs` still spawns Python for parsing, then upserts the validated JSON into Supabase via service-role. Idempotent — re-running after a fresh export overwrites the same primary keys (`started_at` for sessions, `date` for trends).
- **Backfill script:** new `npm run cardio:backfill` does a one-shot import of an existing `public/data/cardio.json` into Supabase.
- **Docs:** PRD §7.11 amended to reflect Supabase as cardio source-of-truth.

## Required env vars

Same Supabase env as #131 (already documented in `.env.example`):

```
NEXT_PUBLIC_SUPABASE_URL=...
NEXT_PUBLIC_SUPABASE_ANON_KEY=...
SUPABASE_SERVICE_ROLE_KEY=...   # local-only, for the import script
```

## ⚠️ Dependency

Built on top of #144 (Supabase admin writes — issue #131). PR base is `feat/131-supabase-admin-writes`, **not** `main`. Merge #144 first; rebase this branch onto main afterwards (one cardio commit lands cleanly).

## Test plan

- [ ] Verify the migration applied: `select count(*) from public.cardio_sessions, public.cardio_resting_hr, public.cardio_vo2max` returns 11 / 7 / 4 (matches the legacy `cardio.json`).
- [ ] Vercel preview: visit `/training-facility/gym/stair` — HR-zone bars + per-session avg-HR bars render with the seeded data.
- [ ] Vercel preview: visit `/training-facility/gym/treadmill` — running sessions show distance + pace.
- [ ] DevTools network tab: confirm calls to `*.supabase.co/rest/v1/cardio_*` succeed; no `/data/cardio.json` fetch.
- [ ] Local: `SUPABASE_SERVICE_ROLE_KEY=<key> npm run cardio:backfill` is a no-op on a populated DB (idempotency).
- [ ] Local: `npm run import-health -- /path/to/health-export.zip` runs Python, validates the JSON, and upserts to Supabase end-to-end.
- [ ] `npx tsc --noEmit` clean.
- [ ] `npm test` — 345 unit tests pass.
- [ ] `npx next build` — all 23 routes compile.

## Out of scope

- Per-second HR samples in Supabase (deferred — keep aggregated only)
- Editing cardio entries in the UI (PRD §7.11 — fix in HealthKit, re-import)
- Multi-tenant cardio (PRD §7.12 stage 3)
- Real-time sync from HealthKit (manual export → import workflow stays)

Closes #152.