### PR TITLE
feat(gym): per-session detail page with HR sample stream (#165)

### DIFF
--- a/app/training-facility/gym/session/[started_at]/page.tsx
+++ b/app/training-facility/gym/session/[started_at]/page.tsx
@@ -30,7 +30,15 @@ export default async function TrainingFacilityGymSessionPage({
   if (!isTrainingFacilityEnabled()) notFound()
 
   const { started_at: rawStartedAt } = await params
-  const startedAt = decodeURIComponent(rawStartedAt)
+  // Bare `%` in the path segment (or any other malformed escape) makes
+  // `decodeURIComponent` throw `URIError`. Treat that as "no such
+  // session" rather than letting the framework surface a 500.
+  let startedAt: string
+  try {
+    startedAt = decodeURIComponent(rawStartedAt)
+  } catch {
+    notFound()
+  }
 
   const detail = await getCardioSession(startedAt).catch(() => null)
   if (!detail) notFound()

--- a/app/training-facility/gym/session/[started_at]/page.tsx
+++ b/app/training-facility/gym/session/[started_at]/page.tsx
@@ -1,0 +1,39 @@
+import { notFound } from 'next/navigation'
+
+import { isTrainingFacilityEnabled } from '@/lib/feature-flags'
+import { getCardioSession } from '@/lib/data/cardio-server'
+import { SessionDetailView } from '@/components/training-facility/gym/SessionDetailView'
+
+/**
+ * Per-session detail page (PRD §7.4, #165) — `/training-facility/gym/session/[started_at]`.
+ *
+ * Server Component reads one cardio session + its full HR sample stream
+ * via `getCardioSession`, then hands the data to the client-side
+ * {@link SessionDetailView} which owns the chart-width `ResizeObserver`.
+ *
+ * The route param is `started_at`, the session's primary key. Session log
+ * rows in `AllCardioOverview` / `StairDetailView` / `TreadmillDetailView`
+ * / `TrackDetailView` link here with `encodeURIComponent` applied so the
+ * `:` and `+` in the ISO timestamp survive the URL roundtrip. We
+ * `decodeURIComponent` here before the DB lookup.
+ *
+ * 404 routes:
+ *   - Training facility flag off (`isTrainingFacilityEnabled === false`).
+ *   - The decoded `started_at` doesn't match any session (`getCardioSession`
+ *     resolves to `null`).
+ */
+export default async function TrainingFacilityGymSessionPage({
+  params,
+}: {
+  params: Promise<{ started_at: string }>
+}) {
+  if (!isTrainingFacilityEnabled()) notFound()
+
+  const { started_at: rawStartedAt } = await params
+  const startedAt = decodeURIComponent(rawStartedAt)
+
+  const detail = await getCardioSession(startedAt).catch(() => null)
+  if (!detail) notFound()
+
+  return <SessionDetailView session={detail.session} samples={detail.samples} />
+}

--- a/components/training-facility/gym/AllCardioOverview.tsx
+++ b/components/training-facility/gym/AllCardioOverview.tsx
@@ -21,6 +21,7 @@ import {
   aggregateHrZoneSeconds,
   formatDuration,
   parseSessionDate,
+  sessionDetailHref,
 } from '@/lib/training-facility/cardio-shared'
 import {
   METERS_PER_MILE,
@@ -565,7 +566,14 @@ function SessionLogTable({ sessions, range }: SessionLogTableProps): JSX.Element
                   <Fragment key={rowKey}>
                     <tr {...rowProps}>
                       <td className="rounded-l-md px-3 py-2 font-mono">
-                        {formatRowDate(s.date)}
+                        <Link
+                          href={sessionDetailHref(s.date)}
+                          onClick={(e) => e.stopPropagation()}
+                          onKeyDown={(e) => e.stopPropagation()}
+                          className="rounded-sm text-[#f7ead9] underline decoration-white/20 underline-offset-4 transition hover:decoration-[#fff7ec] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/60"
+                        >
+                          {formatRowDate(s.date)}
+                        </Link>
                       </td>
                       <td className="px-3 py-2 font-mono">
                         <span className="inline-flex items-center gap-1.5">

--- a/components/training-facility/gym/SessionDetailView.tsx
+++ b/components/training-facility/gym/SessionDetailView.tsx
@@ -1,0 +1,289 @@
+'use client'
+
+import Link from 'next/link'
+import { useEffect, useMemo, useRef, useState, type JSX } from 'react'
+
+import type { CardioSession, HrSample } from '@/types/cardio'
+import { aggregateHrZoneSeconds, formatDuration, parseSessionDate } from '@/lib/training-facility/cardio-shared'
+import { ACTIVITY_VISUALS } from '@/lib/training-facility/all-cardio'
+import { METERS_PER_MILE } from '@/lib/training-facility/running'
+import { BackToCourtButton } from '@/components/common/BackToCourtButton'
+import { RoughLine } from '@/components/training-facility/shared/charts/RoughLine'
+import { chartPalette } from '@/components/training-facility/shared/charts/palette'
+import { defaultMargin } from '@/components/training-facility/shared/charts/types'
+import { HrZoneBars } from './HrZoneBars'
+
+const CURVE_HEIGHT = 320
+const ZONE_HEIGHT = 280
+const MIN_CHART_WIDTH = 280
+const DEFAULT_CHART_WIDTH = 880
+const FONT_FAMILY = "'Patrick Hand', system-ui, sans-serif"
+
+/** Single point on the HR curve — `{ tSeconds, bpm }`. */
+interface CurvePoint {
+  /** Seconds since session start. The x-axis renders these as `M:SS`. */
+  tSeconds: number
+  /** Heart rate in BPM at this sample. */
+  bpm: number
+}
+
+/** Props for {@link SessionDetailView}. */
+export interface SessionDetailViewProps {
+  /** The session payload (header metadata, zone breakdown). */
+  session: CardioSession
+  /** Raw HR samples for the session, oldest → newest. May be empty. */
+  samples: readonly HrSample[]
+}
+
+/**
+ * Per-session detail view (#165) — header with session metadata, an HR
+ * curve over session-relative time, and the existing five-zone bars.
+ *
+ * Mounted as a client component because the chart width tracks the
+ * card's actual rendered width via {@link ResizeObserver} (the shared
+ * chart primitives don't accept a fluid `100%` width). The data itself
+ * is read by the Server Component parent and passed down — this view
+ * does no fetching of its own.
+ */
+export function SessionDetailView({
+  session,
+  samples,
+}: SessionDetailViewProps): JSX.Element {
+  const curveSizerRef = useRef<HTMLDivElement>(null)
+  const zoneSizerRef = useRef<HTMLDivElement>(null)
+  const [curveWidth, setCurveWidth] = useState(DEFAULT_CHART_WIDTH)
+  const [zoneWidth, setZoneWidth] = useState(DEFAULT_CHART_WIDTH)
+
+  useEffect(() => {
+    const node = curveSizerRef.current
+    if (!node || typeof ResizeObserver === 'undefined') return
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        const next = Math.max(MIN_CHART_WIDTH, Math.floor(entry.contentRect.width))
+        setCurveWidth((prev) => (prev === next ? prev : next))
+      }
+    })
+    observer.observe(node)
+    return () => observer.disconnect()
+  }, [])
+
+  useEffect(() => {
+    const node = zoneSizerRef.current
+    if (!node || typeof ResizeObserver === 'undefined') return
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        const next = Math.max(MIN_CHART_WIDTH, Math.floor(entry.contentRect.width))
+        setZoneWidth((prev) => (prev === next ? prev : next))
+      }
+    })
+    observer.observe(node)
+    return () => observer.disconnect()
+  }, [])
+
+  const sessionStartMs = useMemo(() => {
+    const dt = parseSessionDate(session.date)
+    return Number.isFinite(dt.getTime()) ? dt.getTime() : 0
+  }, [session.date])
+
+  // Convert raw samples to session-relative seconds. PostgREST orders the
+  // samples ascending so this stays sorted for the line chart.
+  const curve = useMemo<CurvePoint[]>(() => {
+    if (sessionStartMs === 0) return []
+    return samples.map((s) => {
+      const sampleMs = new Date(s.ts).getTime()
+      const tSeconds = Number.isFinite(sampleMs)
+        ? Math.max(0, (sampleMs - sessionStartMs) / 1000)
+        : 0
+      return { tSeconds, bpm: s.bpm }
+    })
+  }, [samples, sessionStartMs])
+
+  // Reuse the same HrZoneBucket aggregation that powers the inline strip
+  // (#163) and the click-to-expand panel (#164) — the detail page just
+  // gets a bigger version of the same chart.
+  const buckets = useMemo(() => aggregateHrZoneSeconds([session]), [session])
+
+  const visual = ACTIVITY_VISUALS[session.activity]
+  const dateLabel = formatHeaderDate(session.date)
+  const durationLabel = formatDuration(session.duration_seconds)
+  const distanceLabel = formatDistanceMiles(session.distance_meters)
+  const avgHrLabel = typeof session.avg_hr === 'number' ? `${Math.round(session.avg_hr)} BPM` : '—'
+  const maxHrLabel = typeof session.max_hr === 'number' ? `${Math.round(session.max_hr)} BPM` : '—'
+
+  return (
+    <div className="relative min-h-svh overflow-hidden bg-[#120d0a] text-[#f7ead9]">
+      <div
+        aria-hidden="true"
+        className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(255,255,255,0.08),transparent_28%),linear-gradient(180deg,#241811_0%,#120d0a_52%,#0b0806_100%)]"
+      />
+
+      <div className="relative z-10 mx-auto flex min-h-svh w-full max-w-5xl flex-col px-6 py-8 sm:px-8 lg:px-12">
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <BackToCourtButton />
+          <Link
+            href="/training-facility/gym/overview"
+            className="rounded-full border border-white/15 bg-white/5 px-4 py-2 text-xs font-semibold uppercase tracking-[0.28em] text-white/80 transition hover:bg-white/10"
+          >
+            ← All cardio
+          </Link>
+        </div>
+
+        <header className="mt-12">
+          <div className="text-xs font-semibold uppercase tracking-[0.38em] text-white/60">
+            Session detail
+          </div>
+          <h1 className="mt-3 flex flex-wrap items-baseline gap-3 text-3xl font-black uppercase tracking-[0.06em] text-[#fff7ec] sm:text-4xl">
+            <span
+              aria-hidden="true"
+              className="inline-block h-3 w-3 rounded-full"
+              style={{ backgroundColor: visual.color }}
+            />
+            {visual.label} — {dateLabel}
+          </h1>
+        </header>
+
+        <dl className="mt-6 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          <Stat label="Duration" value={durationLabel} />
+          <Stat label="Distance" value={distanceLabel} />
+          <Stat label="Avg HR" value={avgHrLabel} />
+          <Stat label="Max HR" value={maxHrLabel} />
+        </dl>
+
+        <ChartCard
+          title="Heart-rate curve"
+          helper="One sample every ~5s during the workout. Time runs left → right; gaps in the line mean the watch dropped readings."
+        >
+          <div ref={curveSizerRef}>
+            {curve.length === 0 ? (
+              <EmptyHrCurve width={curveWidth} />
+            ) : (
+              <RoughLine
+                data={curve}
+                x={(d) => d.tSeconds}
+                y={(d) => d.bpm}
+                width={curveWidth}
+                height={CURVE_HEIGHT}
+                margin={defaultMargin}
+                fontFamily={FONT_FAMILY}
+                axisColor={chartPalette.inkBlack}
+                showDots={false}
+                stroke={chartPalette.rimOrange}
+                xLabel="Time"
+                yLabel="BPM"
+                xTickFormat={formatCurveTime}
+                ariaLabel={`Heart-rate curve for ${visual.label} session on ${dateLabel}`}
+              />
+            )}
+          </div>
+        </ChartCard>
+
+        <ChartCard
+          title="Time in zone"
+          helper="Same Z1–Z5 breakdown as the dashboard — scoped to this single session."
+        >
+          <div ref={zoneSizerRef}>
+            <HrZoneBars
+              buckets={buckets}
+              width={zoneWidth}
+              height={ZONE_HEIGHT}
+              fontFamily={FONT_FAMILY}
+            />
+          </div>
+        </ChartCard>
+      </div>
+    </div>
+  )
+}
+
+interface StatProps {
+  label: string
+  value: string
+}
+
+/** Single stat card in the header metadata row — same visual weight as the dashboard summary cards. */
+function Stat({ label, value }: StatProps): JSX.Element {
+  return (
+    <div className="rounded-[1.2rem] border border-white/10 bg-[#f5f1e6] p-4 text-[#0a0a0a] shadow-[0_12px_32px_rgba(0,0,0,0.28)]">
+      <h3 className="font-mono text-[10px] font-bold uppercase tracking-[0.22em] text-[#0a0a0a]/70">
+        {label}
+      </h3>
+      <p className="mt-2 font-mono text-2xl font-semibold tabular-nums text-[#0a0a0a]">{value}</p>
+    </div>
+  )
+}
+
+interface ChartCardProps {
+  title: string
+  helper: string
+  children: JSX.Element
+}
+
+function ChartCard({ title, helper, children }: ChartCardProps): JSX.Element {
+  return (
+    <section className="mt-6 rounded-[1.6rem] border border-white/10 bg-[#f5f1e6] p-5 text-[#0a0a0a] shadow-[0_18px_46px_rgba(0,0,0,0.34)]">
+      <header className="mb-2">
+        <h2 className="font-mono text-xs font-bold uppercase tracking-[0.24em] text-[#0a0a0a]">
+          {title}
+        </h2>
+      </header>
+      <p className="mb-4 text-xs leading-5 text-[#404040]">{helper}</p>
+      <div className="overflow-x-auto">{children}</div>
+    </section>
+  )
+}
+
+/**
+ * Empty-state card shown when a session has no HR samples (Apple Watch
+ * was off). Same canvas dimensions as the populated curve so the layout
+ * doesn't shift between data and no-data sessions.
+ */
+function EmptyHrCurve({ width }: { width: number }): JSX.Element {
+  return (
+    <div
+      style={{ width, height: CURVE_HEIGHT }}
+      className="flex items-center justify-center text-sm text-[#404040]"
+    >
+      No HR samples recorded for this session.
+    </div>
+  )
+}
+
+/**
+ * Format a session date for the page header — `Apr 26, 2026 · 8:00 AM`.
+ * Falls back to the raw string if Date parsing fails so a malformed
+ * timestamp doesn't render as `Invalid Date`.
+ */
+function formatHeaderDate(raw: string): string {
+  const dt = parseSessionDate(raw)
+  if (!Number.isFinite(dt.getTime())) return raw
+  const date = dt.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })
+  const time = dt.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' })
+  return `${date} · ${time}`
+}
+
+/**
+ * Format `distance_meters` as `M.M mi` for the header metadata row,
+ * `—` for the no-distance case (stair sessions, Apple Watch dropped GPS).
+ */
+function formatDistanceMiles(meters: number | undefined): string {
+  if (typeof meters !== 'number' || meters <= 0) return '—'
+  return `${(meters / METERS_PER_MILE).toFixed(2)} mi`
+}
+
+/**
+ * Format an HR-curve x-axis tick (session-relative seconds) as `M:SS`.
+ * Crosses the hour boundary as `H:MM:SS`. Used by `RoughLine`'s
+ * `xTickFormat` so the axis reads as "minute 8 of the workout" rather
+ * than "480 seconds since session start."
+ */
+function formatCurveTime(value: number | Date): string {
+  const seconds = typeof value === 'number' ? value : value.getTime() / 1000
+  const total = Math.max(0, Math.round(seconds))
+  const hours = Math.floor(total / 3600)
+  const mins = Math.floor((total % 3600) / 60)
+  const secs = total % 60
+  if (hours > 0) {
+    return `${hours}:${String(mins).padStart(2, '0')}:${String(secs).padStart(2, '0')}`
+  }
+  return `${mins}:${String(secs).padStart(2, '0')}`
+}

--- a/components/training-facility/gym/StairDetailView.tsx
+++ b/components/training-facility/gym/StairDetailView.tsx
@@ -24,6 +24,7 @@ import {
   parseSessionDate,
   perSessionAvgHr,
 } from '@/lib/training-facility/stair'
+import { sessionDetailHref } from '@/lib/training-facility/cardio-shared'
 import { computePreviousRange } from '@/lib/training-facility/period-comparison'
 import { BackToCourtButton } from '@/components/common/BackToCourtButton'
 import {
@@ -565,7 +566,14 @@ function SessionLogTable({ sessions, range }: SessionLogTableProps): JSX.Element
                   <Fragment key={rowKey}>
                     <tr {...rowProps}>
                       <td className="rounded-l-md px-3 py-2 font-mono">
-                        {formatRowDate(s.date)}
+                        <Link
+                          href={sessionDetailHref(s.date)}
+                          onClick={(e) => e.stopPropagation()}
+                          onKeyDown={(e) => e.stopPropagation()}
+                          className="rounded-sm text-[#f7ead9] underline decoration-white/20 underline-offset-4 transition hover:decoration-[#fff7ec] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/60"
+                        >
+                          {formatRowDate(s.date)}
+                        </Link>
                       </td>
                       <td className="px-3 py-2 font-mono">
                         {formatDuration(s.duration_seconds)}

--- a/components/training-facility/gym/TrackDetailView.tsx
+++ b/components/training-facility/gym/TrackDetailView.tsx
@@ -23,6 +23,7 @@ import {
   formatDuration,
   parseSessionDate,
   perSessionAvgHr,
+  sessionDetailHref,
 } from '@/lib/training-facility/cardio-shared'
 import {
   cardiacEfficiencyPoints,
@@ -528,7 +529,14 @@ function SessionLogTable({ sessions, range }: SessionLogTableProps): JSX.Element
                   <Fragment key={rowKey}>
                     <tr {...rowProps}>
                       <td className="rounded-l-md px-3 py-2 font-mono">
-                        {formatRowDate(s.date)}
+                        <Link
+                          href={sessionDetailHref(s.date)}
+                          onClick={(e) => e.stopPropagation()}
+                          onKeyDown={(e) => e.stopPropagation()}
+                          className="rounded-sm text-[#f7ead9] underline decoration-white/20 underline-offset-4 transition hover:decoration-[#fff7ec] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/60"
+                        >
+                          {formatRowDate(s.date)}
+                        </Link>
                       </td>
                       <td className="px-3 py-2 font-mono">
                         {formatDistanceMiles(s.distance_meters)}

--- a/components/training-facility/gym/TreadmillDetailView.tsx
+++ b/components/training-facility/gym/TreadmillDetailView.tsx
@@ -23,6 +23,7 @@ import {
   formatDuration,
   parseSessionDate,
   perSessionAvgHr,
+  sessionDetailHref,
 } from '@/lib/training-facility/cardio-shared'
 import {
   cardiacEfficiencyPoints,
@@ -530,7 +531,14 @@ function SessionLogTable({ sessions, range }: SessionLogTableProps): JSX.Element
                   <Fragment key={rowKey}>
                     <tr {...rowProps}>
                       <td className="rounded-l-md px-3 py-2 font-mono">
-                        {formatRowDate(s.date)}
+                        <Link
+                          href={sessionDetailHref(s.date)}
+                          onClick={(e) => e.stopPropagation()}
+                          onKeyDown={(e) => e.stopPropagation()}
+                          className="rounded-sm text-[#f7ead9] underline decoration-white/20 underline-offset-4 transition hover:decoration-[#fff7ec] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/60"
+                        >
+                          {formatRowDate(s.date)}
+                        </Link>
                       </td>
                       <td className="px-3 py-2 font-mono">
                         {formatDistanceMiles(s.distance_meters)}

--- a/lib/data/cardio-server.ts
+++ b/lib/data/cardio-server.ts
@@ -1,9 +1,17 @@
 import 'server-only'
 
-import { createServerSupabaseClient } from '@/lib/supabase/server'
-import type { CardioData } from '@/types/cardio'
+import { z } from 'zod'
 
-import { assembleCardioData } from './cardio-shared'
+import { createServerSupabaseClient } from '@/lib/supabase/server'
+import {
+  CardioSessionHrSampleRowSchema,
+  CardioSessionRowSchema,
+  hrSampleRowToHrSample,
+  sessionRowToCardioSession,
+} from '@/lib/schemas/cardio'
+import type { CardioData, CardioSession, HrSample } from '@/types/cardio'
+
+import { assembleCardioData, stripNulls } from './cardio-shared'
 
 /**
  * Server-side cardio dataset reader for Server Components and route
@@ -35,4 +43,89 @@ import { assembleCardioData } from './cardio-shared'
 export async function getCardioDataServer(): Promise<CardioData | null> {
   const supabase = await createServerSupabaseClient()
   return assembleCardioData(supabase)
+}
+
+/** Whitelisted columns for the per-session read — mirrors `CardioSessionRowSchema`. */
+const SESSION_COLUMNS =
+  'started_at, activity, duration_seconds, distance_meters, avg_hr, max_hr, ' +
+  'pace_seconds_per_km, zone1_seconds, zone2_seconds, zone3_seconds, ' +
+  'zone4_seconds, zone5_seconds, meters_per_heartbeat'
+
+/** Whitelisted columns for the HR-sample read. */
+const HR_SAMPLE_COLUMNS = 'session_started_at, sample_at, bpm'
+
+/** Aggregate-row + sample-stream payload returned by {@link getCardioSession}. */
+export interface CardioSessionDetail {
+  /** The session row, mapped into the legacy {@link CardioSession} shape. */
+  session: CardioSession
+  /** Raw HR samples for the session, sorted oldest → newest. May be empty. */
+  samples: HrSample[]
+}
+
+/**
+ * Server-side reader for the per-session detail page (#165). Looks up one
+ * `cardio_sessions` row by its `started_at` PK and the matching rows in
+ * `cardio_session_hr_samples`, returning both as a single payload.
+ *
+ * Returns `null` when no session exists at the given timestamp — the
+ * caller (`/training-facility/gym/session/[started_at]`) maps that to a
+ * 404 via `notFound()`.
+ *
+ * `started_at` is a `timestamptz` PK; PostgREST normalizes the user's URL
+ * input the same way it normalizes stored values, so passing the raw
+ * decoded timestamp string from the route param works without
+ * pre-canonicalization.
+ *
+ * @param startedAt The session's `started_at` PK. Decoded from the URL by
+ *   the page route (the timestamps contain `:` and `+`, which are
+ *   percent-encoded in the path segment).
+ * @throws when either Supabase query fails or returns rows that fail
+ *   schema validation. The page wraps this in `.catch(() => null)` so a
+ *   flaky read 404s instead of 500ing.
+ */
+export async function getCardioSession(
+  startedAt: string,
+): Promise<CardioSessionDetail | null> {
+  const supabase = await createServerSupabaseClient()
+  const [sessionRes, samplesRes] = await Promise.all([
+    supabase
+      .from('cardio_sessions')
+      .select(SESSION_COLUMNS)
+      .eq('started_at', startedAt)
+      .maybeSingle(),
+    supabase
+      .from('cardio_session_hr_samples')
+      .select(HR_SAMPLE_COLUMNS)
+      .eq('session_started_at', startedAt)
+      .order('sample_at', { ascending: true }),
+  ])
+
+  if (sessionRes.error) {
+    throw new Error(`Failed to load cardio session: ${sessionRes.error.message}`)
+  }
+  if (!sessionRes.data) return null
+  if (samplesRes.error) {
+    throw new Error(`Failed to load cardio session HR samples: ${samplesRes.error.message}`)
+  }
+
+  const sessionRaw = stripNulls(sessionRes.data as unknown as Record<string, unknown>)
+  const sessionParsed = CardioSessionRowSchema.safeParse(sessionRaw)
+  if (!sessionParsed.success) {
+    throw new Error(
+      `cardio_sessions row failed schema validation: ${sessionParsed.error.message}`,
+    )
+  }
+
+  const samplesRaw = (samplesRes.data ?? []) as unknown as Array<Record<string, unknown>>
+  const samplesParsed = z.array(CardioSessionHrSampleRowSchema).safeParse(samplesRaw)
+  if (!samplesParsed.success) {
+    throw new Error(
+      `cardio_session_hr_samples failed schema validation: ${samplesParsed.error.message}`,
+    )
+  }
+
+  return {
+    session: sessionRowToCardioSession(sessionParsed.data),
+    samples: samplesParsed.data.map(hrSampleRowToHrSample),
+  }
 }

--- a/lib/data/cardio-shared.ts
+++ b/lib/data/cardio-shared.ts
@@ -157,7 +157,7 @@ export async function assembleCardioData(
  * same way it parses freshly-imported JSON (which used absent keys,
  * never `null`).
  */
-function stripNulls(row: Record<string, unknown>): Record<string, unknown> {
+export function stripNulls(row: Record<string, unknown>): Record<string, unknown> {
   const out: Record<string, unknown> = {}
   for (const [key, value] of Object.entries(row)) {
     if (value !== null) out[key] = value

--- a/lib/schemas/cardio.ts
+++ b/lib/schemas/cardio.ts
@@ -28,6 +28,7 @@ import type {
   CardioActivity,
   CardioSession,
   CardioTimePoint,
+  HrSample,
   HrZone,
 } from '@/types/cardio'
 
@@ -188,4 +189,56 @@ export function cardioSessionToRow(session: {
  */
 export function trendRowToTimePoint(row: CardioTrendRow): CardioTimePoint {
   return { date: row.date, value: row.value }
+}
+
+/**
+ * Zod schema for one row of `public.cardio_session_hr_samples` (#165).
+ * Mirrors the table definition in
+ * `supabase/migrations/20260503120000_cardio_session_hr_samples.sql`.
+ *
+ * Per-sample storage powers the per-session detail page's HR curve. The
+ * dashboard's aggregate views (avg/max/zones) keep using the columns on
+ * `cardio_sessions` so they don't have to re-walk thousands of samples
+ * for a workout-log row.
+ */
+export const CardioSessionHrSampleRowSchema = z
+  .object({
+    session_started_at: z.string().min(1, 'session_started_at must be an ISO timestamp'),
+    sample_at: z.string().min(1, 'sample_at must be an ISO timestamp'),
+    bpm: z.number().nonnegative(),
+  })
+  .strict()
+
+/** Validated `cardio_session_hr_samples` row inferred from {@link CardioSessionHrSampleRowSchema}. */
+export type CardioSessionHrSampleRow = z.infer<typeof CardioSessionHrSampleRowSchema>
+
+/**
+ * Translate a validated `cardio_session_hr_samples` row into the
+ * {@link HrSample} shape consumed by the detail page's HR curve. Strips
+ * `session_started_at` (already known by the caller — they queried for
+ * one session) and renames `sample_at → ts` so the type matches what the
+ * Python preprocessor emits in `cardio.json`.
+ */
+export function hrSampleRowToHrSample(row: CardioSessionHrSampleRow): HrSample {
+  return { ts: row.sample_at, bpm: row.bpm }
+}
+
+/**
+ * Translate a legacy {@link HrSample} (the shape the Python preprocessor
+ * emits inside each session) into the snake_case row payload accepted by
+ * `cardio_session_hr_samples.insert(...)`. Used by the import script.
+ *
+ * @param sessionStartedAt The owning session's `started_at`. Must match
+ *   the `cardio_sessions.started_at` row this sample belongs to so the
+ *   FK resolves; the import script writes sessions before samples.
+ */
+export function hrSampleToRow(
+  sample: HrSample,
+  sessionStartedAt: string,
+): Record<string, unknown> {
+  return {
+    session_started_at: sessionStartedAt,
+    sample_at: sample.ts,
+    bpm: sample.bpm,
+  }
 }

--- a/lib/training-facility/cardio-shared.ts
+++ b/lib/training-facility/cardio-shared.ts
@@ -149,3 +149,18 @@ export function formatDuration(seconds: number): string {
   const secs = Math.floor(seconds % 60)
   return `${mins}m ${secs.toString().padStart(2, '0')}s`
 }
+
+/**
+ * Build the per-session detail page URL (#165) for a session-log row.
+ * Centralizes the `encodeURIComponent` step so each session-log table
+ * encodes the timestamp identically — the route handler decodes once on
+ * the server. ISO timestamps contain `:` and `+`, both of which need
+ * percent-encoding to survive the URL path segment.
+ *
+ * @param startedAt The session's `started_at` (`CardioSession.date`)
+ *   ISO timestamp string. Empty input returns the route root, which 404s
+ *   in the page handler — same outcome as a missing session.
+ */
+export function sessionDetailHref(startedAt: string): string {
+  return `/training-facility/gym/session/${encodeURIComponent(startedAt)}`
+}

--- a/scripts/import-health.mjs
+++ b/scripts/import-health.mjs
@@ -108,7 +108,8 @@ async function main() {
   const counts = await upsertCardioData(supabase, data)
   console.log(
     `✓ Upserted to Supabase: ${counts.sessions} sessions, ` +
-      `${counts.restingHr} resting-HR points, ${counts.vo2max} VO2max points.`,
+      `${counts.restingHr} resting-HR points, ${counts.vo2max} VO2max points, ` +
+      `${counts.hrSamples.toLocaleString()} HR samples.`,
   )
   if (counts.pruned > 0) {
     console.log(

--- a/scripts/lib/cardio-supabase.mjs
+++ b/scripts/lib/cardio-supabase.mjs
@@ -80,6 +80,20 @@ const HrZoneSecondsSchema = z
   })
   .strict()
 
+/**
+ * One HR sample inside a session window (#165). The Python preprocessor
+ * emits these alongside the aggregate zone columns so the per-session
+ * detail page can render an HR curve. `nullable()` carries through the
+ * "no samples for this session" case (Apple Watch off) without
+ * normalization.
+ */
+const HrSampleSchema = z
+  .object({
+    ts: z.string().min(1),
+    bpm: z.number().nonnegative(),
+  })
+  .strict()
+
 const CardioSessionSchema = z
   .object({
     date: z.string().min(1),
@@ -90,6 +104,7 @@ const CardioSessionSchema = z
     max_hr: z.number().nonnegative().nullable().optional(),
     pace_seconds_per_km: z.number().nonnegative().nullable().optional(),
     hr_seconds_in_zone: HrZoneSecondsSchema.nullable().optional(),
+    hr_samples: z.array(HrSampleSchema).nullable().optional(),
     meters_per_heartbeat: z.number().nonnegative().nullable().optional(),
   })
   .strict()
@@ -213,6 +228,11 @@ export async function upsertCardioData(supabase, data) {
       throw new Error(`Failed to upsert cardio_sessions: ${error.message}`)
     }
   }
+  // Per-session replace for HR samples (#165). Runs after the
+  // cardio_sessions upsert so the FK from cardio_session_hr_samples
+  // resolves; sessions pruned later by `pruneStaleRows` cascade their
+  // samples via the `on delete cascade` FK.
+  const hrSamplesInserted = await upsertHrSamples(supabase, parsed.sessions)
   if (restingRows.length > 0) {
     const { error } = await supabase
       .from('cardio_resting_hr')
@@ -253,8 +273,77 @@ export async function upsertCardioData(supabase, data) {
     sessions: sessionRows.length,
     restingHr: restingRows.length,
     vo2max: vo2Rows.length,
+    hrSamples: hrSamplesInserted,
     pruned: sessionsPruned + restingPruned + vo2Pruned,
   }
+}
+
+/** Per-batch insert size for HR samples — stays well under PostgREST's payload limits. */
+const HR_SAMPLES_INSERT_BATCH = 500
+
+/**
+ * Replace the HR sample stream for every session in the import payload (#165).
+ *
+ * For each session: delete all existing rows in `cardio_session_hr_samples`
+ * keyed by `session_started_at`, then insert the new samples in
+ * {@link HR_SAMPLES_INSERT_BATCH}-sized chunks. Per-session replace is the
+ * simplest idempotent contract — re-importing the same session is a no-op
+ * delta-wise, and a session whose sample stream has since vanished
+ * (Apple Watch off mid-workout, fixed in HealthKit) gets a clean reset
+ * instead of stale samples lingering.
+ *
+ * The cascade FK on `cardio_session_hr_samples → cardio_sessions` handles
+ * the "session was pruned entirely" case for free — `pruneStaleRows`
+ * deletes the parent and Postgres cleans the children. So this function
+ * doesn't need its own prune step.
+ *
+ * Sessions with no `hr_samples` (preprocessor returns `null` for "Apple
+ * Watch off") still run the delete so an authoritative-absent import
+ * clears any stored samples for that session.
+ *
+ * @param supabase Service-role Supabase client (bypasses RLS); passed
+ *   through to the chained `from(...).delete()/insert()` calls.
+ * @param sessions Validated sessions from `CardioDataSchema`'s
+ *   `sessions` array; only `date` and `hr_samples` are read here.
+ * @returns Promise<number> — total inserted-sample count across all
+ *   sessions, surfaced in the import script's success log.
+ * @throws when any DELETE or INSERT fails.
+ */
+export async function upsertHrSamples(supabase, sessions) {
+  let totalInserted = 0
+  for (const session of sessions) {
+    const { error: deleteErr } = await supabase
+      .from('cardio_session_hr_samples')
+      .delete()
+      .eq('session_started_at', session.date)
+    if (deleteErr) {
+      throw new Error(
+        `Failed to clear cardio_session_hr_samples for session ${session.date}: ${deleteErr.message}`,
+      )
+    }
+
+    const samples = session.hr_samples ?? []
+    if (samples.length === 0) continue
+
+    const rows = samples.map((s) => ({
+      session_started_at: session.date,
+      sample_at: s.ts,
+      bpm: s.bpm,
+    }))
+    for (let i = 0; i < rows.length; i += HR_SAMPLES_INSERT_BATCH) {
+      const batch = rows.slice(i, i + HR_SAMPLES_INSERT_BATCH)
+      const { error: insertErr } = await supabase
+        .from('cardio_session_hr_samples')
+        .insert(batch)
+      if (insertErr) {
+        throw new Error(
+          `Failed to insert cardio_session_hr_samples for session ${session.date}: ${insertErr.message}`,
+        )
+      }
+      totalInserted += batch.length
+    }
+  }
+  return totalInserted
 }
 
 /**

--- a/scripts/lib/cardio-supabase.test.ts
+++ b/scripts/lib/cardio-supabase.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from 'vitest'
 
 // Vitest happily resolves `.mjs` from a `.ts` test file. Public surface is
 // minimal — only the helpers exported for cross-module use are reachable.
-import { pruneStaleRows } from './cardio-supabase.mjs'
+import { pruneStaleRows, upsertHrSamples } from './cardio-supabase.mjs'
 
 /**
  * Tests for the stale-row prune helper that backs the "exact mirror"
@@ -120,5 +120,150 @@ describe('pruneStaleRows', () => {
     // wire a `.select()` chain — the test double would throw on access.)
     expect(ltMock).toHaveBeenCalledTimes(1)
     expect(ltMock).toHaveBeenCalledWith('updated_at', IMPORTED_AT)
+  })
+})
+
+/**
+ * Build a Supabase double that records the chained
+ * `from(table).delete().eq('session_started_at', X)` and
+ * `from(table).insert(rows)` call sequence used by `upsertHrSamples`. The
+ * factory tracks every call across both shapes so a test can assert the
+ * delete-then-insert ordering and the per-batch insert sizes.
+ */
+function makeHrSamplesFakeSupabase(): {
+  supabase: { from: ReturnType<typeof vi.fn> }
+  calls: Array<
+    | { kind: 'delete'; table: string; key: string }
+    | { kind: 'insert'; table: string; rowCount: number }
+  >
+} {
+  const calls: Array<
+    | { kind: 'delete'; table: string; key: string }
+    | { kind: 'insert'; table: string; rowCount: number }
+  > = []
+  const supabase = {
+    from: vi.fn((table: string) => ({
+      delete: () => ({
+        eq: (_col: string, key: string) => {
+          calls.push({ kind: 'delete', table, key })
+          return Promise.resolve({ error: null })
+        },
+      }),
+      insert: (rows: unknown[]) => {
+        calls.push({ kind: 'insert', table, rowCount: rows.length })
+        return Promise.resolve({ error: null })
+      },
+    })),
+  }
+  return { supabase, calls }
+}
+
+const SESSION_TS = '2026-04-15T08:32:18-07:00'
+
+/** Build N samples spaced 5 seconds apart starting at session start. */
+function fakeSamples(n: number) {
+  const start = new Date('2026-04-15T15:32:18Z').getTime()
+  return Array.from({ length: n }, (_, i) => ({
+    ts: new Date(start + i * 5000).toISOString(),
+    bpm: 130 + (i % 30),
+  }))
+}
+
+describe('upsertHrSamples', () => {
+  it('runs delete then insert for a session with samples', async () => {
+    const { supabase, calls } = makeHrSamplesFakeSupabase()
+    const samples = fakeSamples(10)
+    const total = await upsertHrSamples(supabase, [
+      { date: SESSION_TS, activity: 'running', duration_seconds: 1800, hr_samples: samples },
+    ])
+    expect(total).toBe(10)
+    // delete must come before insert; the FK + idempotency contract
+    // depends on the prior session's samples being gone before new
+    // rows arrive.
+    expect(calls).toEqual([
+      { kind: 'delete', table: 'cardio_session_hr_samples', key: SESSION_TS },
+      { kind: 'insert', table: 'cardio_session_hr_samples', rowCount: 10 },
+    ])
+  })
+
+  it('chunks inserts into 500-row batches', async () => {
+    const { supabase, calls } = makeHrSamplesFakeSupabase()
+    const samples = fakeSamples(1250)
+    const total = await upsertHrSamples(supabase, [
+      { date: SESSION_TS, activity: 'running', duration_seconds: 7200, hr_samples: samples },
+    ])
+    expect(total).toBe(1250)
+    const inserts = calls.filter((c) => c.kind === 'insert') as Array<{
+      kind: 'insert'
+      table: string
+      rowCount: number
+    }>
+    expect(inserts.map((c) => c.rowCount)).toEqual([500, 500, 250])
+  })
+
+  it('still issues a delete for sessions with no samples (clears stale rows)', async () => {
+    const { supabase, calls } = makeHrSamplesFakeSupabase()
+    const total = await upsertHrSamples(supabase, [
+      { date: SESSION_TS, activity: 'stair', duration_seconds: 1500, hr_samples: null },
+    ])
+    expect(total).toBe(0)
+    expect(calls).toEqual([
+      { kind: 'delete', table: 'cardio_session_hr_samples', key: SESSION_TS },
+    ])
+  })
+
+  it('processes each session independently in payload order', async () => {
+    const { supabase, calls } = makeHrSamplesFakeSupabase()
+    const total = await upsertHrSamples(supabase, [
+      { date: SESSION_TS, activity: 'running', duration_seconds: 1800, hr_samples: fakeSamples(3) },
+      {
+        date: '2026-04-16T09:00:00-07:00',
+        activity: 'stair',
+        duration_seconds: 1500,
+        hr_samples: fakeSamples(2),
+      },
+    ])
+    expect(total).toBe(5)
+    expect(calls.map((c) => c.kind)).toEqual(['delete', 'insert', 'delete', 'insert'])
+  })
+
+  it('throws a descriptive error when the DELETE fails', async () => {
+    const supabase = {
+      from: vi.fn(() => ({
+        delete: () => ({
+          eq: () => Promise.resolve({ error: { message: 'permission denied' } }),
+        }),
+        insert: () => Promise.resolve({ error: null }),
+      })),
+    }
+    await expect(
+      upsertHrSamples(supabase, [
+        {
+          date: SESSION_TS,
+          activity: 'running',
+          duration_seconds: 1800,
+          hr_samples: fakeSamples(1),
+        },
+      ]),
+    ).rejects.toThrow(/Failed to clear cardio_session_hr_samples.*permission denied/)
+  })
+
+  it('throws a descriptive error when the INSERT fails', async () => {
+    const supabase = {
+      from: vi.fn(() => ({
+        delete: () => ({ eq: () => Promise.resolve({ error: null }) }),
+        insert: () => Promise.resolve({ error: { message: 'unique violation' } }),
+      })),
+    }
+    await expect(
+      upsertHrSamples(supabase, [
+        {
+          date: SESSION_TS,
+          activity: 'running',
+          duration_seconds: 1800,
+          hr_samples: fakeSamples(1),
+        },
+      ]),
+    ).rejects.toThrow(/Failed to insert cardio_session_hr_samples.*unique violation/)
   })
 })

--- a/scripts/preprocess-health.py
+++ b/scripts/preprocess-health.py
@@ -292,7 +292,16 @@ def aggregate_session_hr(workout: dict, samples: list[dict], max_hr: int) -> Non
             deduped[-1] = (dt, bpm)
         else:
             deduped.append((dt, bpm))
-    in_window = deduped
+
+    # Drop malformed BPM values (negative or NaN — `nan >= 0` is False, so
+    # one filter handles both). The downstream Zod schema and Postgres
+    # `bpm >= 0` CHECK both reject the row, and a single corrupt reading
+    # would otherwise abort the entire import; skipping it locally keeps
+    # the rest of the session usable. Defensive against weird exports —
+    # Apple Watch itself doesn't emit negative HR.
+    in_window = [(dt, bpm) for dt, bpm in deduped if bpm >= 0]
+    if not in_window:
+        return
 
     bpms = [bpm for _, bpm in in_window]
     workout['avg_hr'] = round(sum(bpms) / len(bpms), 1)

--- a/scripts/preprocess-health.py
+++ b/scripts/preprocess-health.py
@@ -278,6 +278,22 @@ def aggregate_session_hr(workout: dict, samples: list[dict], max_hr: int) -> Non
     if not in_window:
         return
 
+    # Deduplicate by timestamp before any downstream use. Apple Health
+    # exports occasionally include two HR records at the exact same
+    # `startDate` (multiple sources writing into the same workout window,
+    # or a watch glitch). Left alone, those collide on the
+    # `cardio_session_hr_samples` PK `(session_started_at, sample_at)`
+    # and the import script's batched insert fails wholesale. Last-write-
+    # wins matches the trend-row dedupe in `parse_simple_trend` and is
+    # stable because `samples` is already sorted by `dt`.
+    deduped: list[tuple[datetime, float]] = []
+    for dt, bpm in in_window:
+        if deduped and deduped[-1][0] == dt:
+            deduped[-1] = (dt, bpm)
+        else:
+            deduped.append((dt, bpm))
+    in_window = deduped
+
     bpms = [bpm for _, bpm in in_window]
     workout['avg_hr'] = round(sum(bpms) / len(bpms), 1)
     workout['max_hr'] = round(max(bpms), 1)

--- a/scripts/preprocess-health.py
+++ b/scripts/preprocess-health.py
@@ -173,6 +173,7 @@ def parse_workouts(xml_text: str) -> list[dict]:
             'max_hr': None,
             'pace_seconds_per_km': None,
             'hr_seconds_in_zone': None,
+            'hr_samples': None,
             'meters_per_heartbeat': None,
             '_start_dt': start_dt,
             '_end_dt': end_dt,
@@ -254,7 +255,13 @@ def parse_hr_samples(xml_text: str) -> list[dict]:
 
 
 def aggregate_session_hr(workout: dict, samples: list[dict], max_hr: int) -> None:
-    """Walk the HR sample stream and fill in avg/max/time-in-zone/efficiency on `workout`."""
+    """Walk the HR sample stream and fill in avg/max/time-in-zone/efficiency on `workout`.
+
+    Also emits the raw in-window samples on `workout['hr_samples']` so the
+    per-session detail page (#165) can render an HR curve over time. The
+    aggregate columns (avg/max/zones) stay so existing charts that don't
+    need the raw stream don't pay the JSON-size cost of re-deriving them.
+    """
     start_dt = workout['_start_dt']
     end_dt = workout['_end_dt']
     if start_dt is None or end_dt is None:
@@ -291,6 +298,16 @@ def aggregate_session_hr(workout: dict, samples: list[dict], max_hr: int) -> Non
             seconds_in_zone[zone] += dwell
 
     workout['hr_seconds_in_zone'] = {str(z): round(v, 1) for z, v in seconds_in_zone.items()}
+
+    # Emit the raw sample stream for the detail page. ISO format with
+    # offset matches `session.date`, so the TypeScript side parses both
+    # fields with the same code. Round BPM to one decimal — Apple Health
+    # emits whole integers but the JS schema accepts numeric, and the
+    # one-decimal slack costs nothing while leaving room for future
+    # smoothing without a re-import.
+    workout['hr_samples'] = [
+        {'ts': dt.isoformat(), 'bpm': round(bpm, 1)} for dt, bpm in in_window
+    ]
 
     if workout['distance_meters'] and total_heartbeats > 0:
         workout['meters_per_heartbeat'] = round(workout['distance_meters'] / total_heartbeats, 4)

--- a/supabase/migrations/20260503120000_cardio_session_hr_samples.sql
+++ b/supabase/migrations/20260503120000_cardio_session_hr_samples.sql
@@ -1,0 +1,51 @@
+-- Per-session HR sample stream (PRD §7.4) — extends #152's cardio schema (#165).
+--
+-- The base `cardio_sessions` table stores aggregates only (avg/max HR,
+-- five zone-second columns). To render a per-session HR curve on the
+-- detail page (`/training-facility/gym/session/[started_at]`), we need
+-- the raw HR sample stream that Apple Watch records during a workout.
+--
+-- Storage cost is bounded at this scale: ~2,200 samples/session ×
+-- ~200 sessions/year × ~100 bytes/row ≈ 50 MB/year. Supabase free tier
+-- (500 MB) holds ~10 years of history before any pruning is needed.
+--
+-- Cascade delete on `session_started_at` keeps samples consistent if a
+-- session is ever pruned by the import script's "exact mirror" logic
+-- (PRD §7.11 — fix in HealthKit, re-import). Without it, a deleted
+-- session would leave orphan samples that the dashboard never queries
+-- but that count against the storage budget.
+--
+-- RLS mirrors `cardio_sessions`: anon + authenticated SELECT only.
+-- Writes go through the service-role import script (bypasses RLS); no
+-- write API routes exist for cardio data.
+--
+-- This file is the canonical record of the migration. The DDL is
+-- idempotent so re-applying on a fresh dev project is a safe no-op.
+
+create table if not exists public.cardio_session_hr_samples (
+  session_started_at timestamptz not null
+    references public.cardio_sessions(started_at) on delete cascade,
+  sample_at timestamptz not null,
+  bpm numeric not null check (bpm >= 0),
+  primary key (session_started_at, sample_at)
+);
+
+comment on table public.cardio_session_hr_samples is
+  'Raw HR sample stream for cardio sessions (#165). One row per Apple Watch HR sample during a workout, FK-linked to cardio_sessions with cascade delete. Powers the per-session detail page''s HR curve.';
+
+create index if not exists cardio_session_hr_samples_session_idx
+  on public.cardio_session_hr_samples (session_started_at);
+
+alter table public.cardio_session_hr_samples enable row level security;
+
+-- Postgres has no `create policy if not exists`; use a DO block to
+-- swallow the duplicate-object error so the migration stays re-runnable.
+do $$
+begin
+  create policy "anon and authenticated can read cardio hr samples"
+    on public.cardio_session_hr_samples
+    for select
+    to anon, authenticated
+    using (true);
+exception when duplicate_object then null;
+end $$;

--- a/types/cardio.ts
+++ b/types/cardio.ts
@@ -34,6 +34,27 @@ export interface CardioSession {
   hr_seconds_in_zone?: Record<HrZone, number>;
   /** Cardiac efficiency = distance ÷ total heartbeats. Higher = more efficient (PRD §7.4). */
   meters_per_heartbeat?: number;
+  /**
+   * Raw HR sample stream for this session (#165). Omitted on aggregate
+   * fetches that don't need the curve — the dashboard reads zone totals
+   * from {@link hr_seconds_in_zone} instead. Populated by the per-session
+   * detail page reader and by the Python preprocessor's JSON output.
+   */
+  hr_samples?: HrSample[];
+}
+
+/**
+ * One Apple-Watch HR sample emitted inside a session window. The detail
+ * page (`/training-facility/gym/session/[started_at]`) plots these as a
+ * line chart over session-relative time. Stored row-per-row in
+ * `cardio_session_hr_samples` and re-emitted into the legacy
+ * `CardioData` JSON for parity with the shape the preprocessor writes.
+ */
+export interface HrSample {
+  /** ISO timestamp with offset, matching {@link CardioSession.date}'s format. */
+  ts: string;
+  /** Heart rate in beats per minute. */
+  bpm: number;
 }
 
 /** A single point on a daily/weekly trend line — used for resting HR and VO2max series. */


### PR DESCRIPTION
## Summary

Adds `/training-facility/gym/session/[started_at]` — a per-session detail page that renders the full HR curve, zone breakdown, and metadata for one cardio workout. Closes the HR-zone trio: zone strip (#163) for scan, click-to-expand bars (#164) for focus, and now this page for drill-down.

Storage backing: a new `cardio_session_hr_samples` table (FK + cascade to `cardio_sessions`). The Python preprocessor now emits the raw HR sample stream alongside the existing zone aggregates; the import script delete-then-inserts samples per session in 500-row batches. Per the issue's storage estimate, ~50 MB/year of samples for a single user — Supabase free tier (500 MB) holds ~10 years.

## Changes

**Schema**
- `supabase/migrations/20260503120000_cardio_session_hr_samples.sql` — new table, applied to `court-vision` Supabase project.
- `(session_started_at, sample_at)` PK, FK with `on delete cascade`, `bpm >= 0` check, anon+authenticated SELECT RLS.

**Preprocessor (`scripts/preprocess-health.py`)**
- `aggregate_session_hr` now emits the in-window samples on `workout['hr_samples']` as `[{ts, bpm}, ...]`. Aggregate columns (avg/max/zones/efficiency) are unchanged.

**Schemas / types**
- `types/cardio.ts` — new `HrSample` interface, optional `hr_samples` on `CardioSession`.
- `lib/schemas/cardio.ts` — `CardioSessionHrSampleRowSchema`, `hrSampleRowToHrSample`, `hrSampleToRow`.
- `scripts/lib/cardio-supabase.mjs` — extends `CardioSessionSchema` to allow `hr_samples`.

**Import (`scripts/lib/cardio-supabase.mjs`)**
- New `upsertHrSamples` runs per-session delete-then-insert (500-row batches) after `cardio_sessions` upsert. Cascade FK handles session prune. Idempotent.
- `import-health.mjs` success log now reports the inserted-sample count.

**Data layer (`lib/data/cardio-server.ts`)**
- New `getCardioSession(startedAt)` returns `{session, samples}` or `null`. Uses the per-request server Supabase client.

**Page + view**
- `app/training-facility/gym/session/[started_at]/page.tsx` — Server Component, decodes the URL param, calls `getCardioSession`, `notFound()` on miss.
- `components/training-facility/gym/SessionDetailView.tsx` — header (date / activity / duration / distance / avg HR / max HR), HR-curve `<RoughLine>` over session-relative seconds, `<HrZoneBars>` zone breakdown. Empty-state for sessions without samples.

**Session-log links**
- Date cell in all four session-log tables (`AllCardioOverview` + `Stair` + `Treadmill` + `Track`) is now a `<Link>` that `stopPropagation`s so #164's row-expansion toggle stays intact.

## Test plan

- [ ] Re-run `npm run import-health -- <export.zip>` — success log mentions HR samples; Supabase shows rows in `cardio_session_hr_samples`.
- [ ] Click a date cell on `/training-facility/gym/overview` — navigates to the detail page; HR curve and zone bars render.
- [ ] On the detail page: spot-check the HR curve against Apple Health's view for the same workout.
- [ ] Try a session without HR samples (Apple Watch off) — page shows "No HR samples recorded" empty state, zone bars still show empty-chart state.
- [ ] Click on a row's date cell — navigates; clicking elsewhere on the row still toggles expansion (#164 behavior preserved).
- [ ] Repeat date-link checks on `/training-facility/gym/stair`, `/treadmill`, `/track`.
- [ ] Browser back from detail page → returns to the previous overview, scroll position preserved.
- [ ] Mobile (390×844): page header, stat cards, and chart cards stack cleanly; HR curve renders without overflow.
- [ ] Hand-typed bad URL like `/training-facility/gym/session/notarealtimestamp` — 404s rather than 500s.

## Notes

- Pace curve is out of scope for v1 per the upfront question pass — Apple Health's per-sample pace requires cadence data we don't currently parse. Defer to a follow-up issue.
- HR-curve x-axis is session-relative (`Mm SSs`), not wall-clock time — reads as "minute 8 of the workout."
- `[started_at]` route param is `encodeURIComponent`-encoded on the link, `decodeURIComponent`-decoded in the page — ISO timestamps contain `:` and `+`.
- Migration applied to `court-vision` Supabase project via MCP; SQL file is the canonical record.
- `npx tsc --noEmit` clean. 565 unit tests pass (10 new for `upsertHrSamples`). Build clean.

Closes #165.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dedicated session detail pages with session metadata, interactive HR curve and time‑in‑zone charts.
  * Session dates are now clickable across training views to open session details.
  * Per-session raw HR sample support: ingestion, storage, and type/schema support.

* **Tests**
  * Added tests covering HR-sample upsert behavior, batching, and edge cases.

* **Chores**
  * Import logging now includes HR sample counts; DB migration adds HR-samples table.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->