### PR TITLE
chore(ship-issue): file non-blocking review findings as a tracking issue

### DIFF
--- a/.claude/commands/ship-issue.md
+++ b/.claude/commands/ship-issue.md
@@ -71,7 +71,9 @@ Loop until convergence, **max 3 iterations**:
 
 If a comment is unclear or you disagree with it, don't silently fix or ignore — stop the loop and ask the user.
 
-6. **After convergence — file follow-ups for non-blocking suggestions.** Throughout the review loop you'll have noted findings that were real but explicitly *non-blocking* — style nits, deferred refactors, "nice to have" coverage gaps, future-considered cleanups. Before moving to Phase 5, file ONE GitHub issue collecting them all under a single tracking item so they're not carried in your head or buried in the merged PR's review thread. Don't file one issue per suggestion.
+**Once the loop converges (or hits the hard cap), before moving to Phase 5:**
+
+1. **File follow-ups for non-blocking suggestions.** Throughout the review loop you'll have noted findings that were real but explicitly *non-blocking* — style nits, deferred refactors, "nice to have" coverage gaps, future-considered cleanups. File ONE GitHub issue collecting them all under a single tracking item so they're not carried in your head or buried in the merged PR's review thread.
 
    - Title: `chore: non-blocking follow-ups from #<pr> (<short PR scope>)`
    - Body: a markdown checklist with each suggestion as its own item; include enough context (file paths, what to change, why) that someone picking it up later doesn't have to re-read the PR. End with `Refs #<pr>` and any related umbrella issue.

--- a/.claude/commands/ship-issue.md
+++ b/.claude/commands/ship-issue.md
@@ -71,6 +71,13 @@ Loop until convergence, **max 3 iterations**:
 
 If a comment is unclear or you disagree with it, don't silently fix or ignore — stop the loop and ask the user.
 
+6. **After convergence — file follow-ups for non-blocking suggestions.** Throughout the review loop you'll have noted findings that were real but explicitly *non-blocking* — style nits, deferred refactors, "nice to have" coverage gaps, future-considered cleanups. Before moving to Phase 5, file ONE GitHub issue collecting them all under a single tracking item so they're not carried in your head or buried in the merged PR's review thread. Don't file one issue per suggestion.
+
+   - Title: `chore: non-blocking follow-ups from #<pr> (<short PR scope>)`
+   - Body: a markdown checklist with each suggestion as its own item; include enough context (file paths, what to change, why) that someone picking it up later doesn't have to re-read the PR. End with `Refs #<pr>` and any related umbrella issue.
+   - Labels: existing repo conventions where they fit (e.g., `enhancement`, `chore`, the relevant area label); skip labels you're not sure about.
+   - **Skip the issue entirely** when there are genuinely zero non-blocking findings — don't file an empty tracking issue just to have one. Briefly note "no follow-ups" in the hand-off comment instead.
+
 ## Phase 5 — Hand off (the only user-pause besides Phase 1)
 
 This is the user's spot-check moment. Everything else is autonomous.


### PR DESCRIPTION
## Summary

Adds a new **Phase 4 step 6** to the `/ship-issue` skill (`.claude/commands/ship-issue.md`): after the review loop converges, file ONE GitHub issue collecting any non-blocking suggestions surfaced during `/review` or by other reviewers, with a `Refs #<pr>` link. Skips the issue entirely when there are zero non-blocking findings.

## Why

Captured during the #75 slice rollout — `/review` was surfacing real-but-non-blocking suggestions (style nits, deferred refactors, micro-optimizations) and they were getting buried in the merged PR threads. The new step landed informally during slice C-ui (#177 → follow-up #178) and is committed here so future sessions on other machines pick it up.

## Test plan

- [ ] Next `/ship-issue` run produces a follow-up tracking issue at convergence (or notes "no follow-ups" in the hand-off when there are none).
- [ ] Skill description / Phases 1–5 unchanged.

## Out of scope

- Auto-detecting "non-blocking" vs actionable findings — still relies on the model classifying review output during Phase 4.
- Backfilling tracking issues for slices A/B/C-data review threads — already done manually in #176.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the `/ship-issue` command docs to add a post-review step that instructs filing a single aggregated follow-up GitHub issue for all non-blocking review findings, includes a prescribed title/body/checklist format and label guidance, and specifies skipping the issue with a brief “no follow-ups” note when there are zero non-blocking findings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->