### PR TITLE
feat(combine): preview-with-sample-data toggle covers jump tracker (#171)

### DIFF
--- a/app/training-facility/combine/page.tsx
+++ b/app/training-facility/combine/page.tsx
@@ -81,7 +81,13 @@ export default function TrainingFacilityCombinePage(): JSX.Element {
           <CombineDataIsland />
         </Suspense>
 
-        <JumpTrackerSection />
+        {/* Same Suspense rule applies to `JumpTrackerSection` once it
+            reads `useSearchParams()` for the preview swap (#171). The
+            island owns its own placeholder skeleton, so the fallback
+            stays null. */}
+        <Suspense fallback={null}>
+          <JumpTrackerSection />
+        </Suspense>
 
         <div className="mx-auto w-full max-w-6xl rounded-[1.6rem] border border-white/10 bg-black/35 p-3 shadow-[0_28px_70px_rgba(0,0,0,0.4)] sm:p-5">
           <CombineScene />

--- a/components/training-facility/combine/JumpTrackerSection.test.tsx
+++ b/components/training-facility/combine/JumpTrackerSection.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 
 import { JumpTrackerSection } from './JumpTrackerSection'
@@ -36,10 +36,6 @@ beforeEach(() => {
   searchParamsMock.mockReset()
   searchParamsMock.mockReturnValue(new URLSearchParams())
   getMovementBenchmarksMock.mockReset()
-})
-
-afterEach(() => {
-  vi.restoreAllMocks()
 })
 
 describe('JumpTrackerSection', () => {
@@ -92,11 +88,11 @@ describe('JumpTrackerSection', () => {
     expect(screen.queryByText(/May 1 · 23/)).not.toBeInTheDocument()
   })
 
-  it('returns to the empty state when ?preview=demo is removed (param exit)', async () => {
-    // Sanity check the inverse of test 2: with a fresh, empty fetch and
-    // no preview param, both children render their empty branch. Guards
-    // against a future refactor that ties the swap to the wrong gate
-    // (e.g. param presence regardless of param value).
+  it('ignores ?preview=<non-demo-value> and renders the empty state', async () => {
+    // Guards the swap gate against widening to "any preview value." Only
+    // the literal `preview=demo` should trigger the fixture swap; an
+    // arbitrary value (here `preview=other`) must fall through to the
+    // empty-state branch alongside the absent-param case (test #1).
     getMovementBenchmarksMock.mockResolvedValueOnce([])
     searchParamsMock.mockReturnValue(new URLSearchParams('preview=other'))
 

--- a/components/training-facility/combine/JumpTrackerSection.test.tsx
+++ b/components/training-facility/combine/JumpTrackerSection.test.tsx
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+
+import { JumpTrackerSection } from './JumpTrackerSection'
+
+/**
+ * Tests for the silhouette + ceiling-view client island. The interesting
+ * surface here is the empty-state preview swap (#171): when the URL has
+ * `?preview=demo` and the real benchmark fetch settles empty, the island
+ * substitutes `COMBINE_DEMO_BENCHMARKS` so the silhouette stack and rim
+ * gauge hydrate alongside the rest of the Combine page (which
+ * `CombineDataIsland` already wires up via #160).
+ *
+ * `getMovementBenchmarks` is stubbed at the data layer; `useSearchParams`
+ * is stubbed via `next/navigation` so each test controls the preview
+ * param independently.
+ */
+
+const searchParamsMock = vi.fn<() => URLSearchParams>(() => new URLSearchParams())
+vi.mock('next/navigation', () => ({
+  useSearchParams: () => searchParamsMock(),
+}))
+
+const getMovementBenchmarksMock = vi.fn()
+vi.mock('@/lib/data/movement', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/data/movement')>(
+    '@/lib/data/movement',
+  )
+  return {
+    ...actual,
+    getMovementBenchmarks: (...args: unknown[]) => getMovementBenchmarksMock(...args),
+  }
+})
+
+beforeEach(() => {
+  searchParamsMock.mockReset()
+  searchParamsMock.mockReturnValue(new URLSearchParams())
+  getMovementBenchmarksMock.mockReset()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('JumpTrackerSection', () => {
+  it('renders both child empty states when the fetch resolves empty and no preview param is set', async () => {
+    getMovementBenchmarksMock.mockResolvedValueOnce([])
+
+    render(<JumpTrackerSection />)
+
+    // Both children expose `role="status"` + aria-label "No jump data" in
+    // their empty branch; assert we see exactly two of them so neither
+    // child silently slipped into a populated render.
+    const empties = await screen.findAllByRole('status', { name: /no jump data/i })
+    expect(empties).toHaveLength(2)
+    expect(getMovementBenchmarksMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('hydrates from COMBINE_DEMO_BENCHMARKS when the fetch is empty and ?preview=demo is set', async () => {
+    getMovementBenchmarksMock.mockResolvedValueOnce([])
+    searchParamsMock.mockReturnValue(new URLSearchParams('preview=demo'))
+
+    render(<JumpTrackerSection />)
+
+    // Wait for the fetch to settle; the latest fixture row is 2026-05-01
+    // with vertical 23" — the silhouette tracker renders a `MMM D · N"`
+    // callout for that entry, which is unique to the populated branch.
+    await waitFor(() =>
+      expect(screen.getByText(/May 1 · 23/)).toBeInTheDocument(),
+    )
+    // Empty-state copy from either child must be gone — both children
+    // are rendering fixture data now.
+    expect(screen.queryByRole('status', { name: /no jump data/i })).not.toBeInTheDocument()
+  })
+
+  it('ignores ?preview=demo when real entries exist (real data wins)', async () => {
+    // Real, non-empty fetch — the island must NOT swap to the demo
+    // fixture even though the URL param is present. Mirrors
+    // CombineDataIsland's "real data wins" branch.
+    getMovementBenchmarksMock.mockResolvedValueOnce([
+      { date: '2026-04-15', vertical_in: 22, bodyweight_lbs: 234 },
+    ])
+    searchParamsMock.mockReturnValue(new URLSearchParams('preview=demo'))
+
+    render(<JumpTrackerSection />)
+
+    // Real entry's date-derived label: "Apr 15 · 22""
+    await waitFor(() =>
+      expect(screen.getByText(/Apr 15 · 22/)).toBeInTheDocument(),
+    )
+    // Fixture's latest row should NOT appear.
+    expect(screen.queryByText(/May 1 · 23/)).not.toBeInTheDocument()
+  })
+
+  it('returns to the empty state when ?preview=demo is removed (param exit)', async () => {
+    // Sanity check the inverse of test 2: with a fresh, empty fetch and
+    // no preview param, both children render their empty branch. Guards
+    // against a future refactor that ties the swap to the wrong gate
+    // (e.g. param presence regardless of param value).
+    getMovementBenchmarksMock.mockResolvedValueOnce([])
+    searchParamsMock.mockReturnValue(new URLSearchParams('preview=other'))
+
+    render(<JumpTrackerSection />)
+
+    const empties = await screen.findAllByRole('status', { name: /no jump data/i })
+    expect(empties).toHaveLength(2)
+  })
+})

--- a/components/training-facility/combine/JumpTrackerSection.tsx
+++ b/components/training-facility/combine/JumpTrackerSection.tsx
@@ -5,7 +5,7 @@ import { useEffect, useState, type JSX } from 'react'
 import { COMBINE_DEMO_BENCHMARKS } from '@/constants/combine-demo-fixture'
 import { getMovementBenchmarks } from '@/lib/data/movement'
 import {
-  CARDIO_PREVIEW_PARAM,
+  TRAINING_FACILITY_PREVIEW_PARAM,
   isPreviewDemoActive,
 } from '@/lib/training-facility/preview-param'
 import type { Benchmark } from '@/types/movement'
@@ -38,7 +38,7 @@ export function JumpTrackerSection(): JSX.Element {
   const [entries, setEntries] = useState<Benchmark[] | undefined>(undefined)
   const searchParams = useSearchParams()
   const previewActive = isPreviewDemoActive(
-    searchParams?.get(CARDIO_PREVIEW_PARAM),
+    searchParams?.get(TRAINING_FACILITY_PREVIEW_PARAM),
   )
 
   useEffect(() => {

--- a/components/training-facility/combine/JumpTrackerSection.tsx
+++ b/components/training-facility/combine/JumpTrackerSection.tsx
@@ -1,7 +1,13 @@
 'use client'
 
+import { useSearchParams } from 'next/navigation'
 import { useEffect, useState, type JSX } from 'react'
+import { COMBINE_DEMO_BENCHMARKS } from '@/constants/combine-demo-fixture'
 import { getMovementBenchmarks } from '@/lib/data/movement'
+import {
+  CARDIO_PREVIEW_PARAM,
+  isPreviewDemoActive,
+} from '@/lib/training-facility/preview-param'
 import type { Benchmark } from '@/types/movement'
 import { CeilingView } from './CeilingView'
 import { SilhouetteJumpTracker } from './SilhouetteJumpTracker'
@@ -18,9 +24,22 @@ import { SilhouetteJumpTracker } from './SilhouetteJumpTracker'
  * Layout: stacked on mobile, side-by-side on `lg` and up. The silhouette
  * tracker takes ~2/3 of the desktop width and the ceiling gauge ~1/3,
  * matching their natural information densities.
+ *
+ * Empty-state preview affordance (#160 → #171): when the URL has
+ * `?preview=demo` AND the real fetch settled empty, swap in the shared
+ * demo fixture so the silhouette + ceiling view hydrate alongside the
+ * rest of the Combine surfaces (which `CombineDataIsland` already wires
+ * up). This island deliberately does NOT render its own preview badge
+ * or CTA — the page-level affordance lives in `CombineDataIsland`, and
+ * duplicating it here would double the chrome. A real fetch with rows
+ * always wins, regardless of the URL param.
  */
 export function JumpTrackerSection(): JSX.Element {
   const [entries, setEntries] = useState<Benchmark[] | undefined>(undefined)
+  const searchParams = useSearchParams()
+  const previewActive = isPreviewDemoActive(
+    searchParams?.get(CARDIO_PREVIEW_PARAM),
+  )
 
   useEffect(() => {
     let cancelled = false
@@ -53,6 +72,13 @@ export function JumpTrackerSection(): JSX.Element {
     )
   }
 
+  // Preview swap: only fires when the real fetch settled empty AND the
+  // URL param is active. A populated `entries` always passes through
+  // unchanged so a real benchmark history is never shadowed by the demo.
+  const realIsEmpty = entries.length === 0
+  const isPreviewMode = realIsEmpty && previewActive
+  const surfaceEntries = isPreviewMode ? COMBINE_DEMO_BENCHMARKS : entries
+
   return (
     <section
       aria-label="Jump tracker — silhouette and ceiling view"
@@ -67,7 +93,7 @@ export function JumpTrackerSection(): JSX.Element {
             §9.3
           </span>
         </header>
-        <SilhouetteJumpTracker entries={entries} />
+        <SilhouetteJumpTracker entries={surfaceEntries} />
       </div>
       <div className="rounded-2xl border border-amber-300/20 bg-black/40 p-4 sm:p-6">
         <header className="mb-3 flex items-baseline justify-between">
@@ -78,7 +104,7 @@ export function JumpTrackerSection(): JSX.Element {
             §9.4
           </span>
         </header>
-        <CeilingView entries={entries} />
+        <CeilingView entries={surfaceEntries} />
       </div>
     </section>
   )

--- a/lib/training-facility/preview-param.ts
+++ b/lib/training-facility/preview-param.ts
@@ -1,17 +1,23 @@
 /**
- * Pure (non-client, non-hook) helpers for the cardio empty-state
- * preview URL contract (#162). Lives in its own file — *without* a
- * `'use client'` directive — so a Server Component (e.g.
- * `/training-facility/gym/page.tsx`) can import the predicate the
- * same way the client islands do via the hook in
+ * Pure (non-client, non-hook) helpers for the Training-Facility-wide
+ * empty-state preview URL contract (#162 cardio, #160 / #171 combine).
+ * Lives in its own file — *without* a `'use client'` directive — so a
+ * Server Component (e.g. `/training-facility/gym/page.tsx`) can import
+ * the predicate the same way the client islands do via the hook in
  * `use-cardio-preview.ts`. A `'use client'` file would make every
  * export a client reference, which Next 15+ refuses to call from a
  * Server Component.
+ *
+ * Naming note: the constants and hook still carry the `CARDIO_` /
+ * `useCardioPreview` prefix because cardio was the first surface to
+ * adopt them. Combine now uses the same contract without
+ * surface-specific renames — the param key (`preview`) and value
+ * (`demo`) are shared across the entire Training Facility.
  */
 
 /** URL param key + value that activates the empty-state demo fixture. */
-export const CARDIO_PREVIEW_PARAM = 'preview'
-export const CARDIO_PREVIEW_VALUE = 'demo'
+export const TRAINING_FACILITY_PREVIEW_PARAM = 'preview'
+export const TRAINING_FACILITY_PREVIEW_VALUE = 'demo'
 
 /**
  * Cross-context predicate for "is `?preview=demo` active in this URL?"
@@ -35,7 +41,7 @@ export const CARDIO_PREVIEW_VALUE = 'demo'
 export function isPreviewDemoActive(
   raw: string | string[] | null | undefined,
 ): boolean {
-  if (raw === CARDIO_PREVIEW_VALUE) return true
-  if (Array.isArray(raw) && raw.includes(CARDIO_PREVIEW_VALUE)) return true
+  if (raw === TRAINING_FACILITY_PREVIEW_VALUE) return true
+  if (Array.isArray(raw) && raw.includes(TRAINING_FACILITY_PREVIEW_VALUE)) return true
   return false
 }

--- a/lib/training-facility/use-cardio-preview.ts
+++ b/lib/training-facility/use-cardio-preview.ts
@@ -6,8 +6,8 @@ import { CARDIO_DEMO_DATA } from '@/constants/cardio-demo-fixture'
 import type { CardioActivity, CardioData } from '@/types/cardio'
 
 import {
-  CARDIO_PREVIEW_PARAM,
-  CARDIO_PREVIEW_VALUE,
+  TRAINING_FACILITY_PREVIEW_PARAM,
+  TRAINING_FACILITY_PREVIEW_VALUE,
   isPreviewDemoActive,
 } from './preview-param'
 
@@ -16,7 +16,11 @@ import {
 // components must NOT import these via this module — they're inside a
 // `'use client'` boundary, which Next 15+ refuses to call from a
 // Server Component. Import directly from `./preview-param` instead.
-export { CARDIO_PREVIEW_PARAM, CARDIO_PREVIEW_VALUE, isPreviewDemoActive }
+export {
+  TRAINING_FACILITY_PREVIEW_PARAM,
+  TRAINING_FACILITY_PREVIEW_VALUE,
+  isPreviewDemoActive,
+}
 
 /** Optional knobs for {@link useCardioPreview}. */
 export interface UseCardioPreviewOptions {
@@ -84,7 +88,9 @@ export function useCardioPreview(
   options: UseCardioPreviewOptions = {},
 ): CardioPreviewState {
   const searchParams = useSearchParams()
-  const previewActive = isPreviewDemoActive(searchParams?.get(CARDIO_PREVIEW_PARAM))
+  const previewActive = isPreviewDemoActive(
+    searchParams?.get(TRAINING_FACILITY_PREVIEW_PARAM),
+  )
   const realIsEmpty = computeRealIsEmpty(real, options.requireActivity)
   const isPreviewMode = realIsEmpty && previewActive
   const showEmptyStateCta = realIsEmpty && !previewActive
@@ -107,7 +113,7 @@ export function useCardioPreview(
  */
 export function useCardioPreviewHref(): string {
   const pathname = usePathname()
-  return `${pathname}?${CARDIO_PREVIEW_PARAM}=${CARDIO_PREVIEW_VALUE}`
+  return `${pathname}?${TRAINING_FACILITY_PREVIEW_PARAM}=${TRAINING_FACILITY_PREVIEW_VALUE}`
 }
 
 /**


### PR DESCRIPTION
## Summary

- The Combine empty-state preview (#160) populated the radar / scoreboard / trading card / history table from `COMBINE_DEMO_BENCHMARKS` when `?preview=demo` was set and the real fetch returned `[]` — but the silhouette tracker + ceiling view rendered from `JumpTrackerSection`'s own fetch and ignored the param, leaving a "no jumps logged yet" gap mid-page for portfolio reviewers.
- Wires the same per-island preview swap as `CombineDataIsland` (Option A from the issue): `useSearchParams()` → `isPreviewDemoActive()` → fall back to the shared fixture only when the real fetch settled empty. Real data with rows always wins. No new badge / CTA — `CombineDataIsland` owns the page-level chrome.
- Wraps `<JumpTrackerSection />` in `<Suspense fallback={null}>` in `app/training-facility/combine/page.tsx` so Next 15+ doesn't opt the entire route out of static rendering once the island starts reading `useSearchParams()`. Mirrors the existing wrapper around `CombineDataIsland`.

## Test plan

- [ ] On `/training-facility/combine` with no benchmarks logged and no preview param, the silhouette + ceiling cards still show their "no jumps logged yet" empty states.
- [ ] On `/training-facility/combine?preview=demo` with no benchmarks logged, the silhouette stack is populated and the ceiling-view rim gauge animates to a fixture jump-touch (last fixture row: 2026-05-01, vertical 23").
- [ ] Clicking "Exit preview" on the page-level badge strips `?preview=demo` and the jump tracker returns to its empty-state cards (no flash of stale fixture data).
- [ ] With at least one real benchmark in the DB, navigating to `/training-facility/combine?preview=demo` continues to render the real silhouette / ceiling view — the demo never shadows live data.
- [ ] `npx tsc --noEmit` clean, `npx next build` clean, the full vitest suite passes (4 pre-existing `server-only` resolver failures in worktree environments are unrelated to this change and pass on `main`).

Closes #171.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added preview mode support to training facility combine page, allowing demo data to display via URL parameter when real data is unavailable.

* **Tests**
  * Introduced comprehensive test suite for JumpTrackerSection covering empty states, demo data fallback, and data precedence scenarios.

* **Refactor**
  * Renamed preview parameters to reflect broader training facility context; improved component loading performance with dedicated Suspense boundary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->