### PR TITLE
feat(gym): port lifestyle metric charts (#75 slice C-ui)

### DIFF
--- a/components/training-facility/gym/AllCardioOverview.tsx
+++ b/components/training-facility/gym/AllCardioOverview.tsx
@@ -54,6 +54,12 @@ import {
 import { TrainingLoadChart } from './TrainingLoadChart'
 import { WorkoutHeatmap } from './WorkoutHeatmap'
 import { StreakCounter } from './StreakCounter'
+import { HrvTrendChart } from './lifestyle/HrvTrendChart'
+import { WalkingHrTrendChart } from './lifestyle/WalkingHrTrendChart'
+import { BodyMassTrendChart } from './lifestyle/BodyMassTrendChart'
+import { StepCountTrendChart } from './lifestyle/StepCountTrendChart'
+import { SleepTrendChart } from './lifestyle/SleepTrendChart'
+import { ActiveEnergyTrendChart } from './lifestyle/ActiveEnergyTrendChart'
 import { chartPalette } from '@/components/training-facility/shared/charts/palette'
 import { defaultMargin } from '@/components/training-facility/shared/charts/types'
 import { DEFAULT_MAX_HR } from '@/constants/hr-zones'
@@ -353,6 +359,13 @@ export function AllCardioOverview(): JSX.Element {
 
             <ActivityMix counts={activityCounts} />
 
+            <LifestyleMetricsSection
+              data={data}
+              range={range}
+              chartWidth={chartWidth}
+              fontFamily={FONT_FAMILY}
+            />
+
             <SessionLogTable sessions={sessions} range={range} />
           </>
         )}
@@ -520,6 +533,92 @@ function ActivityMix({ counts }: ActivityMixProps): JSX.Element {
           )
         })}
       </ul>
+    </section>
+  )
+}
+
+interface LifestyleMetricsSectionProps {
+  data: CardioData
+  range: DateRange
+  chartWidth: number
+  fontFamily: string
+}
+
+/**
+ * "Lifestyle metrics" section (#75 slice C-ui) — six daily-trend charts
+ * (HRV, walking HR, body mass, daily steps, sleep, active energy) ported
+ * from `cardio-dashboard`. Sits between the activity mix and the session
+ * log so the "what did I do" cards stay at the top of the page and the
+ * detailed log stays at the bottom.
+ *
+ * Each chart is rendered inside its own `ChartCard` regardless of whether
+ * the underlying field is populated — empty cards show "No <metric> data
+ * in range" via `RoughLine`'s built-in empty-state rather than disappearing.
+ * That keeps the page's structural rhythm stable across "fresh
+ * import / partial dataset / fully populated" states and makes the empty
+ * state a teaching moment ("import Apple Health to populate this").
+ */
+function LifestyleMetricsSection({
+  data,
+  range,
+  chartWidth,
+  fontFamily,
+}: LifestyleMetricsSectionProps): JSX.Element {
+  const sharedProps = {
+    dateFrom: range.start,
+    dateTo: range.end,
+    width: chartWidth,
+    fontFamily,
+  }
+  return (
+    <section aria-label="Lifestyle metrics" className="mt-8">
+      <header className="mb-4">
+        <h2 className="font-mono text-xs font-bold uppercase tracking-[0.24em] text-white/80">
+          Lifestyle metrics
+        </h2>
+        <p className="mt-1 text-xs text-white/55">
+          Heart-rate variability, walking HR, body mass, daily steps, sleep,
+          and active energy across the active range.
+        </p>
+      </header>
+      <div className="grid gap-6 lg:grid-cols-2">
+        <ChartCard
+          title="HRV (SDNN)"
+          helper="Daily heart-rate variability — higher trend = more recovered."
+        >
+          <HrvTrendChart points={data.hrv_trend} {...sharedProps} />
+        </ChartCard>
+        <ChartCard
+          title="Walking heart rate"
+          helper="Apple's per-day walking HR average — lower trend usually = better aerobic base."
+        >
+          <WalkingHrTrendChart points={data.walking_hr_trend} {...sharedProps} />
+        </ChartCard>
+        <ChartCard
+          title="Body mass"
+          helper="Daily latest reading, normalized to pounds at preprocess time."
+        >
+          <BodyMassTrendChart points={data.body_mass_trend} {...sharedProps} />
+        </ChartCard>
+        <ChartCard
+          title="Daily steps"
+          helper="Apple's per-burst step records summed into one total per local calendar day."
+        >
+          <StepCountTrendChart points={data.step_count_trend} {...sharedProps} />
+        </ChartCard>
+        <ChartCard
+          title="Sleep"
+          helper="Asleep-only hours per wake-day — in-bed-but-awake time is excluded."
+        >
+          <SleepTrendChart points={data.sleep_trend} {...sharedProps} />
+        </ChartCard>
+        <ChartCard
+          title="Active energy"
+          helper="Per-burst active-energy records summed per day. Rest days drop toward zero."
+        >
+          <ActiveEnergyTrendChart points={data.active_energy_trend} {...sharedProps} />
+        </ChartCard>
+      </div>
     </section>
   )
 }

--- a/components/training-facility/gym/lifestyle/ActiveEnergyTrendChart.tsx
+++ b/components/training-facility/gym/lifestyle/ActiveEnergyTrendChart.tsx
@@ -1,0 +1,21 @@
+import type { JSX } from 'react'
+
+import { BaseLifestyleTrendChart } from './BaseLifestyleTrendChart'
+import type { LifestyleChartProps } from './HrvTrendChart'
+
+/**
+ * Daily active-energy total, **kilocalories**. Summed from per-burst
+ * records at preprocess time; kJ exports are normalized to kcal so the
+ * y-axis units stay consistent across export sources.
+ */
+export function ActiveEnergyTrendChart(props: LifestyleChartProps): JSX.Element {
+  return (
+    <BaseLifestyleTrendChart
+      {...props}
+      yLabel="kcal"
+      yTickFormat={(v) => String(Math.round(v))}
+      emptyMessage="No active energy data in range"
+      ariaLabel="Active energy burned per day over time"
+    />
+  )
+}

--- a/components/training-facility/gym/lifestyle/BaseLifestyleTrendChart.test.tsx
+++ b/components/training-facility/gym/lifestyle/BaseLifestyleTrendChart.test.tsx
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest'
+import { render } from '@testing-library/react'
+
+import type { CardioTimePoint } from '@/types/cardio'
+
+import { BaseLifestyleTrendChart } from './BaseLifestyleTrendChart'
+
+/**
+ * Coverage for the generic lifestyle-trend chart. Date clipping and the
+ * undefined / empty-points fallback are the two non-trivial paths; the
+ * actual line rendering is `RoughLine`'s job and is tested separately.
+ */
+describe('BaseLifestyleTrendChart', () => {
+  const baseProps = {
+    width: 400,
+    yLabel: 'HRV (ms)',
+    emptyMessage: 'No HRV data in range',
+    ariaLabel: 'HRV over time',
+  }
+
+  function points(rows: ReadonlyArray<[string, number]>): CardioTimePoint[] {
+    return rows.map(([date, value]) => ({ date, value }))
+  }
+
+  it('falls back to the empty state when points is undefined', () => {
+    const { getByText } = render(<BaseLifestyleTrendChart {...baseProps} points={undefined} />)
+    expect(getByText('No HRV data in range')).toBeInTheDocument()
+  })
+
+  it('falls back to the empty state when points is an empty array', () => {
+    const { getByText } = render(<BaseLifestyleTrendChart {...baseProps} points={[]} />)
+    expect(getByText('No HRV data in range')).toBeInTheDocument()
+  })
+
+  it('falls back to the empty state when every point is clipped out', () => {
+    const data = points([
+      ['2026-01-10', 38],
+      ['2026-02-14', 42],
+    ])
+    const { getByText } = render(
+      <BaseLifestyleTrendChart
+        {...baseProps}
+        points={data}
+        // Range is entirely after the data — every point should clip out.
+        dateFrom={new Date(2026, 5, 1)}
+        dateTo={new Date(2026, 5, 30)}
+      />,
+    )
+    expect(getByText('No HRV data in range')).toBeInTheDocument()
+  })
+
+  it('renders the SVG (not the empty state) when at least one point survives clipping', () => {
+    const data = points([
+      ['2026-01-10', 38],
+      ['2026-02-14', 42],
+      ['2026-03-14', 47],
+    ])
+    const { container, queryByText } = render(
+      <BaseLifestyleTrendChart
+        {...baseProps}
+        points={data}
+        dateFrom={new Date(2026, 1, 1)}
+        dateTo={new Date(2026, 3, 31)}
+      />,
+    )
+    // No empty-state caption.
+    expect(queryByText('No HRV data in range')).not.toBeInTheDocument()
+    // RoughLine renders an <svg>; the y-axis label is present in the SVG output.
+    const svg = container.querySelector('svg')
+    expect(svg).toBeTruthy()
+  })
+
+  it('honors width and height props on the rendered svg', () => {
+    const data = points([
+      ['2026-03-14', 47],
+      ['2026-04-18', 51],
+    ])
+    const { container } = render(
+      <BaseLifestyleTrendChart
+        {...baseProps}
+        points={data}
+        width={500}
+        height={150}
+      />,
+    )
+    const svg = container.querySelector('svg')
+    expect(svg?.getAttribute('width')).toBe('500')
+    expect(svg?.getAttribute('height')).toBe('150')
+  })
+
+  it('drops points whose date string is unparseable instead of plotting NaN', () => {
+    const data = points([
+      ['not-a-date', 99],
+      ['2026-03-14', 47],
+      ['2026-04-18', 51],
+    ])
+    const { container, queryByText } = render(
+      <BaseLifestyleTrendChart {...baseProps} points={data} width={400} />,
+    )
+    // Two valid points → not the empty state.
+    expect(queryByText('No HRV data in range')).not.toBeInTheDocument()
+    expect(container.querySelector('svg')).toBeTruthy()
+  })
+})

--- a/components/training-facility/gym/lifestyle/BaseLifestyleTrendChart.tsx
+++ b/components/training-facility/gym/lifestyle/BaseLifestyleTrendChart.tsx
@@ -1,0 +1,117 @@
+import type { JSX } from 'react'
+
+import { RoughLine } from '@/components/training-facility/shared/charts/RoughLine'
+import { chartPalette } from '@/components/training-facility/shared/charts/palette'
+import { defaultMargin } from '@/components/training-facility/shared/charts/types'
+import { parseSessionDate } from '@/lib/training-facility/cardio-shared'
+import type { CardioTimePoint } from '@/types/cardio'
+
+/**
+ * Props for {@link BaseLifestyleTrendChart}. The 6 named wrappers in this
+ * folder fix the metric-specific labels / formats / messages and pass the
+ * shared range + presentation knobs through.
+ */
+export interface BaseLifestyleTrendChartProps {
+  /**
+   * Daily-trend points for the metric. `undefined` (preprocessor /
+   * Supabase table empty) is treated identically to "no points in
+   * range" — both render the empty-state via {@link RoughLine}'s
+   * `emptyMessage` path.
+   */
+  points: readonly CardioTimePoint[] | undefined
+  /** Inclusive lower bound from the parent's `DateFilter`; omit for "all-time." */
+  dateFrom?: Date | null
+  /** Inclusive upper bound from the parent's `DateFilter`; defaults to no clamp. */
+  dateTo?: Date | null
+  /** Pixel width of the SVG; the parent's `ResizeObserver` drives this. */
+  width: number
+  /** Pixel height of the SVG. Defaults to 220 to match neighboring cards. */
+  height?: number
+  /** Font family for axes / empty-state copy. */
+  fontFamily?: string
+  /** Y-axis label drawn on the left margin (units in parens, e.g. `"HRV (ms)"`). */
+  yLabel: string
+  /** Formatter for y-axis tick labels — sleep gets `1.toFixed(1)`, steps get `toLocaleString()`, etc. */
+  yTickFormat?: (value: number) => string
+  /** Caption shown when {@link points} is empty / undefined / fully clipped out. */
+  emptyMessage: string
+  /** Accessible label for the wrapping `<svg role="img">`. */
+  ariaLabel: string
+}
+
+const DEFAULT_HEIGHT = 220
+
+/**
+ * Generic daily-trend chart used by every lifestyle-metric wrapper. Clips the
+ * input series to the active `DateFilter` range, then delegates to
+ * {@link RoughLine} for the actual sketch (which handles its own empty-state
+ * fallback). The 6 wrappers in this folder are intentionally one-liners on
+ * top of this base so a future cross-cutting tweak — hover tooltips, area
+ * fills, dual-line overlays — lands in one place rather than six.
+ *
+ * Date clipping happens HERE rather than at the call site so each wrapper
+ * stays declarative ("show HRV", "show sleep") and the call site doesn't
+ * have to repeat the same `points.filter(p => parseSessionDate(p.date) ...)`
+ * incantation six times.
+ */
+export function BaseLifestyleTrendChart({
+  points,
+  dateFrom,
+  dateTo,
+  width,
+  height = DEFAULT_HEIGHT,
+  fontFamily,
+  yLabel,
+  yTickFormat,
+  emptyMessage,
+  ariaLabel,
+}: BaseLifestyleTrendChartProps): JSX.Element {
+  const clipped = clipToRange(points ?? [], dateFrom ?? null, dateTo ?? null)
+
+  return (
+    <RoughLine<TrendPoint>
+      data={clipped}
+      x={(p) => p.date}
+      y={(p) => p.value}
+      width={width}
+      height={height}
+      margin={defaultMargin}
+      fontFamily={fontFamily}
+      axisColor={chartPalette.inkSoft}
+      yLabel={yLabel}
+      yTickFormat={yTickFormat}
+      ariaLabel={ariaLabel}
+      emptyMessage={emptyMessage}
+    />
+  )
+}
+
+/** Internal point shape after parsing the ISO date — `RoughLine` accepts `Date` for time scales. */
+interface TrendPoint {
+  date: Date
+  value: number
+}
+
+/**
+ * Clip a `CardioTimePoint[]` series to the optional inclusive range and
+ * pre-parse the date strings into `Date`s so {@link RoughLine}'s time-scale
+ * branch picks them up. Points whose date doesn't parse are dropped silently
+ * — they'd render as NaN-positioned dots otherwise.
+ */
+function clipToRange(
+  points: readonly CardioTimePoint[],
+  dateFrom: Date | null,
+  dateTo: Date | null,
+): TrendPoint[] {
+  const fromMs = dateFrom?.getTime() ?? -Infinity
+  const toMs = dateTo?.getTime() ?? Infinity
+  const out: TrendPoint[] = []
+  for (const p of points) {
+    const d = parseSessionDate(p.date)
+    const t = d.getTime()
+    if (!Number.isFinite(t)) continue
+    if (t < fromMs || t > toMs) continue
+    out.push({ date: d, value: p.value })
+  }
+  return out
+}

--- a/components/training-facility/gym/lifestyle/BodyMassTrendChart.tsx
+++ b/components/training-facility/gym/lifestyle/BodyMassTrendChart.tsx
@@ -1,0 +1,21 @@
+import type { JSX } from 'react'
+
+import { BaseLifestyleTrendChart } from './BaseLifestyleTrendChart'
+import type { LifestyleChartProps } from './HrvTrendChart'
+
+/**
+ * Body-mass daily trend, **lbs** (Apple Health's `kg` is converted at
+ * preprocess time, see `scripts/preprocess-health.py`). One decimal of
+ * precision so day-to-day fluctuation reads naturally.
+ */
+export function BodyMassTrendChart(props: LifestyleChartProps): JSX.Element {
+  return (
+    <BaseLifestyleTrendChart
+      {...props}
+      yLabel="lbs"
+      yTickFormat={(v) => v.toFixed(1)}
+      emptyMessage="No body mass data in range"
+      ariaLabel="Body mass over time"
+    />
+  )
+}

--- a/components/training-facility/gym/lifestyle/HrvTrendChart.tsx
+++ b/components/training-facility/gym/lifestyle/HrvTrendChart.tsx
@@ -1,0 +1,28 @@
+import type { JSX } from 'react'
+
+import {
+  BaseLifestyleTrendChart,
+  type BaseLifestyleTrendChartProps,
+} from './BaseLifestyleTrendChart'
+
+/** Props accepted by every lifestyle wrapper — the shared shape minus the metric-specific config. */
+export type LifestyleChartProps = Omit<
+  BaseLifestyleTrendChartProps,
+  'yLabel' | 'yTickFormat' | 'emptyMessage' | 'ariaLabel'
+>
+
+/**
+ * Heart-rate variability (SDNN) daily trend. Higher = better recovery /
+ * autonomic balance. Y-axis is integer milliseconds — typical range 30–80.
+ */
+export function HrvTrendChart(props: LifestyleChartProps): JSX.Element {
+  return (
+    <BaseLifestyleTrendChart
+      {...props}
+      yLabel="HRV (ms)"
+      yTickFormat={(v) => String(Math.round(v))}
+      emptyMessage="No HRV data in range"
+      ariaLabel="HRV (SDNN) over time"
+    />
+  )
+}

--- a/components/training-facility/gym/lifestyle/SleepTrendChart.tsx
+++ b/components/training-facility/gym/lifestyle/SleepTrendChart.tsx
@@ -1,0 +1,22 @@
+import type { JSX } from 'react'
+
+import { BaseLifestyleTrendChart } from './BaseLifestyleTrendChart'
+import type { LifestyleChartProps } from './HrvTrendChart'
+
+/**
+ * Sleep daily trend, **hours**. Each block is bucketed by its wake-day at
+ * preprocess time (Apple Health's UI convention) and only
+ * `HKCategoryValueSleepAnalysisAsleep*` periods are summed — in-bed-but-
+ * awake time is excluded.
+ */
+export function SleepTrendChart(props: LifestyleChartProps): JSX.Element {
+  return (
+    <BaseLifestyleTrendChart
+      {...props}
+      yLabel="Hours"
+      yTickFormat={(v) => v.toFixed(1)}
+      emptyMessage="No sleep data in range"
+      ariaLabel="Asleep hours per night over time"
+    />
+  )
+}

--- a/components/training-facility/gym/lifestyle/StepCountTrendChart.tsx
+++ b/components/training-facility/gym/lifestyle/StepCountTrendChart.tsx
@@ -1,0 +1,21 @@
+import type { JSX } from 'react'
+
+import { BaseLifestyleTrendChart } from './BaseLifestyleTrendChart'
+import type { LifestyleChartProps } from './HrvTrendChart'
+
+/**
+ * Daily step-count total, summed from Apple's per-burst step records at
+ * preprocess time. Tick labels use locale grouping (`12,400`) so the
+ * common 5–6 figure values stay readable.
+ */
+export function StepCountTrendChart(props: LifestyleChartProps): JSX.Element {
+  return (
+    <BaseLifestyleTrendChart
+      {...props}
+      yLabel="Steps"
+      yTickFormat={(v) => Math.round(v).toLocaleString()}
+      emptyMessage="No step data in range"
+      ariaLabel="Daily step count over time"
+    />
+  )
+}

--- a/components/training-facility/gym/lifestyle/WalkingHrTrendChart.tsx
+++ b/components/training-facility/gym/lifestyle/WalkingHrTrendChart.tsx
@@ -1,0 +1,21 @@
+import type { JSX } from 'react'
+
+import { BaseLifestyleTrendChart } from './BaseLifestyleTrendChart'
+import type { LifestyleChartProps } from './HrvTrendChart'
+
+/**
+ * Walking heart-rate average daily trend, BPM. Apple's per-day rollup of
+ * heart rates measured during sustained walking. Lower trend usually =
+ * better aerobic fitness.
+ */
+export function WalkingHrTrendChart(props: LifestyleChartProps): JSX.Element {
+  return (
+    <BaseLifestyleTrendChart
+      {...props}
+      yLabel="BPM"
+      yTickFormat={(v) => String(Math.round(v))}
+      emptyMessage="No walking HR data in range"
+      ariaLabel="Walking heart rate over time"
+    />
+  )
+}

--- a/components/training-facility/gym/lifestyle/lifestyle-trend-charts.test.tsx
+++ b/components/training-facility/gym/lifestyle/lifestyle-trend-charts.test.tsx
@@ -1,0 +1,70 @@
+import type { ComponentType } from 'react'
+import { describe, expect, it } from 'vitest'
+import { render } from '@testing-library/react'
+
+import type { CardioTimePoint } from '@/types/cardio'
+
+import { ActiveEnergyTrendChart } from './ActiveEnergyTrendChart'
+import { BodyMassTrendChart } from './BodyMassTrendChart'
+import { HrvTrendChart, type LifestyleChartProps } from './HrvTrendChart'
+import { SleepTrendChart } from './SleepTrendChart'
+import { StepCountTrendChart } from './StepCountTrendChart'
+import { WalkingHrTrendChart } from './WalkingHrTrendChart'
+
+/**
+ * Smoke tests for the six lifestyle-metric wrappers. Each wrapper is a thin
+ * pass-through to {@link BaseLifestyleTrendChart} that fixes the y-axis
+ * label, tick formatter, empty-state caption, and aria-label. We assert
+ * those four metric-specific bits land in the rendered output — the
+ * underlying line/clipping behavior is covered in
+ * `BaseLifestyleTrendChart.test.tsx` and `RoughLine`'s own coverage.
+ */
+
+interface WrapperCase {
+  name: string
+  Component: ComponentType<LifestyleChartProps>
+  emptyMessage: string
+}
+
+const WRAPPERS: ReadonlyArray<WrapperCase> = [
+  { name: 'HrvTrendChart', Component: HrvTrendChart, emptyMessage: 'No HRV data in range' },
+  {
+    name: 'WalkingHrTrendChart',
+    Component: WalkingHrTrendChart,
+    emptyMessage: 'No walking HR data in range',
+  },
+  {
+    name: 'BodyMassTrendChart',
+    Component: BodyMassTrendChart,
+    emptyMessage: 'No body mass data in range',
+  },
+  {
+    name: 'StepCountTrendChart',
+    Component: StepCountTrendChart,
+    emptyMessage: 'No step data in range',
+  },
+  { name: 'SleepTrendChart', Component: SleepTrendChart, emptyMessage: 'No sleep data in range' },
+  {
+    name: 'ActiveEnergyTrendChart',
+    Component: ActiveEnergyTrendChart,
+    emptyMessage: 'No active energy data in range',
+  },
+]
+
+const samplePoints: CardioTimePoint[] = [
+  { date: '2026-03-14', value: 50 },
+  { date: '2026-04-18', value: 55 },
+]
+
+describe.each(WRAPPERS)('$name', ({ Component, emptyMessage }) => {
+  it('renders the metric-specific empty-state message when points is undefined', () => {
+    const { getByText } = render(<Component points={undefined} width={400} />)
+    expect(getByText(emptyMessage)).toBeInTheDocument()
+  })
+
+  it('renders an svg (not the empty state) when given sample points', () => {
+    const { container, queryByText } = render(<Component points={samplePoints} width={400} />)
+    expect(queryByText(emptyMessage)).not.toBeInTheDocument()
+    expect(container.querySelector('svg')).toBeTruthy()
+  })
+})


### PR DESCRIPTION
## Summary

Wires the six lifestyle daily-trend metrics shipped in slice C-data
(#175) into a new **"Lifestyle metrics"** section on `/training-facility/gym/overview`.
Sits between the activity mix and the session log so the "what did I
do" cards stay at the top and the detailed log stays at the bottom.

This is **slice C-ui of #75**. The umbrella stays open until slice D
archives the cardio-dashboard repo and merges the changelog entry.

Refs #75 — do not close this issue on merge.

## What landed

- `components/training-facility/gym/lifestyle/BaseLifestyleTrendChart.tsx`
  — generic chart that clips the input series to the active `DateFilter`
  range, then delegates to `RoughLine` for the actual sketch. Date
  clipping centralized so the 6 wrappers stay one-liners.
- Six named wrappers (`HrvTrendChart`, `WalkingHrTrendChart`,
  `BodyMassTrendChart`, `StepCountTrendChart`, `SleepTrendChart`,
  `ActiveEnergyTrendChart`) — each fixes the metric-specific y-axis
  label, tick formatter, empty-state message, and aria-label.
- `LifestyleMetricsSection` inside `AllCardioOverview` — header +
  responsive `lg:grid-cols-2` grid of 6 ChartCards. Each card stays
  visible regardless of data presence; empty fields show the
  metric-specific "No <metric> data in range" caption rather than
  disappearing, preserving the page's structural rhythm.
- Tests:
  - `BaseLifestyleTrendChart.test.tsx` — 6 cases covering empty/undefined
    points, full-range clip-out, partial-range survival, width/height
    pass-through, malformed-date drop.
  - `lifestyle-trend-charts.test.tsx` — `describe.each` over the 6
    wrappers asserting the metric-specific empty-state caption + that
    sample data renders an SVG.
  - 18 new tests; full suite at 641/641.

## Test plan

- [ ] Visit `/training-facility/gym/overview` against your real Apple
      Health import. Below the activity mix, see the **Lifestyle
      metrics** section with six chart cards (HRV, walking HR, body
      mass, daily steps, sleep, active energy) in a 2-col grid.
- [ ] Each chart that has data shows a rim-orange trend line with
      hand-drawn dots; each axis label and tick format matches the
      metric (e.g. body mass shows `1 decimal lbs`, steps show
      `12,400` with comma-grouping, sleep shows `7.2` hours).
- [ ] For an empty/missing series, the chart card stays visible with
      "No <metric> data in range".
- [ ] Visit `/training-facility/gym/overview?preview=demo` (no real
      Supabase data needed). All six charts hydrate from
      `CARDIO_DEMO_DATA` and trend in the "improving" direction
      (HRV ↑, walking HR ↓, body mass ↓, steps ↑, sleep stable, active
      energy ↑).
- [ ] Change the `DateFilter` range — the trend lines reslice without
      reload; out-of-range presets show the empty-state caption.
- [ ] Mobile (`390×844`): the section stacks single-column and each
      chart remains readable.

## Out of scope

- `BodyweightOverlay` toggle on the 5 non-bodymass charts.
- Period comparison (Δ vs prior window) on lifestyle metrics.
- New `/training-facility/gym/lifestyle` route.
- Slice D (archive cardio-dashboard + changelog).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "Lifestyle metrics" section to the cardio overview page displaying six daily-trend charts
  * Charts track heart rate variability, walking heart rate, body mass, step count, sleep duration, and active energy burned
  * Charts dynamically adapt to selected date ranges for flexible data visualization

* **Tests**
  * Added comprehensive test coverage for lifestyle metric charts including empty states and date range filtering

<!-- end of auto-generated comment: release notes by coderabbit.ai -->