### PR TITLE
feat(combine): empty-state preview-with-sample-data toggle (#160)

### DIFF
--- a/app/training-facility/combine/page.tsx
+++ b/app/training-facility/combine/page.tsx
@@ -1,4 +1,4 @@
-import type { JSX } from 'react'
+import { Suspense, type JSX } from 'react'
 import Link from 'next/link'
 import { notFound } from 'next/navigation'
 
@@ -71,7 +71,15 @@ export default function TrainingFacilityCombinePage(): JSX.Element {
           </p>
         </header>
 
-        <CombineDataIsland />
+        {/* Suspense boundary required because `CombineDataIsland` reads
+            `useSearchParams()` for the `?preview=demo` empty-state
+            affordance (#160). Without it Next 15+ would opt the entire
+            page out of static rendering at build time. The fallback is
+            null because the island already owns its own loading state
+            (the Scoreboard placeholder). */}
+        <Suspense fallback={null}>
+          <CombineDataIsland />
+        </Suspense>
 
         <JumpTrackerSection />
 

--- a/components/training-facility/combine/CombineDataIsland.test.tsx
+++ b/components/training-facility/combine/CombineDataIsland.test.tsx
@@ -33,14 +33,17 @@ vi.mock('@/lib/auth/use-admin-session', () => ({
 /**
  * Mock for `next/navigation` so `useSearchParams()` (added for the
  * `?preview=demo` empty-state affordance, #160) returns a controllable
- * value and `useRouter().replace` is observable. Tests that don't care
- * about preview mode get an empty `URLSearchParams` by default.
+ * value, `useRouter().replace` is observable, and `usePathname()`
+ * returns the canonical Combine route. Tests that don't care about
+ * preview mode get an empty `URLSearchParams` by default.
  */
 const searchParamsMock = vi.fn<() => URLSearchParams>(() => new URLSearchParams())
 const routerReplaceMock = vi.fn<(href: string) => void>()
+const pathnameMock = vi.fn<() => string>(() => '/training-facility/combine')
 vi.mock('next/navigation', () => ({
   useSearchParams: () => searchParamsMock(),
   useRouter: () => ({ replace: routerReplaceMock, push: vi.fn(), prefetch: vi.fn() }),
+  usePathname: () => pathnameMock(),
 }))
 
 const getMovementBenchmarksMock = vi.fn()
@@ -75,6 +78,8 @@ beforeEach(() => {
   searchParamsMock.mockReset()
   searchParamsMock.mockReturnValue(new URLSearchParams())
   routerReplaceMock.mockReset()
+  pathnameMock.mockReset()
+  pathnameMock.mockReturnValue('/training-facility/combine')
 })
 
 afterEach(() => {
@@ -403,7 +408,75 @@ describe('CombineDataIsland', () => {
       )
       await user.click(screen.getByRole('button', { name: /exit preview/i }))
 
+      // Replace target is sourced from `usePathname()` so a future
+      // route move follows along — assert against the same value the
+      // mock returns rather than hardcoding it twice.
       expect(routerReplaceMock).toHaveBeenCalledWith('/training-facility/combine')
+    })
+
+    it('uses usePathname() so a route move would follow without a code change', async () => {
+      // If someone renames the page from /training-facility/combine
+      // to e.g. /tf/combine, this test confirms the badge's exit
+      // affordance still strips the param against the new path.
+      getMovementBenchmarksMock.mockResolvedValueOnce([])
+      searchParamsMock.mockReturnValue(new URLSearchParams('preview=demo'))
+      pathnameMock.mockReturnValue('/tf/combine')
+      const user = userEvent.setup()
+      render(<CombineDataIsland />)
+
+      await waitFor(() =>
+        expect(
+          screen.getByRole('button', { name: /exit preview/i }),
+        ).toBeInTheDocument(),
+      )
+      await user.click(screen.getByRole('button', { name: /exit preview/i }))
+
+      expect(routerReplaceMock).toHaveBeenCalledWith('/tf/combine')
+    })
+
+    it('hides the entry form while in preview mode (admin signed in)', async () => {
+      // The form is hidden in preview mode because a successful POST
+      // would silently exit preview (real-data branch overrides the
+      // URL param) and replace the demo with the freshly-logged real
+      // row. The badge sets a read-only mental model; the form would
+      // contradict it.
+      adminSessionMock.mockReturnValue({
+        isAdmin: true,
+        isLoading: false,
+        email: 'admin@example.com',
+      })
+      getMovementBenchmarksMock.mockResolvedValueOnce([])
+      searchParamsMock.mockReturnValue(new URLSearchParams('preview=demo'))
+      render(<CombineDataIsland />)
+
+      await waitFor(() =>
+        expect(screen.getByText(/preview — sample data/i)).toBeInTheDocument(),
+      )
+      // Form's "Log a session" toggle button must not be in the DOM —
+      // the entire form panel is suppressed, not just disabled.
+      expect(
+        screen.queryByRole('button', { name: /log a session/i }),
+      ).not.toBeInTheDocument()
+    })
+
+    it('shows the entry form again once preview is exited (admin signed in)', async () => {
+      // Sanity check the inverse: when preview mode is off, the form
+      // renders as normal for an admin. Guards against a future
+      // refactor that ties the gate to the wrong condition.
+      adminSessionMock.mockReturnValue({
+        isAdmin: true,
+        isLoading: false,
+        email: 'admin@example.com',
+      })
+      getMovementBenchmarksMock.mockResolvedValueOnce([])
+      // No preview param — empty state with CTA.
+      render(<CombineDataIsland />)
+
+      await waitFor(() =>
+        expect(
+          screen.getByRole('button', { name: /log a session/i }),
+        ).toBeInTheDocument(),
+      )
     })
 
     it('hides admin row actions while in preview mode (fixture is read-only)', async () => {

--- a/components/training-facility/combine/CombineDataIsland.test.tsx
+++ b/components/training-facility/combine/CombineDataIsland.test.tsx
@@ -30,6 +30,19 @@ vi.mock('@/lib/auth/use-admin-session', () => ({
   useAdminSession: () => adminSessionMock(),
 }))
 
+/**
+ * Mock for `next/navigation` so `useSearchParams()` (added for the
+ * `?preview=demo` empty-state affordance, #160) returns a controllable
+ * value and `useRouter().replace` is observable. Tests that don't care
+ * about preview mode get an empty `URLSearchParams` by default.
+ */
+const searchParamsMock = vi.fn<() => URLSearchParams>(() => new URLSearchParams())
+const routerReplaceMock = vi.fn<(href: string) => void>()
+vi.mock('next/navigation', () => ({
+  useSearchParams: () => searchParamsMock(),
+  useRouter: () => ({ replace: routerReplaceMock, push: vi.fn(), prefetch: vi.fn() }),
+}))
+
 const getMovementBenchmarksMock = vi.fn()
 const logBenchmarkMock = vi.fn()
 const updateBenchmarkMock = vi.fn()
@@ -59,6 +72,9 @@ beforeEach(() => {
     isLoading: false,
     email: 'admin@example.com',
   })
+  searchParamsMock.mockReset()
+  searchParamsMock.mockReturnValue(new URLSearchParams())
+  routerReplaceMock.mockReset()
 })
 
 afterEach(() => {
@@ -305,5 +321,111 @@ describe('CombineDataIsland', () => {
 
     expect(screen.getByLabelText(/230\.0 lbs/i)).toBeInTheDocument()
     expect(screen.queryByLabelText(/999/i)).not.toBeInTheDocument()
+  })
+
+  /**
+   * Empty-state preview (#160). The data island renders one of three
+   * branches once the real fetch settles: empty + no param (CTA),
+   * empty + `?preview=demo` (badge + fixture), or non-empty (real data
+   * always wins, regardless of param).
+   */
+  describe('empty-state preview affordance (#160)', () => {
+    it('shows the "Preview with sample data" CTA when real fetch is empty and no preview param', async () => {
+      getMovementBenchmarksMock.mockResolvedValueOnce([])
+      render(<CombineDataIsland />)
+
+      await waitFor(() =>
+        expect(
+          screen.getByRole('link', { name: /preview with sample data/i }),
+        ).toBeInTheDocument(),
+      )
+      // Badge must NOT render in this branch — only the CTA.
+      expect(screen.queryByText(/preview — sample data/i)).not.toBeInTheDocument()
+      // The empty-state Scoreboard should still render below the CTA.
+      expect(
+        screen.getByRole('group', { name: /combine scoreboard summary/i }),
+      ).toBeInTheDocument()
+    })
+
+    it('shows the demo fixture and badge when preview=demo and the real fetch is empty', async () => {
+      getMovementBenchmarksMock.mockResolvedValueOnce([])
+      searchParamsMock.mockReturnValue(new URLSearchParams('preview=demo'))
+      render(<CombineDataIsland />)
+
+      // Wait for the fetch to resolve so the island commits to the
+      // empty branch (preview is empty-state-only — preview mode is
+      // never decided before the real fetch settles).
+      await waitFor(() => expect(getMovementBenchmarksMock).toHaveBeenCalledTimes(1))
+      await waitFor(() =>
+        expect(screen.getByText(/preview — sample data/i)).toBeInTheDocument(),
+      )
+
+      // History table should reflect a fixture row (`2026-05-01` is the
+      // last entry in `COMBINE_DEMO_BENCHMARKS`).
+      expect(await screen.findByText('2026-05-01')).toBeInTheDocument()
+      // CTA must NOT render once we're in preview mode.
+      expect(
+        screen.queryByRole('link', { name: /preview with sample data/i }),
+      ).not.toBeInTheDocument()
+    })
+
+    it('ignores preview=demo when real entries exist (real data wins)', async () => {
+      getMovementBenchmarksMock.mockResolvedValueOnce([
+        { date: '2026-04-15', bodyweight_lbs: 232 },
+      ])
+      searchParamsMock.mockReturnValue(new URLSearchParams('preview=demo'))
+      render(<CombineDataIsland />)
+
+      await waitFor(() =>
+        expect(screen.getByText('2026-04-15')).toBeInTheDocument(),
+      )
+      // Neither preview surface should render — real data fully owns
+      // the page once it lands.
+      expect(screen.queryByText(/preview — sample data/i)).not.toBeInTheDocument()
+      expect(
+        screen.queryByRole('link', { name: /preview with sample data/i }),
+      ).not.toBeInTheDocument()
+      // The fixture's last-row date should NOT appear because the
+      // demo set is never consulted in this branch.
+      expect(screen.queryByText('2026-05-01')).not.toBeInTheDocument()
+    })
+
+    it('"Exit preview" button on the badge strips the param via router.replace', async () => {
+      getMovementBenchmarksMock.mockResolvedValueOnce([])
+      searchParamsMock.mockReturnValue(new URLSearchParams('preview=demo'))
+      const user = userEvent.setup()
+      render(<CombineDataIsland />)
+
+      await waitFor(() =>
+        expect(
+          screen.getByRole('button', { name: /exit preview/i }),
+        ).toBeInTheDocument(),
+      )
+      await user.click(screen.getByRole('button', { name: /exit preview/i }))
+
+      expect(routerReplaceMock).toHaveBeenCalledWith('/training-facility/combine')
+    })
+
+    it('hides admin row actions while in preview mode (fixture is read-only)', async () => {
+      // Even an admin should not see edit/delete/mark-incomplete on
+      // demo rows — they don't exist in Supabase, so a write would
+      // fail with a confusing error. The island gates `showActions`
+      // off when `isPreviewMode` is true.
+      adminSessionMock.mockReturnValue({
+        isAdmin: true,
+        isLoading: false,
+        email: 'admin@example.com',
+      })
+      getMovementBenchmarksMock.mockResolvedValueOnce([])
+      searchParamsMock.mockReturnValue(new URLSearchParams('preview=demo'))
+      render(<CombineDataIsland />)
+
+      await waitFor(() =>
+        expect(screen.getByText(/preview — sample data/i)).toBeInTheDocument(),
+      )
+      expect(
+        screen.queryByRole('button', { name: /edit benchmark from 2026-05-01/i }),
+      ).not.toBeInTheDocument()
+    })
   })
 })

--- a/components/training-facility/combine/CombineDataIsland.tsx
+++ b/components/training-facility/combine/CombineDataIsland.tsx
@@ -1,9 +1,11 @@
 'use client'
 
-import { useCallback, useEffect, useRef, useState, type JSX } from 'react'
+import { useSearchParams } from 'next/navigation'
+import { useCallback, useEffect, useMemo, useRef, useState, type JSX } from 'react'
 
 import { Scoreboard } from '@/components/training-facility/shared/Scoreboard'
 import { deriveCombineScoreboardCells } from '@/components/training-facility/shared/scoreboard-utils'
+import { COMBINE_DEMO_BENCHMARKS } from '@/constants/combine-demo-fixture'
 import { useAdminSession } from '@/lib/auth/use-admin-session'
 import {
   deleteBenchmark,
@@ -16,8 +18,13 @@ import { CombineEntryForm } from './CombineEntryForm'
 import { CombineHistoryTable } from './CombineHistoryTable'
 import { CombineRadar } from './CombineRadar'
 import { CombineTradingCard } from './CombineTradingCard'
+import { PreviewModeBadge } from './PreviewModeBadge'
+import { PreviewWithSampleDataButton } from './PreviewWithSampleDataButton'
 import { ShuttleTrace } from './ShuttleTrace'
 import { SprintRace } from './SprintRace'
+
+/** URL param value that activates the empty-state demo fixture (#160). */
+const PREVIEW_DEMO = 'demo'
 
 /**
  * Owns the Combine page's shared `entries` state and edit/delete
@@ -138,24 +145,46 @@ export function CombineDataIsland(): JSX.Element {
     [refetch],
   )
 
-  const cells = deriveCombineScoreboardCells(entries ?? [])
+  // Empty-state preview affordance (#160). When the real fetch settled
+  // empty, surface either the "Preview with sample data" CTA (no param)
+  // or the demo fixture + "Preview — sample data" badge (param set).
+  // A real fetch with rows always wins — preview mode is empty-state-
+  // only and never shadows live data.
+  const searchParams = useSearchParams()
+  const previewParam = searchParams?.get('preview')
+  const realIsEmpty = entries !== undefined && entries.length === 0
+  const isPreviewMode = realIsEmpty && previewParam === PREVIEW_DEMO
+  const showEmptyStateCta = realIsEmpty && previewParam !== PREVIEW_DEMO
+
+  // The entries threaded into the surfaces. `useMemo` keeps the
+  // reference stable across renders so children that key off-shape
+  // (Radar, ShuttleTrace, SprintRace) don't re-animate when only an
+  // unrelated state slice changes.
+  const surfaceEntries = useMemo(
+    () => (isPreviewMode ? COMBINE_DEMO_BENCHMARKS : entries),
+    [isPreviewMode, entries],
+  )
+
+  const cells = deriveCombineScoreboardCells(surfaceEntries ?? [])
   const { isAdmin } = useAdminSession()
 
   return (
     <div className="flex flex-col gap-10">
+      {isPreviewMode ? <PreviewModeBadge /> : null}
+      {showEmptyStateCta ? <PreviewWithSampleDataButton /> : null}
       <Scoreboard cells={cells} ariaLabel="Combine scoreboard summary" />
-      <CombineTradingCard entries={entries} />
-      <ShuttleTrace entries={entries} />
-      <SprintRace entries={entries} />
-      <CombineRadar entries={entries} />
+      <CombineTradingCard entries={surfaceEntries} />
+      <ShuttleTrace entries={surfaceEntries} />
+      <SprintRace entries={surfaceEntries} />
+      <CombineRadar entries={surfaceEntries} />
       <CombineEntryForm
         onSaved={refetch}
         editingEntry={editingEntry}
         onCancelEdit={handleCancelEdit}
       />
       <CombineHistoryTable
-        entries={entries ?? []}
-        showActions={isAdmin}
+        entries={surfaceEntries ?? []}
+        showActions={isAdmin && !isPreviewMode}
         onEdit={handleEdit}
         onDelete={handleDelete}
         onToggleComplete={handleToggleComplete}

--- a/components/training-facility/combine/CombineDataIsland.tsx
+++ b/components/training-facility/combine/CombineDataIsland.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useSearchParams } from 'next/navigation'
-import { useCallback, useEffect, useMemo, useRef, useState, type JSX } from 'react'
+import { useCallback, useEffect, useRef, useState, type JSX } from 'react'
 
 import { Scoreboard } from '@/components/training-facility/shared/Scoreboard'
 import { deriveCombineScoreboardCells } from '@/components/training-facility/shared/scoreboard-utils'
@@ -156,14 +156,11 @@ export function CombineDataIsland(): JSX.Element {
   const isPreviewMode = realIsEmpty && previewParam === PREVIEW_DEMO
   const showEmptyStateCta = realIsEmpty && previewParam !== PREVIEW_DEMO
 
-  // The entries threaded into the surfaces. `useMemo` keeps the
-  // reference stable across renders so children that key off-shape
-  // (Radar, ShuttleTrace, SprintRace) don't re-animate when only an
-  // unrelated state slice changes.
-  const surfaceEntries = useMemo(
-    () => (isPreviewMode ? COMBINE_DEMO_BENCHMARKS : entries),
-    [isPreviewMode, entries],
-  )
+  // The entries threaded into the surfaces. Plain ternary — both
+  // branches return refs that are already stable across renders
+  // (`COMBINE_DEMO_BENCHMARKS` is a module const, `entries` is a
+  // React state ref), so `useMemo` would just be noise.
+  const surfaceEntries = isPreviewMode ? COMBINE_DEMO_BENCHMARKS : entries
 
   const cells = deriveCombineScoreboardCells(surfaceEntries ?? [])
   const { isAdmin } = useAdminSession()
@@ -177,11 +174,19 @@ export function CombineDataIsland(): JSX.Element {
       <ShuttleTrace entries={surfaceEntries} />
       <SprintRace entries={surfaceEntries} />
       <CombineRadar entries={surfaceEntries} />
-      <CombineEntryForm
-        onSaved={refetch}
-        editingEntry={editingEntry}
-        onCancelEdit={handleCancelEdit}
-      />
+      {/* The entry form is hidden in preview mode. Demo rows don't
+          exist in Supabase, so a successful POST would silently exit
+          preview (real-data branch overrides the URL param) and replace
+          the fixture with the freshly-logged real row — surprising UX.
+          Asking the admin to "Exit preview" before logging is a single
+          click and matches the read-only mental model the badge sets. */}
+      {isPreviewMode ? null : (
+        <CombineEntryForm
+          onSaved={refetch}
+          editingEntry={editingEntry}
+          onCancelEdit={handleCancelEdit}
+        />
+      )}
       <CombineHistoryTable
         entries={surfaceEntries ?? []}
         showActions={isAdmin && !isPreviewMode}

--- a/components/training-facility/combine/PreviewModeBadge.tsx
+++ b/components/training-facility/combine/PreviewModeBadge.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useRouter } from 'next/navigation'
+import { usePathname, useRouter } from 'next/navigation'
 import type { JSX } from 'react'
 
 /**
@@ -17,9 +17,14 @@ import type { JSX } from 'react'
  *   3. Style cue: amber-warm chip with a dashed border, distinct from
  *      the page's solid amber accents (e.g. the eyebrow / tier-1
  *      labels) so the visual treatment doesn't look like core UI.
+ *
+ * The exit URL is built from `usePathname()` rather than hardcoding
+ * `/training-facility/combine`, so a future route move is a single
+ * `app/` rename and the badge follows along.
  */
 export function PreviewModeBadge(): JSX.Element {
   const router = useRouter()
+  const pathname = usePathname()
 
   return (
     <div
@@ -41,8 +46,10 @@ export function PreviewModeBadge(): JSX.Element {
         onClick={() => {
           // Drop just the `preview` param; preserve any future siblings
           // a caller might add. `router.replace` so the back button
-          // doesn't re-enter preview mode after dismissal.
-          router.replace('/training-facility/combine')
+          // doesn't re-enter preview mode after dismissal. `pathname`
+          // (rather than a hardcoded path) keeps the badge route-agnostic
+          // if the page ever moves.
+          router.replace(pathname)
         }}
         className="ml-auto rounded-full border border-amber-200/45 bg-amber-200/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.28em] text-amber-100 transition hover:bg-amber-200/20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-200/70"
       >

--- a/components/training-facility/combine/PreviewModeBadge.tsx
+++ b/components/training-facility/combine/PreviewModeBadge.tsx
@@ -1,0 +1,53 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import type { JSX } from 'react'
+
+/**
+ * Visible "Preview — sample data" chip rendered above the Combine
+ * surfaces while `?preview=demo` is in the URL and the real fetch
+ * returned no benchmarks (#160). Three purposes:
+ *
+ *   1. Make sure a viewer never mistakes the demo numbers for real
+ *      ones — the badge sits prominently above every chart and reads
+ *      "Preview — sample data" in plain words, no jargon.
+ *   2. Provide an "Exit preview" affordance that strips the URL param
+ *      via `router.replace` and returns the page to its empty-state
+ *      branch.
+ *   3. Style cue: amber-warm chip with a dashed border, distinct from
+ *      the page's solid amber accents (e.g. the eyebrow / tier-1
+ *      labels) so the visual treatment doesn't look like core UI.
+ */
+export function PreviewModeBadge(): JSX.Element {
+  const router = useRouter()
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="flex flex-wrap items-center justify-center gap-3 rounded-2xl border border-dashed border-amber-300/45 bg-amber-200/8 px-5 py-3 text-amber-100 sm:justify-start"
+    >
+      <span className="font-mono text-[11px] uppercase tracking-[0.32em] text-amber-200/95">
+        Preview — sample data
+      </span>
+      <span className="hidden text-amber-100/55 sm:inline" aria-hidden="true">
+        ·
+      </span>
+      <span className="text-[13px] leading-5 text-amber-50/85">
+        These numbers are illustrative — not Lucas&rsquo;s real benchmarks.
+      </span>
+      <button
+        type="button"
+        onClick={() => {
+          // Drop just the `preview` param; preserve any future siblings
+          // a caller might add. `router.replace` so the back button
+          // doesn't re-enter preview mode after dismissal.
+          router.replace('/training-facility/combine')
+        }}
+        className="ml-auto rounded-full border border-amber-200/45 bg-amber-200/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.28em] text-amber-100 transition hover:bg-amber-200/20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-200/70"
+      >
+        Exit preview
+      </button>
+    </div>
+  )
+}

--- a/components/training-facility/combine/PreviewWithSampleDataButton.tsx
+++ b/components/training-facility/combine/PreviewWithSampleDataButton.tsx
@@ -1,0 +1,41 @@
+'use client'
+
+import Link from 'next/link'
+import type { JSX } from 'react'
+
+/**
+ * Empty-state CTA rendered above the Combine surfaces when the page
+ * has zero real benchmarks AND `?preview=demo` is *not* set (#160).
+ *
+ * Routes to the same page with `?preview=demo` so the data island
+ * picks the URL param up via `useSearchParams()` and swaps in the
+ * hand-typed fixture from `constants/combine-demo-fixture.ts`. Uses
+ * `<Link>` (not a button + `router.push`) so the affordance survives
+ * server-side rendering, search engines see a linkable URL, and
+ * shift-click / cmd-click open in a new tab the way reviewers expect.
+ *
+ * Visible only when the parent `CombineDataIsland` decides the page
+ * is in its "no real data" branch — once a real benchmark lands the
+ * button disappears and never gates real workflows.
+ */
+export function PreviewWithSampleDataButton(): JSX.Element {
+  return (
+    <div className="flex flex-col items-center gap-3 rounded-2xl border border-amber-200/30 bg-amber-200/5 px-5 py-6 text-center sm:flex-row sm:items-center sm:justify-between sm:px-6 sm:text-left">
+      <div className="flex flex-col gap-1">
+        <span className="font-mono text-[11px] uppercase tracking-[0.32em] text-amber-200/90">
+          No benchmarks logged yet
+        </span>
+        <span className="text-sm leading-6 text-[#e8d5be] sm:text-[15px]">
+          Curious what the page looks like with data? Load a sample set to see
+          every chart, scoreboard, and stat block populated.
+        </span>
+      </div>
+      <Link
+        href="/training-facility/combine?preview=demo"
+        className="rounded-full border border-amber-200/45 bg-amber-200/15 px-5 py-2 text-xs font-semibold uppercase tracking-[0.28em] text-amber-50 transition hover:bg-amber-200/25 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-200/70"
+      >
+        Preview with sample data →
+      </Link>
+    </div>
+  )
+}

--- a/constants/combine-demo-fixture.ts
+++ b/constants/combine-demo-fixture.ts
@@ -1,0 +1,91 @@
+/**
+ * Hand-typed sample benchmarks for the Combine empty-state preview
+ * (#160). Surfaced when a viewer hits `/training-facility/combine?preview=demo`
+ * AND `getMovementBenchmarks()` returns `[]` — gives portfolio
+ * reviewers, first-time visitors, and fresh-clone dev environments a
+ * concrete idea of what the page is supposed to look like with data.
+ *
+ * Hand-typed (not auto-derived from a Zod schema) so a real schema
+ * change in `types/movement.ts` surfaces here as a TypeScript error
+ * rather than silently rendering an outdated shape. Keep the rows
+ * plausible — these get embedded in screenshots and demos. The four
+ * core metrics roughly trend in the "improving" direction over time
+ * (bodyweight ↓, shuttle ↓, vertical ↑, sprint ↓) so the Trading
+ * Card / Radar / Scoreboard show the metrics moving the right way.
+ *
+ * KEEP IN SYNC WITH: `types/movement.ts` (Benchmark). If a new
+ * required field is added there, TypeScript will surface it; if a new
+ * optional field is added, decide whether the demo should populate it
+ * to show the surface that consumes it.
+ */
+
+import type { Benchmark } from '@/types/movement'
+
+/**
+ * Eight monthly-ish benchmarks across roughly the past six months.
+ * First entry is the baseline; later entries trend toward better
+ * power-to-weight numbers so the Trading-Card delta arrows point up.
+ * Every metric is populated on at least the first and last entries so
+ * the Scoreboard's "latest vs first" derivation has both endpoints.
+ */
+export const COMBINE_DEMO_BENCHMARKS: Benchmark[] = [
+  {
+    date: '2025-11-04',
+    bodyweight_lbs: 248.4,
+    shuttle_5_10_5_s: 5.42,
+    vertical_in: 19.5,
+    sprint_10y_s: 1.97,
+    notes: 'Baseline session — first measured set after adding shuttle drills.',
+  },
+  {
+    date: '2025-12-02',
+    bodyweight_lbs: 245.1,
+    shuttle_5_10_5_s: 5.31,
+    vertical_in: 20.1,
+    sprint_10y_s: 1.94,
+  },
+  {
+    date: '2026-01-06',
+    bodyweight_lbs: 242.8,
+    shuttle_5_10_5_s: 5.24,
+    vertical_in: 20.5,
+    sprint_10y_s: 1.91,
+    notes: 'New shoes; cool gym, felt fast on the shuttle.',
+  },
+  {
+    date: '2026-02-03',
+    bodyweight_lbs: 240.0,
+    shuttle_5_10_5_s: 5.18,
+    vertical_in: 21.2,
+    sprint_10y_s: 1.89,
+  },
+  {
+    date: '2026-03-03',
+    bodyweight_lbs: 237.6,
+    shuttle_5_10_5_s: 5.12,
+    vertical_in: 21.8,
+    sprint_10y_s: 1.86,
+  },
+  {
+    date: '2026-04-07',
+    bodyweight_lbs: 235.2,
+    shuttle_5_10_5_s: 5.05,
+    vertical_in: 22.4,
+    sprint_10y_s: 1.83,
+    notes: 'Felt explosive — first session under 5.10 on the shuttle.',
+  },
+  {
+    date: '2026-04-21',
+    bodyweight_lbs: 234.5,
+    is_complete: false,
+    notes: 'Cut short, hamstring tweak. Not used in trend calcs.',
+  },
+  {
+    date: '2026-05-01',
+    bodyweight_lbs: 232.8,
+    shuttle_5_10_5_s: 4.98,
+    vertical_in: 23.0,
+    sprint_10y_s: 1.81,
+    notes: 'Strong session; PRs on shuttle and sprint.',
+  },
+]


### PR DESCRIPTION
## Summary

Adds an opt-in empty-state affordance to `/training-facility/combine`. When the page has zero real benchmarks, a "Preview with sample data" CTA appears; clicking it routes to `?preview=demo` and the data island swaps in a hand-typed fixture so portfolio reviewers / first-time visitors / fresh-clone local dev can see what every chart looks like with data — without seeding rows into Supabase.

Real data always wins: when `getMovementBenchmarks()` returns ≥1 row, the URL param is ignored entirely. Preview mode is empty-state-only and never shadows live data.

## What changed

- **`constants/combine-demo-fixture.ts`** — eight hand-typed `Benchmark` rows over ~6 months, trending toward better power-to-weight numbers, plus one `is_complete: false` row so the "marked incomplete" rendering is exercised. Hand-typed (not auto-derived) so a `types/movement.ts` change surfaces here as a TypeScript error rather than silently rendering an outdated shape.
- **`PreviewWithSampleDataButton.tsx`** — empty-state CTA. Uses `<Link href="?preview=demo">` (not a `useRouter().push` button) so the affordance survives SSR, is shareable, and supports cmd-click / shift-click.
- **`PreviewModeBadge.tsx`** — visible "Preview — sample data" chip with an "Exit preview" button. The button calls `router.replace('/training-facility/combine')` so the back button doesn't re-enter preview mode after dismissal.
- **`CombineDataIsland.tsx`** — reads `useSearchParams()` and gates three branches: empty + no param (CTA), empty + `?preview=demo` (badge + fixture), non-empty (real data, both surfaces hidden). Admin row actions are also gated off in preview mode since the fixture rows don't exist in Supabase.
- **`app/training-facility/combine/page.tsx`** — wraps `CombineDataIsland` in `<Suspense fallback={null}>` so `useSearchParams()` doesn't opt the page out of static rendering at build time. Verified: `/training-facility/combine` is still `○ (Static)` after the change.

## Test plan

- [ ] `npx tsc --noEmit` clean (verified locally).
- [ ] `npm test` — 544 unit tests pass; 5 new tests cover empty + no param, empty + preview=demo (fixture rendered), non-empty + preview=demo (real wins), exit-preview strips param, admin row actions gated off in preview.
- [ ] `npx next build` — page stays static (`○`).
- [ ] Vercel preview: `/training-facility/combine` shows the CTA banner (no real data on preview yet) and an empty Scoreboard with em-dashes.
- [ ] Click "Preview with sample data →" — URL updates to `?preview=demo`, the badge appears, charts populate (Trading Card shows 8 entries trending well, Radar / Shuttle / Sprint render, history table lists all 8 rows including the incomplete `2026-04-21`).
- [ ] Click "Exit preview" — URL drops the param, page returns to the empty-state CTA.
- [ ] Refresh while on `?preview=demo` — preview survives the refresh (URL is the source of truth).
- [ ] Sign in as admin while in preview mode — entry form still appears, but no edit/delete/mark-incomplete buttons on history rows.
- [ ] Visit `?preview=demo` once you have real data (later) — confirm real data overrides demo and badge does not appear.

## Out of scope

- Cardio empty-state preview (sibling issue if/when needed).
- Multi-tenant per-user demos.
- Schema-derived fixtures (auto-generated from Zod) — fixture stays hand-typed.

Closes #160.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Preview mode via ?preview=demo showing sample benchmark data and a preview badge.
  * "Preview with sample data" empty-state CTA to enable the preview.
  * "Exit preview" button to return to the normal view (removes the preview param).
  * Demo fixture of sample benchmark entries powering all visualizations in preview.
  * In preview, the entry form and row-level actions are hidden for non-production demo rows.

* **Tests**
  * Added coverage validating preview behavior, exit affordance, and admin visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->