### PR TITLE
feat(gym): port WorkoutHeatmap + StreakCounter from cardio-dashboard (#75 slice B)

### DIFF
--- a/components/training-facility/gym/AllCardioOverview.tsx
+++ b/components/training-facility/gym/AllCardioOverview.tsx
@@ -40,6 +40,7 @@ import {
   trainingLoadInRange,
   type TrainingLoadPoint,
 } from '@/lib/training-facility/training-load'
+import { computeStreaks, type StreakResult } from '@/lib/training-facility/streaks'
 import { BackToCourtButton } from '@/components/common/BackToCourtButton'
 import { HrZoneBars } from './HrZoneBars'
 import { ActivityLegend, AvgHrBarsByActivity } from './AvgHrBarsByActivity'
@@ -51,6 +52,8 @@ import {
   useSessionRowExpansion,
 } from './SessionRowExpansion'
 import { TrainingLoadChart } from './TrainingLoadChart'
+import { WorkoutHeatmap } from './WorkoutHeatmap'
+import { StreakCounter } from './StreakCounter'
 import { chartPalette } from '@/components/training-facility/shared/charts/palette'
 import { defaultMargin } from '@/components/training-facility/shared/charts/types'
 import { DEFAULT_MAX_HR } from '@/constants/hr-zones'
@@ -205,6 +208,19 @@ export function AllCardioOverview(): JSX.Element {
     [data, range, maxHr],
   )
 
+  // Streaks (slice B of #75). All-time numbers come from `data.sessions`;
+  // the in-range "longest" comes from the already-filtered `sessions`. We
+  // pass the raw filtered list (not the range bounds) so the streak
+  // helper agrees with what the heatmap and session-log table also see.
+  const allTimeStreak = useMemo<StreakResult>(
+    () => (data ? computeStreaks(data.sessions) : { current: 0, longest: 0 }),
+    [data],
+  )
+  const filteredStreak = useMemo<StreakResult | null>(
+    () => (sessions.length > 0 ? computeStreaks(sessions) : null),
+    [sessions],
+  )
+
   return (
     <div className="relative min-h-svh overflow-hidden bg-[#120d0a] text-[#f7ead9]">
       <div
@@ -268,7 +284,24 @@ export function AllCardioOverview(): JSX.Element {
           <LoadingPanel />
         ) : (
           <>
+            <div className="mt-8">
+              <StreakCounter streak={allTimeStreak} filteredStreak={filteredStreak} />
+            </div>
+
             <SummaryRow summary={summary} />
+
+            <ChartCard
+              title="Workout frequency"
+              helper="One cell per day in the active range — color saturates as the day's session count rises. Hover a cell for the exact count and activities."
+              wide
+            >
+              <WorkoutHeatmap
+                sessions={data.sessions}
+                dateFrom={range.start}
+                dateTo={range.end}
+                fontFamily={FONT_FAMILY}
+              />
+            </ChartCard>
 
             <div className="mt-8 grid gap-6 lg:grid-cols-2">
               <ChartCard

--- a/components/training-facility/gym/StreakCounter.test.tsx
+++ b/components/training-facility/gym/StreakCounter.test.tsx
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+import { StreakCounter } from './StreakCounter'
+
+describe('StreakCounter', () => {
+  it('shows the current and longest day counts', () => {
+    render(<StreakCounter streak={{ current: 5, longest: 12 }} />)
+    expect(screen.getByText('5')).toBeInTheDocument()
+    expect(screen.getByText('day streak')).toBeInTheDocument()
+    expect(screen.getByText('12d')).toBeInTheDocument()
+  })
+
+  it('renders the in-range stat only when filteredStreak.longest > 0', () => {
+    const { rerender } = render(
+      <StreakCounter
+        streak={{ current: 3, longest: 10 }}
+        filteredStreak={{ current: 0, longest: 4 }}
+      />,
+    )
+    expect(screen.getByText(/in range/i)).toBeInTheDocument()
+    expect(screen.getByText('4d')).toBeInTheDocument()
+
+    rerender(
+      <StreakCounter
+        streak={{ current: 3, longest: 10 }}
+        filteredStreak={{ current: 0, longest: 0 }}
+      />,
+    )
+    expect(screen.queryByText(/in range/i)).not.toBeInTheDocument()
+  })
+
+  it('desaturates the flame when the current streak is 0', () => {
+    render(<StreakCounter streak={{ current: 0, longest: 8 }} />)
+    const flame = screen.getByText('\u{1F525}')
+    expect(flame.className).toContain('grayscale')
+  })
+
+  it('keeps the flame at full saturation when current > 0', () => {
+    render(<StreakCounter streak={{ current: 1, longest: 1 }} />)
+    const flame = screen.getByText('\u{1F525}')
+    expect(flame.className).not.toContain('grayscale')
+  })
+})

--- a/components/training-facility/gym/StreakCounter.tsx
+++ b/components/training-facility/gym/StreakCounter.tsx
@@ -1,0 +1,74 @@
+import type { JSX } from 'react'
+
+import type { StreakResult } from '@/lib/training-facility/streaks'
+
+/** Props for {@link StreakCounter}. */
+export interface StreakCounterProps {
+  /** All-time current and longest streaks (computed from `data.sessions`). */
+  streak: StreakResult
+  /**
+   * Streak result for sessions filtered by the active `DateFilter` range.
+   * Pass `null` (or omit) when no range is active — the component renders
+   * only the all-time numbers in that case. When provided, the longest
+   * streak in the range is shown alongside the all-time numbers.
+   */
+  filteredStreak?: StreakResult | null
+  /**
+   * Optional Tailwind classes appended to the outer card. Lets the parent
+   * tweak grid placement / width without rewriting the card chrome.
+   */
+  className?: string
+}
+
+/**
+ * Compact streak indicator for the All Cardio Overview, ported from the
+ * standalone cardio-dashboard repo (slice B of #75) and re-styled to the
+ * cream-card aesthetic that `SummaryRow` uses elsewhere on the page.
+ *
+ * Renders three stat columns inside one card: 🔥 current, longest (all
+ * time), and longest in the active filter range. The flame goes
+ * desaturated when the current streak is 0 so an inactive run doesn't
+ * fight the rest of the page for attention.
+ */
+export function StreakCounter({
+  streak,
+  filteredStreak,
+  className = '',
+}: StreakCounterProps): JSX.Element {
+  const isActive = streak.current > 0
+  return (
+    <section
+      aria-label="Workout streaks"
+      data-testid="streak-counter"
+      className={`rounded-[1.2rem] border border-white/10 bg-[#f5f1e6] p-4 text-[#0a0a0a] shadow-[0_12px_32px_rgba(0,0,0,0.28)] ${className}`}
+    >
+      <div className="flex flex-wrap items-baseline gap-x-6 gap-y-3">
+        <div className="flex items-baseline gap-3">
+          <span aria-hidden="true" className={`text-2xl ${isActive ? '' : 'opacity-30 grayscale'}`}>
+            {'\u{1F525}'}
+          </span>
+          <div>
+            <p className="font-mono text-2xl font-semibold tabular-nums">{streak.current}</p>
+            <p className="font-mono text-[10px] font-bold uppercase tracking-[0.22em] text-[#0a0a0a]/70">
+              day streak
+            </p>
+          </div>
+        </div>
+
+        <div className="font-mono text-xs uppercase tracking-[0.18em] text-[#0a0a0a]/70">
+          longest{' '}
+          <span className="font-semibold tabular-nums text-[#0a0a0a]">{streak.longest}d</span>
+        </div>
+
+        {filteredStreak && filteredStreak.longest > 0 ? (
+          <div className="font-mono text-xs uppercase tracking-[0.18em] text-[#0a0a0a]/70">
+            in range{' '}
+            <span className="font-semibold tabular-nums text-[#0a0a0a]">
+              {filteredStreak.longest}d
+            </span>
+          </div>
+        ) : null}
+      </div>
+    </section>
+  )
+}

--- a/components/training-facility/gym/WorkoutHeatmap.test.tsx
+++ b/components/training-facility/gym/WorkoutHeatmap.test.tsx
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { render } from '@testing-library/react'
+
+import type { CardioSession } from '@/types/cardio'
+
+import { WorkoutHeatmap } from './WorkoutHeatmap'
+
+function session(
+  dateStr: string,
+  activity: CardioSession['activity'] = 'stair',
+): Pick<CardioSession, 'date' | 'activity'> {
+  return { date: `${dateStr}T08:00:00`, activity }
+}
+
+/**
+ * Render coverage for `WorkoutHeatmap`. Asserts:
+ *   1. The SVG mounts with the expected accessible role/label.
+ *   2. The grid contains 7 × N cells matching the helper's grid.
+ *   3. Active cells get an intensity color from the rim-orange family
+ *      (verifies the helper-result → fill-color wiring; the bucket math
+ *      itself is covered in `heatmap-grid.test.ts`).
+ *   4. Cell tooltips describe the date and any sessions on it.
+ */
+describe('WorkoutHeatmap', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('renders an SVG with the expected aria-label', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 3, 15))
+    const { getByRole } = render(<WorkoutHeatmap sessions={[]} />)
+    const svg = getByRole('img', { name: 'Workout frequency heatmap' })
+    expect(svg).toBeInTheDocument()
+  })
+
+  it('renders 7 × N cells inside the grid', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 3, 15))
+    const from = new Date(2026, 3, 1) // Apr 1
+    const to = new Date(2026, 3, 15) // Apr 15
+    const { container } = render(<WorkoutHeatmap sessions={[]} dateFrom={from} dateTo={to} />)
+    // The 4 legend swatches share the same <rect> shape; 4 of the rects in
+    // the SVG come from the legend, the rest are grid cells. Subtracting
+    // the legend swatch count yields 7 × N for the grid.
+    const rects = container.querySelectorAll('svg rect')
+    const gridCells = rects.length - 4
+    expect(gridCells % 7).toBe(0)
+    const cols = gridCells / 7
+    expect(cols).toBeGreaterThanOrEqual(3)
+    expect(cols).toBeLessThanOrEqual(4)
+  })
+
+  it('paints active cells with a rim-orange shade', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 3, 15))
+    const from = new Date(2026, 3, 1)
+    const to = new Date(2026, 3, 15)
+    const { container } = render(
+      <WorkoutHeatmap sessions={[session('2026-04-14')]} dateFrom={from} dateTo={to} />,
+    )
+    // At least one rect should reference the rim-orange palette (either the
+    // full hex or the rgba family).
+    const rects = Array.from(container.querySelectorAll('svg rect'))
+    const fills = rects.map((r) => r.getAttribute('fill') ?? '')
+    expect(fills.some((f) => /234, 88, 12|EA580C/i.test(f))).toBe(true)
+  })
+
+  it('writes a session-count tooltip on populated cells', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 3, 15))
+    const from = new Date(2026, 3, 1)
+    const to = new Date(2026, 3, 15)
+    const { container } = render(
+      <WorkoutHeatmap
+        sessions={[session('2026-04-14', 'running'), session('2026-04-14', 'walking')]}
+        dateFrom={from}
+        dateTo={to}
+      />,
+    )
+    const titles = Array.from(container.querySelectorAll('svg rect title')).map(
+      (n) => n.textContent ?? '',
+    )
+    const populated = titles.find((t) => t.includes('2 sessions'))
+    expect(populated).toBeDefined()
+    expect(populated).toContain('Running')
+    expect(populated).toContain('Walking')
+  })
+})

--- a/components/training-facility/gym/WorkoutHeatmap.tsx
+++ b/components/training-facility/gym/WorkoutHeatmap.tsx
@@ -1,0 +1,189 @@
+import type { JSX } from 'react'
+
+import { chartPalette } from '@/components/training-facility/shared/charts/palette'
+import {
+  buildHeatmapGrid,
+  intensityLevel,
+  type HeatmapCell,
+} from '@/lib/training-facility/heatmap-grid'
+import type { CardioSession } from '@/types/cardio'
+
+/** Props for {@link WorkoutHeatmap}. */
+export interface WorkoutHeatmapProps {
+  /** All cardio sessions; the helper buckets them by local calendar day. */
+  sessions: ReadonlyArray<Pick<CardioSession, 'date' | 'activity'>>
+  /** Inclusive start of the visible window. Omit for the trailing 52 weeks. */
+  dateFrom?: Date | null
+  /** Inclusive end of the visible window. Defaults to today. */
+  dateTo?: Date | null
+  /**
+   * Pixel width of one cell, including the trailing inter-cell gap; the
+   * grid lays out columns left-to-right at this stride. Defaults to 14.
+   */
+  cellSize?: number
+  /** Pixel gap between cells. Defaults to 2. */
+  cellGap?: number
+  /**
+   * Font family for the day-of-week and month labels. Defaults to `inherit`
+   * so the surrounding `ChartCard` can drive the typeface.
+   */
+  fontFamily?: string
+  /** Accessible label for the chart's `<svg>` `role="img"` wrapper. */
+  ariaLabel?: string
+}
+
+const DAY_LABELS = ['Mon', '', 'Wed', '', 'Fri', '', ''] as const
+/** Pixel width reserved for the day-of-week label column. */
+const DAY_LABEL_WIDTH = 32
+/** Pixel height reserved for the month label row above the grid. */
+const MONTH_LABEL_HEIGHT = 18
+
+/**
+ * Color palette for the four intensity levels. Indexed by the value
+ * `intensityLevel` returns. `0` is the empty cell (faint ink wash so the
+ * empty grid is still visible against the cream `ChartCard`); 1–3 step
+ * up the rim-orange saturation so denser weeks read as warmer.
+ */
+const CELL_COLORS = [
+  'rgba(10, 10, 10, 0.07)',
+  'rgba(234, 88, 12, 0.28)',
+  'rgba(234, 88, 12, 0.62)',
+  chartPalette.rimOrange,
+] as const
+
+/**
+ * Calendar heatmap of cardio session frequency, ported from the standalone
+ * cardio-dashboard repo (slice B of #75) and re-styled to the courtfolio
+ * `chartPalette`. Plain `<rect>` cells inside an SVG so 52w × 7d ≈ 364
+ * cells render instantly even on mobile — the surrounding `ChartCard`
+ * provides the hand-drawn frame.
+ *
+ * Reads `dateFrom` / `dateTo` from the parent's `DateFilter` so the visible
+ * window matches every other chart on the All Cardio Overview. Cells are
+ * keyed by local calendar day; multiple sessions on the same day stack
+ * into higher intensity buckets via {@link intensityLevel}.
+ *
+ * The `<title>` per cell is the native browser tooltip that reviewers see
+ * on hover; screen readers also read it for keyboard navigation.
+ */
+export function WorkoutHeatmap({
+  sessions,
+  dateFrom,
+  dateTo,
+  cellSize = 14,
+  cellGap = 2,
+  fontFamily = 'inherit',
+  ariaLabel = 'Workout frequency heatmap',
+}: WorkoutHeatmapProps): JSX.Element {
+  const { grid, monthLabels } = buildHeatmapGrid(sessions, dateFrom, dateTo)
+  const cols = grid[0]?.length ?? 0
+  const cellInner = cellSize - cellGap
+  const gridWidth = cols * cellSize
+  const gridHeight = 7 * cellSize
+  const totalWidth = DAY_LABEL_WIDTH + gridWidth
+  const totalHeight = MONTH_LABEL_HEIGHT + gridHeight + 18 // +18 for the legend strip
+
+  return (
+    <svg
+      viewBox={`0 0 ${totalWidth} ${totalHeight}`}
+      width={totalWidth}
+      height={totalHeight}
+      role="img"
+      aria-label={ariaLabel}
+      style={{ fontFamily }}
+    >
+      {/* Month labels along the top */}
+      <g transform={`translate(${DAY_LABEL_WIDTH}, ${MONTH_LABEL_HEIGHT - 4})`}>
+        {monthLabels.map((m) => (
+          <text
+            key={`month-${m.col}-${m.label}`}
+            x={m.col * cellSize}
+            y={0}
+            fontSize={11}
+            fill={chartPalette.inkSoft}
+          >
+            {m.label}
+          </text>
+        ))}
+      </g>
+
+      {/* Day-of-week labels along the left */}
+      <g transform={`translate(0, ${MONTH_LABEL_HEIGHT})`}>
+        {DAY_LABELS.map((label, row) =>
+          label ? (
+            <text
+              key={`day-${row}`}
+              x={DAY_LABEL_WIDTH - 6}
+              y={row * cellSize + cellSize / 2 + 3}
+              textAnchor="end"
+              fontSize={10}
+              fill={chartPalette.inkSoft}
+            >
+              {label}
+            </text>
+          ) : null,
+        )}
+      </g>
+
+      {/* Heatmap cells */}
+      <g transform={`translate(${DAY_LABEL_WIDTH}, ${MONTH_LABEL_HEIGHT})`}>
+        {grid.map((row, rowIdx) =>
+          row.map((cell, colIdx) => (
+            <rect
+              key={`cell-${colIdx}-${rowIdx}`}
+              x={colIdx * cellSize}
+              y={rowIdx * cellSize}
+              width={cellInner}
+              height={cellInner}
+              rx={2}
+              ry={2}
+              fill={CELL_COLORS[intensityLevel(cell.count)]}
+            >
+              <title>{describeCell(cell)}</title>
+            </rect>
+          )),
+        )}
+      </g>
+
+      {/* Legend strip — "Less" + 4 swatches + "More" */}
+      <g
+        transform={`translate(${DAY_LABEL_WIDTH + gridWidth - 140}, ${MONTH_LABEL_HEIGHT + gridHeight + 14})`}
+      >
+        <text x={0} y={0} fontSize={10} fill={chartPalette.inkSoft}>
+          Less
+        </text>
+        {CELL_COLORS.map((color, i) => (
+          <rect
+            key={`legend-${i}`}
+            x={32 + i * (cellSize + 1)}
+            y={-9}
+            width={cellInner}
+            height={cellInner}
+            rx={2}
+            ry={2}
+            fill={color}
+          />
+        ))}
+        <text x={32 + 4 * (cellSize + 1) + 4} y={0} fontSize={10} fill={chartPalette.inkSoft}>
+          More
+        </text>
+      </g>
+    </svg>
+  )
+}
+
+/**
+ * Compose the per-cell tooltip — `Apr 14, 2026: 2 sessions (Running, Walking)`
+ * for active days, just the formatted date for empty days. Reads naturally
+ * for both sighted users (browser title-tooltip on hover) and screen readers.
+ */
+function describeCell(cell: HeatmapCell): string {
+  const dateLabel = cell.date.toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  })
+  if (cell.count === 0) return dateLabel
+  const noun = cell.count === 1 ? 'session' : 'sessions'
+  return `${dateLabel}: ${cell.count} ${noun} (${cell.types.join(', ')})`
+}

--- a/lib/training-facility/heatmap-grid.test.ts
+++ b/lib/training-facility/heatmap-grid.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+
+import type { CardioSession } from '@/types/cardio'
+
+import { buildHeatmapGrid, intensityLevel, type HeatmapGrid } from './heatmap-grid'
+
+function findCell(grid: HeatmapGrid['grid'], year: number, month: number, day: number) {
+  for (const row of grid) {
+    for (const cell of row) {
+      if (
+        cell.date.getFullYear() === year &&
+        cell.date.getMonth() === month &&
+        cell.date.getDate() === day
+      ) {
+        return cell
+      }
+    }
+  }
+  return null
+}
+
+function session(
+  dateStr: string,
+  activity: CardioSession['activity'] = 'stair',
+): Pick<CardioSession, 'date' | 'activity'> {
+  return { date: `${dateStr}T08:00:00`, activity }
+}
+
+describe('buildHeatmapGrid', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('returns 7 rows when no dates given', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 3, 15)) // Wed Apr 15 2026
+    const { grid } = buildHeatmapGrid([])
+    expect(grid).toHaveLength(7)
+    expect(grid[0].length).toBeGreaterThanOrEqual(53)
+  })
+
+  it('grid starts on a Monday', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 3, 15))
+    const { grid } = buildHeatmapGrid([])
+    expect(grid[0][0].date.getDay()).toBe(1)
+  })
+
+  it('respects dateFrom and dateTo', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 3, 15))
+    const from = new Date(2026, 2, 1) // Mar 1
+    const to = new Date(2026, 3, 15) // Apr 15
+    const { grid } = buildHeatmapGrid([], from, to)
+    expect(grid).toHaveLength(7)
+    const cols = grid[0].length
+    expect(cols).toBeGreaterThanOrEqual(7)
+    expect(cols).toBeLessThanOrEqual(9)
+    expect(grid[0][0].date.getTime()).toBeLessThanOrEqual(from.getTime())
+  })
+
+  it('counts sessions on the correct date', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 3, 15))
+    const sessions = [session('2026-04-14', 'running'), session('2026-04-14', 'walking')]
+    const { grid } = buildHeatmapGrid(sessions)
+    const cell = findCell(grid, 2026, 3, 14)
+    expect(cell).not.toBeNull()
+    expect(cell!.count).toBe(2)
+    expect(cell!.types).toContain('Running')
+    expect(cell!.types).toContain('Walking')
+  })
+
+  it('empty days have count 0 and no types', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 3, 15))
+    const from = new Date(2026, 3, 1)
+    const to = new Date(2026, 3, 15)
+    const { grid } = buildHeatmapGrid([], from, to)
+    for (const row of grid) {
+      for (const cell of row) {
+        expect(cell.count).toBe(0)
+        expect(cell.types).toEqual([])
+      }
+    }
+  })
+
+  it('generates month labels for visible months', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 3, 15))
+    const { monthLabels } = buildHeatmapGrid([])
+    expect(monthLabels.length).toBeGreaterThan(0)
+    expect(monthLabels.find((l) => l.label === 'Apr')).toBeDefined()
+  })
+
+  it('does not duplicate friendly types when the same activity repeats', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 3, 15))
+    const sessions = [session('2026-04-14', 'running'), session('2026-04-14', 'running')]
+    const { grid } = buildHeatmapGrid(sessions)
+    const cell = findCell(grid, 2026, 3, 14)
+    expect(cell).not.toBeNull()
+    expect(cell!.count).toBe(2)
+    expect(cell!.types).toEqual(['Running'])
+  })
+
+  it('clamps dateFrom to MAX_COLS (~2 years) before dateTo', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 3, 15))
+    const from = new Date(2020, 0, 1) // way too early
+    const to = new Date(2026, 3, 15)
+    const { grid } = buildHeatmapGrid([], from, to)
+    expect(grid[0].length).toBeLessThanOrEqual(105)
+  })
+})
+
+describe('intensityLevel', () => {
+  it('buckets counts into 0/1/2/3', () => {
+    expect(intensityLevel(0)).toBe(0)
+    expect(intensityLevel(-1)).toBe(0)
+    expect(intensityLevel(1)).toBe(1)
+    expect(intensityLevel(2)).toBe(2)
+    expect(intensityLevel(3)).toBe(3)
+    expect(intensityLevel(10)).toBe(3)
+  })
+})

--- a/lib/training-facility/heatmap-grid.ts
+++ b/lib/training-facility/heatmap-grid.ts
@@ -1,0 +1,150 @@
+import type { CardioActivity, CardioSession } from '@/types/cardio'
+
+import { ACTIVITY_VISUALS } from './all-cardio'
+import { parseSessionDate } from './cardio-shared'
+
+/** A single cell in the workout-frequency heatmap grid. */
+export interface HeatmapCell {
+  /** Local-time date this cell represents. */
+  date: Date
+  /** Number of sessions logged on {@link date}. `0` for empty days. */
+  count: number
+  /** Distinct activity labels (`Stair`, `Running`, `Walking`) for tooltips. */
+  types: string[]
+}
+
+/** Result of {@link buildHeatmapGrid}. */
+export interface HeatmapGrid {
+  /** 7-row × N-column grid; row 0 is Monday, row 6 is Sunday. */
+  grid: HeatmapCell[][]
+  /** First-of-month markers for the column header labels. */
+  monthLabels: { col: number; label: string }[]
+}
+
+const DAY_MS = 86_400_000
+const WEEK_MS = 7 * DAY_MS
+/** Cap at ~2 years to limit DOM node count when a wide range is requested. */
+const MAX_COLS = 104
+
+/** Get the Monday at or before a given local date. */
+function getMondayOf(d: Date): Date {
+  const m = new Date(d.getFullYear(), d.getMonth(), d.getDate())
+  const dow = m.getDay()
+  m.setDate(m.getDate() - (dow === 0 ? 6 : dow - 1))
+  return m
+}
+
+const MONTH_LABELS = [
+  'Jan',
+  'Feb',
+  'Mar',
+  'Apr',
+  'May',
+  'Jun',
+  'Jul',
+  'Aug',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dec',
+] as const
+
+/**
+ * Build a 7-row × N-column heatmap of session counts per local calendar day.
+ * Row 0 is Monday so a typical year reads top-down as Mon→Sun. The grid
+ * spans the supplied range when both `dateFrom` and `dateTo` are provided;
+ * otherwise it falls back to the trailing 52 weeks ending at the current
+ * week. Capped at {@link MAX_COLS} weeks (~2 years) to keep the DOM small
+ * even when a long range is requested.
+ *
+ * Empty days have `count: 0` and `types: []` — the caller renders them as
+ * the lowest-intensity cell. Multiple sessions on the same day increment
+ * `count` once per session and add unique activity labels to `types`.
+ *
+ * @param sessions cardio sessions to aggregate; activity drives only the
+ *   tooltip label, not the cell intensity.
+ * @param dateFrom optional inclusive start of the range; clamped to
+ *   {@link MAX_COLS} weeks before `dateTo` if the span exceeds the cap.
+ * @param dateTo optional inclusive end; defaults to today.
+ */
+export function buildHeatmapGrid(
+  sessions: ReadonlyArray<Pick<CardioSession, 'date' | 'activity'>>,
+  dateFrom?: Date | null,
+  dateTo?: Date | null,
+): HeatmapGrid {
+  const endMonday = getMondayOf(dateTo ?? new Date())
+  const endDate = new Date(endMonday.getTime() + 6 * DAY_MS)
+
+  let startMonday: Date
+  if (dateFrom) {
+    startMonday = getMondayOf(dateFrom)
+    const maxStart = new Date(endMonday.getTime() - MAX_COLS * WEEK_MS)
+    if (startMonday.getTime() < maxStart.getTime()) {
+      startMonday = maxStart
+    }
+  } else {
+    startMonday = new Date(endMonday.getTime() - 52 * WEEK_MS)
+  }
+
+  // Lookup: local-date key → { count, distinct activity labels }
+  const lookup = new Map<string, { count: number; types: string[] }>()
+  for (const s of sessions) {
+    const d = parseSessionDate(s.date)
+    if (!Number.isFinite(d.getTime())) continue
+    const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+    const friendly = friendlyActivityLabel(s.activity)
+    const entry = lookup.get(key)
+    if (entry) {
+      entry.count++
+      if (!entry.types.includes(friendly)) entry.types.push(friendly)
+    } else {
+      lookup.set(key, { count: 1, types: [friendly] })
+    }
+  }
+
+  // Use timestamp arithmetic (not setDate) so DST transitions don't desync
+  // the column count from real elapsed weeks.
+  const startMs = startMonday.getTime()
+  const diffMs = endDate.getTime() - startMs
+  const totalCols = Math.floor(diffMs / WEEK_MS) + 1
+  const grid: HeatmapCell[][] = Array.from({ length: 7 }, () => [])
+  const monthLabels: { col: number; label: string }[] = []
+  let lastMonth = -1
+
+  for (let col = 0; col < totalCols; col++) {
+    for (let row = 0; row < 7; row++) {
+      const date = new Date(startMs + (col * 7 + row) * DAY_MS)
+
+      const key = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`
+      const entry = lookup.get(key)
+
+      grid[row].push({
+        date,
+        count: entry?.count ?? 0,
+        types: entry?.types ?? [],
+      })
+
+      if (date.getMonth() !== lastMonth) {
+        lastMonth = date.getMonth()
+        monthLabels.push({ col, label: MONTH_LABELS[date.getMonth()] })
+      }
+    }
+  }
+
+  return { grid, monthLabels }
+}
+
+/**
+ * Bucket a session count into one of four intensity levels for the heatmap
+ * cell color. `0` is the empty/baseline level; `3` is the max ("3+ sessions").
+ */
+export function intensityLevel(count: number): 0 | 1 | 2 | 3 {
+  if (count <= 0) return 0
+  if (count === 1) return 1
+  if (count === 2) return 2
+  return 3
+}
+
+function friendlyActivityLabel(activity: CardioActivity): string {
+  return ACTIVITY_VISUALS[activity].label
+}

--- a/lib/training-facility/streaks.test.ts
+++ b/lib/training-facility/streaks.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+
+import type { CardioSession } from '@/types/cardio'
+
+import { computeStreaks } from './streaks'
+
+/**
+ * Local helper — build a minimal CardioSession for a given local date so test
+ * cases can read as date-only without restating the whole session shape.
+ */
+function session(dateStr: string, activity: CardioSession['activity'] = 'stair'): CardioSession {
+  return {
+    date: `${dateStr}T08:00:00`,
+    activity,
+    duration_seconds: 1800,
+  }
+}
+
+describe('computeStreaks', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('returns 0/0 for no sessions', () => {
+    expect(computeStreaks([])).toEqual({ current: 0, longest: 0 })
+  })
+
+  it('returns 1-day streak when only today has a session', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-04-16T12:00:00'))
+    expect(computeStreaks([session('2026-04-16')])).toEqual({ current: 1, longest: 1 })
+  })
+
+  it('counts consecutive calendar days', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-04-16T12:00:00'))
+    const sessions = [
+      session('2026-04-13'),
+      session('2026-04-14'),
+      session('2026-04-15'),
+      session('2026-04-16'),
+    ]
+    expect(computeStreaks(sessions)).toEqual({ current: 4, longest: 4 })
+  })
+
+  it('resets current streak on a gap', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-04-16T12:00:00'))
+    const sessions = [
+      session('2026-04-10'),
+      session('2026-04-11'),
+      session('2026-04-12'),
+      // gap on 04-13, 04-14
+      session('2026-04-15'),
+      session('2026-04-16'),
+    ]
+    const result = computeStreaks(sessions)
+    expect(result.current).toBe(2)
+    expect(result.longest).toBe(3)
+  })
+
+  it('current streak is 0 when last session was 2+ days ago', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-04-16T12:00:00'))
+    const sessions = [
+      session('2026-04-10'),
+      session('2026-04-11'),
+      session('2026-04-12'),
+    ]
+    const result = computeStreaks(sessions)
+    expect(result.current).toBe(0)
+    expect(result.longest).toBe(3)
+  })
+
+  it('counts yesterday as current if no session today yet', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-04-16T12:00:00'))
+    const sessions = [session('2026-04-13'), session('2026-04-14'), session('2026-04-15')]
+    const result = computeStreaks(sessions)
+    expect(result.current).toBe(3)
+    expect(result.longest).toBe(3)
+  })
+
+  it('deduplicates multiple sessions on the same day', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-04-16T12:00:00'))
+    const sessions = [
+      session('2026-04-15', 'stair'),
+      session('2026-04-15', 'running'),
+      session('2026-04-16', 'stair'),
+      session('2026-04-16', 'walking'),
+    ]
+    expect(computeStreaks(sessions)).toEqual({ current: 2, longest: 2 })
+  })
+
+  it('skips sessions with unparseable date strings', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-04-16T12:00:00'))
+    const sessions = [
+      { date: 'not-a-date', activity: 'stair' as const, duration_seconds: 60 },
+      session('2026-04-16'),
+    ]
+    expect(computeStreaks(sessions)).toEqual({ current: 1, longest: 1 })
+  })
+})

--- a/lib/training-facility/streaks.ts
+++ b/lib/training-facility/streaks.ts
@@ -1,0 +1,93 @@
+import type { CardioSession } from '@/types/cardio'
+
+import { parseSessionDate } from './cardio-shared'
+
+/**
+ * Result of {@link computeStreaks}: the all-time current and longest
+ * streaks of consecutive calendar days with at least one cardio session.
+ */
+export interface StreakResult {
+  /**
+   * Length in days of the streak that includes today (or yesterday, if
+   * today's session hasn't been logged yet). `0` when the most recent
+   * session is older than yesterday.
+   */
+  current: number
+  /**
+   * Length in days of the longest run of consecutive calendar days with at
+   * least one session, ever — independent of {@link current}.
+   */
+  longest: number
+}
+
+/** Get a `YYYY-MM-DD` local-date key from a Date. */
+function toDateKey(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
+
+/**
+ * Add `n` days to a `YYYY-MM-DD` key, returning a new key. Uses local-noon
+ * as the base time so DST transitions don't accidentally shift the date.
+ */
+function addDays(dateKey: string, n: number): string {
+  const d = new Date(dateKey + 'T12:00:00')
+  d.setDate(d.getDate() + n)
+  return toDateKey(d)
+}
+
+/**
+ * Count consecutive calendar days (in local time) with at least one cardio
+ * session. Multiple sessions on the same day count as one day. The "current"
+ * streak counts backwards from today (or yesterday if today has no session
+ * logged yet) and is `0` if the last logged day is older than yesterday.
+ *
+ * Intended for the all-cardio overview's `StreakCounter`: pass `data.sessions`
+ * for the all-time numbers, and pass the date-filtered sessions to compute a
+ * "longest streak in this range" variant.
+ *
+ * @param sessions cardio sessions to score; activity does not matter — any
+ *   logged session counts as a workout day.
+ */
+export function computeStreaks(sessions: readonly CardioSession[]): StreakResult {
+  if (sessions.length === 0) return { current: 0, longest: 0 }
+
+  const days = new Set<string>()
+  for (const s of sessions) {
+    const d = parseSessionDate(s.date)
+    if (!Number.isFinite(d.getTime())) continue
+    days.add(toDateKey(d))
+  }
+  if (days.size === 0) return { current: 0, longest: 0 }
+
+  const sorted = Array.from(days).sort()
+
+  let longest = 1
+  let run = 1
+  for (let i = 1; i < sorted.length; i++) {
+    if (addDays(sorted[i - 1], 1) === sorted[i]) {
+      run++
+      if (run > longest) longest = run
+    } else {
+      run = 1
+    }
+  }
+
+  const today = toDateKey(new Date())
+  const yesterday = addDays(today, -1)
+  const lastDay = sorted[sorted.length - 1]
+
+  if (lastDay !== today && lastDay !== yesterday) {
+    return { current: 0, longest }
+  }
+
+  let current = 1
+  for (let i = sorted.length - 2; i >= 0; i--) {
+    if (addDays(sorted[i], 1) === sorted[i + 1]) {
+      current++
+    } else {
+      break
+    }
+  }
+
+  return { current, longest: Math.max(longest, current) }
+}


### PR DESCRIPTION
## Summary

Brings the calendar heatmap and streak counter from the standalone
`lucasklawrence/cardio-dashboard` repo into courtfolio's All Cardio
Overview, re-styled to the `chartPalette` / Patrick Hand aesthetic. Both
components read off the existing `CardioSession` shape so no schema or
preprocessor changes are required — pure component + helper port.

This is **slice B of #75**. The umbrella stays open until slices C
(lifestyle metrics port) and D (archive cardio-dashboard + changelog
entry) land.

Refs #75 — do not close this issue on merge.

## What landed

- `lib/training-facility/streaks.ts` (+ test) — `computeStreaks(sessions)`
  returns `{ current, longest }` over local calendar days. Handles "today
  vs yesterday" rules, dedupes multi-session days, skips bad date strings.
- `lib/training-facility/heatmap-grid.ts` (+ test) — `buildHeatmapGrid`
  returns a 7-row × N-col grid keyed by Monday boundaries; `intensityLevel`
  buckets per-day session counts into 0/1/2/3 for cell coloring. Capped
  at ~104 weeks (2 years) so a wide range can't blow up the DOM.
- `components/training-facility/gym/WorkoutHeatmap.tsx` (+ test) — SVG
  with plain `<rect>` cells (instant render even on long ranges), 4
  intensity levels keyed off `chartPalette.rimOrange`, hover/focus tooltip
  per cell, "Less … More" legend strip.
- `components/training-facility/gym/StreakCounter.tsx` (+ test) — cream
  card matching `SummaryRow`'s aesthetic. Flame goes desaturated when
  current streak is 0; in-range "longest" only renders when a date filter
  is active and produces a non-zero longest.
- `AllCardioOverview` wires both: `<StreakCounter>` strip above
  `<SummaryRow>`, `<WorkoutHeatmap>` as `ChartCard wide` between the
  summary row and the existing zone/avg-HR pair.

## Test plan

- [ ] Visit `/training-facility/gym/overview` on the preview. Streak
      strip + heatmap are visible above the existing zone/avg-HR cards.
- [ ] Heatmap cells brighten where there are real sessions; empty days
      show the faintest level.
- [ ] Hover a populated cell → browser tooltip shows
      `Apr 14, 2026: 2 sessions (Running, Walking)`.
- [ ] Hover an empty cell → tooltip shows just the date.
- [ ] Change the `DateFilter` range — heatmap reslices to the new
      window, streak's "in range" stat updates accordingly.
- [ ] Visit `/training-facility/gym/overview?preview=demo` (empty
      Supabase). Heatmap + streak hydrate against `CARDIO_DEMO_DATA`.
- [ ] Mobile (`390×844`): heatmap scrolls horizontally inside its
      ChartCard if the active range is wide; streak card wraps cleanly.

## Out of scope

- Slice C (lifestyle metrics — HRV / walking-HR / body-mass / steps /
  sleep / active-energy port) and slice D (archive + changelog).
- Heatmap responsive cell-size scaling — fixed 14px stride for now;
  the surrounding `ChartCard` provides `overflow-x-auto`. We can revisit
  if narrow ranges look awkwardly small.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added streak tracking to cardio overview, displaying current streak and all-time longest streak with visual flame indicator.
  * Added workout frequency heatmap visualization to show cardio session patterns across calendar dates with intensity-based color coding.
  * Integrated streak counter and workout frequency charts into the cardio overview dashboard.

* **Tests**
  * Added comprehensive test coverage for streak calculations and heatmap visualization components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->