### PR TITLE
feat(gym): click-to-expand session row for per-session HR zone bars (#164)

### DIFF
--- a/components/training-facility/gym/AllCardioOverview.tsx
+++ b/components/training-facility/gym/AllCardioOverview.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import Link from 'next/link'
-import { useEffect, useMemo, useRef, useState, type JSX } from 'react'
+import { Fragment, useEffect, useMemo, useRef, useState, type JSX } from 'react'
 import type { CardioData, CardioSession } from '@/types/cardio'
 import { PreviewModeBadge } from '@/components/training-facility/shared/PreviewModeBadge'
 import { PreviewWithSampleDataButton } from '@/components/training-facility/shared/PreviewWithSampleDataButton'
@@ -43,6 +43,12 @@ import { BackToCourtButton } from '@/components/common/BackToCourtButton'
 import { HrZoneBars } from './HrZoneBars'
 import { ActivityLegend, AvgHrBarsByActivity } from './AvgHrBarsByActivity'
 import { SessionZoneStrip } from './SessionZoneStrip'
+import {
+  ExpandedHrZoneRow,
+  getRowExpansionProps,
+  hasZoneData,
+  useSessionRowExpansion,
+} from './SessionRowExpansion'
 import { TrainingLoadChart } from './TrainingLoadChart'
 import { chartPalette } from '@/components/training-facility/shared/charts/palette'
 import { defaultMargin } from '@/components/training-facility/shared/charts/types'
@@ -493,6 +499,7 @@ function SessionLogTable({ sessions, range }: SessionLogTableProps): JSX.Element
   const rows = useMemo(() => sessions.slice().reverse(), [sessions])
   const startLabel = formatRangeBound(range.start, 'start')
   const endLabel = formatRangeBound(range.end, 'end')
+  const expansion = useSessionRowExpansion()
 
   return (
     <section className="mt-8 rounded-[1.6rem] border border-white/10 bg-black/25 p-5">
@@ -545,41 +552,54 @@ function SessionLogTable({ sessions, range }: SessionLogTableProps): JSX.Element
             <tbody className="text-[#f7ead9]">
               {rows.map((s, i) => {
                 const visual = ACTIVITY_VISUALS[s.activity]
+                const rowKey = `${s.date}-${s.activity}-${s.duration_seconds}-${i}`
+                const interactive = hasZoneData(s.hr_seconds_in_zone)
+                const rowProps = getRowExpansionProps(
+                  rowKey,
+                  expansion,
+                  interactive,
+                  'rounded-md bg-white/5 align-middle',
+                )
+                const isExpanded = expansion.expandedKey === rowKey
                 return (
-                  <tr
-                    key={`${s.date}-${s.activity}-${s.duration_seconds}-${i}`}
-                    className="rounded-md bg-white/5 align-middle"
-                  >
-                    <td className="rounded-l-md px-3 py-2 font-mono">
-                      {formatRowDate(s.date)}
-                    </td>
-                    <td className="px-3 py-2 font-mono">
-                      <span className="inline-flex items-center gap-1.5">
-                        <span
-                          aria-hidden="true"
-                          className="inline-block h-2 w-2 rounded-full"
-                          style={{ backgroundColor: visual.color }}
-                        />
-                        {visual.label}
-                      </span>
-                    </td>
-                    <td className="px-3 py-2 font-mono">
-                      {formatDistanceMiles(s.distance_meters)}
-                    </td>
-                    <td className="px-3 py-2 font-mono">{formatDuration(s.duration_seconds)}</td>
-                    <td className="px-3 py-2 font-mono">
-                      {formatPaceCellFromSecPerKm(s.pace_seconds_per_km)}
-                    </td>
-                    <td className="px-3 py-2 font-mono">
-                      {typeof s.avg_hr === 'number' ? `${Math.round(s.avg_hr)}` : '—'}
-                    </td>
-                    <td className="px-3 py-2 font-mono">
-                      {typeof s.max_hr === 'number' ? `${Math.round(s.max_hr)}` : '—'}
-                    </td>
-                    <td className="rounded-r-md px-3 py-2 font-mono">
-                      <SessionZoneStrip hrSecondsInZone={s.hr_seconds_in_zone} />
-                    </td>
-                  </tr>
+                  <Fragment key={rowKey}>
+                    <tr {...rowProps}>
+                      <td className="rounded-l-md px-3 py-2 font-mono">
+                        {formatRowDate(s.date)}
+                      </td>
+                      <td className="px-3 py-2 font-mono">
+                        <span className="inline-flex items-center gap-1.5">
+                          <span
+                            aria-hidden="true"
+                            className="inline-block h-2 w-2 rounded-full"
+                            style={{ backgroundColor: visual.color }}
+                          />
+                          {visual.label}
+                        </span>
+                      </td>
+                      <td className="px-3 py-2 font-mono">
+                        {formatDistanceMiles(s.distance_meters)}
+                      </td>
+                      <td className="px-3 py-2 font-mono">
+                        {formatDuration(s.duration_seconds)}
+                      </td>
+                      <td className="px-3 py-2 font-mono">
+                        {formatPaceCellFromSecPerKm(s.pace_seconds_per_km)}
+                      </td>
+                      <td className="px-3 py-2 font-mono">
+                        {typeof s.avg_hr === 'number' ? `${Math.round(s.avg_hr)}` : '—'}
+                      </td>
+                      <td className="px-3 py-2 font-mono">
+                        {typeof s.max_hr === 'number' ? `${Math.round(s.max_hr)}` : '—'}
+                      </td>
+                      <td className="rounded-r-md px-3 py-2 font-mono">
+                        <SessionZoneStrip hrSecondsInZone={s.hr_seconds_in_zone} />
+                      </td>
+                    </tr>
+                    {isExpanded && interactive && (
+                      <ExpandedHrZoneRow session={s} colSpan={8} fontFamily={FONT_FAMILY} />
+                    )}
+                  </Fragment>
                 )
               })}
             </tbody>

--- a/components/training-facility/gym/SessionRowExpansion.test.tsx
+++ b/components/training-facility/gym/SessionRowExpansion.test.tsx
@@ -1,0 +1,218 @@
+import { describe, expect, it } from 'vitest'
+import { act, render, screen, renderHook } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import type { CardioSession, HrZone } from '@/types/cardio'
+import {
+  ExpandedHrZoneRow,
+  getRowExpansionProps,
+  hasZoneData,
+  useSessionRowExpansion,
+} from './SessionRowExpansion'
+
+/**
+ * Build a zones-in-seconds map with sane defaults; pass overrides for the
+ * cases the test cares about. Mirrors the helper in `SessionZoneStrip.test`.
+ */
+const zones = (overrides: Partial<Record<HrZone, number>> = {}): Record<HrZone, number> => ({
+  1: 0,
+  2: 0,
+  3: 0,
+  4: 0,
+  5: 0,
+  ...overrides,
+})
+
+/** Minimal `CardioSession` fixture — we only care about zone data + identity here. */
+const session = (overrides: Partial<CardioSession> = {}): CardioSession => ({
+  date: '2026-04-30',
+  activity: 'stair',
+  duration_seconds: 1800,
+  distance_meters: 0,
+  pace_seconds_per_km: undefined,
+  avg_hr: 142,
+  max_hr: 168,
+  hr_seconds_in_zone: zones({ 2: 600, 3: 900, 4: 300 }),
+  ...overrides,
+})
+
+describe('hasZoneData', () => {
+  it('returns false when the field is missing', () => {
+    expect(hasZoneData(undefined)).toBe(false)
+  })
+  it('returns false when every zone is zero', () => {
+    expect(hasZoneData(zones())).toBe(false)
+  })
+  it('returns true when at least one zone has logged seconds', () => {
+    expect(hasZoneData(zones({ 3: 60 }))).toBe(true)
+  })
+})
+
+describe('useSessionRowExpansion', () => {
+  it('starts with no row expanded', () => {
+    const { result } = renderHook(() => useSessionRowExpansion())
+    expect(result.current.expandedKey).toBeNull()
+  })
+
+  it('toggle opens the row, repeating the same key closes it', () => {
+    const { result } = renderHook(() => useSessionRowExpansion())
+    act(() => result.current.toggle('row-a'))
+    expect(result.current.expandedKey).toBe('row-a')
+    act(() => result.current.toggle('row-a'))
+    expect(result.current.expandedKey).toBeNull()
+  })
+
+  it('opening a different row replaces the previously open row', () => {
+    const { result } = renderHook(() => useSessionRowExpansion())
+    act(() => result.current.toggle('row-a'))
+    act(() => result.current.toggle('row-b'))
+    expect(result.current.expandedKey).toBe('row-b')
+  })
+})
+
+describe('getRowExpansionProps', () => {
+  const baseClassName = 'rounded-md bg-white/5'
+
+  it('returns inert props when the session has no zone data', () => {
+    const { result } = renderHook(() => useSessionRowExpansion())
+    const props = getRowExpansionProps('row-a', result.current, false, baseClassName)
+    expect(props.role).toBeUndefined()
+    expect(props.tabIndex).toBeUndefined()
+    expect(props['aria-expanded']).toBeUndefined()
+    expect(props.onClick).toBeUndefined()
+    expect(props.onKeyDown).toBeUndefined()
+    expect(props.className).toBe(baseClassName)
+  })
+
+  it('marks the row interactive when zone data is present', () => {
+    const { result } = renderHook(() => useSessionRowExpansion())
+    const props = getRowExpansionProps('row-a', result.current, true, baseClassName)
+    expect(props.role).toBe('button')
+    expect(props.tabIndex).toBe(0)
+    expect(props['aria-expanded']).toBe(false)
+    expect(props.className).toContain(baseClassName)
+    expect(props.className).toContain('cursor-pointer')
+  })
+
+  it('reflects expanded state when keys match', () => {
+    const { result } = renderHook(() => useSessionRowExpansion())
+    act(() => result.current.toggle('row-a'))
+    const props = getRowExpansionProps('row-a', result.current, true, baseClassName)
+    expect(props['aria-expanded']).toBe(true)
+  })
+})
+
+describe('row interaction (click + keyboard)', () => {
+  /**
+   * Tiny harness that mounts a 2-row table using the helper. Lets us assert
+   * the click/keyboard flow without standing up the full `AllCardioOverview`
+   * (which would require mocking `getCardioData`, `MaxHrControl` storage,
+   * `ResizeObserver`, etc.).
+   */
+  function Harness() {
+    const state = useSessionRowExpansion()
+    const rows = [
+      { key: 'row-a', hasZones: true },
+      { key: 'row-b', hasZones: true },
+      { key: 'row-c', hasZones: false },
+    ]
+    return (
+      <table>
+        <tbody>
+          {rows.map((r) => {
+            const props = getRowExpansionProps(r.key, state, r.hasZones, '')
+            return (
+              <tr key={r.key} data-testid={r.key} {...props}>
+                <td>{r.key}</td>
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+    )
+  }
+
+  it('click toggles the row open and closed', async () => {
+    const user = userEvent.setup()
+    render(<Harness />)
+    const rowA = screen.getByTestId('row-a')
+    expect(rowA).toHaveAttribute('aria-expanded', 'false')
+    await user.click(rowA)
+    expect(rowA).toHaveAttribute('aria-expanded', 'true')
+    await user.click(rowA)
+    expect(rowA).toHaveAttribute('aria-expanded', 'false')
+  })
+
+  it('opening a second row collapses the first', async () => {
+    const user = userEvent.setup()
+    render(<Harness />)
+    const rowA = screen.getByTestId('row-a')
+    const rowB = screen.getByTestId('row-b')
+    await user.click(rowA)
+    expect(rowA).toHaveAttribute('aria-expanded', 'true')
+    await user.click(rowB)
+    expect(rowA).toHaveAttribute('aria-expanded', 'false')
+    expect(rowB).toHaveAttribute('aria-expanded', 'true')
+  })
+
+  it('Enter and Space toggle expansion via keyboard', async () => {
+    const user = userEvent.setup()
+    render(<Harness />)
+    const rowA = screen.getByTestId('row-a')
+    rowA.focus()
+    await user.keyboard('{Enter}')
+    expect(rowA).toHaveAttribute('aria-expanded', 'true')
+    await user.keyboard(' ')
+    expect(rowA).toHaveAttribute('aria-expanded', 'false')
+  })
+
+  it('rows without zone data have no interactive affordance', () => {
+    render(<Harness />)
+    const rowC = screen.getByTestId('row-c')
+    expect(rowC).not.toHaveAttribute('role', 'button')
+    expect(rowC).not.toHaveAttribute('tabindex')
+    expect(rowC).not.toHaveAttribute('aria-expanded')
+  })
+})
+
+describe('ExpandedHrZoneRow', () => {
+  it('renders an HrZoneBars labelled with the time-in-zone aria text', () => {
+    render(
+      <table>
+        <tbody>
+          <ExpandedHrZoneRow session={session()} colSpan={5} fontFamily="sans-serif" />
+        </tbody>
+      </table>,
+    )
+    // HrZoneBars renders as an SVG with role="img" and an explicit aria-label
+    // — the strongest signal that the chart hydrated for this single session.
+    expect(screen.getByRole('img', { name: /time in heart-rate zone/i })).toBeInTheDocument()
+    expect(screen.getByTestId('session-row-expansion')).toBeInTheDocument()
+  })
+
+  it('renders the empty-chart fallback when zone data is all zeros', () => {
+    const empty = session({ hr_seconds_in_zone: zones() })
+    render(
+      <table>
+        <tbody>
+          <ExpandedHrZoneRow session={empty} colSpan={5} />
+        </tbody>
+      </table>,
+    )
+    // Empty-state: HrZoneBars renders an `EmptyChart` with the default message.
+    expect(screen.getByText(/no hr-zone data/i)).toBeInTheDocument()
+  })
+
+  it('uses the provided colSpan on the cell', () => {
+    render(
+      <table>
+        <tbody>
+          <ExpandedHrZoneRow session={session()} colSpan={8} />
+        </tbody>
+      </table>,
+    )
+    const cell = screen.getByTestId('session-row-expansion').querySelector('td')
+    expect(cell).toHaveAttribute('colspan', '8')
+  })
+})
+

--- a/components/training-facility/gym/SessionRowExpansion.tsx
+++ b/components/training-facility/gym/SessionRowExpansion.tsx
@@ -1,0 +1,206 @@
+'use client'
+
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type JSX,
+  type KeyboardEvent,
+  type MouseEvent,
+} from 'react'
+
+import type { CardioSession, HrZone } from '@/types/cardio'
+import { aggregateHrZoneSeconds } from '@/lib/training-facility/cardio-shared'
+import { HrZoneBars } from './HrZoneBars'
+
+/** Initial render width for the expansion panel before `ResizeObserver` fires. */
+const DEFAULT_PANEL_WIDTH = 560
+
+/** Floor on the panel's measured width — keeps the chart readable on narrow viewports. */
+const MIN_PANEL_WIDTH = 280
+
+/** Vertical room reserved for the expanded zone-bars chart. */
+const PANEL_HEIGHT = 200
+
+/**
+ * State + toggle returned by {@link useSessionRowExpansion}. Exactly one row
+ * may be open at a time across the parent table — opening a new key replaces
+ * any previously expanded key.
+ */
+export interface SessionRowExpansionState {
+  /** Composite key of the currently expanded row, or `null` if none. */
+  readonly expandedKey: string | null
+  /**
+   * Toggle expansion for the given key. Re-applying the same key collapses
+   * the row; a different key replaces the open row in a single render.
+   */
+  toggle: (key: string) => void
+}
+
+/**
+ * Single-row expansion controller for the cardio session-log tables. Holds
+ * one composite key (or `null`) so opening row B implicitly closes row A —
+ * the table never renders two expansion panels at once.
+ */
+export function useSessionRowExpansion(): SessionRowExpansionState {
+  const [expandedKey, setExpandedKey] = useState<string | null>(null)
+  const toggle = useCallback((key: string) => {
+    setExpandedKey((prev) => (prev === key ? null : key))
+  }, [])
+  return { expandedKey, toggle }
+}
+
+/**
+ * True iff the session has at least one logged second across Z1–Z5. Sessions
+ * that come back from `cardio.json` without `hr_seconds_in_zone` (Apple Watch
+ * off) or with all zones at zero return `false` — those rows skip the
+ * expansion affordance entirely so the user can't open an empty chart.
+ */
+export function hasZoneData(hrSecondsInZone?: Record<HrZone, number>): boolean {
+  if (!hrSecondsInZone) return false
+  return (Object.values(hrSecondsInZone) as number[]).some((v) => (v ?? 0) > 0)
+}
+
+/**
+ * Props returned by {@link getRowExpansionProps} — designed to spread directly
+ * onto a `<tr>`. Each field is `undefined` when the row is non-interactive
+ * (no zone data) so React treats the prop as unset rather than binding a
+ * no-op handler.
+ */
+export interface RowExpansionProps {
+  /** `'button'` when interactive; `undefined` otherwise. */
+  role: 'button' | undefined
+  /** `0` when interactive (focusable); `undefined` otherwise (not in the tab order). */
+  tabIndex: number | undefined
+  /** Reflects the current expansion state. `undefined` when the row has no expansion. */
+  'aria-expanded': boolean | undefined
+  /** Click toggle. `undefined` when the row has no expansion. */
+  onClick: ((e: MouseEvent<HTMLTableRowElement>) => void) | undefined
+  /** Keyboard toggle on Enter/Space. `undefined` when the row has no expansion. */
+  onKeyDown: ((e: KeyboardEvent<HTMLTableRowElement>) => void) | undefined
+  /** Final className — extends `baseClassName` with focus / hover states when interactive. */
+  className: string
+}
+
+/**
+ * Build the a11y + interaction props for a session-log row. Keeps the four
+ * cardio session-log tables (overview / stair / treadmill / track) in sync on
+ * keyboard support, hover/focus styling, and `aria-expanded` semantics so
+ * each table doesn't reinvent the same wiring.
+ *
+ * @param key composite row key — pass the same string the parent uses for React's `key`.
+ * @param state value returned by {@link useSessionRowExpansion}.
+ * @param hasZoneData whether the session has any zone-time logged.
+ *   `false` returns inert props so the row stays out of the tab order.
+ * @param baseClassName the row's existing class string — preserved as-is and
+ *   suffixed with focus / hover utilities only when the row is interactive.
+ */
+export function getRowExpansionProps(
+  key: string,
+  state: SessionRowExpansionState,
+  hasZoneData: boolean,
+  baseClassName: string,
+): RowExpansionProps {
+  if (!hasZoneData) {
+    return {
+      role: undefined,
+      tabIndex: undefined,
+      'aria-expanded': undefined,
+      onClick: undefined,
+      onKeyDown: undefined,
+      className: baseClassName,
+    }
+  }
+  const isExpanded = state.expandedKey === key
+  return {
+    role: 'button',
+    tabIndex: 0,
+    'aria-expanded': isExpanded,
+    onClick: () => state.toggle(key),
+    onKeyDown: (e) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault()
+        state.toggle(key)
+      }
+    },
+    className: `${baseClassName} cursor-pointer transition-colors hover:bg-white/10 focus-visible:bg-white/10 focus-visible:outline-none aria-expanded:bg-white/10`,
+  }
+}
+
+/** Props for {@link ExpandedHrZoneRow}. */
+export interface ExpandedHrZoneRowProps {
+  /** Session whose zone breakdown is rendered in the expansion panel. */
+  session: CardioSession
+  /** Number of columns in the parent table — used as the cell's `colSpan`. */
+  colSpan: number
+  /**
+   * Optional font family forwarded to {@link HrZoneBars}. Cardio surfaces use
+   * `'Patrick Hand', system-ui, sans-serif`; omit to inherit.
+   */
+  fontFamily?: string
+}
+
+/**
+ * Expanded `<tr>` rendered immediately below a clicked row. Hosts a single
+ * `<HrZoneBars>` instance keyed to the session's `hr_seconds_in_zone` so the
+ * five-zone breakdown reads at full chart fidelity instead of the inline
+ * sparkline strip from {@link SessionZoneStrip}.
+ *
+ * Width tracks the cell via `ResizeObserver` (mirroring the per-card sizing
+ * pattern used by `AllCardioOverview` / `StairDetailView` / etc.); SSR or
+ * environments without `ResizeObserver` fall back to the initial width.
+ *
+ * Mount-fade: opacity transitions from 0 → 100 over 150ms after the panel
+ * mounts so it doesn't hard-pop into existence. Collapse is unanimated —
+ * the row simply unmounts when `expandedKey` no longer matches.
+ */
+export function ExpandedHrZoneRow({
+  session,
+  colSpan,
+  fontFamily,
+}: ExpandedHrZoneRowProps): JSX.Element {
+  const sizerRef = useRef<HTMLDivElement>(null)
+  const [width, setWidth] = useState(DEFAULT_PANEL_WIDTH)
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  useEffect(() => {
+    const node = sizerRef.current
+    if (!node || typeof ResizeObserver === 'undefined') return
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        const next = Math.max(MIN_PANEL_WIDTH, Math.floor(entry.contentRect.width))
+        setWidth((prev) => (prev === next ? prev : next))
+      }
+    })
+    observer.observe(node)
+    return () => observer.disconnect()
+  }, [])
+
+  const buckets = useMemo(() => aggregateHrZoneSeconds([session]), [session])
+
+  return (
+    <tr data-testid="session-row-expansion">
+      <td colSpan={colSpan} className="rounded-md bg-white/5 px-4 py-4">
+        <div
+          ref={sizerRef}
+          className={`transition-opacity duration-150 ease-out ${
+            mounted ? 'opacity-100' : 'opacity-0'
+          }`}
+        >
+          <HrZoneBars
+            buckets={buckets}
+            width={width}
+            height={PANEL_HEIGHT}
+            fontFamily={fontFamily}
+          />
+        </div>
+      </td>
+    </tr>
+  )
+}

--- a/components/training-facility/gym/StairDetailView.tsx
+++ b/components/training-facility/gym/StairDetailView.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import Link from 'next/link'
-import { useEffect, useMemo, useRef, useState, type JSX } from 'react'
+import { Fragment, useEffect, useMemo, useRef, useState, type JSX } from 'react'
 import type { CardioData, CardioSession } from '@/types/cardio'
 import { PreviewModeBadge } from '@/components/training-facility/shared/PreviewModeBadge'
 import { PreviewWithSampleDataButton } from '@/components/training-facility/shared/PreviewWithSampleDataButton'
@@ -33,6 +33,12 @@ import {
 import { HrZoneBars } from './HrZoneBars'
 import { AvgHrBars } from './AvgHrBars'
 import { SessionZoneStrip } from './SessionZoneStrip'
+import {
+  ExpandedHrZoneRow,
+  getRowExpansionProps,
+  hasZoneData,
+  useSessionRowExpansion,
+} from './SessionRowExpansion'
 import { TrainingLoadChart } from './TrainingLoadChart'
 import {
   trainingLoadInRange,
@@ -499,6 +505,7 @@ function SessionLogTable({ sessions, range }: SessionLogTableProps): JSX.Element
   const rows = useMemo(() => sessions.slice().reverse(), [sessions])
   const startLabel = formatRangeBound(range.start, 'start')
   const endLabel = formatRangeBound(range.end, 'end')
+  const expansion = useSessionRowExpansion()
 
   return (
     <section className="mt-8 rounded-[1.6rem] border border-white/10 bg-black/25 p-5">
@@ -540,28 +547,45 @@ function SessionLogTable({ sessions, range }: SessionLogTableProps): JSX.Element
               </tr>
             </thead>
             <tbody className="text-[#f7ead9]">
-              {rows.map((s, i) => (
-                <tr
-                  // Append the row index to disambiguate the rare case of two
-                  // sessions sharing both a date and an exact duration_seconds
-                  // (back-to-back stair sessions). Stable as long as the
-                  // reverse-sorted row order is.
-                  key={`${s.date}-${s.duration_seconds}-${i}`}
-                  className="rounded-md bg-white/5 align-middle"
-                >
-                  <td className="rounded-l-md px-3 py-2 font-mono">{formatRowDate(s.date)}</td>
-                  <td className="px-3 py-2 font-mono">{formatDuration(s.duration_seconds)}</td>
-                  <td className="px-3 py-2 font-mono">
-                    {typeof s.avg_hr === 'number' ? `${Math.round(s.avg_hr)}` : '—'}
-                  </td>
-                  <td className="px-3 py-2 font-mono">
-                    {typeof s.max_hr === 'number' ? `${Math.round(s.max_hr)}` : '—'}
-                  </td>
-                  <td className="rounded-r-md px-3 py-2 font-mono">
-                    <SessionZoneStrip hrSecondsInZone={s.hr_seconds_in_zone} />
-                  </td>
-                </tr>
-              ))}
+              {rows.map((s, i) => {
+                // Append the row index to disambiguate the rare case of two
+                // sessions sharing both a date and an exact duration_seconds
+                // (back-to-back stair sessions). Stable as long as the
+                // reverse-sorted row order is.
+                const rowKey = `${s.date}-${s.duration_seconds}-${i}`
+                const interactive = hasZoneData(s.hr_seconds_in_zone)
+                const rowProps = getRowExpansionProps(
+                  rowKey,
+                  expansion,
+                  interactive,
+                  'rounded-md bg-white/5 align-middle',
+                )
+                const isExpanded = expansion.expandedKey === rowKey
+                return (
+                  <Fragment key={rowKey}>
+                    <tr {...rowProps}>
+                      <td className="rounded-l-md px-3 py-2 font-mono">
+                        {formatRowDate(s.date)}
+                      </td>
+                      <td className="px-3 py-2 font-mono">
+                        {formatDuration(s.duration_seconds)}
+                      </td>
+                      <td className="px-3 py-2 font-mono">
+                        {typeof s.avg_hr === 'number' ? `${Math.round(s.avg_hr)}` : '—'}
+                      </td>
+                      <td className="px-3 py-2 font-mono">
+                        {typeof s.max_hr === 'number' ? `${Math.round(s.max_hr)}` : '—'}
+                      </td>
+                      <td className="rounded-r-md px-3 py-2 font-mono">
+                        <SessionZoneStrip hrSecondsInZone={s.hr_seconds_in_zone} />
+                      </td>
+                    </tr>
+                    {isExpanded && interactive && (
+                      <ExpandedHrZoneRow session={s} colSpan={5} fontFamily={FONT_FAMILY} />
+                    )}
+                  </Fragment>
+                )
+              })}
             </tbody>
           </table>
         </div>

--- a/components/training-facility/gym/TrackDetailView.tsx
+++ b/components/training-facility/gym/TrackDetailView.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import Link from 'next/link'
-import { useEffect, useMemo, useRef, useState, type JSX } from 'react'
+import { Fragment, useEffect, useMemo, useRef, useState, type JSX } from 'react'
 import type { CardioData, CardioSession } from '@/types/cardio'
 import type { Benchmark } from '@/types/movement'
 import { PreviewModeBadge } from '@/components/training-facility/shared/PreviewModeBadge'
@@ -40,6 +40,12 @@ import { BackToCourtButton } from '@/components/common/BackToCourtButton'
 import { HrZoneBars } from './HrZoneBars'
 import { AvgHrBars } from './AvgHrBars'
 import { SessionZoneStrip } from './SessionZoneStrip'
+import {
+  ExpandedHrZoneRow,
+  getRowExpansionProps,
+  hasZoneData,
+  useSessionRowExpansion,
+} from './SessionRowExpansion'
 import { RoughLine } from '@/components/training-facility/shared/charts/RoughLine'
 import { RoughScatter } from '@/components/training-facility/shared/charts/RoughScatter'
 import { BodyweightOverlay } from '@/components/training-facility/shared/charts/BodyweightOverlay'
@@ -460,6 +466,7 @@ function SessionLogTable({ sessions, range }: SessionLogTableProps): JSX.Element
   const rows = useMemo(() => sessions.slice().reverse(), [sessions])
   const startLabel = formatRangeBound(range.start, 'start')
   const endLabel = formatRangeBound(range.end, 'end')
+  const expansion = useSessionRowExpansion()
 
   return (
     <section className="mt-8 rounded-[1.6rem] border border-white/10 bg-black/25 p-5">
@@ -507,26 +514,47 @@ function SessionLogTable({ sessions, range }: SessionLogTableProps): JSX.Element
               </tr>
             </thead>
             <tbody className="text-[#f7ead9]">
-              {rows.map((s, i) => (
-                <tr
-                  key={`${s.date}-${s.duration_seconds}-${i}`}
-                  className="rounded-md bg-white/5 align-middle"
-                >
-                  <td className="rounded-l-md px-3 py-2 font-mono">{formatRowDate(s.date)}</td>
-                  <td className="px-3 py-2 font-mono">{formatDistanceMiles(s.distance_meters)}</td>
-                  <td className="px-3 py-2 font-mono">{formatDuration(s.duration_seconds)}</td>
-                  <td className="px-3 py-2 font-mono">{formatPaceCellFromSecPerKm(s.pace_seconds_per_km)}</td>
-                  <td className="px-3 py-2 font-mono">
-                    {typeof s.avg_hr === 'number' ? `${Math.round(s.avg_hr)}` : '—'}
-                  </td>
-                  <td className="px-3 py-2 font-mono">
-                    {typeof s.max_hr === 'number' ? `${Math.round(s.max_hr)}` : '—'}
-                  </td>
-                  <td className="rounded-r-md px-3 py-2 font-mono">
-                    <SessionZoneStrip hrSecondsInZone={s.hr_seconds_in_zone} />
-                  </td>
-                </tr>
-              ))}
+              {rows.map((s, i) => {
+                const rowKey = `${s.date}-${s.duration_seconds}-${i}`
+                const interactive = hasZoneData(s.hr_seconds_in_zone)
+                const rowProps = getRowExpansionProps(
+                  rowKey,
+                  expansion,
+                  interactive,
+                  'rounded-md bg-white/5 align-middle',
+                )
+                const isExpanded = expansion.expandedKey === rowKey
+                return (
+                  <Fragment key={rowKey}>
+                    <tr {...rowProps}>
+                      <td className="rounded-l-md px-3 py-2 font-mono">
+                        {formatRowDate(s.date)}
+                      </td>
+                      <td className="px-3 py-2 font-mono">
+                        {formatDistanceMiles(s.distance_meters)}
+                      </td>
+                      <td className="px-3 py-2 font-mono">
+                        {formatDuration(s.duration_seconds)}
+                      </td>
+                      <td className="px-3 py-2 font-mono">
+                        {formatPaceCellFromSecPerKm(s.pace_seconds_per_km)}
+                      </td>
+                      <td className="px-3 py-2 font-mono">
+                        {typeof s.avg_hr === 'number' ? `${Math.round(s.avg_hr)}` : '—'}
+                      </td>
+                      <td className="px-3 py-2 font-mono">
+                        {typeof s.max_hr === 'number' ? `${Math.round(s.max_hr)}` : '—'}
+                      </td>
+                      <td className="rounded-r-md px-3 py-2 font-mono">
+                        <SessionZoneStrip hrSecondsInZone={s.hr_seconds_in_zone} />
+                      </td>
+                    </tr>
+                    {isExpanded && interactive && (
+                      <ExpandedHrZoneRow session={s} colSpan={7} fontFamily={FONT_FAMILY} />
+                    )}
+                  </Fragment>
+                )
+              })}
             </tbody>
           </table>
         </div>

--- a/components/training-facility/gym/TreadmillDetailView.tsx
+++ b/components/training-facility/gym/TreadmillDetailView.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import Link from 'next/link'
-import { useEffect, useMemo, useRef, useState, type JSX } from 'react'
+import { Fragment, useEffect, useMemo, useRef, useState, type JSX } from 'react'
 import type { CardioData, CardioSession } from '@/types/cardio'
 import type { Benchmark } from '@/types/movement'
 import { PreviewModeBadge } from '@/components/training-facility/shared/PreviewModeBadge'
@@ -38,6 +38,12 @@ import { BackToCourtButton } from '@/components/common/BackToCourtButton'
 import { HrZoneBars } from './HrZoneBars'
 import { AvgHrBars } from './AvgHrBars'
 import { SessionZoneStrip } from './SessionZoneStrip'
+import {
+  ExpandedHrZoneRow,
+  getRowExpansionProps,
+  hasZoneData,
+  useSessionRowExpansion,
+} from './SessionRowExpansion'
 import { RoughLine } from '@/components/training-facility/shared/charts/RoughLine'
 import { RoughScatter } from '@/components/training-facility/shared/charts/RoughScatter'
 import { BodyweightOverlay } from '@/components/training-facility/shared/charts/BodyweightOverlay'
@@ -462,6 +468,7 @@ function SessionLogTable({ sessions, range }: SessionLogTableProps): JSX.Element
   const rows = useMemo(() => sessions.slice().reverse(), [sessions])
   const startLabel = formatRangeBound(range.start, 'start')
   const endLabel = formatRangeBound(range.end, 'end')
+  const expansion = useSessionRowExpansion()
 
   return (
     <section className="mt-8 rounded-[1.6rem] border border-white/10 bg-black/25 p-5">
@@ -509,26 +516,47 @@ function SessionLogTable({ sessions, range }: SessionLogTableProps): JSX.Element
               </tr>
             </thead>
             <tbody className="text-[#f7ead9]">
-              {rows.map((s, i) => (
-                <tr
-                  key={`${s.date}-${s.duration_seconds}-${i}`}
-                  className="rounded-md bg-white/5 align-middle"
-                >
-                  <td className="rounded-l-md px-3 py-2 font-mono">{formatRowDate(s.date)}</td>
-                  <td className="px-3 py-2 font-mono">{formatDistanceMiles(s.distance_meters)}</td>
-                  <td className="px-3 py-2 font-mono">{formatDuration(s.duration_seconds)}</td>
-                  <td className="px-3 py-2 font-mono">{formatPaceCellFromSecPerKm(s.pace_seconds_per_km)}</td>
-                  <td className="px-3 py-2 font-mono">
-                    {typeof s.avg_hr === 'number' ? `${Math.round(s.avg_hr)}` : '—'}
-                  </td>
-                  <td className="px-3 py-2 font-mono">
-                    {typeof s.max_hr === 'number' ? `${Math.round(s.max_hr)}` : '—'}
-                  </td>
-                  <td className="rounded-r-md px-3 py-2 font-mono">
-                    <SessionZoneStrip hrSecondsInZone={s.hr_seconds_in_zone} />
-                  </td>
-                </tr>
-              ))}
+              {rows.map((s, i) => {
+                const rowKey = `${s.date}-${s.duration_seconds}-${i}`
+                const interactive = hasZoneData(s.hr_seconds_in_zone)
+                const rowProps = getRowExpansionProps(
+                  rowKey,
+                  expansion,
+                  interactive,
+                  'rounded-md bg-white/5 align-middle',
+                )
+                const isExpanded = expansion.expandedKey === rowKey
+                return (
+                  <Fragment key={rowKey}>
+                    <tr {...rowProps}>
+                      <td className="rounded-l-md px-3 py-2 font-mono">
+                        {formatRowDate(s.date)}
+                      </td>
+                      <td className="px-3 py-2 font-mono">
+                        {formatDistanceMiles(s.distance_meters)}
+                      </td>
+                      <td className="px-3 py-2 font-mono">
+                        {formatDuration(s.duration_seconds)}
+                      </td>
+                      <td className="px-3 py-2 font-mono">
+                        {formatPaceCellFromSecPerKm(s.pace_seconds_per_km)}
+                      </td>
+                      <td className="px-3 py-2 font-mono">
+                        {typeof s.avg_hr === 'number' ? `${Math.round(s.avg_hr)}` : '—'}
+                      </td>
+                      <td className="px-3 py-2 font-mono">
+                        {typeof s.max_hr === 'number' ? `${Math.round(s.max_hr)}` : '—'}
+                      </td>
+                      <td className="rounded-r-md px-3 py-2 font-mono">
+                        <SessionZoneStrip hrSecondsInZone={s.hr_seconds_in_zone} />
+                      </td>
+                    </tr>
+                    {isExpanded && interactive && (
+                      <ExpandedHrZoneRow session={s} colSpan={7} fontFamily={FONT_FAMILY} />
+                    )}
+                  </Fragment>
+                )
+              })}
             </tbody>
           </table>
         </div>


### PR DESCRIPTION
## Summary

Builds on #166 (the per-session zone strip): clicking any session row in the cardio session-log table now toggles a panel below it that renders the full `HrZoneBars` chart for just that session. Bigger and more legible than the inline strip — for when *Z3 was 12m* isn't enough and you want to see the full five-zone breakdown.

- Click / Enter / Space toggles the row open and closed.
- Only one row is expanded at a time per table (opening B collapses A).
- Sessions without zone data have no expansion affordance — they stay out of the tab order and keep the default cursor.
- `role="button"`, `tabIndex=0`, and `aria-expanded` reflect interaction state.
- Wired into all four cardio session-log tables (overview / stair / treadmill / track) so the affordance lives wherever the new Zone column does.

## Architecture

New helper module `components/training-facility/gym/SessionRowExpansion.tsx`:
- `useSessionRowExpansion()` — single-key state hook (only one row open).
- `getRowExpansionProps()` — assembles role / tabIndex / aria-expanded / handlers.
- `<ExpandedHrZoneRow>` — `<tr>` with `colSpan` + `ResizeObserver`-driven width hosting `<HrZoneBars>` for the single session.
- `hasZoneData()` — guard for the no-affordance branch.

Each table's `SessionLogTable` now wraps each row + optional expansion in a `<Fragment>` keyed by the same composite key the row uses for React's `key`.

## History

This PR replaces #168, which auto-closed when its base branch (`feat/163-zone-strip`) was deleted on the squash-merge of #166. Identical commit content, rebased onto current `main`.

## Test plan

- [ ] Click a session row in `/training-facility/gym/overview` → expansion panel appears below with `<HrZoneBars>` for that session.
- [ ] Click the same row again → panel collapses.
- [ ] Click a different row → previous expansion collapses, new row expands.
- [ ] Tab to a row, press Enter → expands. Press Space → collapses.
- [ ] Tab past a session that has `—` in the Zone column → that row is skipped (not focusable).
- [ ] Repeat the click/keyboard checks on `/training-facility/gym/stair`, `/treadmill`, `/track`.
- [ ] Resize the window — the expanded chart resizes with the table.
- [ ] Mobile (390×844): horizontal scroll still works; click on a row inside the scrolled view still expands the right one.
- [ ] Accessibility: `aria-expanded="true"` announces on screen reader when a row is open.
- [ ] No regressions on `/training-facility/gym/overview` summary cards, charts, or activity-mix grid.

## Notes

`npx tsc --noEmit` clean. 16 new tests pass on rebase (`SessionRowExpansion.test.tsx`).

CodeRabbit + Codex on #168 flagged two non-blocking observations (`role="button"` on `<tr>` is a known a11y compromise consistent with the issue spec; index-based expansion key silently closes on filter change — defensible UX). Both acknowledged in the original review verdict; not addressed in this PR.

Closes #164.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Session rows in cardio training logs can now be expanded to display detailed heart rate zone distribution visualizations. Select a session row to view its zone breakdown; select again to collapse.

* **Tests**
  * Added comprehensive test coverage for row expansion functionality and heart rate zone chart rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->