### PR TITLE
fix(cardio): prune by updated_at instead of PK set diff (#158)

### DIFF
--- a/scripts/lib/cardio-supabase.mjs
+++ b/scripts/lib/cardio-supabase.mjs
@@ -143,8 +143,8 @@ function sessionToRow(session, importedAt) {
 
 /**
  * Upsert the entire validated `CardioData` payload into Supabase, then
- * delete any rows whose primary key isn't in the payload — making each
- * import an exact mirror of the source dataset, not a cumulative
+ * delete any row whose `updated_at` is older than this batch — making
+ * each import an exact mirror of the source dataset, not a cumulative
  * append.
  *
  * Why prune: the documented workflow is "fix in HealthKit, re-import."
@@ -154,11 +154,13 @@ function sessionToRow(session, importedAt) {
  * "Export All Health Data" produces the full archive, so the import
  * payload is authoritative — pruning is the right default.
  *
- * Idempotent — re-running on the same payload is a series of
- * no-op upserts (which still bump `updated_at`) and zero deletes.
- * `updated_at = importedAt` is stamped on every upserted row so the
- * data layer's `imported_at` computation (MAX(updated_at) across the
- * three tables) advances on every re-import even when nothing changed.
+ * Idempotent — re-running on the same payload is a series of no-op
+ * upserts (which still bump `updated_at` to the new batch timestamp)
+ * and zero deletes (every row's `updated_at` matches the batch, so
+ * `lt('updated_at', importedAt)` returns nothing). `updated_at =
+ * importedAt` is stamped on every upserted row so the data layer's
+ * `imported_at` computation (MAX(updated_at) across the three tables)
+ * advances on every re-import even when nothing changed.
  *
  * @param {ReturnType<createServiceRoleClient>} supabase Service-role
  *   client; must bypass RLS to write.
@@ -220,23 +222,23 @@ export async function upsertCardioData(supabase, data) {
     }
   }
 
-  const sessionsPruned = await pruneOrphans(
+  const sessionsPruned = await pruneStaleRows(
     supabase,
     'cardio_sessions',
-    'started_at',
-    sessionRows.map((r) => r.started_at),
+    importedAt,
+    sessionRows.length > 0,
   )
-  const restingPruned = await pruneOrphans(
+  const restingPruned = await pruneStaleRows(
     supabase,
     'cardio_resting_hr',
-    'date',
-    restingRows.map((r) => r.date),
+    importedAt,
+    restingRows.length > 0,
   )
-  const vo2Pruned = await pruneOrphans(
+  const vo2Pruned = await pruneStaleRows(
     supabase,
     'cardio_vo2max',
-    'date',
-    vo2Rows.map((r) => r.date),
+    importedAt,
+    vo2Rows.length > 0,
   )
 
   return {
@@ -248,90 +250,55 @@ export async function upsertCardioData(supabase, data) {
 }
 
 /**
- * PostgREST default cap: a plain `select()` returns at most this many
- * rows, regardless of how many exist. Configurable per-project via
- * `db-max-rows`; we don't change the default. {@link pruneOrphans}
- * paginates with `.range()` to cover tables that grow past this limit.
- */
-const DEFAULT_PAGE_SIZE = 1000
-
-/**
- * Delete rows from `table` whose primary-key value isn't in the
- * caller-supplied `keepKeys` set. The "exact mirror" half of
- * {@link upsertCardioData} — without this, a workout deleted from
- * HealthKit and re-imported would leave a stale Supabase row that the
- * dashboard would keep rendering.
+ * Delete rows from `table` whose `updated_at` is older than this batch's
+ * `importedAt`. The "exact mirror" half of {@link upsertCardioData} —
+ * without this, a workout deleted from HealthKit and re-imported would
+ * leave a stale Supabase row that the dashboard would keep rendering.
  *
- * **Empty-payload guard.** When `keepKeys` is `[]`, this function is a
- * no-op (returns 0 without touching the DB). An import that happens to
- * have zero rows for one table is interpreted as "this import has no
- * opinion on that table," not "delete everything in it" — that
- * protects against parser bugs, partial Apple Health exports, and
- * mis-typed inputs from silently wiping the dataset. If you genuinely
- * want to empty a table, do it with a manual SQL `delete`.
+ * Why timestamp-based instead of PK-set diff (the original #152
+ * implementation): the PK-set approach compared source PK strings
+ * against PostgREST's normalized output, which fails when the source
+ * emits a date-only string for a `timestamptz` PK. Postgres normalizes
+ * `"2026-02-08"` to `"2026-02-08T00:00:00+00:00"`, so the keep set
+ * `{"2026-02-08"}` and the existing set `{"2026-02-08T00:00:00+00:00"}`
+ * never overlap, every row is misclassified as an orphan, and the
+ * table is wiped on the first import. See #158 for the full repro.
  *
- * Implementation note: PostgREST doesn't expose a clean `NOT IN` for
- * large lists, so we fetch all existing PKs and DELETE the ones missing
- * from the import. PostgREST caps a plain `select()` at 1000 rows
- * (`db-max-rows`), so the scan paginates with `.range()` until a short
- * page comes back — otherwise orphans past row 1000 would silently
- * survive. With a v2 multi-tenant rewrite this would become a
- * server-side `delete from ... where pk not in (...)` instead.
+ * Since `upsertCardioData` stamps `updated_at = importedAt` on every
+ * upserted row in this batch, anything left with `updated_at <
+ * importedAt` is by definition not in the source. One DELETE,
+ * server-side `timestamptz < timestamptz` comparison — no SELECT, no
+ * pagination, no PK-format gotchas, no 1000-row cap.
+ *
+ * **Empty-payload guard.** When `hadAnyUpserts` is `false`, this is a
+ * no-op (returns 0 without touching the DB). An import with no rows
+ * for a table is interpreted as "this import has no opinion on that
+ * table," not "delete everything in it" — protects parser bugs,
+ * partial Apple Health exports, and mis-typed inputs from silently
+ * wiping the dataset. To genuinely empty a table, use manual SQL.
  *
  * Returns the number of rows deleted so the caller can surface
  * surprising prunes in the success log.
  *
  * Exported so unit tests can pin the empty-payload guard, the
- * pagination loop, and the orphan-detection logic; production callers
+ * timestamp comparison, and the failure paths; production callers
  * should use {@link upsertCardioData}.
  *
- * @param {number} [pageSize] Override the page size used for the PK
- *   scan. Defaults to {@link DEFAULT_PAGE_SIZE}; tests pass small
- *   values to exercise the pagination loop without enormous fixtures.
+ * @param {string} importedAt ISO 8601 batch timestamp; every row
+ *   upserted in this batch has `updated_at = importedAt`, so the strict
+ *   `<` keeps them and removes only earlier-batch rows.
+ * @param {boolean} hadAnyUpserts True iff at least one row was
+ *   upserted into `table` in this batch. When false the prune is
+ *   skipped entirely (see Empty-payload guard above).
  */
-export async function pruneOrphans(
-  supabase,
-  table,
-  pkColumn,
-  keepKeys,
-  pageSize = DEFAULT_PAGE_SIZE,
-) {
-  if (keepKeys.length === 0) return 0
-  if (!Number.isInteger(pageSize) || pageSize < 1) {
-    // The loop advances `from` by `pageSize` each iteration; a value of
-    // 0 or negative would never make progress and an infinite loop in
-    // an import script means a wedged terminal at best, a runaway
-    // Supabase bill at worst. Fail loud instead of degrading silently.
-    throw new Error(`pageSize must be a positive integer; got ${pageSize}.`)
-  }
-
-  const existing = []
-  for (let from = 0; ; from += pageSize) {
-    const { data, error } = await supabase
-      .from(table)
-      .select(pkColumn)
-      .range(from, from + pageSize - 1)
-    if (error) {
-      throw new Error(`Failed to scan ${table} for orphans: ${error.message}`)
-    }
-    const page = data ?? []
-    if (page.length === 0) break
-    existing.push(...page)
-    // A short page means we've drained the table — no more rows past
-    // this point. Stops one round-trip earlier than waiting for an
-    // empty page to come back.
-    if (page.length < pageSize) break
-  }
-
-  const keep = new Set(keepKeys)
-  const orphans = existing.map((row) => row[pkColumn]).filter((key) => !keep.has(key))
-  if (orphans.length === 0) return 0
-  const { error: deleteErr } = await supabase
+export async function pruneStaleRows(supabase, table, importedAt, hadAnyUpserts) {
+  if (!hadAnyUpserts) return 0
+  const { error, count } = await supabase
     .from(table)
-    .delete()
-    .in(pkColumn, orphans)
-  if (deleteErr) {
-    throw new Error(`Failed to prune orphans from ${table}: ${deleteErr.message}`)
+    .delete({ count: 'exact' })
+    .lt('updated_at', importedAt)
+  if (error) {
+    throw new Error(`Failed to prune stale rows from ${table}: ${error.message}`)
   }
-  return orphans.length
+  return count ?? 0
 }

--- a/scripts/lib/cardio-supabase.mjs
+++ b/scripts/lib/cardio-supabase.mjs
@@ -143,16 +143,24 @@ function sessionToRow(session, importedAt) {
 
 /**
  * Upsert the entire validated `CardioData` payload into Supabase, then
- * delete any row whose `updated_at` is older than this batch — making
- * each import an exact mirror of the source dataset, not a cumulative
- * append.
+ * delete any row whose `updated_at` is older than this batch — for any
+ * table that received at least one upsert. Each import is an exact
+ * mirror of the source dataset *for the tables it touches*, not a
+ * cumulative append; tables for which the batch had zero rows are left
+ * alone (see {@link pruneStaleRows}'s empty-payload guard).
  *
  * Why prune: the documented workflow is "fix in HealthKit, re-import."
  * Without a prune step, deleting a workout in HealthKit (or having a
  * trend day disappear from the export) would leave stale rows in
  * Supabase that the dashboard would keep rendering. The Apple Health
- * "Export All Health Data" produces the full archive, so the import
- * payload is authoritative — pruning is the right default.
+ * "Export All Health Data" produces the full archive, so a non-empty
+ * payload is authoritative for that table — pruning is the right default.
+ *
+ * Caveat for partial payloads: a batch that includes *some* rows for
+ * a table makes the batch authoritative for that table — rows that
+ * exist in Supabase but aren't in the batch will be deleted. Don't
+ * pass a deliberately-truncated payload (e.g. "just the last 30 days")
+ * unless you want everything older removed.
  *
  * Idempotent — re-running on the same payload is a series of no-op
  * upserts (which still bump `updated_at` to the new batch timestamp)
@@ -274,8 +282,12 @@ export async function upsertCardioData(supabase, data) {
  * no-op (returns 0 without touching the DB). An import with no rows
  * for a table is interpreted as "this import has no opinion on that
  * table," not "delete everything in it" — protects parser bugs,
- * partial Apple Health exports, and mis-typed inputs from silently
- * wiping the dataset. To genuinely empty a table, use manual SQL.
+ * empty-table payloads, and mis-typed inputs from silently wiping
+ * the dataset. Note this does *not* protect partial-but-non-empty
+ * payloads: if `hadAnyUpserts` is true and the batch contains, say,
+ * 5 of the 100 sessions actually in HealthKit, the other 95 will be
+ * pruned. Pass full-archive payloads only. To genuinely empty a
+ * table, use manual SQL.
  *
  * Returns the number of rows deleted so the caller can surface
  * surprising prunes in the success log.

--- a/scripts/lib/cardio-supabase.test.ts
+++ b/scripts/lib/cardio-supabase.test.ts
@@ -2,204 +2,123 @@ import { describe, it, expect, vi } from 'vitest'
 
 // Vitest happily resolves `.mjs` from a `.ts` test file. Public surface is
 // minimal — only the helpers exported for cross-module use are reachable.
-import { pruneOrphans } from './cardio-supabase.mjs'
+import { pruneStaleRows } from './cardio-supabase.mjs'
 
 /**
- * Tests for the orphan-prune helper that backs the "exact mirror"
- * import semantics introduced in #152. The real script integrates this
- * with `upsertCardioData`; these tests pin the empty-payload guard,
- * the PostgREST pagination loop, and the SELECT/DELETE wiring so a
- * future refactor can't silently turn a partial-export into a table
- * wipe — or miss orphans past PostgREST's default 1000-row cap.
+ * Tests for the stale-row prune helper that backs the "exact mirror"
+ * import semantics introduced in #152 and corrected in #158. The real
+ * script integrates this with `upsertCardioData`; these tests pin the
+ * empty-payload guard, the timestamp-based DELETE wiring, and the
+ * failure path so a future refactor can't reintroduce the PK-string
+ * comparison bug or silently turn a partial-export into a table wipe.
+ *
+ * Regression guard: the original `pruneOrphans` (replaced by
+ * `pruneStaleRows`) compared source PK strings against PostgREST's
+ * normalized output, which fails the moment Postgres normalizes the
+ * source value (`"2026-02-08"` → `"2026-02-08T00:00:00+00:00"`). The
+ * new strategy never does string-PK comparison, so the bug class is
+ * structurally impossible to recreate without redesigning the helper.
  */
 
 interface FakeSupabase {
   from: ReturnType<typeof vi.fn>
 }
 
-interface SelectResult {
-  data: Array<Record<string, unknown>> | null
-  error: unknown
-}
-
 /**
- * Build a chainable Supabase test double for the `from(table).select(col).range(from, to)`
- * call shape. `selectPages` is consumed in order — each entry returned
- * for one `.range()` call, so callers can simulate paginated results
- * by passing multiple pages.
+ * Build a chainable Supabase test double for the
+ * `from(table).delete({ count: 'exact' }).lt('updated_at', importedAt)`
+ * call shape. `deleteResult` is what the awaited `.lt(...)` resolves
+ * to — `{ data, error, count }` per the real Supabase response.
  */
 function makeFakeSupabase(opts: {
-  selectPages?: SelectResult[]
-  deleteResult?: { error: unknown }
+  deleteResult?: { error: unknown; count?: number | null }
 }): {
   supabase: FakeSupabase
-  rangeMock: ReturnType<typeof vi.fn>
-  selectMock: ReturnType<typeof vi.fn>
-  deleteMock: ReturnType<typeof vi.fn>
-  deleteIn: ReturnType<typeof vi.fn>
+  deleteFactory: ReturnType<typeof vi.fn>
+  ltMock: ReturnType<typeof vi.fn>
 } {
-  const pages = opts.selectPages ?? [{ data: [], error: null }]
-  const deleteResult = opts.deleteResult ?? { error: null }
-
-  let pageIdx = 0
-  const rangeMock = vi.fn().mockImplementation(() => {
-    const page = pages[pageIdx++] ?? { data: [], error: null }
-    return Promise.resolve(page)
-  })
-  const selectMock = vi.fn().mockReturnValue({ range: rangeMock })
-
-  const deleteIn = vi.fn().mockResolvedValue(deleteResult)
-  const deleteMock = vi.fn().mockReturnValue({ in: deleteIn })
-
+  const result = opts.deleteResult ?? { error: null, count: 0 }
+  const ltMock = vi.fn().mockResolvedValue(result)
+  const deleteFactory = vi.fn().mockReturnValue({ lt: ltMock })
   const supabase: FakeSupabase = {
-    from: vi.fn(() => ({ select: selectMock, delete: deleteMock })),
+    from: vi.fn(() => ({ delete: deleteFactory })),
   }
-  return { supabase, rangeMock, selectMock, deleteMock, deleteIn }
+  return { supabase, deleteFactory, ltMock }
 }
 
-describe('pruneOrphans', () => {
-  it('is a no-op when keepKeys is empty (does not touch Supabase)', async () => {
+const IMPORTED_AT = '2026-05-02T01:30:00.123Z'
+
+describe('pruneStaleRows', () => {
+  it('is a no-op when the batch upserted nothing for this table', async () => {
     const { supabase } = makeFakeSupabase({})
-    const result = await pruneOrphans(supabase, 'cardio_sessions', 'started_at', [])
+    const result = await pruneStaleRows(supabase, 'cardio_sessions', IMPORTED_AT, false)
     expect(result).toBe(0)
-    // The whole point of the guard — an empty payload must not even
-    // SELECT the table, otherwise a future refactor that drops the
-    // early-return on `.length === 0` would silently wipe the table.
+    // The whole point of the empty-payload guard — an import with no
+    // rows for a table must not even attempt the DELETE, otherwise a
+    // future refactor that drops the early-return would silently wipe
+    // every existing row.
     expect(supabase.from).not.toHaveBeenCalled()
   })
 
-  it('returns 0 and does not delete when there are no orphans', async () => {
-    const { supabase, selectMock, deleteMock, rangeMock } = makeFakeSupabase({
-      selectPages: [
-        {
-          data: [
-            { started_at: '2026-04-26T08:00:00Z' },
-            { started_at: '2026-04-21T07:00:00Z' },
-          ],
-          error: null,
-        },
-      ],
+  it('issues delete().lt with the exact batch timestamp when upserts happened', async () => {
+    const { supabase, deleteFactory, ltMock } = makeFakeSupabase({
+      deleteResult: { error: null, count: 0 },
     })
-    const result = await pruneOrphans(supabase, 'cardio_sessions', 'started_at', [
-      '2026-04-26T08:00:00Z',
-      '2026-04-21T07:00:00Z',
-    ])
+    const result = await pruneStaleRows(supabase, 'cardio_sessions', IMPORTED_AT, true)
     expect(result).toBe(0)
-    expect(selectMock).toHaveBeenCalledWith('started_at')
-    expect(rangeMock).toHaveBeenCalledWith(0, 999)
-    expect(deleteMock).not.toHaveBeenCalled()
+    expect(supabase.from).toHaveBeenCalledWith('cardio_sessions')
+    // `count: 'exact'` is required so the response includes the row
+    // count — without it the helper can't surface the number to the
+    // import script's success log.
+    expect(deleteFactory).toHaveBeenCalledWith({ count: 'exact' })
+    // Strict less-than against the batch timestamp; just-upserted rows
+    // (updated_at == importedAt) are preserved by `<`, only earlier
+    // rows are removed.
+    expect(ltMock).toHaveBeenCalledWith('updated_at', IMPORTED_AT)
   })
 
-  it('deletes only the rows whose PK is not in keepKeys', async () => {
-    const { supabase, deleteIn } = makeFakeSupabase({
-      selectPages: [
-        {
-          data: [
-            { started_at: '2026-04-26T08:00:00Z' },
-            { started_at: '2026-04-21T07:00:00Z' },
-            { started_at: '2026-04-17T08:00:00Z' },
-          ],
-          error: null,
-        },
-      ],
-    })
-    const result = await pruneOrphans(supabase, 'cardio_sessions', 'started_at', [
-      '2026-04-26T08:00:00Z',
-    ])
-    expect(result).toBe(2)
-    expect(deleteIn).toHaveBeenCalledWith('started_at', [
-      '2026-04-21T07:00:00Z',
-      '2026-04-17T08:00:00Z',
-    ])
-  })
-
-  it('paginates the PK scan to cover tables larger than the page cap', async () => {
-    // Use pageSize=2 so we don't have to fixture 1001 rows. Page 1 is
-    // full (2 rows), page 2 is partial (1 row) → loop terminates after
-    // the partial page without an extra empty-response request.
-    const { supabase, rangeMock, deleteIn } = makeFakeSupabase({
-      selectPages: [
-        {
-          data: [{ started_at: 'a' }, { started_at: 'b' }],
-          error: null,
-        },
-        {
-          data: [{ started_at: 'c' }],
-          error: null,
-        },
-      ],
-    })
-    const result = await pruneOrphans(
-      supabase,
-      'cardio_sessions',
-      'started_at',
-      ['a', 'b'], // keep the first two; 'c' is an orphan only visible after pagination
-      2, // pageSize
-    )
-    expect(result).toBe(1)
-    expect(rangeMock).toHaveBeenCalledTimes(2)
-    expect(rangeMock).toHaveBeenNthCalledWith(1, 0, 1)
-    expect(rangeMock).toHaveBeenNthCalledWith(2, 2, 3)
-    expect(deleteIn).toHaveBeenCalledWith('started_at', ['c'])
-  })
-
-  it('terminates pagination on a full page followed by an empty page', async () => {
-    // Edge case: every page is exactly full. Loop has to make one more
-    // request to learn the table is drained, then break on the empty
-    // response.
-    const { supabase, rangeMock, deleteIn } = makeFakeSupabase({
-      selectPages: [
-        { data: [{ started_at: 'a' }, { started_at: 'b' }], error: null },
-        { data: [], error: null },
-      ],
-    })
-    const result = await pruneOrphans(supabase, 'cardio_sessions', 'started_at', ['a'], 2)
-    expect(result).toBe(1)
-    expect(rangeMock).toHaveBeenCalledTimes(2)
-    expect(deleteIn).toHaveBeenCalledWith('started_at', ['b'])
-  })
-
-  it('throws a descriptive error when the SELECT fails', async () => {
+  it('returns the count surfaced by Supabase when rows are pruned', async () => {
     const { supabase } = makeFakeSupabase({
-      selectPages: [{ data: null, error: { message: 'JWT expired' } }],
+      deleteResult: { error: null, count: 3 },
     })
-    await expect(
-      pruneOrphans(supabase, 'cardio_sessions', 'started_at', ['2026-04-26T08:00:00Z']),
-    ).rejects.toThrow(/Failed to scan cardio_sessions for orphans.*JWT expired/)
+    const result = await pruneStaleRows(supabase, 'cardio_sessions', IMPORTED_AT, true)
+    expect(result).toBe(3)
+  })
+
+  it('returns 0 when Supabase reports a null count (no matches)', async () => {
+    const { supabase } = makeFakeSupabase({
+      deleteResult: { error: null, count: null },
+    })
+    const result = await pruneStaleRows(supabase, 'cardio_resting_hr', IMPORTED_AT, true)
+    expect(result).toBe(0)
   })
 
   it('throws a descriptive error when the DELETE fails', async () => {
     const { supabase } = makeFakeSupabase({
-      selectPages: [
-        {
-          data: [{ started_at: '2026-04-26T08:00:00Z' }, { started_at: '2026-04-21T07:00:00Z' }],
-          error: null,
-        },
-      ],
-      deleteResult: { error: { message: 'permission denied' } },
+      deleteResult: { error: { message: 'permission denied' }, count: null },
     })
     await expect(
-      pruneOrphans(supabase, 'cardio_sessions', 'started_at', ['2026-04-26T08:00:00Z']),
-    ).rejects.toThrow(/Failed to prune orphans from cardio_sessions.*permission denied/)
+      pruneStaleRows(supabase, 'cardio_sessions', IMPORTED_AT, true),
+    ).rejects.toThrow(/Failed to prune stale rows from cardio_sessions.*permission denied/)
   })
 
-  it.each([0, -1, 1.5, Number.NaN])(
-    'rejects invalid pageSize %s before any DB call (would infinite-loop)',
-    async (pageSize) => {
-      const { supabase } = makeFakeSupabase({})
-      await expect(
-        pruneOrphans(supabase, 'cardio_sessions', 'started_at', ['a'], pageSize),
-      ).rejects.toThrow(/pageSize must be a positive integer/)
-      expect(supabase.from).not.toHaveBeenCalled()
-    },
-  )
-
-  it('treats a null SELECT page the same as an empty page (no rows yet)', async () => {
-    const { supabase, deleteMock } = makeFakeSupabase({
-      selectPages: [{ data: null, error: null }],
+  it('REGRESSION (#158): does not depend on PK string equality between source and DB', async () => {
+    // The bug being defended against: Postgres normalizes a date-only
+    // source value (`"2026-02-08"`) to a full timestamp
+    // (`"2026-02-08T00:00:00+00:00"`), so a PK-set-diff prune treated
+    // every existing row as an orphan and wiped the table on the first
+    // import. The new strategy compares timestamps server-side, so the
+    // existence (or content) of any PK column is irrelevant to whether
+    // a row gets pruned. This test pins that property by asserting the
+    // helper never reads or compares PK columns at all.
+    const { supabase, ltMock } = makeFakeSupabase({
+      deleteResult: { error: null, count: 0 },
     })
-    const result = await pruneOrphans(supabase, 'cardio_resting_hr', 'date', ['2026-04-26'])
-    expect(result).toBe(0)
-    expect(deleteMock).not.toHaveBeenCalled()
+    await pruneStaleRows(supabase, 'cardio_sessions', IMPORTED_AT, true)
+    // Verify the prune issued exactly one delete-by-timestamp call,
+    // never a select on a PK column. (`makeFakeSupabase` doesn't even
+    // wire a `.select()` chain — the test double would throw on access.)
+    expect(ltMock).toHaveBeenCalledTimes(1)
+    expect(ltMock).toHaveBeenCalledWith('updated_at', IMPORTED_AT)
   })
 })


### PR DESCRIPTION
## Summary

P0 hotfix for #152. The cardio import script's `pruneOrphans` step was wiping `cardio_sessions` on every run because of a primary-key string-format mismatch between the source (`"2026-02-08"` from the sample JSON) and PostgREST's normalized output (`"2026-02-08T00:00:00+00:00"`). Replaces the PK-set-diff strategy with a server-side `delete().lt('updated_at', importedAt)`.

## What changed

- **`pruneOrphans` → `pruneStaleRows`.** New signature: `(supabase, table, importedAt, hadAnyUpserts)`. Single DELETE keyed by the batch timestamp; no SELECT, no pagination, no PK-format gotcha.
- **Empty-payload guard preserved.** `hadAnyUpserts: false` short-circuits without touching the DB — same protection against parser bugs / partial exports / typos that #152's `keepKeys.length === 0` check provided.
- **Test rewrite.** Test file mocks the new `delete({ count: 'exact' }).lt('updated_at', ...)` chain and includes an explicit regression case (#158) asserting the helper never reads or compares PK columns. Net change: 12 tests → 6 tests (the 4 pageSize-guard parametric cases and 2 pagination-loop cases became unreachable when SELECT + pagination went away).
- **JSDoc on `upsertCardioData` and `pruneStaleRows`** updated to describe the new strategy and call out #158 as the reason for the change.

## Verification against the live DB

Ran `npm run cardio:backfill` against the `court-vision` project (`ryxbnvhxxkrmsrmocume`):

```
✓ Backfilled to Supabase: 11 sessions, 7 resting-HR points, 4 VO2max points.
```

Counts after first run: **11 sessions, 7 resting-HR, 4 VO2max** (matches source).
Counts after second run (idempotency): **11 / 7 / 4**, zero prunes, no log line.

Compare to the buggy behavior on the previous commit (`f62769a`):
```
✓ Backfilled to Supabase: 11 sessions, 7 resting-HR points, 4 VO2max points.
  (Pruned 11 orphan row(s) — present in Supabase but not in this backfill source.)
```

Counts after that run: **0 / 7 / 4** (sessions wiped).

## Test plan

- [ ] `npx tsc --noEmit` clean.
- [ ] `npm test` — 533 unit tests pass (was 539; 6 unreachable pruneOrphans tests removed, 6 new pruneStaleRows tests added).
- [ ] `npx next build` — all 26 routes compile.
- [ ] Vercel preview: visit `/training-facility/gym/stair`, `/treadmill`, `/track`, `/overview` — sessions render.
- [ ] Local: `npm run cardio:backfill` after pulling this branch — output reports 11/7/4 with no "Pruned" line; second consecutive run unchanged.
- [ ] DevTools network on `/training-facility/gym`: confirm `*.supabase.co/rest/v1/cardio_sessions?...` returns 11 rows.

## Out of scope

- Restoring Apple Health metrics dropped by the Python preprocessor (HRV, body mass, sleep, etc.) — separate parity-sweep effort.
- Concurrent-import safety (single-user dev script).
- Multi-tenant data import.

Closes #158.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of stale database records by using timestamp-based pruning for more reliable and efficient removal.
  * Added a guard to skip cleanup when no new data was processed, reducing unnecessary operations.
  * Improved error messaging when cleanup operations fail.

* **Tests**
  * Updated tests to validate the new timestamp-based deletion behavior and associated guards and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->