### PR TITLE
feat(weight-room): data model, Supabase tables, admin API, and settings UI (#79)

### DIFF
--- a/app/api/admin/weight-room/goals/[exercise]/route.test.ts
+++ b/app/api/admin/weight-room/goals/[exercise]/route.test.ts
@@ -6,8 +6,10 @@ import { DELETE } from './route'
 /**
  * Tests for `DELETE /api/admin/weight-room/goals/[exercise]`. Auth gate +
  * Supabase service-role client are mocked; the route's own logic
- * (URL-decoding, empty-segment guard, 404-vs-200 mapping) is exercised
- * in isolation.
+ * (empty-segment guard, 404-vs-200 mapping, trimmed lookup) is
+ * exercised in isolation. Next.js App Router decodes path segments
+ * before invoking the handler, so the route doesn't re-decode and the
+ * tests pass already-decoded values.
  */
 
 const requireAdminMock = vi.fn()
@@ -69,15 +71,24 @@ describe('DELETE /api/admin/weight-room/goals/[exercise]', () => {
     expect(res.status).toBe(404)
   })
 
-  it('URL-decodes the exercise segment before querying', async () => {
+  it('trims whitespace around the exercise segment before querying', async () => {
     requireAdminMock.mockResolvedValue({ ok: true, email: 'a@b.com' })
     deleteMock.mockResolvedValueOnce({
-      data: { exercise: 'shoulder taps', daily_target: 50, color: '#EA580C' },
+      data: { exercise: 'pushups', daily_target: 100, color: '#EA580C' },
       error: null,
     })
-    const res = await DELETE(req() as never, ctx('shoulder%20taps'))
+    const res = await DELETE(req() as never, ctx('  pushups  '))
     expect(res.status).toBe(200)
-    expect(supabaseChain.eq).toHaveBeenCalledWith('exercise', 'shoulder taps')
+    expect(supabaseChain.eq).toHaveBeenCalledWith('exercise', 'pushups')
+  })
+
+  it('does not throw on bare-percent input — trim path is decode-free', async () => {
+    requireAdminMock.mockResolvedValue({ ok: true, email: 'a@b.com' })
+    deleteMock.mockResolvedValueOnce({ data: null, error: null })
+    // A bare `%` character would crash an unsafe `decodeURIComponent` call
+    // with `URIError`; the route should funnel through to the 404 instead.
+    const res = await DELETE(req() as never, ctx('%bad'))
+    expect(res.status).toBe(404)
   })
 
   it('returns 200 with the removed row on success', async () => {

--- a/app/api/admin/weight-room/goals/[exercise]/route.test.ts
+++ b/app/api/admin/weight-room/goals/[exercise]/route.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextResponse } from 'next/server'
+
+import { DELETE } from './route'
+
+/**
+ * Tests for `DELETE /api/admin/weight-room/goals/[exercise]`. Auth gate +
+ * Supabase service-role client are mocked; the route's own logic
+ * (URL-decoding, empty-segment guard, 404-vs-200 mapping) is exercised
+ * in isolation.
+ */
+
+const requireAdminMock = vi.fn()
+vi.mock('@/lib/auth/require-admin', () => ({
+  requireAdmin: () => requireAdminMock(),
+}))
+
+const deleteMock = vi.fn()
+const supabaseChain = {
+  from: vi.fn(() => supabaseChain),
+  delete: vi.fn(() => supabaseChain),
+  eq: vi.fn(() => supabaseChain),
+  select: vi.fn(() => supabaseChain),
+  maybeSingle: vi.fn(() => deleteMock()),
+}
+vi.mock('@/lib/supabase/admin', () => ({
+  createAdminSupabaseClient: () => supabaseChain,
+}))
+
+beforeEach(() => {
+  requireAdminMock.mockReset()
+  deleteMock.mockReset()
+  supabaseChain.from.mockClear()
+  supabaseChain.delete.mockClear()
+  supabaseChain.eq.mockClear()
+  supabaseChain.select.mockClear()
+  supabaseChain.maybeSingle.mockClear()
+  supabaseChain.from.mockReturnValue(supabaseChain)
+  supabaseChain.delete.mockReturnValue(supabaseChain)
+  supabaseChain.eq.mockReturnValue(supabaseChain)
+  supabaseChain.select.mockReturnValue(supabaseChain)
+  supabaseChain.maybeSingle.mockImplementation(() => deleteMock())
+})
+
+const ctx = (exercise: string) => ({ params: Promise.resolve({ exercise }) })
+const req = () =>
+  new Request('http://localhost/api/admin/weight-room/goals/pushups', { method: 'DELETE' })
+
+describe('DELETE /api/admin/weight-room/goals/[exercise]', () => {
+  it('returns 401 when not signed in', async () => {
+    requireAdminMock.mockResolvedValueOnce({
+      ok: false,
+      response: NextResponse.json({ error: 'Sign in required.' }, { status: 401 }),
+    })
+    const res = await DELETE(req() as never, ctx('pushups'))
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 400 when exercise is empty after URL-decoding', async () => {
+    requireAdminMock.mockResolvedValue({ ok: true, email: 'a@b.com' })
+    const res = await DELETE(req() as never, ctx('   '))
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 404 when no goal exists for exercise', async () => {
+    requireAdminMock.mockResolvedValue({ ok: true, email: 'a@b.com' })
+    deleteMock.mockResolvedValueOnce({ data: null, error: null })
+    const res = await DELETE(req() as never, ctx('unknown'))
+    expect(res.status).toBe(404)
+  })
+
+  it('URL-decodes the exercise segment before querying', async () => {
+    requireAdminMock.mockResolvedValue({ ok: true, email: 'a@b.com' })
+    deleteMock.mockResolvedValueOnce({
+      data: { exercise: 'shoulder taps', daily_target: 50, color: '#EA580C' },
+      error: null,
+    })
+    const res = await DELETE(req() as never, ctx('shoulder%20taps'))
+    expect(res.status).toBe(200)
+    expect(supabaseChain.eq).toHaveBeenCalledWith('exercise', 'shoulder taps')
+  })
+
+  it('returns 200 with the removed row on success', async () => {
+    requireAdminMock.mockResolvedValue({ ok: true, email: 'a@b.com' })
+    const removed = { exercise: 'pushups', daily_target: 100, color: '#EA580C' }
+    deleteMock.mockResolvedValueOnce({ data: removed, error: null })
+    const res = await DELETE(req() as never, ctx('pushups'))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toEqual(removed)
+  })
+})

--- a/app/api/admin/weight-room/goals/[exercise]/route.ts
+++ b/app/api/admin/weight-room/goals/[exercise]/route.ts
@@ -41,9 +41,14 @@ export async function DELETE(_request: NextRequest, ctx: Context): Promise<NextR
   const auth = await requireAdmin()
   if (!auth.ok) return auth.response
 
+  // Next.js App Router decodes dynamic route segments before handing them
+  // to the handler, so `params.exercise` is the already-decoded user input
+  // — no `decodeURIComponent` call here (matches the
+  // `movement-benchmarks/[date]/route.ts` precedent and avoids the
+  // URIError crash a malformed `%` sequence would otherwise produce).
   const { exercise } = await ctx.params
-  const decoded = decodeURIComponent(exercise).trim()
-  if (decoded.length === 0) {
+  const trimmed = exercise.trim()
+  if (trimmed.length === 0) {
     return NextResponse.json({ error: 'exercise must be non-empty.' }, { status: 400 })
   }
 
@@ -51,7 +56,7 @@ export async function DELETE(_request: NextRequest, ctx: Context): Promise<NextR
   const { data, error } = await supabase
     .from('weight_room_goals')
     .delete()
-    .eq('exercise', decoded)
+    .eq('exercise', trimmed)
     .select()
     .maybeSingle()
 
@@ -62,7 +67,7 @@ export async function DELETE(_request: NextRequest, ctx: Context): Promise<NextR
     )
   }
   if (!data) {
-    return NextResponse.json({ error: `No goal for '${decoded}'.` }, { status: 404 })
+    return NextResponse.json({ error: `No goal for '${trimmed}'.` }, { status: 404 })
   }
   return NextResponse.json(data, { status: 200 })
 }

--- a/app/api/admin/weight-room/goals/[exercise]/route.ts
+++ b/app/api/admin/weight-room/goals/[exercise]/route.ts
@@ -1,0 +1,68 @@
+/**
+ * Admin-only item endpoint for Weight Room goal deletion (#79). Sibling
+ * of the collection POST — same admin gate, same service-role client.
+ * Used by the Settings UI's "remove exercise" affordance.
+ *
+ * Deletes are FK-cascaded: removing a goal also drops every set logged
+ * for that exercise (per the migration's `on delete cascade`). The
+ * Settings UI surfaces a confirmation prompt before calling DELETE so
+ * the cascade isn't silent.
+ */
+
+import { NextResponse, type NextRequest } from 'next/server'
+
+import { requireAdmin } from '@/lib/auth/require-admin'
+import { createAdminSupabaseClient } from '@/lib/supabase/admin'
+
+interface Context {
+  params: Promise<{ exercise: string }>
+}
+
+/**
+ * Delete a goal (and, via FK cascade, every set for that exercise).
+ *
+ * Status codes:
+ * - 200 — deleted (response body echoes the removed row)
+ * - 400 — empty `exercise` segment (shouldn't happen — Next.js routing
+ *   wouldn't match — but kept defensive in case of a manual fetch)
+ * - 401 — not signed in
+ * - 403 — not on the allowlist
+ * - 404 — no goal exists for `exercise`
+ * - 500 — unexpected Supabase error
+ *
+ * @param _request Unused — DELETE has no body. Required by Next.js
+ *   handler signature.
+ * @param ctx Next.js route context; `ctx.params.exercise` is the goal's
+ *   primary key parsed from the URL segment.
+ * @throws when Supabase env vars are missing (misconfigured deploy).
+ *   Domain failures are returned as JSON responses, not thrown.
+ */
+export async function DELETE(_request: NextRequest, ctx: Context): Promise<NextResponse> {
+  const auth = await requireAdmin()
+  if (!auth.ok) return auth.response
+
+  const { exercise } = await ctx.params
+  const decoded = decodeURIComponent(exercise).trim()
+  if (decoded.length === 0) {
+    return NextResponse.json({ error: 'exercise must be non-empty.' }, { status: 400 })
+  }
+
+  const supabase = createAdminSupabaseClient()
+  const { data, error } = await supabase
+    .from('weight_room_goals')
+    .delete()
+    .eq('exercise', decoded)
+    .select()
+    .maybeSingle()
+
+  if (error) {
+    return NextResponse.json(
+      { error: `Failed to delete goal: ${error.message}` },
+      { status: 500 },
+    )
+  }
+  if (!data) {
+    return NextResponse.json({ error: `No goal for '${decoded}'.` }, { status: 404 })
+  }
+  return NextResponse.json(data, { status: 200 })
+}

--- a/app/api/admin/weight-room/goals/route.test.ts
+++ b/app/api/admin/weight-room/goals/route.test.ts
@@ -92,6 +92,23 @@ describe('POST /api/admin/weight-room/goals', () => {
     expect(res.status).toBe(200)
     const body = await res.json()
     expect(body).toEqual(validGoal)
-    expect(supabaseChain.upsert).toHaveBeenCalledWith(validGoal, { onConflict: 'exercise' })
+    // Route stamps `updated_at` so edits advance the row's audit
+    // timestamp; the value is `new Date().toISOString()` so we just
+    // assert it's an ISO-shaped string.
+    expect(supabaseChain.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({ ...validGoal, updated_at: expect.any(String) }),
+      { onConflict: 'exercise' },
+    )
+  })
+
+  it('stamps updated_at so edits advance the row freshness', async () => {
+    requireAdminMock.mockResolvedValue({ ok: true, email: 'a@b.com' })
+    upsertMock.mockResolvedValueOnce({ data: validGoal, error: null })
+    await POST(makeRequest(validGoal) as never)
+    expect(supabaseChain.upsert).toHaveBeenCalledWith(
+      // Loose ISO-8601 check: starts with YYYY-MM-DD.
+      expect.objectContaining({ updated_at: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T/) }),
+      { onConflict: 'exercise' },
+    )
   })
 })

--- a/app/api/admin/weight-room/goals/route.test.ts
+++ b/app/api/admin/weight-room/goals/route.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextResponse } from 'next/server'
+
+import { POST } from './route'
+
+/**
+ * Tests for `POST /api/admin/weight-room/goals`. Auth gate + Supabase
+ * service-role client are mocked; the route's own logic (JSON parsing,
+ * Zod validation, hex-color enforcement, upsert success path) is
+ * exercised in isolation.
+ */
+
+const requireAdminMock = vi.fn()
+vi.mock('@/lib/auth/require-admin', () => ({
+  requireAdmin: () => requireAdminMock(),
+}))
+
+const upsertMock = vi.fn()
+const supabaseChain = {
+  from: vi.fn(() => supabaseChain),
+  upsert: vi.fn(() => supabaseChain),
+  select: vi.fn(() => supabaseChain),
+  single: vi.fn(() => upsertMock()),
+}
+vi.mock('@/lib/supabase/admin', () => ({
+  createAdminSupabaseClient: () => supabaseChain,
+}))
+
+beforeEach(() => {
+  requireAdminMock.mockReset()
+  upsertMock.mockReset()
+  supabaseChain.from.mockClear()
+  supabaseChain.upsert.mockClear()
+  supabaseChain.select.mockClear()
+  supabaseChain.single.mockClear()
+  supabaseChain.from.mockReturnValue(supabaseChain)
+  supabaseChain.upsert.mockReturnValue(supabaseChain)
+  supabaseChain.select.mockReturnValue(supabaseChain)
+  supabaseChain.single.mockImplementation(() => upsertMock())
+})
+
+function makeRequest(body: unknown): Request {
+  return new Request('http://localhost/api/admin/weight-room/goals', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: typeof body === 'string' ? body : JSON.stringify(body),
+  })
+}
+
+describe('POST /api/admin/weight-room/goals', () => {
+  const validGoal = { exercise: 'pushups', daily_target: 100, color: '#EA580C' }
+
+  it('returns 401 when not signed in', async () => {
+    requireAdminMock.mockResolvedValueOnce({
+      ok: false,
+      response: NextResponse.json({ error: 'Sign in required.' }, { status: 401 }),
+    })
+    const res = await POST(makeRequest(validGoal) as never)
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 400 when color is not a hex string', async () => {
+    requireAdminMock.mockResolvedValue({ ok: true, email: 'a@b.com' })
+    const res = await POST(
+      makeRequest({ exercise: 'pushups', daily_target: 100, color: 'orange' }) as never,
+    )
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.error).toMatch(/validation failed/i)
+  })
+
+  it('rejects unknown extra fields via Zod .strict()', async () => {
+    requireAdminMock.mockResolvedValue({ ok: true, email: 'a@b.com' })
+    const res = await POST(makeRequest({ ...validGoal, sneaky: 1 }) as never)
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 500 on unexpected Supabase errors', async () => {
+    requireAdminMock.mockResolvedValue({ ok: true, email: 'a@b.com' })
+    upsertMock.mockResolvedValueOnce({
+      data: null,
+      error: { code: 'XX001', message: 'data corruption' },
+    })
+    const res = await POST(makeRequest(validGoal) as never)
+    expect(res.status).toBe(500)
+  })
+
+  it('returns 200 with the upserted row on success', async () => {
+    requireAdminMock.mockResolvedValue({ ok: true, email: 'a@b.com' })
+    upsertMock.mockResolvedValueOnce({ data: validGoal, error: null })
+    const res = await POST(makeRequest(validGoal) as never)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toEqual(validGoal)
+    expect(supabaseChain.upsert).toHaveBeenCalledWith(validGoal, { onConflict: 'exercise' })
+  })
+})

--- a/app/api/admin/weight-room/goals/route.ts
+++ b/app/api/admin/weight-room/goals/route.ts
@@ -57,9 +57,15 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   }
 
   const supabase = createAdminSupabaseClient()
+  // Stamp `updated_at` explicitly so the upsert advances the row's audit
+  // timestamp on edits — without this, the existing-row branch keeps
+  // `updated_at` frozen at the original insert time and the data layer's
+  // `MAX(updated_at)` freshness computation never reflects goal edits.
+  // Mirrors the pattern used by the cardio import script's upserts.
+  const upsertRow = { ...goal, updated_at: new Date().toISOString() }
   const { data, error } = await supabase
     .from('weight_room_goals')
-    .upsert(goal, { onConflict: 'exercise' })
+    .upsert(upsertRow, { onConflict: 'exercise' })
     .select()
     .single()
 

--- a/app/api/admin/weight-room/goals/route.ts
+++ b/app/api/admin/weight-room/goals/route.ts
@@ -1,0 +1,74 @@
+/**
+ * Admin-only collection endpoint for Weight Room goal upserts (#79).
+ *
+ * Settings UI hits this both for adding a new exercise and for updating
+ * an existing goal's `daily_target` / `color`. The exercise name is the
+ * primary key, so a single POST with `onConflict: 'exercise'` covers
+ * both create and update — no separate PUT.
+ *
+ * Pair with `[exercise]/route.ts` for DELETE.
+ */
+
+import { NextResponse, type NextRequest } from 'next/server'
+import { ZodError } from 'zod'
+
+import { requireAdmin } from '@/lib/auth/require-admin'
+import { WeightRoomGoalRowSchema } from '@/lib/schemas/weight-room'
+import { createAdminSupabaseClient } from '@/lib/supabase/admin'
+
+/**
+ * Upsert a goal — create-or-replace by `exercise`. Body must conform
+ * to {@link WeightRoomGoalRowSchema}.
+ *
+ * Status codes:
+ * - 200 — upserted (response echoes the merged row)
+ * - 400 — payload failed Zod validation or wasn't valid JSON
+ * - 401 — not signed in
+ * - 403 — signed in but email not on the allowlist
+ * - 500 — unexpected Supabase error
+ *
+ * @param request Incoming JSON request whose body matches
+ *   {@link WeightRoomGoalRowSchema}.
+ * @throws when Supabase env vars are missing (misconfigured deploy).
+ *   Domain failures are returned as JSON responses, not thrown.
+ */
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const auth = await requireAdmin()
+  if (!auth.ok) return auth.response
+
+  let payload: unknown
+  try {
+    payload = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Body must be valid JSON.' }, { status: 400 })
+  }
+
+  let goal
+  try {
+    goal = WeightRoomGoalRowSchema.parse(payload)
+  } catch (err) {
+    if (err instanceof ZodError) {
+      return NextResponse.json(
+        { error: 'Validation failed.', issues: err.flatten() },
+        { status: 400 },
+      )
+    }
+    throw err
+  }
+
+  const supabase = createAdminSupabaseClient()
+  const { data, error } = await supabase
+    .from('weight_room_goals')
+    .upsert(goal, { onConflict: 'exercise' })
+    .select()
+    .single()
+
+  if (error) {
+    return NextResponse.json(
+      { error: `Failed to upsert goal: ${error.message}` },
+      { status: 500 },
+    )
+  }
+
+  return NextResponse.json(data, { status: 200 })
+}

--- a/app/api/admin/weight-room/sets/[id]/route.test.ts
+++ b/app/api/admin/weight-room/sets/[id]/route.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextResponse } from 'next/server'
+
+import { DELETE } from './route'
+
+/**
+ * Tests for `DELETE /api/admin/weight-room/sets/[id]`. Auth gate and
+ * Supabase service-role client are mocked; the route's own logic
+ * (UUID guard, 404-vs-200 mapping) is exercised in isolation.
+ */
+
+const requireAdminMock = vi.fn()
+vi.mock('@/lib/auth/require-admin', () => ({
+  requireAdmin: () => requireAdminMock(),
+}))
+
+const deleteMock = vi.fn()
+const supabaseChain = {
+  from: vi.fn(() => supabaseChain),
+  delete: vi.fn(() => supabaseChain),
+  eq: vi.fn(() => supabaseChain),
+  select: vi.fn(() => supabaseChain),
+  maybeSingle: vi.fn(() => deleteMock()),
+}
+vi.mock('@/lib/supabase/admin', () => ({
+  createAdminSupabaseClient: () => supabaseChain,
+}))
+
+beforeEach(() => {
+  requireAdminMock.mockReset()
+  deleteMock.mockReset()
+  supabaseChain.from.mockClear()
+  supabaseChain.delete.mockClear()
+  supabaseChain.eq.mockClear()
+  supabaseChain.select.mockClear()
+  supabaseChain.maybeSingle.mockClear()
+  supabaseChain.from.mockReturnValue(supabaseChain)
+  supabaseChain.delete.mockReturnValue(supabaseChain)
+  supabaseChain.eq.mockReturnValue(supabaseChain)
+  supabaseChain.select.mockReturnValue(supabaseChain)
+  supabaseChain.maybeSingle.mockImplementation(() => deleteMock())
+})
+
+const ctx = (id: string) => ({ params: Promise.resolve({ id }) })
+const req = () =>
+  new Request('http://localhost/api/admin/weight-room/sets/x', { method: 'DELETE' })
+
+describe('DELETE /api/admin/weight-room/sets/[id]', () => {
+  it('returns 401 when not signed in', async () => {
+    requireAdminMock.mockResolvedValueOnce({
+      ok: false,
+      response: NextResponse.json({ error: 'Sign in required.' }, { status: 401 }),
+    })
+    const res = await DELETE(req() as never, ctx('11111111-1111-4111-8111-111111111111'))
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 400 when id is not a UUID', async () => {
+    requireAdminMock.mockResolvedValue({ ok: true, email: 'a@b.com' })
+    const res = await DELETE(req() as never, ctx('not-a-uuid'))
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 404 when no set exists for id', async () => {
+    requireAdminMock.mockResolvedValue({ ok: true, email: 'a@b.com' })
+    deleteMock.mockResolvedValueOnce({ data: null, error: null })
+    const res = await DELETE(req() as never, ctx('11111111-1111-4111-8111-111111111111'))
+    expect(res.status).toBe(404)
+  })
+
+  it('returns 500 on unexpected Supabase errors', async () => {
+    requireAdminMock.mockResolvedValue({ ok: true, email: 'a@b.com' })
+    deleteMock.mockResolvedValueOnce({
+      data: null,
+      error: { code: 'XX001', message: 'connection lost' },
+    })
+    const res = await DELETE(req() as never, ctx('11111111-1111-4111-8111-111111111111'))
+    expect(res.status).toBe(500)
+  })
+
+  it('returns 200 with the removed row on success', async () => {
+    requireAdminMock.mockResolvedValue({ ok: true, email: 'a@b.com' })
+    const removed = {
+      id: '11111111-1111-4111-8111-111111111111',
+      logged_at: '2026-05-07T08:00:00Z',
+      exercise: 'pushups',
+      reps: 25,
+    }
+    deleteMock.mockResolvedValueOnce({ data: removed, error: null })
+    const res = await DELETE(req() as never, ctx(removed.id))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toEqual(removed)
+  })
+})

--- a/app/api/admin/weight-room/sets/[id]/route.ts
+++ b/app/api/admin/weight-room/sets/[id]/route.ts
@@ -1,0 +1,68 @@
+/**
+ * Admin-only item endpoint for Weight Room set deletion (#79). Sibling
+ * of the collection POST — same admin gate, same service-role client.
+ * Used by the Today View's swipe-to-delete / undo affordance.
+ */
+
+import { NextResponse, type NextRequest } from 'next/server'
+
+import { requireAdmin } from '@/lib/auth/require-admin'
+import { createAdminSupabaseClient } from '@/lib/supabase/admin'
+
+interface Context {
+  params: Promise<{ id: string }>
+}
+
+/**
+ * Loose UUID guard — Postgres rejects malformed UUIDs at query time, but
+ * a pre-check here keeps the 400 vs 404 distinction clean (a malformed
+ * id is a client bug, a valid-but-missing id is a 404).
+ */
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+/**
+ * Delete one strength set by `id`.
+ *
+ * Status codes:
+ * - 200 — deleted (response body echoes the removed row)
+ * - 400 — `id` is not a valid UUID
+ * - 401 — not signed in
+ * - 403 — not on the allowlist
+ * - 404 — no set exists for `id`
+ * - 500 — unexpected Supabase error
+ *
+ * @param _request Unused — DELETE has no body. Required by Next.js
+ *   handler signature.
+ * @param ctx Next.js route context; `ctx.params.id` is the set's UUID
+ *   primary key parsed from the URL segment.
+ * @throws when Supabase env vars are missing (misconfigured deploy).
+ *   Domain failures are returned as JSON responses, not thrown.
+ */
+export async function DELETE(_request: NextRequest, ctx: Context): Promise<NextResponse> {
+  const auth = await requireAdmin()
+  if (!auth.ok) return auth.response
+
+  const { id } = await ctx.params
+  if (!UUID_REGEX.test(id)) {
+    return NextResponse.json({ error: 'id must be a UUID.' }, { status: 400 })
+  }
+
+  const supabase = createAdminSupabaseClient()
+  const { data, error } = await supabase
+    .from('weight_room_sets')
+    .delete()
+    .eq('id', id)
+    .select()
+    .maybeSingle()
+
+  if (error) {
+    return NextResponse.json(
+      { error: `Failed to delete set: ${error.message}` },
+      { status: 500 },
+    )
+  }
+  if (!data) {
+    return NextResponse.json({ error: `No set for id '${id}'.` }, { status: 404 })
+  }
+  return NextResponse.json(data, { status: 200 })
+}

--- a/app/api/admin/weight-room/sets/route.test.ts
+++ b/app/api/admin/weight-room/sets/route.test.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextResponse } from 'next/server'
+
+import { POST } from './route'
+
+/**
+ * Tests for `POST /api/admin/weight-room/sets`. Both the auth gate and
+ * the Supabase service-role client are mocked so the route's own logic
+ * (JSON parsing, Zod validation, FK-violation mapping, default
+ * `logged_at`) is exercised in isolation.
+ */
+
+const requireAdminMock = vi.fn()
+vi.mock('@/lib/auth/require-admin', () => ({
+  requireAdmin: () => requireAdminMock(),
+}))
+
+const insertMock = vi.fn()
+const supabaseChain = {
+  from: vi.fn(() => supabaseChain),
+  insert: vi.fn(() => supabaseChain),
+  select: vi.fn(() => supabaseChain),
+  single: vi.fn(() => insertMock()),
+}
+vi.mock('@/lib/supabase/admin', () => ({
+  createAdminSupabaseClient: () => supabaseChain,
+}))
+
+beforeEach(() => {
+  requireAdminMock.mockReset()
+  insertMock.mockReset()
+  supabaseChain.from.mockClear()
+  supabaseChain.insert.mockClear()
+  supabaseChain.select.mockClear()
+  supabaseChain.single.mockClear()
+  supabaseChain.from.mockReturnValue(supabaseChain)
+  supabaseChain.insert.mockReturnValue(supabaseChain)
+  supabaseChain.select.mockReturnValue(supabaseChain)
+  supabaseChain.single.mockImplementation(() => insertMock())
+})
+
+function makeRequest(body: unknown): Request {
+  return new Request('http://localhost/api/admin/weight-room/sets', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: typeof body === 'string' ? body : JSON.stringify(body),
+  })
+}
+
+describe('POST /api/admin/weight-room/sets', () => {
+  it('returns 401 when not signed in', async () => {
+    requireAdminMock.mockResolvedValueOnce({
+      ok: false,
+      response: NextResponse.json({ error: 'Sign in required.' }, { status: 401 }),
+    })
+    const res = await POST(makeRequest({ exercise: 'pushups', reps: 25 }) as never)
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 403 when not on the allowlist', async () => {
+    requireAdminMock.mockResolvedValueOnce({
+      ok: false,
+      response: NextResponse.json({ error: 'Admin only.' }, { status: 403 }),
+    })
+    const res = await POST(makeRequest({ exercise: 'pushups', reps: 25 }) as never)
+    expect(res.status).toBe(403)
+  })
+
+  it('returns 400 when the body is not valid JSON', async () => {
+    requireAdminMock.mockResolvedValue({ ok: true, email: 'a@b.com' })
+    const res = await POST(makeRequest('not-json') as never)
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 with Zod issues when reps is missing', async () => {
+    requireAdminMock.mockResolvedValue({ ok: true, email: 'a@b.com' })
+    const res = await POST(makeRequest({ exercise: 'pushups' }) as never)
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.error).toMatch(/validation failed/i)
+  })
+
+  it('returns 400 when reps is not positive', async () => {
+    requireAdminMock.mockResolvedValue({ ok: true, email: 'a@b.com' })
+    const res = await POST(makeRequest({ exercise: 'pushups', reps: 0 }) as never)
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 409 on FK violation (exercise not in goals)', async () => {
+    requireAdminMock.mockResolvedValue({ ok: true, email: 'a@b.com' })
+    insertMock.mockResolvedValueOnce({
+      data: null,
+      error: { code: '23503', message: 'foreign key violation' },
+    })
+    const res = await POST(makeRequest({ exercise: 'unknown', reps: 25 }) as never)
+    expect(res.status).toBe(409)
+  })
+
+  it('returns 500 on unexpected Supabase errors', async () => {
+    requireAdminMock.mockResolvedValue({ ok: true, email: 'a@b.com' })
+    insertMock.mockResolvedValueOnce({
+      data: null,
+      error: { code: 'XX001', message: 'data corruption' },
+    })
+    const res = await POST(makeRequest({ exercise: 'pushups', reps: 25 }) as never)
+    expect(res.status).toBe(500)
+  })
+
+  it('returns 201 with the inserted row on success and defaults logged_at', async () => {
+    requireAdminMock.mockResolvedValue({ ok: true, email: 'a@b.com' })
+    const insertedRow = {
+      id: '11111111-1111-4111-8111-111111111111',
+      logged_at: '2026-05-07T08:00:00Z',
+      exercise: 'pushups',
+      reps: 25,
+    }
+    insertMock.mockResolvedValueOnce({ data: insertedRow, error: null })
+    const res = await POST(makeRequest({ exercise: 'pushups', reps: 25 }) as never)
+    expect(res.status).toBe(201)
+    const body = await res.json()
+    expect(body).toEqual(insertedRow)
+    // logged_at was defaulted in the insert call.
+    expect(supabaseChain.insert).toHaveBeenCalledWith(
+      expect.objectContaining({ exercise: 'pushups', reps: 25, logged_at: expect.any(String) }),
+    )
+  })
+})

--- a/app/api/admin/weight-room/sets/route.ts
+++ b/app/api/admin/weight-room/sets/route.ts
@@ -1,0 +1,90 @@
+/**
+ * Admin-only collection endpoint for Weight Room set inserts (#79).
+ *
+ * The Today View's quick-log writes here whenever the admin taps a set
+ * count. RLS on `weight_room_sets` permits SELECT only, so writes
+ * funnel through this gate via the service-role client.
+ *
+ * Pair with `[id]/route.ts` for DELETE.
+ */
+
+import { NextResponse, type NextRequest } from 'next/server'
+import { ZodError } from 'zod'
+
+import { requireAdmin } from '@/lib/auth/require-admin'
+import { WeightRoomSetCreateSchema } from '@/lib/schemas/weight-room'
+import { createAdminSupabaseClient } from '@/lib/supabase/admin'
+
+/**
+ * Insert a new strength set. Body must conform to
+ * {@link WeightRoomSetCreateSchema} — `exercise` and `reps` required;
+ * `logged_at` optional (defaults to `now()` when omitted).
+ *
+ * Status codes:
+ * - 201 — created (response echoes the row)
+ * - 400 — payload failed Zod validation or wasn't valid JSON
+ * - 401 — not signed in
+ * - 403 — signed in but email not on the allowlist
+ * - 409 — `exercise` doesn't exist in `weight_room_goals` (FK violation;
+ *   add it via the settings UI first)
+ * - 500 — unexpected Supabase error
+ *
+ * @param request Incoming JSON request whose body matches
+ *   {@link WeightRoomSetCreateSchema}.
+ * @throws when Supabase env vars are missing (misconfigured deploy).
+ *   Domain failures are returned as JSON responses, not thrown.
+ */
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const auth = await requireAdmin()
+  if (!auth.ok) return auth.response
+
+  let payload: unknown
+  try {
+    payload = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Body must be valid JSON.' }, { status: 400 })
+  }
+
+  let entry
+  try {
+    entry = WeightRoomSetCreateSchema.parse(payload)
+  } catch (err) {
+    if (err instanceof ZodError) {
+      return NextResponse.json(
+        { error: 'Validation failed.', issues: err.flatten() },
+        { status: 400 },
+      )
+    }
+    throw err
+  }
+
+  const supabase = createAdminSupabaseClient()
+  const insertRow = {
+    exercise: entry.exercise,
+    reps: entry.reps,
+    logged_at: entry.logged_at ?? new Date().toISOString(),
+  }
+  const { data, error } = await supabase
+    .from('weight_room_sets')
+    .insert(insertRow)
+    .select()
+    .single()
+
+  if (error) {
+    // Postgres FK violation — exercise isn't in weight_room_goals.
+    if (error.code === '23503') {
+      return NextResponse.json(
+        {
+          error: `Exercise '${entry.exercise}' is not configured. Add it via the settings UI before logging sets.`,
+        },
+        { status: 409 },
+      )
+    }
+    return NextResponse.json(
+      { error: `Failed to insert set: ${error.message}` },
+      { status: 500 },
+    )
+  }
+
+  return NextResponse.json(data, { status: 201 })
+}

--- a/app/training-facility/weight-room/settings/page.tsx
+++ b/app/training-facility/weight-room/settings/page.tsx
@@ -1,0 +1,84 @@
+import type { JSX } from 'react'
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+
+import { BackToCourtButton } from '@/components/common/BackToCourtButton'
+import { StrengthSettings } from '@/components/training-facility/weight-room/StrengthSettings'
+import { isAdminEmail } from '@/lib/auth/admin-allowlist'
+import { getWeightRoomDataServer } from '@/lib/data/weight-room-server'
+import { isTrainingFacilityEnabled } from '@/lib/feature-flags'
+import { createServerSupabaseClient } from '@/lib/supabase/server'
+
+/**
+ * Weight Room settings page (#79). Admin-only — non-admins get a 404
+ * via `notFound()` so the route doesn't even hint at its existence to
+ * unauthenticated viewers.
+ *
+ * Server Component because the admin check has to run server-side
+ * (`ADMIN_EMAILS` is intentionally not a `NEXT_PUBLIC_*` var, so the
+ * allowlist never reaches the browser bundle). The actual editor UI is
+ * a client component that posts to the admin API routes — see
+ * {@link StrengthSettings}.
+ *
+ * Goals are read server-side and passed to the client island so the
+ * form hydrates with current values; the client refreshes via
+ * `router.refresh()` after each mutation to pick up the new state.
+ */
+export default async function WeightRoomSettingsPage(): Promise<JSX.Element> {
+  if (!isTrainingFacilityEnabled()) notFound()
+
+  // Server-side admin gate. Mirrors `requireAdmin` from the API routes
+  // but routes a hard 404 instead of a JSON error — pages don't have a
+  // status-code response model the same way handlers do.
+  const supabase = await createServerSupabaseClient()
+  const { data: userRes } = await supabase.auth.getUser()
+  if (!isAdminEmail(userRes?.user?.email)) {
+    notFound()
+  }
+
+  // Catch transient read errors so a flaky Supabase response surfaces
+  // as an empty editor instead of 500ing the whole page. The Settings
+  // UI handles `goals: []` gracefully (renders the add-exercise form
+  // without an existing-goal table).
+  const data = await getWeightRoomDataServer().catch(() => null)
+  const goals = data?.goals ?? []
+
+  return (
+    <div className="relative min-h-svh overflow-hidden bg-[#120d0a] text-[#f7ead9]">
+      <div
+        aria-hidden="true"
+        className="absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(248,214,170,0.16),transparent_30%),linear-gradient(180deg,#241811_0%,#120d0a_55%,#0b0806_100%)]"
+      />
+
+      <div className="relative z-10 mx-auto flex min-h-svh w-full max-w-3xl flex-col px-4 py-6 sm:px-6 sm:py-8 lg:px-10">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <BackToCourtButton />
+          <Link
+            href="/training-facility"
+            className="rounded-full border border-white/15 bg-white/5 px-4 py-2 text-xs font-semibold uppercase tracking-[0.28em] text-white/80 transition hover:bg-white/10"
+          >
+            ← Training Facility
+          </Link>
+        </div>
+
+        <header className="mt-12">
+          <p className="font-mono text-[11px] uppercase tracking-[0.32em] text-amber-300/80">
+            Weight Room · Settings
+          </p>
+          <h1 className="mt-2 text-3xl font-black uppercase tracking-[0.06em] text-[#fff7ec] sm:text-5xl">
+            Goals &amp; exercises
+          </h1>
+          <p className="mt-3 max-w-xl text-sm leading-7 text-[#e8d5be] sm:text-base">
+            Daily targets and display colors for the activity rings and
+            heatmap. Add new exercises here — the rings populate live as
+            soon as you log a set.
+          </p>
+        </header>
+
+        <section className="mt-10">
+          <StrengthSettings initialGoals={goals} />
+        </section>
+      </div>
+    </div>
+  )
+}

--- a/components/training-facility/weight-room/StrengthSettings.tsx
+++ b/components/training-facility/weight-room/StrengthSettings.tsx
@@ -1,0 +1,254 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import { useState, useTransition, type FormEvent, type JSX } from 'react'
+
+import type { ExerciseGoal } from '@/types/weight-room'
+
+/** Props for {@link StrengthSettings}. */
+export interface StrengthSettingsProps {
+  /**
+   * Goals as read by the server component on first paint. The form
+   * hydrates from this list; mutations refresh via `router.refresh()`
+   * so the next render comes from a fresh server fetch (no client
+   * cache to invalidate).
+   */
+  initialGoals: readonly ExerciseGoal[]
+}
+
+const DEFAULT_NEW_COLOR = '#EA580C'
+
+/**
+ * Admin-only Weight Room goal editor (#79). Renders the existing
+ * goals as an editable list (target + color) and offers a small form
+ * to add new exercises. Each mutation hits the matching admin API
+ * route under `/api/admin/weight-room/goals`; on success the parent
+ * page's server data refreshes via `router.refresh()` so the next
+ * render reflects the new state without a manual reload.
+ *
+ * Mobile-first per the issue body — the layout stacks single-column
+ * with large touch targets so the editor works on the same phone the
+ * user logs sets from.
+ */
+export function StrengthSettings({ initialGoals }: StrengthSettingsProps): JSX.Element {
+  const router = useRouter()
+  const [error, setError] = useState<string | null>(null)
+  const [isPending, startTransition] = useTransition()
+
+  function refresh(): void {
+    startTransition(() => {
+      router.refresh()
+    })
+  }
+
+  async function postGoal(goal: ExerciseGoal): Promise<void> {
+    setError(null)
+    const res = await fetch('/api/admin/weight-room/goals', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(goal),
+    })
+    if (!res.ok) {
+      const body = (await res.json().catch(() => ({}))) as { error?: string }
+      setError(body.error ?? `Save failed (${res.status})`)
+      return
+    }
+    refresh()
+  }
+
+  async function deleteGoal(exercise: string): Promise<void> {
+    setError(null)
+    const ok = window.confirm(
+      `Delete "${exercise}"? This also removes every set logged for it.`,
+    )
+    if (!ok) return
+    const res = await fetch(
+      `/api/admin/weight-room/goals/${encodeURIComponent(exercise)}`,
+      { method: 'DELETE' },
+    )
+    if (!res.ok) {
+      const body = (await res.json().catch(() => ({}))) as { error?: string }
+      setError(body.error ?? `Delete failed (${res.status})`)
+      return
+    }
+    refresh()
+  }
+
+  return (
+    <div className="space-y-8">
+      {error ? (
+        <p
+          role="alert"
+          className="rounded border border-rose-400/30 bg-rose-950/40 px-3 py-2 font-mono text-[12px] text-rose-200"
+        >
+          {error}
+        </p>
+      ) : null}
+
+      <section aria-label="Existing exercises">
+        <h2 className="font-mono text-[11px] uppercase tracking-[0.32em] text-amber-300/80">
+          Exercises
+        </h2>
+        {initialGoals.length === 0 ? (
+          <p className="mt-3 text-sm text-[#e8d5be]/70">
+            No exercises yet — add one below to start logging sets.
+          </p>
+        ) : (
+          <ul className="mt-3 space-y-3">
+            {initialGoals.map((goal) => (
+              <GoalRow
+                key={goal.exercise}
+                goal={goal}
+                disabled={isPending}
+                onSave={postGoal}
+                onDelete={deleteGoal}
+              />
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <section aria-label="Add a new exercise">
+        <h2 className="font-mono text-[11px] uppercase tracking-[0.32em] text-amber-300/80">
+          Add exercise
+        </h2>
+        <AddGoalForm disabled={isPending} onAdd={postGoal} />
+      </section>
+    </div>
+  )
+}
+
+interface GoalRowProps {
+  goal: ExerciseGoal
+  disabled: boolean
+  onSave: (goal: ExerciseGoal) => Promise<void>
+  onDelete: (exercise: string) => Promise<void>
+}
+
+function GoalRow({ goal, disabled, onSave, onDelete }: GoalRowProps): JSX.Element {
+  const [target, setTarget] = useState<number>(goal.daily_target)
+  const [color, setColor] = useState<string>(goal.color)
+  const dirty = target !== goal.daily_target || color !== goal.color
+
+  async function handleSubmit(e: FormEvent<HTMLFormElement>): Promise<void> {
+    e.preventDefault()
+    if (!dirty) return
+    await onSave({ exercise: goal.exercise, daily_target: target, color })
+  }
+
+  return (
+    <li className="rounded-[1.1rem] border border-white/10 bg-white/5 p-4">
+      <form
+        onSubmit={handleSubmit}
+        className="flex flex-wrap items-center gap-3 sm:gap-4"
+      >
+        <span className="font-mono text-sm font-semibold uppercase tracking-[0.18em] text-white">
+          {goal.exercise}
+        </span>
+        <label className="flex items-center gap-2 text-xs text-white/70">
+          <span className="font-mono uppercase tracking-[0.18em]">target</span>
+          <input
+            type="number"
+            min={1}
+            value={target}
+            onChange={(e) => setTarget(Number(e.target.value))}
+            className="w-20 rounded border border-white/15 bg-black/40 px-2 py-1 text-right font-mono text-sm text-white focus:border-amber-300/60 focus:outline-none"
+          />
+        </label>
+        <label className="flex items-center gap-2 text-xs text-white/70">
+          <span className="font-mono uppercase tracking-[0.18em]">color</span>
+          <input
+            type="color"
+            value={color}
+            onChange={(e) => setColor(e.target.value)}
+            className="h-8 w-12 cursor-pointer rounded border border-white/15 bg-black/40"
+          />
+        </label>
+        <div className="ml-auto flex gap-2">
+          <button
+            type="submit"
+            disabled={disabled || !dirty}
+            className="rounded-full border border-amber-200/30 bg-amber-200/10 px-4 py-1.5 font-mono text-[11px] uppercase tracking-[0.22em] text-amber-100 transition hover:bg-amber-200/20 disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            Save
+          </button>
+          <button
+            type="button"
+            disabled={disabled}
+            onClick={() => onDelete(goal.exercise)}
+            className="rounded-full border border-rose-300/25 bg-rose-300/5 px-4 py-1.5 font-mono text-[11px] uppercase tracking-[0.22em] text-rose-200 transition hover:bg-rose-300/15 disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            Delete
+          </button>
+        </div>
+      </form>
+    </li>
+  )
+}
+
+interface AddGoalFormProps {
+  disabled: boolean
+  onAdd: (goal: ExerciseGoal) => Promise<void>
+}
+
+function AddGoalForm({ disabled, onAdd }: AddGoalFormProps): JSX.Element {
+  const [exercise, setExercise] = useState<string>('')
+  const [target, setTarget] = useState<number>(50)
+  const [color, setColor] = useState<string>(DEFAULT_NEW_COLOR)
+
+  async function handleSubmit(e: FormEvent<HTMLFormElement>): Promise<void> {
+    e.preventDefault()
+    const trimmed = exercise.trim().toLowerCase()
+    if (trimmed.length === 0) return
+    await onAdd({ exercise: trimmed, daily_target: target, color })
+    setExercise('')
+    setTarget(50)
+    setColor(DEFAULT_NEW_COLOR)
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="mt-3 grid gap-3 rounded-[1.1rem] border border-white/10 bg-white/5 p-4 sm:grid-cols-[1fr_auto_auto_auto] sm:items-end"
+    >
+      <label className="flex flex-col gap-1 text-xs text-white/70">
+        <span className="font-mono uppercase tracking-[0.18em]">exercise</span>
+        <input
+          type="text"
+          required
+          value={exercise}
+          onChange={(e) => setExercise(e.target.value)}
+          placeholder="dips"
+          autoCapitalize="none"
+          className="rounded border border-white/15 bg-black/40 px-2 py-1.5 font-mono text-sm text-white focus:border-amber-300/60 focus:outline-none"
+        />
+      </label>
+      <label className="flex flex-col gap-1 text-xs text-white/70">
+        <span className="font-mono uppercase tracking-[0.18em]">target</span>
+        <input
+          type="number"
+          min={1}
+          value={target}
+          onChange={(e) => setTarget(Number(e.target.value))}
+          className="w-24 rounded border border-white/15 bg-black/40 px-2 py-1.5 text-right font-mono text-sm text-white focus:border-amber-300/60 focus:outline-none"
+        />
+      </label>
+      <label className="flex flex-col gap-1 text-xs text-white/70">
+        <span className="font-mono uppercase tracking-[0.18em]">color</span>
+        <input
+          type="color"
+          value={color}
+          onChange={(e) => setColor(e.target.value)}
+          className="h-9 w-16 cursor-pointer rounded border border-white/15 bg-black/40"
+        />
+      </label>
+      <button
+        type="submit"
+        disabled={disabled || exercise.trim().length === 0}
+        className="rounded-full border border-amber-200/30 bg-amber-200/10 px-5 py-2 font-mono text-[11px] uppercase tracking-[0.22em] text-amber-100 transition hover:bg-amber-200/20 disabled:cursor-not-allowed disabled:opacity-40"
+      >
+        Add
+      </button>
+    </form>
+  )
+}

--- a/lib/data/weight-room-server.ts
+++ b/lib/data/weight-room-server.ts
@@ -1,0 +1,30 @@
+import 'server-only'
+
+import { createServerSupabaseClient } from '@/lib/supabase/server'
+import type { WeightRoomData } from '@/types/weight-room'
+
+import { assembleWeightRoomData } from './weight-room-shared'
+
+/**
+ * Server-side Weight Room dataset reader (#79) for Server Components
+ * and route handlers. Mirrors the browser-facing {@link import('./weight-room').getWeightRoomData}
+ * but pulls the per-request Supabase client (anon role + cookie auth)
+ * from `lib/supabase/server.ts`. The query / validation / shape
+ * assembly live in {@link assembleWeightRoomData}
+ * (`./weight-room-shared`), so the two read paths can't drift.
+ *
+ * Returns `null` when both tables are empty (typical pre-baseline
+ * state — the migration seeds two default goals so this branch is
+ * rare in practice). Callers should fall back to placeholder fixtures
+ * rather than treating it as an error.
+ *
+ * `server-only` guards against accidental client imports — Next will
+ * compile-error rather than ship the cookie-aware client to the browser.
+ *
+ * @throws See {@link assembleWeightRoomData} — Supabase query failures
+ *   or row-shape validation errors.
+ */
+export async function getWeightRoomDataServer(): Promise<WeightRoomData | null> {
+  const supabase = await createServerSupabaseClient()
+  return assembleWeightRoomData(supabase)
+}

--- a/lib/data/weight-room-shared.ts
+++ b/lib/data/weight-room-shared.ts
@@ -1,0 +1,137 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { z } from 'zod'
+
+import {
+  WeightRoomGoalRowSchema,
+  WeightRoomSetRowSchema,
+  goalRowToExerciseGoal,
+  setRowToStrengthSet,
+} from '@/lib/schemas/weight-room'
+import type { WeightRoomData } from '@/types/weight-room'
+
+/**
+ * Pure Weight Room read helpers shared between the browser entry
+ * (`lib/data/weight-room.ts`) and the server entry
+ * (`lib/data/weight-room-server.ts`).
+ *
+ * Mirrors the cardio assembler pattern (`lib/data/cardio-shared.ts`):
+ * the entry files own the Supabase client wiring, this module owns the
+ * column whitelist + row validation + shape assembly, and the two
+ * sides can't drift on what gets read or how it's parsed.
+ */
+
+const SETS_TABLE = 'weight_room_sets'
+const GOALS_TABLE = 'weight_room_goals'
+
+/** Whitelisted column lists for each table; `updated_at` rides along for `imported_at` computation. */
+const SETS_COLUMNS = 'id, logged_at, exercise, reps, updated_at'
+const GOALS_COLUMNS = 'exercise, daily_target, color, updated_at'
+
+const WeightRoomSetRowsSchema = z.array(WeightRoomSetRowSchema)
+const WeightRoomGoalRowsSchema = z.array(WeightRoomGoalRowSchema)
+
+/**
+ * Fetch the full Weight Room dataset from Supabase using the supplied
+ * client. Shared between `getWeightRoomData` (browser) and
+ * `getWeightRoomDataServer` (server) so the two read paths can't drift
+ * in column whitelist, validation, or shape assembly.
+ *
+ * Queries both tables in parallel, normalizes Postgres `null` to absent
+ * (the row schemas declare optional fields with `.optional()`, not
+ * `.nullable()`), validates each table against its row-shape schema,
+ * and assembles the result into the public {@link WeightRoomData} shape.
+ *
+ * Returns `null` when both tables are empty — preserves the
+ * "no data yet" contract so detail views can substitute placeholder
+ * fixtures rather than treating it as an error. Note that the migration
+ * seeds two default goals (`pushups`, `pullups`), so in practice the
+ * goals table is never empty after the migration is applied; this null
+ * branch covers the pre-migration state and the case where every
+ * default goal has been deleted via the settings UI.
+ *
+ * `imported_at` is computed as `MAX(updated_at)` across both tables.
+ *
+ * @param supabase Either the browser or the server SSR client. Both
+ *   use the anon role; Weight Room RLS allows anon SELECT.
+ * @throws when either Supabase query fails (network / misconfigured env
+ *   / RLS regression) or when row-shape validation fails. Callers
+ *   usually downgrade this to an empty render.
+ */
+export async function assembleWeightRoomData(
+  supabase: SupabaseClient,
+): Promise<WeightRoomData | null> {
+  const [setsRes, goalsRes] = await Promise.all([
+    supabase.from(SETS_TABLE).select(SETS_COLUMNS).order('logged_at', { ascending: true }),
+    supabase.from(GOALS_TABLE).select(GOALS_COLUMNS).order('exercise', { ascending: true }),
+  ])
+
+  if (setsRes.error) {
+    throw new Error(`Failed to load weight room sets: ${setsRes.error.message}`)
+  }
+  if (goalsRes.error) {
+    throw new Error(`Failed to load weight room goals: ${goalsRes.error.message}`)
+  }
+
+  const setsRaw = (setsRes.data ?? []) as unknown as Array<Record<string, unknown>>
+  const goalsRaw = (goalsRes.data ?? []) as unknown as Array<Record<string, unknown>>
+
+  // Compute imported_at before stripping `updated_at` — that column lives
+  // on every row but isn't part of the row-shape schema (`.strict()`
+  // would reject it).
+  const importedAt = computeImportedAt([setsRaw, goalsRaw])
+
+  if (setsRaw.length === 0 && goalsRaw.length === 0) {
+    return null
+  }
+
+  const setsParsed = WeightRoomSetRowsSchema.safeParse(setsRaw.map(stripUpdatedAt))
+  if (!setsParsed.success) {
+    throw new Error(`weight_room_sets failed schema validation: ${setsParsed.error.message}`)
+  }
+  const goalsParsed = WeightRoomGoalRowsSchema.safeParse(goalsRaw.map(stripUpdatedAt))
+  if (!goalsParsed.success) {
+    throw new Error(`weight_room_goals failed schema validation: ${goalsParsed.error.message}`)
+  }
+
+  return {
+    imported_at: importedAt,
+    sets: setsParsed.data.map(setRowToStrengthSet),
+    goals: goalsParsed.data.map(goalRowToExerciseGoal),
+  }
+}
+
+/**
+ * Drop the `updated_at` audit column before Zod-parsing. The row
+ * schemas use `.strict()`, which would otherwise reject the column —
+ * but we still need it on the raw row to compute `imported_at`, so the
+ * caller pulls it off the un-stripped rows first.
+ */
+function stripUpdatedAt(row: Record<string, unknown>): Record<string, unknown> {
+  if (!('updated_at' in row)) return row
+  const { updated_at: _ignored, ...rest } = row
+  return rest
+}
+
+/**
+ * Determine `imported_at` from the latest `updated_at` across both
+ * tables. Returns `''` when no rows have an `updated_at` value — same
+ * fallback components already use for the "no data yet" state on the
+ * cardio side.
+ *
+ * Lexicographic string compare is safe here because PostgREST returns
+ * every `timestamptz` in the same canonical UTC form
+ * (`YYYY-MM-DDTHH:MM:SS.uuuuuu+00:00`), which sorts by actual time
+ * without parsing.
+ */
+function computeImportedAt(rowGroups: Array<Array<Record<string, unknown>>>): string {
+  let latest = ''
+  for (const rows of rowGroups) {
+    for (const row of rows) {
+      const value = row.updated_at
+      if (typeof value === 'string' && value > latest) {
+        latest = value
+      }
+    }
+  }
+  return latest
+}

--- a/lib/data/weight-room.test.ts
+++ b/lib/data/weight-room.test.ts
@@ -1,0 +1,202 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { getWeightRoomData } from './weight-room'
+
+/**
+ * Read-path tests for the Weight Room data layer (#79). Mocks the
+ * browser Supabase client and tracks per-table fake queries so each
+ * assertion can stub `weight_room_sets` and `weight_room_goals`
+ * results independently.
+ *
+ * Sibling pattern: `lib/data/cardio.test.ts`.
+ */
+
+interface FakeQuery {
+  select: ReturnType<typeof vi.fn>
+  order: ReturnType<typeof vi.fn>
+}
+
+const queriesByTable: Record<string, FakeQuery> = {}
+const fromMock = vi.fn((table: string): FakeQuery => {
+  if (!queriesByTable[table]) {
+    const query: FakeQuery = {
+      select: vi.fn(),
+      order: vi.fn(),
+    }
+    query.select.mockReturnValue(query)
+    query.order.mockResolvedValue({ data: [], error: null })
+    queriesByTable[table] = query
+  }
+  return queriesByTable[table]
+})
+const browserClientMock = { from: fromMock }
+
+vi.mock('@/lib/supabase/browser', () => ({
+  getBrowserSupabaseClient: () => browserClientMock,
+}))
+
+beforeEach(() => {
+  for (const key of Object.keys(queriesByTable)) {
+    delete queriesByTable[key]
+  }
+  fromMock.mockClear()
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+function stubTable(
+  table: string,
+  data: Array<Record<string, unknown>> | null,
+  error: unknown = null,
+): void {
+  const query = fromMock(table)
+  query.order.mockReset()
+  query.order.mockResolvedValue({ data, error })
+}
+
+describe('getWeightRoomData', () => {
+  it('returns null when both tables are empty', async () => {
+    stubTable('weight_room_sets', [])
+    stubTable('weight_room_goals', [])
+    fromMock.mockClear()
+
+    await expect(getWeightRoomData()).resolves.toBeNull()
+
+    expect(fromMock).toHaveBeenCalledWith('weight_room_sets')
+    expect(fromMock).toHaveBeenCalledWith('weight_room_goals')
+  })
+
+  it('orders sets by logged_at ascending and goals by exercise ascending', async () => {
+    stubTable('weight_room_sets', [])
+    stubTable('weight_room_goals', [])
+    await getWeightRoomData()
+
+    expect(queriesByTable.weight_room_sets.order).toHaveBeenCalledWith('logged_at', {
+      ascending: true,
+    })
+    expect(queriesByTable.weight_room_goals.order).toHaveBeenCalledWith('exercise', {
+      ascending: true,
+    })
+  })
+
+  it('assembles the WeightRoomData shape', async () => {
+    stubTable(
+      'weight_room_sets',
+      [
+        {
+          id: '11111111-1111-4111-8111-111111111111',
+          logged_at: '2026-05-07T08:00:00Z',
+          exercise: 'pushups',
+          reps: 25,
+          updated_at: '2026-05-07T08:00:01Z',
+        },
+      ],
+    )
+    stubTable(
+      'weight_room_goals',
+      [
+        {
+          exercise: 'pushups',
+          daily_target: 100,
+          color: '#EA580C',
+          updated_at: '2026-05-07T08:00:00Z',
+        },
+        {
+          exercise: 'pullups',
+          daily_target: 30,
+          color: '#0EA5A1',
+          updated_at: '2026-05-07T08:00:00Z',
+        },
+      ],
+    )
+
+    const data = await getWeightRoomData()
+    expect(data).toEqual({
+      imported_at: '2026-05-07T08:00:01Z',
+      sets: [
+        {
+          id: '11111111-1111-4111-8111-111111111111',
+          logged_at: '2026-05-07T08:00:00Z',
+          exercise: 'pushups',
+          reps: 25,
+        },
+      ],
+      goals: [
+        { exercise: 'pushups', daily_target: 100, color: '#EA580C' },
+        { exercise: 'pullups', daily_target: 30, color: '#0EA5A1' },
+      ],
+    })
+  })
+
+  it('imported_at takes the latest updated_at across both tables', async () => {
+    stubTable(
+      'weight_room_sets',
+      [
+        {
+          id: '11111111-1111-4111-8111-111111111111',
+          logged_at: '2026-05-07T08:00:00Z',
+          exercise: 'pushups',
+          reps: 25,
+          updated_at: '2026-05-07T08:00:01Z',
+        },
+      ],
+    )
+    stubTable(
+      'weight_room_goals',
+      [
+        {
+          exercise: 'pushups',
+          daily_target: 100,
+          color: '#EA580C',
+          updated_at: '2026-05-07T09:30:00Z',
+        },
+      ],
+    )
+
+    const data = await getWeightRoomData()
+    expect(data?.imported_at).toBe('2026-05-07T09:30:00Z')
+  })
+
+  it('throws a descriptive error when the sets query fails', async () => {
+    stubTable('weight_room_sets', null, { message: 'JWT expired' })
+    stubTable('weight_room_goals', [])
+    await expect(getWeightRoomData()).rejects.toThrow(/JWT expired/)
+  })
+
+  it('throws a descriptive error when the goals query fails', async () => {
+    stubTable('weight_room_sets', [])
+    stubTable('weight_room_goals', null, { message: 'permission denied' })
+    await expect(getWeightRoomData()).rejects.toThrow(/permission denied/)
+  })
+
+  it('throws when a row fails schema validation (e.g. negative reps)', async () => {
+    stubTable(
+      'weight_room_sets',
+      [
+        {
+          id: '11111111-1111-4111-8111-111111111111',
+          logged_at: '2026-05-07T08:00:00Z',
+          exercise: 'pushups',
+          reps: -5, // CHECK constraint blocks at DB level, but defense-in-depth at the schema too.
+          updated_at: '2026-05-07T08:00:00Z',
+        },
+      ],
+    )
+    stubTable(
+      'weight_room_goals',
+      [
+        {
+          exercise: 'pushups',
+          daily_target: 100,
+          color: '#EA580C',
+          updated_at: '2026-05-07T08:00:00Z',
+        },
+      ],
+    )
+    await expect(getWeightRoomData()).rejects.toThrow(
+      /weight_room_sets failed schema validation/,
+    )
+  })
+})

--- a/lib/data/weight-room.ts
+++ b/lib/data/weight-room.ts
@@ -1,0 +1,25 @@
+import { getBrowserSupabaseClient } from '@/lib/supabase/browser'
+import type { WeightRoomData } from '@/types/weight-room'
+
+import { assembleWeightRoomData } from './weight-room-shared'
+
+/**
+ * Browser-side Weight Room dataset reader (#79). Wraps the shared
+ * {@link assembleWeightRoomData} helper with the cached browser
+ * Supabase client.
+ *
+ * Component-side data islands (Today View, History View — slices #80
+ * and #81) call this from a client effect; the SSR side uses
+ * `getWeightRoomDataServer` in `lib/data/weight-room-server.ts`.
+ *
+ * Both entries delegate to `assembleWeightRoomData` in
+ * `lib/data/weight-room-shared.ts`, so the read shape, column
+ * whitelist, and validation can't drift between server and client.
+ *
+ * @throws See {@link assembleWeightRoomData} — Supabase query failures
+ *   or row-shape validation errors. Callers usually downgrade this to
+ *   an empty render via `?? { imported_at: '', sets: [], goals: [] }`.
+ */
+export async function getWeightRoomData(): Promise<WeightRoomData | null> {
+  return assembleWeightRoomData(getBrowserSupabaseClient())
+}

--- a/lib/schemas/weight-room.ts
+++ b/lib/schemas/weight-room.ts
@@ -1,0 +1,105 @@
+/**
+ * Pure (isomorphic) Zod schemas for the Weight Room Supabase row contract
+ * (#79). Used by the data layer (`lib/data/weight-room*.ts`) on read and
+ * by the admin write API routes (`app/api/admin/weight-room/*`) on write.
+ *
+ * Sibling pattern: `lib/schemas/cardio.ts`, `lib/schemas/movement.ts`.
+ *
+ * The static {@link import('@/types/weight-room').WeightRoomData} types
+ * mirror these schemas for IDE ergonomics — when the schema changes,
+ * update the static types so component-side `Cmd+hover` stays accurate.
+ */
+
+import { z } from 'zod'
+
+import type { ExerciseGoal, StrengthSet } from '@/types/weight-room'
+
+/**
+ * Hex-color regex used for the per-exercise display token. Loose enough
+ * to accept the existing palette (`#EA580C`, `#0EA5A1`) without tying
+ * the schema to a closed enum — adding a new exercise + color via the
+ * settings UI shouldn't require a schema bump.
+ */
+const HEX_COLOR_REGEX = /^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/
+
+/**
+ * Zod schema for one row of `public.weight_room_sets`. Mirrors the
+ * table definition in
+ * `supabase/migrations/20260507120000_weight_room_tables.sql`.
+ *
+ * `id` is a UUID generated server-side; the API never accepts a
+ * client-supplied id. `logged_at` is an ISO timestamp string from the
+ * `timestamptz` column. `reps` is a positive integer.
+ */
+export const WeightRoomSetRowSchema = z
+  .object({
+    id: z.string().uuid(),
+    logged_at: z.string().min(1, 'logged_at must be an ISO timestamp'),
+    exercise: z.string().min(1),
+    reps: z.number().int().positive(),
+  })
+  .strict()
+
+/** Validated `weight_room_sets` row inferred from {@link WeightRoomSetRowSchema}. */
+export type WeightRoomSetRow = z.infer<typeof WeightRoomSetRowSchema>
+
+/**
+ * Zod schema for one row of `public.weight_room_goals`. Settings UI
+ * upserts via `POST /api/admin/weight-room/goals`; the row schema
+ * doubles as the request-body validator there.
+ */
+export const WeightRoomGoalRowSchema = z
+  .object({
+    exercise: z.string().min(1),
+    daily_target: z.number().int().positive(),
+    color: z.string().regex(HEX_COLOR_REGEX, 'color must be a hex string like #EA580C'),
+  })
+  .strict()
+
+/** Validated `weight_room_goals` row inferred from {@link WeightRoomGoalRowSchema}. */
+export type WeightRoomGoalRow = z.infer<typeof WeightRoomGoalRowSchema>
+
+/**
+ * Request-body schema for `POST /api/admin/weight-room/sets`. Accepts
+ * the exercise + reps pair; `logged_at` is optional (the API defaults
+ * to `now()` when omitted, matching the Today View's "log this set
+ * now" UX) and `id` is server-generated.
+ */
+export const WeightRoomSetCreateSchema = z
+  .object({
+    exercise: z.string().min(1),
+    reps: z.number().int().positive(),
+    logged_at: z.string().min(1).optional(),
+  })
+  .strict()
+
+/** Validated body of `POST /api/admin/weight-room/sets`. */
+export type WeightRoomSetCreate = z.infer<typeof WeightRoomSetCreateSchema>
+
+/**
+ * Translate a validated `weight_room_sets` row into the public
+ * {@link StrengthSet} shape. Trivial pass-through right now, but
+ * sibling-symmetric with `sessionRowToCardioSession` so future shape
+ * divergence (e.g. computed fields) has a natural home.
+ */
+export function setRowToStrengthSet(row: WeightRoomSetRow): StrengthSet {
+  return {
+    id: row.id,
+    logged_at: row.logged_at,
+    exercise: row.exercise,
+    reps: row.reps,
+  }
+}
+
+/**
+ * Translate a validated `weight_room_goals` row into the public
+ * {@link ExerciseGoal} shape. Pass-through; same reasoning as
+ * {@link setRowToStrengthSet}.
+ */
+export function goalRowToExerciseGoal(row: WeightRoomGoalRow): ExerciseGoal {
+  return {
+    exercise: row.exercise,
+    daily_target: row.daily_target,
+    color: row.color,
+  }
+}

--- a/supabase/migrations/20260507120000_weight_room_tables.sql
+++ b/supabase/migrations/20260507120000_weight_room_tables.sql
@@ -1,0 +1,82 @@
+-- Weight Room data model (#79) — bodyweight strength tracking, "grease the
+-- groove" pattern. Two tables backing the Weight Room sub-area at
+-- `/training-facility/weight-room`:
+--
+--   * weight_room_goals — one row per exercise (pushups, pullups, …) with
+--     a daily target rep count and a display color. Settings UI manages
+--     this list; rows are foreign-keyed by sets so an exercise's daily
+--     target is always live.
+--   * weight_room_sets  — one row per logged set (an exercise + a rep
+--     count + a timestamp). The Today View's quick-log writes here.
+--
+-- RLS mirrors `cardio_sessions` / `movement_benchmarks`: anon +
+-- authenticated SELECT only. Writes go through the service-role key
+-- via admin-gated API routes (`app/api/admin/weight-room/*`), so
+-- end-users editing in the browser are funneled through the admin
+-- allowlist, not direct table access.
+--
+-- All DDL is idempotent so re-applying on a fresh dev project (or after
+-- a branch reset) is a safe no-op.
+
+create table if not exists public.weight_room_goals (
+  exercise text primary key,
+  daily_target integer not null check (daily_target > 0),
+  color text not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+comment on table public.weight_room_goals is
+  'Per-exercise daily targets for the Weight Room sub-area (PRD §7.6 / #79). Primary key is the exercise name (e.g. ''pushups'') so the settings UI can upsert by name. Color is a hex string (e.g. ''#EA580C'') used by the Today View activity rings and the History View heatmap.';
+
+alter table public.weight_room_goals enable row level security;
+
+do $$
+begin
+  create policy "anon and authenticated can read weight room goals"
+    on public.weight_room_goals
+    for select
+    to anon, authenticated
+    using (true);
+exception when duplicate_object then null;
+end $$;
+
+create table if not exists public.weight_room_sets (
+  id uuid primary key default gen_random_uuid(),
+  logged_at timestamptz not null,
+  exercise text not null references public.weight_room_goals(exercise) on delete cascade,
+  reps integer not null check (reps > 0),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+comment on table public.weight_room_sets is
+  'Logged strength sets for the Weight Room sub-area (PRD §7.6 / #79). One row per set; the Today View quick-log inserts here. FK on `exercise` cascades on delete so removing an exercise from `weight_room_goals` cleans up its history without orphan rows.';
+
+create index if not exists weight_room_sets_logged_at_idx
+  on public.weight_room_sets (logged_at desc);
+
+create index if not exists weight_room_sets_exercise_logged_at_idx
+  on public.weight_room_sets (exercise, logged_at desc);
+
+alter table public.weight_room_sets enable row level security;
+
+do $$
+begin
+  create policy "anon and authenticated can read weight room sets"
+    on public.weight_room_sets
+    for select
+    to anon, authenticated
+    using (true);
+exception when duplicate_object then null;
+end $$;
+
+-- Seed default exercises so the Today View's activity rings have
+-- something to render the moment a fresh project comes online. Pushups
+-- / pullups match the PRD's "grease the groove" defaults; rim-orange
+-- and teal pull from the existing chartPalette tokens.
+insert into public.weight_room_goals (exercise, daily_target, color)
+values
+  ('pushups', 100, '#EA580C'),
+  ('pullups', 30, '#0EA5A1')
+on conflict (exercise) do nothing;

--- a/types/weight-room.ts
+++ b/types/weight-room.ts
@@ -1,0 +1,71 @@
+/**
+ * Weight Room data schema (PRD §7.6 / #79) — bodyweight strength tracking,
+ * "grease the groove" pattern. Single source of truth shared with the
+ * Supabase row schemas in `lib/schemas/weight-room.ts` and the admin
+ * write API routes (`app/api/admin/weight-room/*`).
+ *
+ * Field names are snake_case to match the Supabase column names, mirroring
+ * the cardio data model's convention.
+ */
+
+/**
+ * One logged set — an exercise + rep count + when it happened. The
+ * Today View's quick-log inserts these as the user taps through their
+ * "grease the groove" sets across the day.
+ */
+export interface StrengthSet {
+  /** UUID primary key, generated server-side. */
+  id: string
+  /** ISO 8601 timestamp the set was logged at (matches `logged_at` column). */
+  logged_at: string
+  /**
+   * Exercise name (`pushups`, `pullups`, …). Foreign-keyed to
+   * {@link ExerciseGoal.exercise}; deleting a goal cascades sets.
+   */
+  exercise: string
+  /** Rep count for this single set. Always positive (DB CHECK enforces). */
+  reps: number
+}
+
+/**
+ * Per-exercise daily target + display color. Drives the Today View's
+ * activity rings and the History View's heatmap intensity. Managed via
+ * the Settings UI; the migration seeds `pushups` (rim-orange) and
+ * `pullups` (teal) so a fresh project has something to render.
+ */
+export interface ExerciseGoal {
+  /** Exercise name; primary key on `weight_room_goals`. */
+  exercise: string
+  /**
+   * Target reps per day for the "grease the groove" goal. Activity
+   * rings fill toward this number; the heatmap colors by % of target.
+   */
+  daily_target: number
+  /**
+   * Hex color (e.g. `#EA580C`) used by the rings and heatmap so each
+   * exercise reads as its own visual lane. Stored as a string rather
+   * than an enum so adding a new exercise via the settings UI doesn't
+   * require a code change.
+   */
+  color: string
+}
+
+/**
+ * Full Weight Room dataset — the assembled shape returned by
+ * `getWeightRoomData()` / `getWeightRoomDataServer()`. `imported_at` is
+ * `MAX(updated_at)` across both tables; mirrors the cardio "last
+ * synced" convention so wall fixtures can show a freshness label.
+ */
+export interface WeightRoomData {
+  /**
+   * ISO timestamp of the most recent write across either table. `''`
+   * when both tables are empty (the data layer returns `null` in that
+   * case; this only matters when components substitute an empty
+   * fallback).
+   */
+  imported_at: string
+  /** Every logged set, sorted oldest → newest. */
+  sets: StrengthSet[]
+  /** Every configured exercise goal, ordered by exercise name. */
+  goals: ExerciseGoal[]
+}


### PR DESCRIPTION
## Summary

Lays the foundation for the Weight Room sub-area (PRD §7.6 / #79) — bodyweight
strength tracking, "grease the groove" pattern. This PR is data-layer + admin
API + Settings UI; the actual user-facing pages (Today / History / scene-link)
land in slices #80, #81, and #82.

Closes #79.

## Architecture decisions

- **Storage: Supabase, not localStorage** — keeps parity with the rest of the
  Training Facility data model. Admin-gated writes via authenticated API routes
  (mirrors the existing `movement_benchmarks` pattern).
- **Route base: `/training-facility/weight-room`** — matches Gym + Combine
  sub-areas.
- **Naming:** "Weight Room" for the area / route / heading. Type names use
  `Strength` (e.g. `StrengthSet`, `ExerciseGoal`).

## What landed

| Layer | File | Notes |
| --- | --- | --- |
| Migration | `supabase/migrations/20260507120000_weight_room_tables.sql` | Two tables. `weight_room_sets` (uuid pk, FK on exercise → goals.exercise with ON DELETE CASCADE). `weight_room_goals` (exercise pk). RLS: anon SELECT only. Seeds `pushups` / `pullups` defaults. |
| Types | `types/weight-room.ts` | `StrengthSet`, `ExerciseGoal`, `WeightRoomData` with full JSDoc. |
| Zod | `lib/schemas/weight-room.ts` | Per-row schemas + `WeightRoomSetCreateSchema` (POST body). Hex-color regex on goal color. |
| Read path | `lib/data/weight-room.ts` + `weight-room-server.ts` + `weight-room-shared.ts` | Mirrors the cardio assembler. Both tables queried in parallel; `imported_at` = `MAX(updated_at)`. Returns `null` when both tables are empty. |
| Admin API | `app/api/admin/weight-room/sets/route.ts` (POST), `sets/[id]/route.ts` (DELETE), `goals/route.ts` (POST upsert), `goals/[exercise]/route.ts` (DELETE) | Each route gated by `requireAdmin`. FK violation maps to 409. UUID guard on set DELETE. URL-decoded exercise on goal DELETE (so `shoulder%20taps` works). |
| Settings UI | `app/training-facility/weight-room/settings/page.tsx` (server, admin-gated via `notFound()`) + `components/training-facility/weight-room/StrengthSettings.tsx` (client) | Lists existing goals with editable target + color, plus an add-exercise form. Posts to admin API; refreshes via `router.refresh()`. Mobile-first layout. |
| Tests | 5 new test files | Read path (8 cases) + 4 API routes (22 cases). Full suite at 671/671. |

## Migration deployment note

The migration is **not auto-applied**. Apply it via Supabase CLI before
relying on the API routes:

```sh
supabase db push
```

Until then, the Settings UI renders for admins but every save / add will
500 on the missing tables. Read path returns `null` (clean fallback).

## Test plan

- [ ] CI green (Vercel + e2e + CodeRabbit).
- [ ] Apply the migration locally; visit `/training-facility/weight-room/settings`
      while signed-in admin. Should see `pushups` (orange, 100) and
      `pullups` (teal, 30) seeded rows.
- [ ] Edit a goal's target → row saves and re-renders with new value.
- [ ] Add a new exercise → row appears in the list.
- [ ] Delete an exercise → confirm dialog prompts; on confirm, row
      disappears and any sets cascade-delete.
- [ ] Try invalid input (color = `orange`) → server rejects with 400 and
      the UI shows a `Save failed` banner.
- [ ] Visit `/training-facility/weight-room/settings` while signed-out
      → 404. Same when signed-in but not on the admin allowlist.
- [ ] Mobile viewport (`390×844`) — form stacks single-column, touch
      targets are large.

## Out of scope

- Today View / activity rings / quick-log — slice #80
- History View / heatmap / stats — slice #81
- Weight Room door on the Training Facility scene + cross-view nav — slice #82

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced Weight Room: log strength sets, track per-exercise daily targets and colors, and view assembled dataset with freshness timestamp.
  * Admin settings UI to manage exercises (create/update/delete) with immediate refresh and improved validation/error feedback.
  * Admin-only pages and server-side data fetching for secure management.

* **Database**
  * Added Weight Room tables with FK cascade, indexes, RLS policies, and seeded default exercises.

* **Tests**
  * Added comprehensive tests covering APIs and data assembly/validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->