### PR TITLE
feat(gym): per-session HR zone strip in cardio session log (#163)

### DIFF
--- a/components/training-facility/gym/AllCardioOverview.tsx
+++ b/components/training-facility/gym/AllCardioOverview.tsx
@@ -36,6 +36,7 @@ import {
 import { BackToCourtButton } from '@/components/common/BackToCourtButton'
 import { HrZoneBars } from './HrZoneBars'
 import { ActivityLegend, AvgHrBarsByActivity } from './AvgHrBarsByActivity'
+import { SessionZoneStrip } from './SessionZoneStrip'
 import { TrainingLoadChart } from './TrainingLoadChart'
 import { chartPalette } from '@/components/training-facility/shared/charts/palette'
 import { defaultMargin } from '@/components/training-facility/shared/charts/types'
@@ -481,7 +482,7 @@ function SessionLogTable({ sessions, range }: SessionLogTableProps): JSX.Element
         </p>
       ) : (
         <div className="overflow-x-auto">
-          <table className="w-full min-w-[680px] border-separate border-spacing-y-1 text-left text-sm">
+          <table className="w-full min-w-[760px] border-separate border-spacing-y-1 text-left text-sm">
             <thead className="text-xs uppercase tracking-[0.18em] text-white/55">
               <tr>
                 <th scope="col" className="px-3 py-2 font-semibold">
@@ -504,6 +505,9 @@ function SessionLogTable({ sessions, range }: SessionLogTableProps): JSX.Element
                 </th>
                 <th scope="col" className="px-3 py-2 font-semibold">
                   Max HR
+                </th>
+                <th scope="col" className="px-3 py-2 font-semibold">
+                  Zone
                 </th>
               </tr>
             </thead>
@@ -538,8 +542,11 @@ function SessionLogTable({ sessions, range }: SessionLogTableProps): JSX.Element
                     <td className="px-3 py-2 font-mono">
                       {typeof s.avg_hr === 'number' ? `${Math.round(s.avg_hr)}` : '—'}
                     </td>
-                    <td className="rounded-r-md px-3 py-2 font-mono">
+                    <td className="px-3 py-2 font-mono">
                       {typeof s.max_hr === 'number' ? `${Math.round(s.max_hr)}` : '—'}
+                    </td>
+                    <td className="rounded-r-md px-3 py-2 font-mono">
+                      <SessionZoneStrip hrSecondsInZone={s.hr_seconds_in_zone} />
                     </td>
                   </tr>
                 )

--- a/components/training-facility/gym/SessionZoneStrip.test.tsx
+++ b/components/training-facility/gym/SessionZoneStrip.test.tsx
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+import { HR_ZONES } from '@/constants/hr-zones'
+import type { HrZone } from '@/types/cardio'
+import { SessionZoneStrip } from './SessionZoneStrip'
+
+/**
+ * Build a zones-in-seconds map with sane defaults; pass overrides for the
+ * cases the test cares about.
+ */
+const zones = (overrides: Partial<Record<HrZone, number>> = {}): Record<HrZone, number> => ({
+  1: 0,
+  2: 0,
+  3: 0,
+  4: 0,
+  5: 0,
+  ...overrides,
+})
+
+describe('SessionZoneStrip', () => {
+  it('renders a segment per non-zero zone with proportional widths and a tooltip', () => {
+    render(
+      <SessionZoneStrip
+        hrSecondsInZone={zones({ 2: 480, 3: 720, 4: 600 })}
+      />,
+    )
+    const strip = screen.getByRole('img')
+    // Tooltip text covers all five zones, in canonical order, with both Mm Ss
+    // and bare Ss for the sub-minute case.
+    expect(strip).toHaveAccessibleName('Z1: 0s, Z2: 8m 00s, Z3: 12m 00s, Z4: 10m 00s, Z5: 0s')
+    expect(strip).toHaveAttribute('title', expect.stringContaining('Z3: 12m 00s'))
+    // Zero zones don't render a segment, so we get exactly three.
+    const z2 = screen.getByTestId('zone-segment-Z2')
+    const z3 = screen.getByTestId('zone-segment-Z3')
+    const z4 = screen.getByTestId('zone-segment-Z4')
+    expect(screen.queryByTestId('zone-segment-Z1')).toBeNull()
+    expect(screen.queryByTestId('zone-segment-Z5')).toBeNull()
+    // Widths are seconds / total — 1800s total, so Z2 = 480/1800 ≈ 26.67%.
+    expect(z2.style.width).toMatch(/^26\.6\d+%$/)
+    expect(z3.style.width).toBe('40%')
+    expect(z4.style.width).toMatch(/^33\.3\d+%$/)
+    // Colors come from the canonical palette.
+    expect(z3.style.backgroundColor).toBe(hexToRgb(HR_ZONES[2]!.color))
+  })
+
+  it('renders the em-dash fallback when hrSecondsInZone is undefined', () => {
+    render(<SessionZoneStrip />)
+    expect(screen.queryByRole('img')).toBeNull()
+    expect(screen.getByLabelText('No zone data')).toHaveTextContent('—')
+  })
+
+  it('renders the em-dash fallback when every zone is zero', () => {
+    render(<SessionZoneStrip hrSecondsInZone={zones()} />)
+    expect(screen.queryByRole('img')).toBeNull()
+    expect(screen.getByLabelText('No zone data')).toHaveTextContent('—')
+  })
+
+  it('renders a single full-width segment when all time is in one zone', () => {
+    render(<SessionZoneStrip hrSecondsInZone={zones({ 3: 1200 })} />)
+    const z3 = screen.getByTestId('zone-segment-Z3')
+    expect(z3.style.width).toBe('100%')
+    // No other segments render — verify by checking the render count.
+    for (const id of ['Z1', 'Z2', 'Z4', 'Z5']) {
+      expect(screen.queryByTestId(`zone-segment-${id}`)).toBeNull()
+    }
+  })
+})
+
+/**
+ * Convert a `#rrggbb` hex to the `rgb(r, g, b)` form jsdom serializes
+ * inline `style.backgroundColor` as. Lets the assertion above stay
+ * symbolic against `HR_ZONES` rather than hard-coding the hex.
+ */
+function hexToRgb(hex: string): string {
+  const clean = hex.replace('#', '')
+  const r = parseInt(clean.slice(0, 2), 16)
+  const g = parseInt(clean.slice(2, 4), 16)
+  const b = parseInt(clean.slice(4, 6), 16)
+  return `rgb(${r}, ${g}, ${b})`
+}

--- a/components/training-facility/gym/SessionZoneStrip.tsx
+++ b/components/training-facility/gym/SessionZoneStrip.tsx
@@ -1,0 +1,97 @@
+import type { JSX } from 'react'
+
+import { HR_ZONES } from '@/constants/hr-zones'
+import type { HrZone } from '@/types/cardio'
+
+/**
+ * Width of the rendered strip in pixels. Fixed (rather than fluid) so the
+ * sparkline reads at a consistent visual weight across all four session-log
+ * tables, regardless of the surrounding column's flex behavior.
+ */
+const STRIP_WIDTH_PX = 80
+
+/** Height of the rendered strip in pixels. Tuned to match the row's text height. */
+const STRIP_HEIGHT_PX = 10
+
+/** Props for {@link SessionZoneStrip}. */
+export interface SessionZoneStripProps {
+  /**
+   * Time spent in each HR zone for a single session, keyed by zone id (1–5).
+   * `undefined` (Apple Watch off) and an all-zero map both render as the
+   * em-dash fallback — neither has anything meaningful to show.
+   */
+  hrSecondsInZone?: Record<HrZone, number>
+}
+
+/**
+ * Inline 5-segment zone strip — a sparkline-class summary of how a single
+ * session's heart-rate time was distributed across Z1–Z5. Sits in the new
+ * "Zone" column on every cardio session-log table (PRD §7.4) so a viewer
+ * can scan rows and tell Z2 endurance work apart from Z4 grinders without
+ * opening a chart.
+ *
+ * Segments use the canonical zone palette from {@link HR_ZONES}; widths are
+ * proportional to seconds in zone. A native `title=` tooltip exposes the
+ * exact per-zone breakdown on hover (and via long-press on touch devices).
+ *
+ * Sessions with no usable zone data — `undefined` field, or every zone at
+ * zero — render as a centered em-dash span instead of a zero-width bar so
+ * the column doesn't visually disappear.
+ */
+export function SessionZoneStrip({ hrSecondsInZone }: SessionZoneStripProps): JSX.Element {
+  const total = hrSecondsInZone
+    ? (Object.values(hrSecondsInZone) as number[]).reduce((acc, v) => acc + (v ?? 0), 0)
+    : 0
+
+  if (!hrSecondsInZone || total <= 0) {
+    return (
+      <span aria-label="No zone data" className="font-mono text-white/35">
+        —
+      </span>
+    )
+  }
+
+  const tooltip = HR_ZONES.map((z, i) => {
+    const seconds = hrSecondsInZone[(i + 1) as HrZone] ?? 0
+    return `${z.shortLabel}: ${formatZoneTime(seconds)}`
+  }).join(', ')
+
+  return (
+    <span
+      role="img"
+      aria-label={tooltip}
+      title={tooltip}
+      className="inline-flex overflow-hidden rounded-sm border border-white/15"
+      style={{ width: `${STRIP_WIDTH_PX}px`, height: `${STRIP_HEIGHT_PX}px` }}
+    >
+      {HR_ZONES.map((zone, i) => {
+        const seconds = hrSecondsInZone[(i + 1) as HrZone] ?? 0
+        if (seconds <= 0) return null
+        const widthPct = (seconds / total) * 100
+        return (
+          <span
+            key={zone.id}
+            data-testid={`zone-segment-${zone.id}`}
+            aria-hidden="true"
+            className="h-full"
+            style={{ width: `${widthPct}%`, backgroundColor: zone.color }}
+          />
+        )
+      })}
+    </span>
+  )
+}
+
+/**
+ * Format a zone duration for the tooltip. Sub-minute spans render as `Ss`,
+ * everything else as `Mm Ss` (matching `formatDuration` in
+ * `lib/training-facility/cardio-shared.ts`) so the tooltip line for a
+ * 12-second Z5 doesn't read as `0m 12s`.
+ */
+function formatZoneTime(seconds: number): string {
+  const total = Math.round(seconds)
+  if (total < 60) return `${total}s`
+  const mins = Math.floor(total / 60)
+  const secs = total % 60
+  return `${mins}m ${secs.toString().padStart(2, '0')}s`
+}

--- a/components/training-facility/gym/StairDetailView.tsx
+++ b/components/training-facility/gym/StairDetailView.tsx
@@ -26,6 +26,7 @@ import {
 } from '@/components/training-facility/shared/CardioStatsCards'
 import { HrZoneBars } from './HrZoneBars'
 import { AvgHrBars } from './AvgHrBars'
+import { SessionZoneStrip } from './SessionZoneStrip'
 import { TrainingLoadChart } from './TrainingLoadChart'
 import {
   trainingLoadInRange,
@@ -480,7 +481,7 @@ function SessionLogTable({ sessions, range }: SessionLogTableProps): JSX.Element
         </p>
       ) : (
         <div className="overflow-x-auto">
-          <table className="w-full min-w-[480px] border-separate border-spacing-y-1 text-left text-sm">
+          <table className="w-full min-w-[560px] border-separate border-spacing-y-1 text-left text-sm">
             <thead className="text-xs uppercase tracking-[0.18em] text-white/55">
               <tr>
                 <th scope="col" className="px-3 py-2 font-semibold">
@@ -494,6 +495,9 @@ function SessionLogTable({ sessions, range }: SessionLogTableProps): JSX.Element
                 </th>
                 <th scope="col" className="px-3 py-2 font-semibold">
                   Max HR
+                </th>
+                <th scope="col" className="px-3 py-2 font-semibold">
+                  Zone
                 </th>
               </tr>
             </thead>
@@ -512,8 +516,11 @@ function SessionLogTable({ sessions, range }: SessionLogTableProps): JSX.Element
                   <td className="px-3 py-2 font-mono">
                     {typeof s.avg_hr === 'number' ? `${Math.round(s.avg_hr)}` : '—'}
                   </td>
-                  <td className="rounded-r-md px-3 py-2 font-mono">
+                  <td className="px-3 py-2 font-mono">
                     {typeof s.max_hr === 'number' ? `${Math.round(s.max_hr)}` : '—'}
+                  </td>
+                  <td className="rounded-r-md px-3 py-2 font-mono">
+                    <SessionZoneStrip hrSecondsInZone={s.hr_seconds_in_zone} />
                   </td>
                 </tr>
               ))}

--- a/components/training-facility/gym/TrackDetailView.tsx
+++ b/components/training-facility/gym/TrackDetailView.tsx
@@ -33,6 +33,7 @@ import { PersonalBests } from './PersonalBests'
 import { BackToCourtButton } from '@/components/common/BackToCourtButton'
 import { HrZoneBars } from './HrZoneBars'
 import { AvgHrBars } from './AvgHrBars'
+import { SessionZoneStrip } from './SessionZoneStrip'
 import { RoughLine } from '@/components/training-facility/shared/charts/RoughLine'
 import { RoughScatter } from '@/components/training-facility/shared/charts/RoughScatter'
 import { BodyweightOverlay } from '@/components/training-facility/shared/charts/BodyweightOverlay'
@@ -447,7 +448,7 @@ function SessionLogTable({ sessions, range }: SessionLogTableProps): JSX.Element
         </p>
       ) : (
         <div className="overflow-x-auto">
-          <table className="w-full min-w-[640px] border-separate border-spacing-y-1 text-left text-sm">
+          <table className="w-full min-w-[720px] border-separate border-spacing-y-1 text-left text-sm">
             <thead className="text-xs uppercase tracking-[0.18em] text-white/55">
               <tr>
                 <th scope="col" className="px-3 py-2 font-semibold">
@@ -468,6 +469,9 @@ function SessionLogTable({ sessions, range }: SessionLogTableProps): JSX.Element
                 <th scope="col" className="px-3 py-2 font-semibold">
                   Max HR
                 </th>
+                <th scope="col" className="px-3 py-2 font-semibold">
+                  Zone
+                </th>
               </tr>
             </thead>
             <tbody className="text-[#f7ead9]">
@@ -483,8 +487,11 @@ function SessionLogTable({ sessions, range }: SessionLogTableProps): JSX.Element
                   <td className="px-3 py-2 font-mono">
                     {typeof s.avg_hr === 'number' ? `${Math.round(s.avg_hr)}` : '—'}
                   </td>
-                  <td className="rounded-r-md px-3 py-2 font-mono">
+                  <td className="px-3 py-2 font-mono">
                     {typeof s.max_hr === 'number' ? `${Math.round(s.max_hr)}` : '—'}
+                  </td>
+                  <td className="rounded-r-md px-3 py-2 font-mono">
+                    <SessionZoneStrip hrSecondsInZone={s.hr_seconds_in_zone} />
                   </td>
                 </tr>
               ))}

--- a/components/training-facility/gym/TreadmillDetailView.tsx
+++ b/components/training-facility/gym/TreadmillDetailView.tsx
@@ -31,6 +31,7 @@ import {
 import { BackToCourtButton } from '@/components/common/BackToCourtButton'
 import { HrZoneBars } from './HrZoneBars'
 import { AvgHrBars } from './AvgHrBars'
+import { SessionZoneStrip } from './SessionZoneStrip'
 import { RoughLine } from '@/components/training-facility/shared/charts/RoughLine'
 import { RoughScatter } from '@/components/training-facility/shared/charts/RoughScatter'
 import { BodyweightOverlay } from '@/components/training-facility/shared/charts/BodyweightOverlay'
@@ -449,7 +450,7 @@ function SessionLogTable({ sessions, range }: SessionLogTableProps): JSX.Element
         </p>
       ) : (
         <div className="overflow-x-auto">
-          <table className="w-full min-w-[640px] border-separate border-spacing-y-1 text-left text-sm">
+          <table className="w-full min-w-[720px] border-separate border-spacing-y-1 text-left text-sm">
             <thead className="text-xs uppercase tracking-[0.18em] text-white/55">
               <tr>
                 <th scope="col" className="px-3 py-2 font-semibold">
@@ -470,6 +471,9 @@ function SessionLogTable({ sessions, range }: SessionLogTableProps): JSX.Element
                 <th scope="col" className="px-3 py-2 font-semibold">
                   Max HR
                 </th>
+                <th scope="col" className="px-3 py-2 font-semibold">
+                  Zone
+                </th>
               </tr>
             </thead>
             <tbody className="text-[#f7ead9]">
@@ -485,8 +489,11 @@ function SessionLogTable({ sessions, range }: SessionLogTableProps): JSX.Element
                   <td className="px-3 py-2 font-mono">
                     {typeof s.avg_hr === 'number' ? `${Math.round(s.avg_hr)}` : '—'}
                   </td>
-                  <td className="rounded-r-md px-3 py-2 font-mono">
+                  <td className="px-3 py-2 font-mono">
                     {typeof s.max_hr === 'number' ? `${Math.round(s.max_hr)}` : '—'}
+                  </td>
+                  <td className="rounded-r-md px-3 py-2 font-mono">
+                    <SessionZoneStrip hrSecondsInZone={s.hr_seconds_in_zone} />
                   </td>
                 </tr>
               ))}


### PR DESCRIPTION
## Summary

Adds a new "Zone" column to all four cardio session-log tables (`AllCardioOverview` + `StairDetailView` + `TreadmillDetailView` + `TrackDetailView`) showing a 5-segment sparkline of how heart-rate time was distributed across Z1–Z5 for that single session. Lets you scan rows and tell Z2 endurance work apart from Z4 grinders without opening a chart.

The data was already there — `cardio_sessions.zone1_seconds … zone5_seconds` ship through to `CardioSession.hr_seconds_in_zone`. This PR is purely a viz add.

## Implementation notes

- New `components/training-facility/gym/SessionZoneStrip.tsx` — flex-divs (no SVG), fixed 80×10px, segments use the canonical `HR_ZONES` palette, native `title=` tooltip.
- Sessions with no zone data (`undefined` field, or every zone at zero) render an em-dash span instead of a zero-width bar.
- Each table's `min-w-[…]` was bumped to accommodate the new column (overview 680→760px, stair 480→560px, treadmill+track 640→720px).

## Test plan

- [ ] Visit `/training-facility/gym/overview` — Sessions table shows a "Zone" column with colored strips for sessions that have HR data
- [ ] Hover a strip — native tooltip shows `Z1: …, Z2: …, Z3: …, Z4: …, Z5: …` per-zone time (sub-minute as `Ns`, otherwise `Mm SSs`)
- [ ] Walking session (no zone data in fixtures) renders `—` in the Zone column
- [ ] `/training-facility/gym/stair` — Zone column appears, sized correctly
- [ ] `/training-facility/gym/treadmill` — Zone column appears, sized correctly
- [ ] `/training-facility/gym/track` — Zone column appears, sized correctly
- [ ] Mobile (≤640px): tables pick up horizontal scroll via the existing `overflow-x-auto`; Zone column is reachable

Closes #163.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added heart rate zone visualization to training session logs across all facility types. Session tables now include a new "Zone" column displaying how time is distributed across heart rate zones (Z1–Z5). Each zone appears with a distinct color, and hovering reveals duration details in a tooltip.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->