### PR TITLE
feat(gym): port lifestyle metrics data flow (#75 slice C-data)

### DIFF
--- a/constants/cardio-demo-fixture.ts
+++ b/constants/cardio-demo-fixture.ts
@@ -133,4 +133,57 @@ export const CARDIO_DEMO_DATA: CardioData = {
     { date: '2026-03-21', value: 42.6 },
     { date: '2026-04-25', value: 43.4 },
   ],
+  // Lifestyle metrics (#75 slice C-data). Six daily-series trends ported
+  // from cardio-dashboard. Numbers trend in the "improving" direction
+  // where applicable — HRV ↑, walking HR ↓, body mass mild ↓, steps ↑,
+  // sleep stable ~7h, active energy ↑ — so the empty-state preview
+  // reads as "this athlete is making progress" rather than as noise.
+  hrv_trend: [
+    { date: '2025-12-06', value: 38 },
+    { date: '2026-01-10', value: 41 },
+    { date: '2026-02-14', value: 44 },
+    { date: '2026-03-14', value: 47 },
+    { date: '2026-04-18', value: 51 },
+    { date: '2026-04-25', value: 54 },
+  ],
+  walking_hr_trend: [
+    { date: '2025-12-06', value: 102 },
+    { date: '2026-01-10', value: 100 },
+    { date: '2026-02-14', value: 97 },
+    { date: '2026-03-14', value: 94 },
+    { date: '2026-04-18', value: 92 },
+    { date: '2026-04-25', value: 91 },
+  ],
+  body_mass_trend: [
+    { date: '2025-12-06', value: 184.2 },
+    { date: '2026-01-10', value: 183.1 },
+    { date: '2026-02-14', value: 181.5 },
+    { date: '2026-03-14', value: 180.8 },
+    { date: '2026-04-18', value: 179.6 },
+    { date: '2026-04-25', value: 179.0 },
+  ],
+  step_count_trend: [
+    { date: '2025-12-06', value: 6420 },
+    { date: '2026-01-10', value: 7180 },
+    { date: '2026-02-14', value: 8340 },
+    { date: '2026-03-14', value: 9210 },
+    { date: '2026-04-18', value: 10450 },
+    { date: '2026-04-25', value: 11020 },
+  ],
+  sleep_trend: [
+    { date: '2025-12-06', value: 6.8 },
+    { date: '2026-01-10', value: 7.0 },
+    { date: '2026-02-14', value: 6.9 },
+    { date: '2026-03-14', value: 7.2 },
+    { date: '2026-04-18', value: 7.1 },
+    { date: '2026-04-25', value: 7.3 },
+  ],
+  active_energy_trend: [
+    { date: '2025-12-06', value: 420 },
+    { date: '2026-01-10', value: 480 },
+    { date: '2026-02-14', value: 540 },
+    { date: '2026-03-14', value: 615 },
+    { date: '2026-04-18', value: 690 },
+    { date: '2026-04-25', value: 740 },
+  ],
 }

--- a/lib/data/cardio-shared.ts
+++ b/lib/data/cardio-shared.ts
@@ -28,6 +28,32 @@ const RESTING_HR_TABLE = 'cardio_resting_hr'
 const VO2MAX_TABLE = 'cardio_vo2max'
 
 /**
+ * Lifestyle-metric trend tables (#75 slice C-data). Each row shape is
+ * identical to {@link RESTING_HR_TABLE} (`date, value, updated_at`),
+ * so the same {@link CardioTrendRowSchema} validator and
+ * {@link trendRowToTimePoint} mapper apply. Keyed by the `CardioData`
+ * field they populate so the assembler can drop each table's rows
+ * straight into the matching key without per-table boilerplate.
+ */
+const LIFESTYLE_TREND_TABLES: Record<LifestyleTrendKey, string> = {
+  hrv_trend: 'cardio_hrv_trend',
+  walking_hr_trend: 'cardio_walking_hr_trend',
+  body_mass_trend: 'cardio_body_mass_trend',
+  step_count_trend: 'cardio_step_count_trend',
+  sleep_trend: 'cardio_sleep_trend',
+  active_energy_trend: 'cardio_active_energy_trend',
+}
+
+/** Names of the optional lifestyle-trend keys on {@link CardioData}. */
+type LifestyleTrendKey =
+  | 'hrv_trend'
+  | 'walking_hr_trend'
+  | 'body_mass_trend'
+  | 'step_count_trend'
+  | 'sleep_trend'
+  | 'active_energy_trend'
+
+/**
  * Whitelisted column lists for each cardio table. Mirror the
  * row-shape Zod schemas in `lib/schemas/cardio.ts` so a column added
  * to the DB without a corresponding schema/type update doesn't
@@ -89,11 +115,20 @@ const CardioTrendRowsSchema = z.array(CardioTrendRowSchema)
 export async function assembleCardioData(
   supabase: SupabaseClient,
 ): Promise<CardioData | null> {
-  const [sessionsRes, restingRes, vo2Res] = await Promise.all([
+  const lifestyleEntries = Object.entries(LIFESTYLE_TREND_TABLES) as Array<
+    [LifestyleTrendKey, string]
+  >
+
+  const coreQueries = [
     supabase.from(SESSIONS_TABLE).select(SESSIONS_COLUMNS).order('started_at', { ascending: true }),
     supabase.from(RESTING_HR_TABLE).select(TREND_COLUMNS).order('date', { ascending: true }),
     supabase.from(VO2MAX_TABLE).select(TREND_COLUMNS).order('date', { ascending: true }),
-  ])
+  ]
+  const lifestyleQueries = lifestyleEntries.map(([, table]) =>
+    supabase.from(table).select(TREND_COLUMNS).order('date', { ascending: true }),
+  )
+  const allResults = await Promise.all([...coreQueries, ...lifestyleQueries])
+  const [sessionsRes, restingRes, vo2Res, ...lifestyleResults] = allResults
 
   if (sessionsRes.error) {
     throw new Error(`Failed to load cardio sessions: ${sessionsRes.error.message}`)
@@ -104,16 +139,31 @@ export async function assembleCardioData(
   if (vo2Res.error) {
     throw new Error(`Failed to load VO2max trend: ${vo2Res.error.message}`)
   }
+  for (const [i, res] of lifestyleResults.entries()) {
+    if (res.error) {
+      const [, table] = lifestyleEntries[i]
+      throw new Error(`Failed to load ${table}: ${res.error.message}`)
+    }
+  }
 
   const sessionsRaw = (sessionsRes.data ?? []) as unknown as Array<Record<string, unknown>>
   const restingRaw = (restingRes.data ?? []) as unknown as Array<Record<string, unknown>>
   const vo2Raw = (vo2Res.data ?? []) as unknown as Array<Record<string, unknown>>
+  const lifestyleRaw = lifestyleResults.map(
+    (res) => (res.data ?? []) as unknown as Array<Record<string, unknown>>,
+  )
 
-  // Compute imported_at before `updated_at` is stripped — it lives on
-  // every row but isn't part of the row-shape schema.
-  const importedAt = computeImportedAt([sessionsRaw, restingRaw, vo2Raw])
+  // Compute imported_at across every cardio table — including the 6
+  // lifestyle trends — so a fresh import that only updates lifestyle
+  // metrics still advances the "last synced" wall display.
+  const importedAt = computeImportedAt([sessionsRaw, restingRaw, vo2Raw, ...lifestyleRaw])
 
-  if (sessionsRaw.length === 0 && restingRaw.length === 0 && vo2Raw.length === 0) {
+  const allEmpty =
+    sessionsRaw.length === 0 &&
+    restingRaw.length === 0 &&
+    vo2Raw.length === 0 &&
+    lifestyleRaw.every((rows) => rows.length === 0)
+  if (allEmpty) {
     // Preserves the pre-Supabase null-on-empty contract that detail
     // views already handle via `?? { imported_at: '', sessions: [], ... }`.
     return null
@@ -142,11 +192,29 @@ export async function assembleCardioData(
     throw new Error(`cardio_vo2max failed schema validation: ${vo2Parsed.error.message}`)
   }
 
+  // Validate and assemble the 6 lifestyle trends. Each table that is empty
+  // is omitted from the returned shape (the `CardioData` keys are
+  // optional) — components that haven't been wired to consume them keep
+  // the same observable behavior they had before #75 slice C-data.
+  const lifestyleTrends: Partial<Record<LifestyleTrendKey, ReturnType<typeof trendRowToTimePoint>[]>> = {}
+  for (const [i, [key, table]] of lifestyleEntries.entries()) {
+    const raw = lifestyleRaw[i]
+    if (raw.length === 0) continue
+    const parsed = CardioTrendRowsSchema.safeParse(
+      raw.map(stripNulls).map(stripUpdatedAt),
+    )
+    if (!parsed.success) {
+      throw new Error(`${table} failed schema validation: ${parsed.error.message}`)
+    }
+    lifestyleTrends[key] = parsed.data.map(trendRowToTimePoint)
+  }
+
   return {
     imported_at: importedAt,
     sessions: sessionsParsed.data.map(sessionRowToCardioSession),
     resting_hr_trend: restingParsed.data.map(trendRowToTimePoint),
     vo2max_trend: vo2Parsed.data.map(trendRowToTimePoint),
+    ...lifestyleTrends,
   }
 }
 

--- a/lib/data/cardio.test.ts
+++ b/lib/data/cardio.test.ts
@@ -266,4 +266,140 @@ describe('getCardioData', () => {
     stubTable('cardio_vo2max', [])
     await expect(getCardioData()).rejects.toThrow(/cardio_sessions failed schema validation/)
   })
+
+  /**
+   * Lifestyle-metric trend coverage (#75 slice C-data). Six new tables
+   * follow the same `(date, value)` shape as `cardio_resting_hr`. They
+   * land on `CardioData` as optional arrays — present when the table has
+   * rows, omitted when it's empty so detail views that don't consume
+   * them keep their pre-#75 observable behavior.
+   */
+  const LIFESTYLE_TABLES: ReadonlyArray<[keyof CardioDataLike, string]> = [
+    ['hrv_trend', 'cardio_hrv_trend'],
+    ['walking_hr_trend', 'cardio_walking_hr_trend'],
+    ['body_mass_trend', 'cardio_body_mass_trend'],
+    ['step_count_trend', 'cardio_step_count_trend'],
+    ['sleep_trend', 'cardio_sleep_trend'],
+    ['active_energy_trend', 'cardio_active_energy_trend'],
+  ]
+
+  it('queries every lifestyle-trend table when assembling the dataset', async () => {
+    stubTable('cardio_sessions', [])
+    stubTable('cardio_resting_hr', [])
+    stubTable('cardio_vo2max', [])
+    for (const [, table] of LIFESTYLE_TABLES) stubTable(table, [])
+    fromMock.mockClear()
+
+    await getCardioData()
+
+    for (const [, table] of LIFESTYLE_TABLES) {
+      expect(fromMock).toHaveBeenCalledWith(table)
+    }
+  })
+
+  it('returns null when every cardio table — core and lifestyle — is empty', async () => {
+    stubTable('cardio_sessions', [])
+    stubTable('cardio_resting_hr', [])
+    stubTable('cardio_vo2max', [])
+    for (const [, table] of LIFESTYLE_TABLES) stubTable(table, [])
+    await expect(getCardioData()).resolves.toBeNull()
+  })
+
+  it('populates each lifestyle field when its table has rows; omits empty ones', async () => {
+    stubTable('cardio_sessions', [])
+    stubTable(
+      'cardio_resting_hr',
+      [{ date: '2026-04-26', value: 57, updated_at: '2026-04-26T08:30:00Z' }],
+    )
+    stubTable('cardio_vo2max', [])
+    stubTable(
+      'cardio_hrv_trend',
+      [{ date: '2026-04-26', value: 54, updated_at: '2026-04-26T08:30:00Z' }],
+    )
+    stubTable(
+      'cardio_body_mass_trend',
+      [{ date: '2026-04-25', value: 179.0, updated_at: '2026-04-25T08:30:00Z' }],
+    )
+    stubTable('cardio_walking_hr_trend', [])
+    stubTable('cardio_step_count_trend', [])
+    stubTable('cardio_sleep_trend', [])
+    stubTable('cardio_active_energy_trend', [])
+
+    const data = await getCardioData()
+    expect(data?.hrv_trend).toEqual([{ date: '2026-04-26', value: 54 }])
+    expect(data?.body_mass_trend).toEqual([{ date: '2026-04-25', value: 179.0 }])
+    // Empty lifestyle tables drop their key entirely so a downstream
+    // `if (data.walking_hr_trend)` reads as "no data" instead of "[]".
+    expect(data).not.toHaveProperty('walking_hr_trend')
+    expect(data).not.toHaveProperty('step_count_trend')
+    expect(data).not.toHaveProperty('sleep_trend')
+    expect(data).not.toHaveProperty('active_energy_trend')
+  })
+
+  it('imported_at advances when only a lifestyle table is the freshest', async () => {
+    // Re-imports that touch only the lifestyle tables (e.g. the user
+    // weighed themselves but did no cardio that day) still need to bump
+    // imported_at — the wall display should read "synced today" not
+    // "synced last week."
+    stubTable(
+      'cardio_sessions',
+      [
+        {
+          started_at: '2026-02-08T08:00:00Z',
+          activity: 'stair',
+          duration_seconds: 1440,
+          distance_meters: null,
+          avg_hr: null,
+          max_hr: null,
+          pace_seconds_per_km: null,
+          zone1_seconds: null,
+          zone2_seconds: null,
+          zone3_seconds: null,
+          zone4_seconds: null,
+          zone5_seconds: null,
+          meters_per_heartbeat: null,
+          updated_at: '2026-02-08T09:00:00Z',
+        },
+      ],
+    )
+    stubTable('cardio_resting_hr', [])
+    stubTable('cardio_vo2max', [])
+    stubTable(
+      'cardio_body_mass_trend',
+      [{ date: '2026-04-25', value: 179.0, updated_at: '2026-05-06T08:30:00Z' }],
+    )
+    for (const [, table] of LIFESTYLE_TABLES) {
+      if (table === 'cardio_body_mass_trend') continue
+      stubTable(table, [])
+    }
+
+    const data = await getCardioData()
+    expect(data?.imported_at).toBe('2026-05-06T08:30:00Z')
+  })
+
+  it('throws when a lifestyle row fails schema validation', async () => {
+    stubTable('cardio_sessions', [])
+    stubTable('cardio_resting_hr', [])
+    stubTable('cardio_vo2max', [])
+    stubTable(
+      'cardio_hrv_trend',
+      // Missing `date` — Zod rejects on the trend row schema.
+      [{ value: 54, updated_at: '2026-04-26T08:30:00Z' }],
+    )
+    for (const [, table] of LIFESTYLE_TABLES) {
+      if (table === 'cardio_hrv_trend') continue
+      stubTable(table, [])
+    }
+    await expect(getCardioData()).rejects.toThrow(/cardio_hrv_trend failed schema validation/)
+  })
 })
+
+/** Local alias used by the LIFESTYLE_TABLES literal; mirrors `CardioData` for type-only context. */
+type CardioDataLike = {
+  hrv_trend?: unknown
+  walking_hr_trend?: unknown
+  body_mass_trend?: unknown
+  step_count_trend?: unknown
+  sleep_trend?: unknown
+  active_energy_trend?: unknown
+}

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -10,7 +10,7 @@ The wrapper does three things:
 
 1. Spawns `python scripts/preprocess-health.py <export.zip> public/data/cardio.json` to produce an intermediate JSON file.
 2. Validates the result against a Zod mirror of `CardioData` (`types/cardio.ts`) so any drift between the Python script and the TypeScript type fails loudly here, not at runtime in the dashboard.
-3. Upserts every session, resting-HR point, and VO2max point into the three `cardio_*` Supabase tables via the service-role key. Idempotent — re-running the import after a fresh Apple Health export overwrites the same primary keys (`started_at` for sessions, `date` for trends) instead of duplicating rows.
+3. Upserts every session, trend point, and lifestyle metric into the nine `cardio_*` Supabase tables via the service-role key. Idempotent — re-running the import after a fresh Apple Health export overwrites the same primary keys (`started_at` for sessions, `date` for trends) instead of duplicating rows.
 
 ### Optional flags
 
@@ -26,13 +26,24 @@ The script reads the same Supabase env vars as the rest of the app (`.env.local`
 
 ### What lands in Supabase
 
-Three tables (PRD §7.4, migration in `supabase/migrations/20260430120000_cardio_tables.sql`):
+Nine tables (PRD §7.4):
+
+Cardio core (`supabase/migrations/20260430120000_cardio_tables.sql`):
 
 - `cardio_sessions` — stair / running / walking workouts with avg HR, max HR, time-in-zone breakdown (5 explicit columns), and cardiac efficiency aggregated from the raw HR sample stream.
 - `cardio_resting_hr` — one row per measurement day.
 - `cardio_vo2max` — one row per measurement day.
 
-Everything else from the Apple Health export (HRV, walking HR average, body mass, step counts, sleep, active energy, plus non-tracked workout types like cycling and rowing) is dropped. Bring fields back when a chart consumes them.
+Lifestyle trends (`supabase/migrations/20260506120000_cardio_lifestyle_trends.sql`, #75 slice C-data):
+
+- `cardio_hrv_trend` — heart-rate variability (SDNN), one row per day, latest-wins.
+- `cardio_walking_hr_trend` — walking HR average, one row per day, latest-wins.
+- `cardio_body_mass_trend` — body mass, one row per day, latest-wins; values normalized to **lbs** at preprocess time (Apple Health `kg` is converted up-front).
+- `cardio_step_count_trend` — daily step total, one row per day, summed from Apple's per-burst step records.
+- `cardio_sleep_trend` — total asleep time per **wake-day** (the calendar day you woke up — Apple Health's convention) in hours; only `HKCategoryValueSleepAnalysisAsleep*` periods are counted, in-bed-but-awake time is excluded.
+- `cardio_active_energy_trend` — daily active-energy total in kcal, summed from per-burst records (kJ → kcal normalized at preprocess time).
+
+Non-tracked workout types from the Apple Health export (cycling, rowing, etc.) are dropped — bring those back when a Gym detail view supports them.
 
 ### Privacy
 

--- a/scripts/lib/cardio-supabase.mjs
+++ b/scripts/lib/cardio-supabase.mjs
@@ -122,6 +122,16 @@ export const CardioDataSchema = z
     sessions: z.array(CardioSessionSchema),
     resting_hr_trend: z.array(CardioTimePointSchema),
     vo2max_trend: z.array(CardioTimePointSchema),
+    // #75 slice C-data — six lifestyle-metric trends ported from
+    // cardio-dashboard. Optional at the schema level so old preprocessor
+    // outputs without these keys still validate; new outputs include
+    // them as (possibly empty) arrays.
+    hrv_trend: z.array(CardioTimePointSchema).optional(),
+    walking_hr_trend: z.array(CardioTimePointSchema).optional(),
+    body_mass_trend: z.array(CardioTimePointSchema).optional(),
+    step_count_trend: z.array(CardioTimePointSchema).optional(),
+    sleep_trend: z.array(CardioTimePointSchema).optional(),
+    active_energy_trend: z.array(CardioTimePointSchema).optional(),
   })
   .strict()
 
@@ -194,6 +204,20 @@ function sessionToRow(session, importedAt) {
  *   removes rows.
  * @throws when any Supabase query fails.
  */
+/**
+ * Lifestyle-trend tables to upsert in the same batch as resting HR /
+ * VO2max (#75 slice C-data). Each maps a `CardioData` field name to its
+ * Supabase table; the upsert / prune loop below treats them uniformly.
+ */
+const LIFESTYLE_TREND_TABLES = [
+  ['hrv_trend', 'cardio_hrv_trend'],
+  ['walking_hr_trend', 'cardio_walking_hr_trend'],
+  ['body_mass_trend', 'cardio_body_mass_trend'],
+  ['step_count_trend', 'cardio_step_count_trend'],
+  ['sleep_trend', 'cardio_sleep_trend'],
+  ['active_energy_trend', 'cardio_active_energy_trend'],
+]
+
 export async function upsertCardioData(supabase, data) {
   // Defense-in-depth schema check at the write boundary. Both production
   // callers (import-health.mjs, backfill-cardio.mjs) already validate via
@@ -218,6 +242,17 @@ export async function upsertCardioData(supabase, data) {
     date: point.date,
     value: point.value,
     updated_at: importedAt,
+  }))
+  // Lifestyle trends share the `(date, value, updated_at)` row shape with
+  // resting HR / VO2max — same row-builder, different field/table names.
+  const lifestyleRows = LIFESTYLE_TREND_TABLES.map(([field, table]) => ({
+    field,
+    table,
+    rows: (parsed[field] ?? []).map((point) => ({
+      date: point.date,
+      value: point.value,
+      updated_at: importedAt,
+    })),
   }))
 
   if (sessionRows.length > 0) {
@@ -249,6 +284,13 @@ export async function upsertCardioData(supabase, data) {
       throw new Error(`Failed to upsert cardio_vo2max: ${error.message}`)
     }
   }
+  for (const { table, rows } of lifestyleRows) {
+    if (rows.length === 0) continue
+    const { error } = await supabase.from(table).upsert(rows, { onConflict: 'date' })
+    if (error) {
+      throw new Error(`Failed to upsert ${table}: ${error.message}`)
+    }
+  }
 
   const sessionsPruned = await pruneStaleRows(
     supabase,
@@ -268,13 +310,20 @@ export async function upsertCardioData(supabase, data) {
     importedAt,
     vo2Rows.length > 0,
   )
+  let lifestylePruned = 0
+  const lifestyleCounts = {}
+  for (const { field, table, rows } of lifestyleRows) {
+    lifestyleCounts[field] = rows.length
+    lifestylePruned += await pruneStaleRows(supabase, table, importedAt, rows.length > 0)
+  }
 
   return {
     sessions: sessionRows.length,
     restingHr: restingRows.length,
     vo2max: vo2Rows.length,
     hrSamples: hrSamplesInserted,
-    pruned: sessionsPruned + restingPruned + vo2Pruned,
+    ...lifestyleCounts,
+    pruned: sessionsPruned + restingPruned + vo2Pruned + lifestylePruned,
   }
 }
 

--- a/scripts/preprocess-health.py
+++ b/scripts/preprocess-health.py
@@ -13,10 +13,10 @@ What we keep (per `CardioData`):
     cardiac efficiency aggregated from the raw heart-rate sample stream.
   - Resting heart-rate trend (one point per measurement).
   - VO2max trend (one point per measurement).
-
-What we drop (in the old script but not in `CardioData` yet):
-  - HRV, walking HR average, body mass, step counts, sleep, active
-    energy. Bring these back when a chart needs them.
+  - HRV (SDNN), walking HR average, body mass, step counts, sleep, and
+    active energy daily trends — six lifestyle-metric series ported from
+    cardio-dashboard (#75 slice C-data). Per-day aggregation policy
+    varies by metric — see the per-metric helpers below.
 
 The Node wrapper (`scripts/import-health.mjs`) validates the output
 against a Zod mirror of `CardioData`, so a divergence between the
@@ -34,7 +34,9 @@ import os
 import re
 import sys
 import zipfile
+from collections import defaultdict
 from datetime import datetime, timezone
+from typing import Callable, Optional
 
 # Windows defaults stdout to cp1252 under Python 3.8 — `→` and other
 # Unicode glyphs in our log lines crash the run. Force UTF-8 so the
@@ -350,12 +352,22 @@ def derive_pace(workout: dict) -> None:
     workout['pace_seconds_per_km'] = round(duration / km, 2)
 
 
-def parse_simple_trend(xml_text: str, hk_type: str) -> list[dict]:
+def parse_simple_trend(
+    xml_text: str,
+    hk_type: str,
+    value_transform: Optional[Callable[[str, float], Optional[float]]] = None,
+) -> list[dict]:
     """
     Generic helper for one-value-per-record trend types (resting HR,
-    VO2max). Collapses to one point per calendar day — when Apple emits
-    multiple records for the same day (e.g. retroactive measurements
-    from different sources), the latest record in document order wins.
+    VO2max, HRV, walking HR, body mass). Collapses to one point per
+    calendar day — when Apple emits multiple records for the same day
+    (e.g. retroactive measurements from different sources), the latest
+    record in document order wins.
+
+    `value_transform` is an optional `(record_str, value) -> value`
+    callback for per-record unit normalization (e.g. body mass kg → lb).
+    Returning `None` skips the record entirely. Receives the full open
+    tag so the callback can read sibling attributes like `unit="..."`.
     """
     pattern = re.compile(
         rf'<Record\b[^>]*type="{re.escape(hk_type)}"[^>]*>'
@@ -371,10 +383,131 @@ def parse_simple_trend(xml_text: str, hk_type: str) -> list[dict]:
             value = float(val_m.group(1))
         except ValueError:
             continue
+        if value_transform is not None:
+            transformed = value_transform(record, value)
+            if transformed is None:
+                continue
+            value = transformed
         # Trim time-of-day; the trend chart shows one tick per day.
         date_str = date_m.group(1).split(' ')[0]
         by_day[date_str] = round(value, 2)
     return [{'date': day, 'value': value} for day, value in sorted(by_day.items())]
+
+
+def parse_summed_trend(
+    xml_text: str,
+    hk_type: str,
+    value_transform: Optional[Callable[[str, float], Optional[float]]] = None,
+) -> list[dict]:
+    """
+    Trend helper for record types where Apple emits many small bursts
+    per day (step counts, active energy) and we want the daily total.
+    Sums every record by its local-date `startDate` rather than
+    last-write-wins like {@link parse_simple_trend}.
+
+    `value_transform` is the same shape as `parse_simple_trend`'s — used
+    for per-record unit normalization (active energy is normally kcal
+    but can arrive as kJ depending on the export source).
+    """
+    pattern = re.compile(
+        rf'<Record\b[^>]*type="{re.escape(hk_type)}"[^>]*>'
+    )
+    by_day: dict[str, float] = defaultdict(float)
+    for m in pattern.finditer(xml_text):
+        record = m.group(0)
+        date_m = re.search(r'\bstartDate="([^"]*)"', record)
+        val_m = re.search(r'\bvalue="([^"]*)"', record)
+        if not date_m or not val_m:
+            continue
+        try:
+            value = float(val_m.group(1))
+        except ValueError:
+            continue
+        if value_transform is not None:
+            transformed = value_transform(record, value)
+            if transformed is None:
+                continue
+            value = transformed
+        date_str = date_m.group(1).split(' ')[0]
+        by_day[date_str] += value
+    return [{'date': day, 'value': round(v, 2)} for day, v in sorted(by_day.items())]
+
+
+def parse_sleep_trend(xml_text: str) -> list[dict]:
+    """
+    Sleep trend — per-wake-day total of `Asleep*` time, in hours.
+
+    Apple Health stores sleep as `<Record type="HKCategoryTypeIdentifier
+    SleepAnalysis">` elements with categorical `value` like
+    `HKCategoryValueSleepAnalysisAsleepCore`,
+    `…AsleepDeep`, `…AsleepREM`, `…AsleepUnspecified` (post-iOS 16) or
+    just `HKCategoryValueSleepAnalysisAsleep` (pre-iOS 16). `InBed` and
+    `Awake` periods exist alongside but are *excluded* — "I got 7 hours
+    of sleep" is the more useful metric than "I was in bed 8 hours."
+
+    Day attribution: each block is bucketed by its `endDate`'s local
+    date (the "wake day"). A block from 2026-04-15 23:00 to 2026-04-16
+    07:00 belongs to 2026-04-16. This matches Apple Health's UI, which
+    surfaces "today's sleep" as the night you just woke up from.
+    """
+    pattern = re.compile(
+        r'<Record\b[^>]*type="HKCategoryTypeIdentifierSleepAnalysis"[^>]*>'
+    )
+    by_wake_day: dict[str, float] = defaultdict(float)
+    for m in pattern.finditer(xml_text):
+        record = m.group(0)
+        val_m = re.search(r'\bvalue="([^"]*)"', record)
+        if not val_m:
+            continue
+        category = val_m.group(1)
+        # All asleep variants count toward the daily total. InBed / Awake
+        # are intentionally excluded (asleep-only convention).
+        if 'Asleep' not in category:
+            continue
+        start_m = re.search(r'\bstartDate="([^"]*)"', record)
+        end_m = re.search(r'\bendDate="([^"]*)"', record)
+        if not start_m or not end_m:
+            continue
+        start_dt = parse_iso(start_m.group(1))
+        end_dt = parse_iso(end_m.group(1))
+        if start_dt is None or end_dt is None:
+            continue
+        duration_seconds = (end_dt - start_dt).total_seconds()
+        if duration_seconds <= 0:
+            continue
+        wake_day = end_m.group(1).split(' ')[0]
+        by_wake_day[wake_day] += duration_seconds / 3600.0
+    return [{'date': day, 'value': round(v, 2)} for day, v in sorted(by_wake_day.items())]
+
+
+def _body_mass_to_lbs(record: str, value: float) -> Optional[float]:
+    """
+    Apple Health's body-mass record carries the user's preferred unit
+    (`unit="lb"` or `unit="kg"`). Normalize everything to pounds at
+    preprocess time so the dashboard renders without a unit-conversion
+    step. Unknown units default to lb (Apple's US default) rather than
+    silently dropping the record.
+    """
+    unit_m = re.search(r'\bunit="([^"]*)"', record)
+    unit = (unit_m.group(1) if unit_m else 'lb').lower()
+    if unit == 'kg':
+        return value * 2.20462
+    if unit in ('lb', 'lbs'):
+        return value
+    return value
+
+
+def _active_energy_to_kcal(record: str, value: float) -> Optional[float]:
+    """
+    Apple Health's active-energy record is normally kcal (Cal in the
+    UI) but some exports carry kJ. Normalize to kilocalories so the
+    daily-total chart's units stay consistent across exports.
+    """
+    unit_m = re.search(r'\bunit="([^"]*)"', record)
+    unit = (unit_m.group(1) if unit_m else 'kcal').lower()
+    if unit == 'kj':
+        return value / 4.184
+    return value
 
 
 def build_cardio_data(xml_text: str, max_hr: int) -> dict:
@@ -401,11 +534,49 @@ def build_cardio_data(xml_text: str, max_hr: int) -> dict:
     vo2 = parse_simple_trend(xml_text, 'HKQuantityTypeIdentifierVO2Max')
     log(f" {len(vo2):,} points")
 
+    log("Parsing HRV (SDNN) trend...", end='')
+    hrv = parse_simple_trend(xml_text, 'HKQuantityTypeIdentifierHeartRateVariabilitySDNN')
+    log(f" {len(hrv):,} points")
+
+    log("Parsing walking HR trend...", end='')
+    walking_hr = parse_simple_trend(
+        xml_text, 'HKQuantityTypeIdentifierWalkingHeartRateAverage'
+    )
+    log(f" {len(walking_hr):,} points")
+
+    log("Parsing body mass trend...", end='')
+    body_mass = parse_simple_trend(
+        xml_text, 'HKQuantityTypeIdentifierBodyMass', value_transform=_body_mass_to_lbs
+    )
+    log(f" {len(body_mass):,} points (lbs)")
+
+    log("Parsing step count trend...", end='')
+    step_count = parse_summed_trend(xml_text, 'HKQuantityTypeIdentifierStepCount')
+    log(f" {len(step_count):,} days")
+
+    log("Parsing sleep trend...", end='')
+    sleep = parse_sleep_trend(xml_text)
+    log(f" {len(sleep):,} nights")
+
+    log("Parsing active energy trend...", end='')
+    active_energy = parse_summed_trend(
+        xml_text,
+        'HKQuantityTypeIdentifierActiveEnergyBurned',
+        value_transform=_active_energy_to_kcal,
+    )
+    log(f" {len(active_energy):,} days (kcal)")
+
     return {
         'imported_at': datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z'),
         'sessions': sessions,
         'resting_hr_trend': resting,
         'vo2max_trend': vo2,
+        'hrv_trend': hrv,
+        'walking_hr_trend': walking_hr,
+        'body_mass_trend': body_mass,
+        'step_count_trend': step_count,
+        'sleep_trend': sleep,
+        'active_energy_trend': active_energy,
     }
 
 
@@ -478,6 +649,12 @@ def main() -> None:
     print(f"  Sessions:           {len(data['sessions']):,}")
     print(f"  Resting HR points:  {len(data['resting_hr_trend']):,}")
     print(f"  VO2max points:      {len(data['vo2max_trend']):,}")
+    print(f"  HRV points:         {len(data['hrv_trend']):,}")
+    print(f"  Walking HR points:  {len(data['walking_hr_trend']):,}")
+    print(f"  Body mass points:   {len(data['body_mass_trend']):,}")
+    print(f"  Step count days:    {len(data['step_count_trend']):,}")
+    print(f"  Sleep nights:       {len(data['sleep_trend']):,}")
+    print(f"  Active energy days: {len(data['active_energy_trend']):,}")
     print(f"{'=' * 50}\n")
 
 

--- a/supabase/migrations/20260506120000_cardio_lifestyle_trends.sql
+++ b/supabase/migrations/20260506120000_cardio_lifestyle_trends.sql
@@ -1,0 +1,161 @@
+-- Cardio lifestyle-metric trend tables (PRD §7.4 / #75 slice C-data).
+--
+-- Six daily-series trends ported from `lucasklawrence/cardio-dashboard` —
+-- each one is a `(date, value)` row keyed by calendar date so a re-import
+-- overwrites a day's measurement rather than duplicating it. Mirrors the
+-- existing `cardio_resting_hr` / `cardio_vo2max` shape from
+-- `20260430120000_cardio_tables.sql`; same RLS policy (anon SELECT,
+-- service-role writes).
+--
+--   * cardio_hrv_trend           — heart-rate variability (SDNN), ms
+--   * cardio_walking_hr_trend    — walking HR average, BPM
+--   * cardio_body_mass_trend     — body mass, normalized to lbs at preprocess time
+--   * cardio_step_count_trend    — daily step total, count
+--   * cardio_sleep_trend         — total asleep time per wake-day, hours
+--   * cardio_active_energy_trend — daily active energy total, kilocalories
+--
+-- Granularity: one row per local calendar day. Apple Health emits these as
+-- per-record bursts; the Python preprocessor (`scripts/preprocess-health.py`)
+-- collapses them to per-day aggregates before the import script writes.
+-- The aggregation policy is intentional and varies by metric — see the
+-- preprocessor for the per-metric rationale.
+--
+-- Constraints: value is `> 0` for metrics where 0 is implausible (HRV,
+-- walking HR, body mass) and `>= 0` for volume metrics where a 0-day is
+-- possible (steps, sleep hours, active energy on a full rest day).
+--
+-- This file is the canonical record of the migration. All DDL is
+-- idempotent (`create table if not exists`, `do $$` policy guards) so
+-- re-applying on a fresh dev project (or after a branch reset) is safe.
+
+create table if not exists public.cardio_hrv_trend (
+  date date primary key,
+  value numeric not null check (value > 0),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+comment on table public.cardio_hrv_trend is
+  'Heart-rate variability (SDNN) trend (PRD §7.4). One row per measurement day; primary key is the calendar date so re-imports overwrite the same day''s value rather than duplicate it.';
+
+alter table public.cardio_hrv_trend enable row level security;
+
+do $$
+begin
+  create policy "anon and authenticated can read hrv trend"
+    on public.cardio_hrv_trend
+    for select
+    to anon, authenticated
+    using (true);
+exception when duplicate_object then null;
+end $$;
+
+create table if not exists public.cardio_walking_hr_trend (
+  date date primary key,
+  value numeric not null check (value > 0),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+comment on table public.cardio_walking_hr_trend is
+  'Walking heart-rate average trend (PRD §7.4). One row per measurement day; primary key is the calendar date.';
+
+alter table public.cardio_walking_hr_trend enable row level security;
+
+do $$
+begin
+  create policy "anon and authenticated can read walking hr trend"
+    on public.cardio_walking_hr_trend
+    for select
+    to anon, authenticated
+    using (true);
+exception when duplicate_object then null;
+end $$;
+
+create table if not exists public.cardio_body_mass_trend (
+  date date primary key,
+  value numeric not null check (value > 0),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+comment on table public.cardio_body_mass_trend is
+  'Body mass trend (PRD §7.4). One row per measurement day; values normalized to pounds at preprocess time so the dashboard can render without a unit-conversion step.';
+
+alter table public.cardio_body_mass_trend enable row level security;
+
+do $$
+begin
+  create policy "anon and authenticated can read body mass trend"
+    on public.cardio_body_mass_trend
+    for select
+    to anon, authenticated
+    using (true);
+exception when duplicate_object then null;
+end $$;
+
+create table if not exists public.cardio_step_count_trend (
+  date date primary key,
+  value numeric not null check (value >= 0),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+comment on table public.cardio_step_count_trend is
+  'Daily step-count total (PRD §7.4). One row per local calendar day; the preprocessor sums Apple Health''s per-burst step records into a single daily total before insert.';
+
+alter table public.cardio_step_count_trend enable row level security;
+
+do $$
+begin
+  create policy "anon and authenticated can read step count trend"
+    on public.cardio_step_count_trend
+    for select
+    to anon, authenticated
+    using (true);
+exception when duplicate_object then null;
+end $$;
+
+create table if not exists public.cardio_sleep_trend (
+  date date primary key,
+  value numeric not null check (value >= 0),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+comment on table public.cardio_sleep_trend is
+  'Sleep trend (PRD §7.4). One row per wake-day (the calendar day the user woke up — Apple Health''s convention); value is the total asleep-time in hours, summing only HKCategoryValueSleepAnalysisAsleep* periods so in-bed-but-awake time is excluded.';
+
+alter table public.cardio_sleep_trend enable row level security;
+
+do $$
+begin
+  create policy "anon and authenticated can read sleep trend"
+    on public.cardio_sleep_trend
+    for select
+    to anon, authenticated
+    using (true);
+exception when duplicate_object then null;
+end $$;
+
+create table if not exists public.cardio_active_energy_trend (
+  date date primary key,
+  value numeric not null check (value >= 0),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+comment on table public.cardio_active_energy_trend is
+  'Daily active-energy total (PRD §7.4), kilocalories. The preprocessor sums Apple Health''s per-burst active-energy records into one daily total before insert.';
+
+alter table public.cardio_active_energy_trend enable row level security;
+
+do $$
+begin
+  create policy "anon and authenticated can read active energy trend"
+    on public.cardio_active_energy_trend
+    for select
+    to anon, authenticated
+    using (true);
+exception when duplicate_object then null;
+end $$;

--- a/types/cardio.ts
+++ b/types/cardio.ts
@@ -75,4 +75,39 @@ export interface CardioData {
   resting_hr_trend: CardioTimePoint[];
   /** VO2max over time — feeds the whiteboard chart. */
   vo2max_trend: CardioTimePoint[];
+  /**
+   * Heart-rate variability (SDNN) daily trend, milliseconds. Latest-wins
+   * per day when Apple emits multiple records — matches `resting_hr_trend`'s
+   * dedup convention. Optional: absent until the lifestyle-port migration
+   * (#75 slice C-data) has been applied AND a chart consumes it.
+   */
+  hrv_trend?: CardioTimePoint[];
+  /**
+   * Walking heart-rate average daily trend, BPM. Latest-wins per day.
+   * Optional — same scoping as {@link hrv_trend}.
+   */
+  walking_hr_trend?: CardioTimePoint[];
+  /**
+   * Body mass daily trend, **pounds** (Apple Health's `kg` is converted at
+   * preprocess time so the dashboard renders without a unit-conversion
+   * step). Latest-wins per day. Optional.
+   */
+  body_mass_trend?: CardioTimePoint[];
+  /**
+   * Daily step-count total. Summed from Apple's per-burst step records to
+   * one value per local calendar day. Optional.
+   */
+  step_count_trend?: CardioTimePoint[];
+  /**
+   * Daily sleep total, **hours**. Only `HKCategoryValueSleepAnalysisAsleep*`
+   * periods are counted — in-bed-but-awake time is excluded so "I got 7
+   * hours of sleep" is the metric, not "I was in bed 8 hours." Each block
+   * is attributed to the wake day (matches Apple Health's UI). Optional.
+   */
+  sleep_trend?: CardioTimePoint[];
+  /**
+   * Daily active-energy total, **kilocalories**. Summed from per-burst
+   * records; kJ exports are converted to kcal at preprocess time. Optional.
+   */
+  active_energy_trend?: CardioTimePoint[];
 }


### PR DESCRIPTION
## Summary

Lands the **data flow** for six daily-series lifestyle metrics ported
from `lucasklawrence/cardio-dashboard` — HRV, walking HR, body mass,
step count, sleep, active energy. **No chart wrappers and no UI changes
in this PR** — that's slice C-ui, a separate follow-up. The existing
UI (heatmap, streak, summary cards, training load, session log)
behaves identically; the new fields land on `CardioData` as optional
arrays that no current consumer reads yet.

This is **slice C-data of #75**. The umbrella stays open until slice
C-ui (chart wrappers) and slice D (archive cardio-dashboard +
changelog) land.

Refs #75 — do not close this issue on merge.

## What landed

| Layer | Change |
| --- | --- |
| Schema | New migration `supabase/migrations/20260506120000_cardio_lifestyle_trends.sql` — six tables (`cardio_hrv_trend`, `cardio_walking_hr_trend`, `cardio_body_mass_trend`, `cardio_step_count_trend`, `cardio_sleep_trend`, `cardio_active_energy_trend`), each `(date pk, value, created_at, updated_at)` mirroring `cardio_resting_hr`. Same anon-SELECT RLS policy. |
| Preprocessor | `scripts/preprocess-health.py` — extended `parse_simple_trend` with optional `value_transform` (used for body-mass kg→lb normalization). New `parse_summed_trend` for step count + active energy (per-day sum). New `parse_sleep_trend` (asleep-only categories, wake-day attribution, hours). Updated `scripts/README.md`. |
| Types | `types/cardio.ts` — added 6 optional `?: CardioTimePoint[]` fields to `CardioData` with full JSDoc. |
| Zod | `scripts/lib/cardio-supabase.mjs` — `CardioDataSchema` accepts the 6 new optional arrays. The per-row `CardioTrendRowSchema` in `lib/schemas/cardio.ts` already matches `(date, value)` so it gets reused for all 6 new tables. |
| Read path | `lib/data/cardio-shared.ts` — `assembleCardioData` now queries 9 tables in parallel (3 existing + 6 new). Empty lifestyle tables drop their key entirely so detail views' `if (data.x)` checks read as "no data" instead of `[]`. `imported_at` is computed across all 9 tables. |
| Write path | `scripts/lib/cardio-supabase.mjs` — `upsertCardioData` upserts each lifestyle series in turn, then prunes (same `pruneStaleRows` pattern as the existing trend tables). |
| Demo | `constants/cardio-demo-fixture.ts` — added 6 plausible "improving-trend" series spanning Dec 2025 → Apr 2026. |
| Tests | `lib/data/cardio.test.ts` — 5 new tests covering: query coverage, all-empty null return, populated-vs-empty key inclusion, `imported_at` advances on lifestyle-only updates, schema-validation failure paths. 14 tests in the file pass; 598/598 across the suite. |

## Migration deployment note

The migration file is **not auto-applied**. Apply it before re-running
the import script (otherwise `upsertCardioData` will fail on the new
tables). Apply via Supabase CLI or the dashboard:

```sh
supabase db push
```

After apply, the next `npm run import-health -- export.zip` will populate
all 6 new tables alongside the existing 3.

## Test plan

- [ ] CI green (Vercel + e2e + CodeRabbit).
- [ ] `/training-facility/gym/overview` renders unchanged with real data
      — no UI consumes the new fields yet, so the heatmap, streak,
      summary, and existing charts should look identical.
- [ ] `/training-facility/gym/overview?preview=demo` still renders the
      streak + heatmap + activity mix from the demo fixture.
- [ ] Apply the migration locally (or against the dev Supabase project)
      and run `npm run import-health -- export.zip`. The success log
      should print counts for HRV / walking HR / body mass / step count /
      sleep / active energy alongside the existing sessions / resting HR
      / VO2max counts.
- [ ] Re-run the import; pruned counts should be 0 (idempotent).

## Out of scope

- Chart wrappers — slice C-ui.
- New `/training-facility/gym/lifestyle` route — same.
- Archive of `cardio-dashboard` repo + changelog — slice D.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added six new lifestyle metric trends to health data tracking: Heart Rate Variability (HRV), Walking Heart Rate, Body Mass, Step Count, Sleep, and Active Energy.
  * These metrics are now imported alongside existing cardio data for comprehensive daily trend analysis.

* **Documentation**
  * Updated health import workflow documentation to reflect expanded data coverage and new data tables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->