### PR TITLE
feat(combine): door to The Gym (#75 slice A)

### DIFF
--- a/components/training-facility/scenes/CombineScene.tsx
+++ b/components/training-facility/scenes/CombineScene.tsx
@@ -8,6 +8,7 @@ import { Basketball, ChalkPuff, Sneakers, WaterBottle } from './assets/character
 import {
   CombineHeaderSign,
   CourtMarkings,
+  DoorToGym,
   ResultsBoard,
   TapeMeasure,
 } from './assets/combine-fixtures'
@@ -41,7 +42,7 @@ export function CombineScene() {
       preserveAspectRatio="xMidYMid meet"
       className="h-full w-full select-none"
       role="img"
-      aria-label="The Combine — staging area with shuttle cones, a stopwatch, a Vertec vertical-jump station, sneakers and a basketball on the floor, and a results board on the wall."
+      aria-label="The Combine — staging area with shuttle cones, a stopwatch, a Vertec vertical-jump station, sneakers and a basketball on the floor, a results board on the wall, and a back door leading to The Gym."
     >
       <SceneDefs />
 
@@ -90,6 +91,8 @@ export function CombineScene() {
       <Basketball cx={1265} cy={808} r={16} seed={990} />
 
       <TapeMeasure />
+
+      <DoorToGym />
     </svg>
   )
 }

--- a/components/training-facility/scenes/assets/DoorToGym.test.tsx
+++ b/components/training-facility/scenes/assets/DoorToGym.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+import { DoorToGym } from './combine-fixtures'
+
+/**
+ * Render coverage for `DoorToGym`. The door is the Combine's mirror of the
+ * Gym's `DoorToCombine` and provides the missing direction in the PRD §7.4
+ * cross-link (slice A of #75). These assertions cover:
+ *
+ *   1. The wrapping `<Link>` resolves to an `<a>` with the right `href` and
+ *      the back-door aria-label so keyboard / screen-reader users can find it.
+ *   2. The "→ the gym" overhead sign and the "back door" underfoot caption
+ *      both render — those texts are how a sighted user knows where the door
+ *      goes without hovering.
+ *
+ * Visual fidelity (rough.js seeds, focus-ring opacity, spotlight ellipse) is
+ * intentionally not asserted — too fragile, spot-checked on the Vercel
+ * preview. The component is rendered inside an `<svg>` parent so the
+ * `<rect>` / `<text>` children land in the correct namespace.
+ */
+describe('DoorToGym', () => {
+  it('renders a link to /training-facility/gym with the back-door aria-label', () => {
+    render(
+      <svg>
+        <DoorToGym />
+      </svg>,
+    )
+    const link = screen.getByRole('link', {
+      name: 'Walk through the back door into The Gym',
+    })
+    expect(link).toBeInTheDocument()
+    expect(link).toHaveAttribute('href', '/training-facility/gym')
+  })
+
+  it('shows the "→ the gym" sign overhead and "back door" underfoot', () => {
+    render(
+      <svg>
+        <DoorToGym />
+      </svg>,
+    )
+    expect(screen.getByText('→ the gym')).toBeInTheDocument()
+    expect(screen.getByText('back door')).toBeInTheDocument()
+  })
+})

--- a/components/training-facility/scenes/assets/combine-fixtures.tsx
+++ b/components/training-facility/scenes/assets/combine-fixtures.tsx
@@ -1,6 +1,9 @@
+import Link from 'next/link'
+
 import { HANDWRITING_FONT, SCENE_PALETTE } from '../scene-primitives'
 import {
   RoughCircle,
+  RoughEllipse,
   RoughLineShape,
   RoughPath,
   RoughRect,
@@ -359,5 +362,157 @@ export function TapeMeasure() {
         )
       })}
     </g>
+  )
+}
+
+/**
+ * Back-wall door that opens into The Gym — the Combine's mirror of the Gym's
+ * `DoorToCombine`. Wraps the full door group in a Next.js `<Link>` so the
+ * spatial connection between the two sub-areas is real navigation in both
+ * directions (PRD §7.4 cross-link). A `:focus-visible` rim-orange dashed ring
+ * gives keyboard users a high-contrast cue beyond the door fill darken on
+ * focus. Coordinates intentionally mirror `DoorToCombine` (back-right wall,
+ * x=1300, y=150) so the two scenes read as paired rooms.
+ */
+export function DoorToGym() {
+  return (
+    <Link
+      href="/training-facility/gym"
+      aria-label="Walk through the back door into The Gym"
+      className="group focus:outline-none"
+    >
+      {/* Door frame */}
+      <RoughRect
+        x={1300}
+        y={150}
+        width={200}
+        height={440}
+        fill={SCENE_PALETTE.hardwoodDark}
+        fillStyle="solid"
+        stroke={SCENE_PALETTE.ink}
+        strokeWidth={3}
+        roughness={1.1}
+        seed={810}
+      />
+      {/* Inset door panel */}
+      <RoughRect
+        x={1316}
+        y={170}
+        width={168}
+        height={400}
+        fill={SCENE_PALETTE.hardwoodMid}
+        fillStyle="solid"
+        stroke={SCENE_PALETTE.ink}
+        strokeWidth={2}
+        roughness={1.0}
+        seed={811}
+      />
+      {/* Hover/focus tint as a translucent overlay using the existing classes */}
+      <rect
+        x={1316}
+        y={170}
+        width={168}
+        height={400}
+        fill="#6b3e1a"
+        className="opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100"
+      />
+      {/* Recessed inner panels */}
+      <RoughRect
+        x={1336}
+        y={194}
+        width={128}
+        height={150}
+        fill="none"
+        stroke={SCENE_PALETTE.ink}
+        strokeWidth={2}
+        roughness={1.0}
+        seed={812}
+      />
+      <RoughRect
+        x={1336}
+        y={364}
+        width={128}
+        height={180}
+        fill="none"
+        stroke={SCENE_PALETTE.ink}
+        strokeWidth={2}
+        roughness={1.0}
+        seed={813}
+      />
+      {/* Door handle */}
+      <RoughCircle
+        cx={1348}
+        cy={380}
+        r={5}
+        fill={SCENE_PALETTE.banner}
+        fillStyle="solid"
+        stroke={SCENE_PALETTE.ink}
+        strokeWidth={1}
+        roughness={0.7}
+        seed={814}
+      />
+      {/* Spotlight underfoot */}
+      <RoughEllipse
+        cx={1400}
+        cy={595}
+        width={240}
+        height={20}
+        fill={SCENE_PALETTE.rim}
+        fillStyle="solid"
+        stroke={SCENE_PALETTE.rim}
+        strokeWidth={0.4}
+        roughness={1.5}
+        seed={815}
+      />
+
+      {/* Focus ring — visible only when the Link is keyboard-focused */}
+      <rect
+        x={1294}
+        y={144}
+        width={212}
+        height={452}
+        fill="none"
+        stroke={SCENE_PALETTE.rim}
+        strokeWidth={4}
+        strokeDasharray="6 4"
+        rx={3}
+        className="opacity-0 transition-opacity group-focus-visible:opacity-100"
+      />
+
+      {/* Sign overhead */}
+      <RoughRect
+        x={1296}
+        y={94}
+        width={208}
+        height={48}
+        fill={SCENE_PALETTE.banner}
+        fillStyle="solid"
+        stroke={SCENE_PALETTE.ink}
+        strokeWidth={2}
+        roughness={1.0}
+        seed={816}
+      />
+      <text
+        x={1400}
+        y={128}
+        textAnchor="middle"
+        fill={SCENE_PALETTE.inkSoft}
+        fontFamily={HANDWRITING_FONT}
+        fontSize={26}
+        fontWeight={700}
+      >
+        → the gym
+      </text>
+      <text
+        x={1400}
+        y={636}
+        textAnchor="middle"
+        fill={SCENE_PALETTE.rimSoft}
+        fontFamily={HANDWRITING_FONT}
+        fontSize={20}
+      >
+        back door
+      </text>
+    </Link>
   )
 }

--- a/components/training-facility/scenes/assets/combine-fixtures.tsx
+++ b/components/training-facility/scenes/assets/combine-fixtures.tsx
@@ -366,13 +366,18 @@ export function TapeMeasure() {
 }
 
 /**
- * Back-wall door that opens into The Gym — the Combine's mirror of the Gym's
- * `DoorToCombine`. Wraps the full door group in a Next.js `<Link>` so the
- * spatial connection between the two sub-areas is real navigation in both
- * directions (PRD §7.4 cross-link). A `:focus-visible` rim-orange dashed ring
- * gives keyboard users a high-contrast cue beyond the door fill darken on
- * focus. Coordinates intentionally mirror `DoorToCombine` (back-right wall,
- * x=1300, y=150) so the two scenes read as paired rooms.
+ * Back-wall door that opens into The Gym — the Combine's side of the PRD §7.4
+ * cross-link, paired with the Gym's `DoorToCombine`. Wraps the full door group
+ * in a Next.js `<Link>` so the spatial connection between the two sub-areas is
+ * real navigation in both directions. A `:focus-visible` rim-orange dashed
+ * ring gives keyboard users a high-contrast cue beyond the door fill darken on
+ * focus.
+ *
+ * Placement: x=1090, y=150 — the back-wall gap between `CombineHeaderSign`
+ * (right edge x=1080) and the `Vertec` rig (base x=1320, "reach: 22"" badge
+ * extends to x=1590). The Gym puts `DoorToCombine` at the mirror x=1300 spot,
+ * but the Combine's right wall is occupied by the Vertec's wall-mounted reach
+ * badge, so the door sits in the gap to its left rather than the right corner.
  */
 export function DoorToGym() {
   return (
@@ -383,7 +388,7 @@ export function DoorToGym() {
     >
       {/* Door frame */}
       <RoughRect
-        x={1300}
+        x={1090}
         y={150}
         width={200}
         height={440}
@@ -396,7 +401,7 @@ export function DoorToGym() {
       />
       {/* Inset door panel */}
       <RoughRect
-        x={1316}
+        x={1106}
         y={170}
         width={168}
         height={400}
@@ -409,7 +414,7 @@ export function DoorToGym() {
       />
       {/* Hover/focus tint as a translucent overlay using the existing classes */}
       <rect
-        x={1316}
+        x={1106}
         y={170}
         width={168}
         height={400}
@@ -418,7 +423,7 @@ export function DoorToGym() {
       />
       {/* Recessed inner panels */}
       <RoughRect
-        x={1336}
+        x={1126}
         y={194}
         width={128}
         height={150}
@@ -429,7 +434,7 @@ export function DoorToGym() {
         seed={812}
       />
       <RoughRect
-        x={1336}
+        x={1126}
         y={364}
         width={128}
         height={180}
@@ -441,7 +446,7 @@ export function DoorToGym() {
       />
       {/* Door handle */}
       <RoughCircle
-        cx={1348}
+        cx={1138}
         cy={380}
         r={5}
         fill={SCENE_PALETTE.banner}
@@ -453,7 +458,7 @@ export function DoorToGym() {
       />
       {/* Spotlight underfoot */}
       <RoughEllipse
-        cx={1400}
+        cx={1190}
         cy={595}
         width={240}
         height={20}
@@ -467,7 +472,7 @@ export function DoorToGym() {
 
       {/* Focus ring — visible only when the Link is keyboard-focused */}
       <rect
-        x={1294}
+        x={1084}
         y={144}
         width={212}
         height={452}
@@ -481,7 +486,7 @@ export function DoorToGym() {
 
       {/* Sign overhead */}
       <RoughRect
-        x={1296}
+        x={1086}
         y={94}
         width={208}
         height={48}
@@ -493,7 +498,7 @@ export function DoorToGym() {
         seed={816}
       />
       <text
-        x={1400}
+        x={1190}
         y={128}
         textAnchor="middle"
         fill={SCENE_PALETTE.inkSoft}
@@ -504,7 +509,7 @@ export function DoorToGym() {
         → the gym
       </text>
       <text
-        x={1400}
+        x={1190}
         y={636}
         textAnchor="middle"
         fill={SCENE_PALETTE.rimSoft}


### PR DESCRIPTION
## Summary

Adds the missing direction in the Gym↔Combine cross-link (PRD §7.4). The
Gym scene already has `DoorToCombine` on its back-right wall; the Combine
page had only the "← Back to Training Facility" pill — no direct path
back to The Gym.

`DoorToGym` mirrors `DoorToCombine`'s exact coords (back-right wall,
x=1300, y=150) so the two scenes read as paired rooms. Sign overhead
reads `→ the gym`; underfoot caption reads `back door`; aria-label is
`Walk through the back door into The Gym`. Focus-visible rim-orange
dashed ring matches the keyboard treatment on `DoorToCombine`.

This is **slice A of #75**. The umbrella stays open until slices B
(WorkoutHeatmap + StreakCounter port), C (lifestyle metrics port), and
D (archive cardio-dashboard + changelog entry) land.

Refs #75 — do not close this issue on merge.

## Test plan

- [ ] Visit `/training-facility/combine` on the preview. The back-right
      wall should show a hardwood door with a yellow sign reading
      `→ the gym` and a `back door` caption underfoot.
- [ ] Click the door → navigates to `/training-facility/gym`.
- [ ] Tab into the door (keyboard nav). A rim-orange dashed focus ring
      should appear around the door.
- [ ] Hover the door — the inset panel darkens.
- [ ] Visit `/training-facility/gym` and confirm `DoorToCombine` still
      works the same (no regression).
- [ ] Screen reader: the door is announced as "Walk through the back
      door into The Gym, link".

## Out of scope

The other three slices of #75:
- Slice B — port `WorkoutHeatmap` + `StreakCounter` from
  `lucasklawrence/cardio-dashboard`
- Slice C — port HRV / walking-HR / body-mass / step-counts / sleep /
  active-energy daily-series metrics (multi-PR by series)
- Slice D — archive `lucasklawrence/cardio-dashboard` + add `v0.3.0 —
  Training Facility` changelog entry

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added a back door navigation element to the Combine area that allows users to access The Gym.

## Tests
* Added comprehensive tests to verify the new navigation functionality and accessibility attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->