### PR TITLE
feat(weight-room): History View — heatmap + stats per exercise (#81)

### DIFF
--- a/app/training-facility/weight-room/history/page.tsx
+++ b/app/training-facility/weight-room/history/page.tsx
@@ -1,0 +1,135 @@
+import type { JSX } from 'react'
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+
+import { BackToCourtButton } from '@/components/common/BackToCourtButton'
+import { StrengthHeatmap } from '@/components/training-facility/weight-room/StrengthHeatmap'
+import { StrengthStats } from '@/components/training-facility/weight-room/StrengthStats'
+import { getWeightRoomDataServer } from '@/lib/data/weight-room-server'
+import { isTrainingFacilityEnabled } from '@/lib/feature-flags'
+import { computeStrengthStats } from '@/lib/training-facility/weight-room-history'
+import type { ExerciseGoal } from '@/types/weight-room'
+
+/**
+ * Weight Room History page (#81). Public route — anyone can read the
+ * heatmap and stats; admin gating only applies to writes (the Settings
+ * page and the admin API). Renders one heatmap per configured exercise
+ * stacked vertically, with the per-exercise stats panel underneath.
+ *
+ * Server Component because the data read is server-side via the
+ * SSR Supabase client; the heatmap and stats are pure visual children
+ * that don't need any interactivity to fulfill the issue's "Done when".
+ *
+ * Empty-state behavior: when `getWeightRoomDataServer()` returns
+ * `null` (no sets and no goals — pre-migration / fully cleared) the
+ * page renders the page chrome with a copy that points the admin at
+ * Settings. When sets exist but for a deleted exercise, those sets are
+ * silently dropped from the per-exercise heatmaps because we render
+ * one heatmap per *goal*, not per encountered exercise — matching how
+ * the Settings page treats goals as the source of truth.
+ */
+export default async function WeightRoomHistoryPage(): Promise<JSX.Element> {
+  if (!isTrainingFacilityEnabled()) notFound()
+
+  // Catch transient read errors so a flaky Supabase response surfaces
+  // as the empty-state copy rather than 500ing the whole page. Mirrors
+  // the same .catch() in the Settings page.
+  const data = await getWeightRoomDataServer().catch(() => null)
+  const goals: readonly ExerciseGoal[] = data?.goals ?? []
+  const sets = data?.sets ?? []
+  const stats = computeStrengthStats(sets, goals)
+
+  return (
+    <div className="relative min-h-svh overflow-hidden bg-[#120d0a] text-[#f7ead9]">
+      <div
+        aria-hidden="true"
+        className="absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(248,214,170,0.16),transparent_30%),linear-gradient(180deg,#241811_0%,#120d0a_55%,#0b0806_100%)]"
+      />
+
+      <div className="relative z-10 mx-auto flex min-h-svh w-full max-w-5xl flex-col px-4 py-6 sm:px-6 sm:py-8 lg:px-10">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <BackToCourtButton />
+          <Link
+            href="/training-facility"
+            className="rounded-full border border-white/15 bg-white/5 px-4 py-2 text-xs font-semibold uppercase tracking-[0.28em] text-white/80 transition hover:bg-white/10"
+          >
+            ← Training Facility
+          </Link>
+        </div>
+
+        <header className="mt-12">
+          <p className="font-mono text-[11px] uppercase tracking-[0.32em] text-amber-300/80">
+            Weight Room · History
+          </p>
+          <h1 className="mt-2 text-3xl font-black uppercase tracking-[0.06em] text-[#fff7ec] sm:text-5xl">
+            Heatmap &amp; stats
+          </h1>
+          <p className="mt-3 max-w-xl text-sm leading-7 text-[#e8d5be] sm:text-base">
+            One row per day for the trailing 52 weeks, colored by how
+            close that day got to the daily goal. Hover any cell for the
+            day&rsquo;s breakdown. Stats below summarize the current
+            week, month, and all-time totals.
+          </p>
+        </header>
+
+        {goals.length === 0 ? (
+          <section
+            data-testid="weight-room-history-empty"
+            className="mt-10 rounded-[1.2rem] border border-white/10 bg-white/5 p-6 text-sm text-[#e8d5be]"
+          >
+            <p>No exercises configured yet.</p>
+            <p className="mt-2 text-[#e8d5be]/70">
+              Add one in{' '}
+              <Link
+                href="/training-facility/weight-room/settings"
+                className="underline decoration-dotted underline-offset-4 hover:text-amber-200"
+              >
+                Settings
+              </Link>{' '}
+              to start tracking history.
+            </p>
+          </section>
+        ) : (
+          <>
+            <section
+              aria-label="Per-exercise heatmaps"
+              data-testid="weight-room-heatmaps"
+              className="mt-10 space-y-8"
+            >
+              {goals.map((goal) => (
+                <article
+                  key={goal.exercise}
+                  className="rounded-[1.2rem] border border-white/10 bg-white/5 p-5"
+                >
+                  <header className="mb-4 flex items-baseline justify-between gap-3">
+                    <h2
+                      className="font-mono text-sm font-bold uppercase tracking-[0.2em]"
+                      style={{ color: goal.color }}
+                    >
+                      {goal.exercise}
+                    </h2>
+                    <span className="font-mono text-[10px] uppercase tracking-[0.22em] text-[#e8d5be]/60">
+                      goal {goal.daily_target}/day
+                    </span>
+                  </header>
+                  <div className="overflow-x-auto">
+                    <StrengthHeatmap sets={sets} goal={goal} />
+                  </div>
+                </article>
+              ))}
+            </section>
+
+            <section className="mt-10">
+              <h2 className="font-mono text-[11px] uppercase tracking-[0.32em] text-amber-300/80">
+                Stats
+              </h2>
+              <div className="mt-4">
+                <StrengthStats stats={stats} />
+              </div>
+            </section>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/components/training-facility/weight-room/StrengthHeatmap.test.tsx
+++ b/components/training-facility/weight-room/StrengthHeatmap.test.tsx
@@ -1,0 +1,133 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { render } from '@testing-library/react'
+
+import type { ExerciseGoal, StrengthSet } from '@/types/weight-room'
+
+import { StrengthHeatmap } from './StrengthHeatmap'
+
+const PUSHUPS: ExerciseGoal = {
+  exercise: 'pushups',
+  daily_target: 100,
+  color: '#EA580C',
+}
+
+function set(dateStr: string, exercise: string, reps: number, hour = 8): StrengthSet {
+  return {
+    id: `${dateStr}-${exercise}-${reps}-${hour}`,
+    logged_at: `${dateStr}T${String(hour).padStart(2, '0')}:00:00`,
+    exercise,
+    reps,
+  }
+}
+
+describe('StrengthHeatmap', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('renders an SVG with an exercise-specific aria-label by default', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 3, 15))
+    const { getByRole } = render(<StrengthHeatmap sets={[]} goal={PUSHUPS} />)
+    expect(getByRole('img', { name: 'pushups heatmap' })).toBeInTheDocument()
+  })
+
+  it('honors a custom ariaLabel when supplied', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 3, 15))
+    const { getByRole } = render(
+      <StrengthHeatmap sets={[]} goal={PUSHUPS} ariaLabel="custom label" />,
+    )
+    expect(getByRole('img', { name: 'custom label' })).toBeInTheDocument()
+  })
+
+  it('renders 7 × N cells inside the grid', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 3, 15))
+    const from = new Date(2026, 3, 1)
+    const to = new Date(2026, 3, 15)
+    const { container } = render(
+      <StrengthHeatmap sets={[]} goal={PUSHUPS} dateFrom={from} dateTo={to} />,
+    )
+    // 4 legend swatches share the same <rect> shape; remaining rects = 7 × N.
+    const rects = container.querySelectorAll('svg rect')
+    const gridCells = rects.length - 4
+    expect(gridCells % 7).toBe(0)
+  })
+
+  it('tints active cells with the exercise color', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 3, 15))
+    const from = new Date(2026, 3, 1)
+    const to = new Date(2026, 3, 15)
+    const { container } = render(
+      <StrengthHeatmap
+        sets={[set('2026-04-14', 'pushups', 100)]}
+        goal={PUSHUPS}
+        dateFrom={from}
+        dateTo={to}
+      />,
+    )
+    const rects = Array.from(container.querySelectorAll('svg rect'))
+    const fills = rects.map((r) => r.getAttribute('fill') ?? '')
+    expect(fills.some((f) => /EA580C/i.test(f))).toBe(true)
+  })
+
+  it('writes a goal-percentage tooltip on populated cells', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 3, 15))
+    const from = new Date(2026, 3, 1)
+    const to = new Date(2026, 3, 15)
+    const { container } = render(
+      <StrengthHeatmap
+        sets={[set('2026-04-14', 'pushups', 50, 8), set('2026-04-14', 'pushups', 50, 18)]}
+        goal={PUSHUPS}
+        dateFrom={from}
+        dateTo={to}
+      />,
+    )
+    const titles = Array.from(container.querySelectorAll('svg rect title')).map(
+      (n) => n.textContent ?? '',
+    )
+    const populated = titles.find((t) => t.includes('100 reps'))
+    expect(populated).toBeDefined()
+    expect(populated).toContain('2 sets')
+    expect(populated).toContain('100% of pushups goal')
+  })
+
+  it('renders empty days with a non-color wash, not the exercise tint', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 3, 15))
+    const from = new Date(2026, 3, 1)
+    const to = new Date(2026, 3, 15)
+    const { container } = render(
+      <StrengthHeatmap sets={[]} goal={PUSHUPS} dateFrom={from} dateTo={to} />,
+    )
+    // With no sets, every grid cell is empty — none should reference the
+    // exercise color (only the legend's "more" swatches do).
+    const rects = Array.from(container.querySelectorAll('svg rect'))
+    const exerciseColored = rects.filter((r) => /EA580C/i.test(r.getAttribute('fill') ?? ''))
+    // 3 of 4 legend swatches use the exercise color (intensities 1, 2, 3).
+    expect(exerciseColored.length).toBe(3)
+  })
+
+  it('ignores sets for other exercises in the rendered grid', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 3, 15))
+    const from = new Date(2026, 3, 1)
+    const to = new Date(2026, 3, 15)
+    const { container } = render(
+      <StrengthHeatmap
+        sets={[set('2026-04-14', 'pullups', 50)]}
+        goal={PUSHUPS}
+        dateFrom={from}
+        dateTo={to}
+      />,
+    )
+    // Pullups set should NOT tint a pushups cell — only the legend
+    // swatches should reference the exercise color.
+    const rects = Array.from(container.querySelectorAll('svg rect'))
+    const exerciseColored = rects.filter((r) => /EA580C/i.test(r.getAttribute('fill') ?? ''))
+    expect(exerciseColored.length).toBe(3)
+  })
+})

--- a/components/training-facility/weight-room/StrengthHeatmap.tsx
+++ b/components/training-facility/weight-room/StrengthHeatmap.tsx
@@ -102,13 +102,17 @@ export function StrengthHeatmap({
   const label = ariaLabel ?? `${goal.exercise} heatmap`
 
   return (
+    // No `maxWidth: 100%` on the SVG — the page wraps each heatmap in
+    // an `overflow-x-auto` card so the trailing-52w grid (≈760 px) can
+    // scroll horizontally on mobile. Capping the SVG to the container
+    // would defeat that and squash 364 cells into a phone width.
     <svg
       viewBox={`0 0 ${totalWidth} ${totalHeight}`}
       width={totalWidth}
       height={totalHeight}
       role="img"
       aria-label={label}
-      style={{ fontFamily, maxWidth: '100%', height: 'auto' }}
+      style={{ fontFamily }}
     >
       {/* Month labels along the top */}
       <g transform={`translate(${DAY_LABEL_WIDTH}, ${MONTH_LABEL_HEIGHT - 4})`}>

--- a/components/training-facility/weight-room/StrengthHeatmap.tsx
+++ b/components/training-facility/weight-room/StrengthHeatmap.tsx
@@ -1,0 +1,218 @@
+import type { JSX } from 'react'
+
+import {
+  buildStrengthHeatmap,
+  intensityFromPct,
+  type StrengthHeatmapCell,
+} from '@/lib/training-facility/weight-room-history'
+import type { ExerciseGoal, StrengthSet } from '@/types/weight-room'
+
+/** Props for {@link StrengthHeatmap}. */
+export interface StrengthHeatmapProps {
+  /**
+   * Every logged set across all exercises; the component filters down
+   * to {@link goal}'s exercise internally so callers can pass the
+   * full `WeightRoomData.sets` list once per exercise.
+   */
+  sets: readonly StrengthSet[]
+  /**
+   * The exercise to render — supplies the color (used as the cell
+   * fill at full intensity) and `daily_target` (the denominator that
+   * decides which intensity bucket each cell falls into).
+   */
+  goal: ExerciseGoal
+  /** Inclusive start of the visible window. Omit for the trailing 52 weeks. */
+  dateFrom?: Date | null
+  /** Inclusive end of the visible window. Defaults to today. */
+  dateTo?: Date | null
+  /**
+   * Pixel width of one cell, including the trailing inter-cell gap; the
+   * grid lays out columns left-to-right at this stride. Defaults to 14.
+   */
+  cellSize?: number
+  /** Pixel gap between cells. Defaults to 2. */
+  cellGap?: number
+  /**
+   * Font family for the day-of-week and month labels. Defaults to
+   * `inherit` so the surrounding card can drive the typeface.
+   */
+  fontFamily?: string
+  /** Accessible label for the chart's `<svg>` `role="img"` wrapper. */
+  ariaLabel?: string
+}
+
+const DAY_LABELS = ['Mon', '', 'Wed', '', 'Fri', '', ''] as const
+/** Pixel width reserved for the day-of-week label column. */
+const DAY_LABEL_WIDTH = 32
+/** Pixel height reserved for the month label row above the grid. */
+const MONTH_LABEL_HEIGHT = 18
+/** Pixel height reserved for the legend strip below the grid. */
+const LEGEND_HEIGHT = 22
+
+/**
+ * Per-intensity opacity applied to the exercise's `goal.color`. Index
+ * matches the value `intensityFromPct` returns: 0 = empty (no exercise
+ * tint, just a faint white wash for grid visibility), 1 = light (1–49%
+ * of goal), 2 = medium (50–99%), 3 = full (≥100%).
+ *
+ * Using `fill-opacity` over pre-mixed colors means a single hex color
+ * from {@link ExerciseGoal.color} drives the whole exercise's heatmap
+ * — adding a new exercise via the settings UI doesn't require a new
+ * palette entry.
+ */
+const INTENSITY_OPACITY = [0, 0.28, 0.62, 1] as const
+
+/** Background fill for empty (0%) cells — sits on a dark card. */
+const EMPTY_CELL_FILL = 'rgba(247, 234, 217, 0.07)'
+
+/** Soft cream label color matching the Weight Room dark surface. */
+const LABEL_FILL = 'rgba(247, 234, 217, 0.55)'
+
+/**
+ * Calendar heatmap of one exercise's daily rep totals as a percentage
+ * of the configured `daily_target` (PRD §7.6 / #81). Mirrors the
+ * cardio-side {@link import('@/components/training-facility/gym/WorkoutHeatmap')}
+ * layout — month labels on top, day-of-week on the left, legend strip
+ * underneath — but colors cells by goal-percentage rather than session
+ * count, and tints with {@link ExerciseGoal.color} so each exercise
+ * reads as its own visual lane.
+ *
+ * Plain `<rect>` cells inside an SVG so 52w × 7d ≈ 364 cells render
+ * instantly even on mobile. The `<title>` per cell is the native
+ * browser tooltip ("Apr 14, 2026: 45 reps (2 sets, 45% of goal)") that
+ * sighted users see on hover and screen readers read for keyboard nav.
+ */
+export function StrengthHeatmap({
+  sets,
+  goal,
+  dateFrom,
+  dateTo,
+  cellSize = 14,
+  cellGap = 2,
+  fontFamily = 'inherit',
+  ariaLabel,
+}: StrengthHeatmapProps): JSX.Element {
+  const { grid, monthLabels } = buildStrengthHeatmap(sets, goal, dateFrom, dateTo)
+  const cols = grid[0]?.length ?? 0
+  const cellInner = cellSize - cellGap
+  const gridWidth = cols * cellSize
+  const gridHeight = 7 * cellSize
+  const totalWidth = DAY_LABEL_WIDTH + gridWidth
+  const totalHeight = MONTH_LABEL_HEIGHT + gridHeight + LEGEND_HEIGHT
+  const label = ariaLabel ?? `${goal.exercise} heatmap`
+
+  return (
+    <svg
+      viewBox={`0 0 ${totalWidth} ${totalHeight}`}
+      width={totalWidth}
+      height={totalHeight}
+      role="img"
+      aria-label={label}
+      style={{ fontFamily, maxWidth: '100%', height: 'auto' }}
+    >
+      {/* Month labels along the top */}
+      <g transform={`translate(${DAY_LABEL_WIDTH}, ${MONTH_LABEL_HEIGHT - 4})`}>
+        {monthLabels.map((m) => (
+          <text
+            key={`month-${m.col}-${m.label}`}
+            x={m.col * cellSize}
+            y={0}
+            fontSize={11}
+            fill={LABEL_FILL}
+          >
+            {m.label}
+          </text>
+        ))}
+      </g>
+
+      {/* Day-of-week labels along the left */}
+      <g transform={`translate(0, ${MONTH_LABEL_HEIGHT})`}>
+        {DAY_LABELS.map((dayLabel, row) =>
+          dayLabel ? (
+            <text
+              key={`day-${row}`}
+              x={DAY_LABEL_WIDTH - 6}
+              y={row * cellSize + cellSize / 2 + 3}
+              textAnchor="end"
+              fontSize={10}
+              fill={LABEL_FILL}
+            >
+              {dayLabel}
+            </text>
+          ) : null,
+        )}
+      </g>
+
+      {/* Heatmap cells */}
+      <g transform={`translate(${DAY_LABEL_WIDTH}, ${MONTH_LABEL_HEIGHT})`}>
+        {grid.map((row, rowIdx) =>
+          row.map((cell, colIdx) => {
+            const level = intensityFromPct(cell.pct)
+            const isEmpty = level === 0
+            return (
+              <rect
+                key={`cell-${colIdx}-${rowIdx}`}
+                x={colIdx * cellSize}
+                y={rowIdx * cellSize}
+                width={cellInner}
+                height={cellInner}
+                rx={2}
+                ry={2}
+                fill={isEmpty ? EMPTY_CELL_FILL : goal.color}
+                fillOpacity={isEmpty ? 1 : INTENSITY_OPACITY[level]}
+              >
+                <title>{describeCell(cell, goal)}</title>
+              </rect>
+            )
+          }),
+        )}
+      </g>
+
+      {/* Legend strip — "Less" + 4 swatches + "More" */}
+      <g
+        transform={`translate(${DAY_LABEL_WIDTH + Math.max(0, gridWidth - 140)}, ${MONTH_LABEL_HEIGHT + gridHeight + 14})`}
+      >
+        <text x={0} y={0} fontSize={10} fill={LABEL_FILL}>
+          Less
+        </text>
+        {INTENSITY_OPACITY.map((opacity, i) => {
+          const empty = i === 0
+          return (
+            <rect
+              key={`legend-${i}`}
+              x={32 + i * (cellSize + 1)}
+              y={-9}
+              width={cellInner}
+              height={cellInner}
+              rx={2}
+              ry={2}
+              fill={empty ? EMPTY_CELL_FILL : goal.color}
+              fillOpacity={empty ? 1 : opacity}
+            />
+          )
+        })}
+        <text x={32 + 4 * (cellSize + 1) + 4} y={0} fontSize={10} fill={LABEL_FILL}>
+          More
+        </text>
+      </g>
+    </svg>
+  )
+}
+
+/**
+ * Compose the per-cell tooltip — `Apr 14, 2026: 45 reps (2 sets, 45%
+ * of goal)` for active days, just the formatted date for empty days.
+ * Reads naturally for both sighted users (browser title-tooltip on
+ * hover) and screen readers.
+ */
+function describeCell(cell: StrengthHeatmapCell, goal: ExerciseGoal): string {
+  const dateLabel = cell.date.toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  })
+  if (cell.reps === 0) return dateLabel
+  const setNoun = cell.setCount === 1 ? 'set' : 'sets'
+  const pctLabel = `${Math.round(cell.pct * 100)}%`
+  return `${dateLabel}: ${cell.reps} reps (${cell.setCount} ${setNoun}, ${pctLabel} of ${goal.exercise} goal)`
+}

--- a/components/training-facility/weight-room/StrengthStats.test.tsx
+++ b/components/training-facility/weight-room/StrengthStats.test.tsx
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest'
+import { render } from '@testing-library/react'
+
+import type { StrengthExerciseStats } from '@/lib/training-facility/weight-room-history'
+
+import { StrengthStats } from './StrengthStats'
+
+const PUSHUP_STATS: StrengthExerciseStats = {
+  exercise: 'pushups',
+  color: '#EA580C',
+  dailyTarget: 100,
+  currentStreak: 4,
+  longestStreak: 12,
+  thisWeekReps: 380,
+  lastWeekReps: 220,
+  thisMonthReps: 1450,
+  lastMonthReps: 980,
+  avgSetsPerActiveDay: 3.5,
+  allTimeReps: 12_400,
+}
+
+describe('StrengthStats', () => {
+  it('renders the empty-state copy when stats is empty', () => {
+    const { getByTestId } = render(<StrengthStats stats={[]} />)
+    expect(getByTestId('strength-stats-empty')).toBeInTheDocument()
+  })
+
+  it('renders one card per exercise', () => {
+    const { getByTestId } = render(
+      <StrengthStats
+        stats={[
+          PUSHUP_STATS,
+          { ...PUSHUP_STATS, exercise: 'pullups', color: '#0EA5A1', allTimeReps: 0 },
+        ]}
+      />,
+    )
+    expect(getByTestId('strength-stat-card-pushups')).toBeInTheDocument()
+    expect(getByTestId('strength-stat-card-pullups')).toBeInTheDocument()
+  })
+
+  it('shows current streak, longest streak, and goal target', () => {
+    const { getByTestId } = render(<StrengthStats stats={[PUSHUP_STATS]} />)
+    const card = getByTestId('strength-stat-card-pushups')
+    expect(card.textContent).toContain('4')
+    expect(card.textContent).toContain('12')
+    expect(card.textContent).toContain('goal 100/day')
+  })
+
+  it('shows weekly and monthly totals with prior-period comparison', () => {
+    const { getByTestId } = render(<StrengthStats stats={[PUSHUP_STATS]} />)
+    const card = getByTestId('strength-stat-card-pushups')
+    expect(card.textContent).toContain('380')
+    expect(card.textContent).toContain('vs 220 prior')
+    expect(card.textContent).toContain('1,450')
+    expect(card.textContent).toContain('vs 980 prior')
+  })
+
+  it('shows average sets per active day with one decimal', () => {
+    const { getByTestId } = render(<StrengthStats stats={[PUSHUP_STATS]} />)
+    const card = getByTestId('strength-stat-card-pushups')
+    expect(card.textContent).toContain('3.5')
+  })
+
+  it('falls back to em-dash when avg sets per active day is zero', () => {
+    const { getByTestId } = render(
+      <StrengthStats stats={[{ ...PUSHUP_STATS, avgSetsPerActiveDay: 0 }]} />,
+    )
+    const card = getByTestId('strength-stat-card-pushups')
+    expect(card.textContent).toContain('—')
+  })
+
+  it('formats all-time reps with thousands separators', () => {
+    const { getByTestId } = render(<StrengthStats stats={[PUSHUP_STATS]} />)
+    const card = getByTestId('strength-stat-card-pushups')
+    expect(card.textContent).toContain('12,400')
+  })
+
+  it('uses the exercise color on the heading', () => {
+    const { getByText } = render(<StrengthStats stats={[PUSHUP_STATS]} />)
+    const heading = getByText('pushups')
+    // jsdom canonicalizes inline `style` to lowercase rgb(); accept either.
+    const styleAttr = heading.getAttribute('style') ?? ''
+    expect(styleAttr).toMatch(/#EA580C|rgb\(\s*234,\s*88,\s*12\s*\)/i)
+  })
+})

--- a/components/training-facility/weight-room/StrengthStats.tsx
+++ b/components/training-facility/weight-room/StrengthStats.tsx
@@ -1,0 +1,175 @@
+import type { JSX } from 'react'
+
+import type { StrengthExerciseStats } from '@/lib/training-facility/weight-room-history'
+
+/** Props for {@link StrengthStats}. */
+export interface StrengthStatsProps {
+  /**
+   * One pre-computed entry per exercise — see
+   * {@link import('@/lib/training-facility/weight-room-history').computeStrengthStats}.
+   * Empty array renders the empty-state message.
+   */
+  stats: readonly StrengthExerciseStats[]
+}
+
+/**
+ * Per-exercise stats panel for the History View (#81): streaks,
+ * weekly/monthly rep totals, average sets per active day, and all-time
+ * reps. One cream card per exercise on the dark Weight Room surface,
+ * matching the cardio overview's `bg-[#f5f1e6]` card aesthetic so the
+ * two facilities feel like one app.
+ *
+ * The "vs last" line on the week / month cells is a literal previous-
+ * period count — no percentage delta. Picking a delta direction would
+ * require deciding whether bigger-is-better universally for strength
+ * (it isn't — a deload week is intentional), so the panel just shows
+ * both numbers and lets the reader interpret.
+ */
+export function StrengthStats({ stats }: StrengthStatsProps): JSX.Element {
+  if (stats.length === 0) {
+    return (
+      <p
+        data-testid="strength-stats-empty"
+        className="rounded-[1.2rem] border border-white/10 bg-white/5 p-6 text-center text-sm text-[#e8d5be]/70"
+      >
+        No exercises configured yet — add one in Settings to start tracking history.
+      </p>
+    )
+  }
+
+  return (
+    <section aria-label="Strength stats" className="grid gap-4 md:grid-cols-2">
+      {stats.map((stat) => (
+        <ExerciseStatCard key={stat.exercise} stat={stat} />
+      ))}
+    </section>
+  )
+}
+
+interface ExerciseStatCardProps {
+  stat: StrengthExerciseStats
+}
+
+function ExerciseStatCard({ stat }: ExerciseStatCardProps): JSX.Element {
+  const isStreaking = stat.currentStreak > 0
+  return (
+    <article
+      data-testid={`strength-stat-card-${stat.exercise}`}
+      className="rounded-[1.2rem] border border-white/10 bg-[#f5f1e6] p-5 text-[#0a0a0a] shadow-[0_12px_32px_rgba(0,0,0,0.28)]"
+    >
+      <header className="flex items-baseline justify-between gap-3">
+        <h3
+          className="font-mono text-sm font-bold uppercase tracking-[0.2em]"
+          style={{ color: stat.color }}
+        >
+          {stat.exercise}
+        </h3>
+        <span className="font-mono text-[10px] uppercase tracking-[0.22em] text-[#0a0a0a]/55">
+          goal {stat.dailyTarget}/day
+        </span>
+      </header>
+
+      <div className="mt-5 grid grid-cols-2 gap-4">
+        <StreakCell
+          label="current"
+          value={stat.currentStreak}
+          highlight={isStreaking}
+          suffix={stat.currentStreak === 1 ? 'day' : 'days'}
+        />
+        <StreakCell
+          label="longest"
+          value={stat.longestStreak}
+          suffix={stat.longestStreak === 1 ? 'day' : 'days'}
+        />
+
+        <PeriodCell label="this week" value={stat.thisWeekReps} compare={stat.lastWeekReps} />
+        <PeriodCell label="this month" value={stat.thisMonthReps} compare={stat.lastMonthReps} />
+
+        <SimpleCell
+          label="avg sets / active day"
+          value={formatAvg(stat.avgSetsPerActiveDay)}
+        />
+        <SimpleCell label="all-time reps" value={stat.allTimeReps.toLocaleString('en-US')} />
+      </div>
+    </article>
+  )
+}
+
+interface StreakCellProps {
+  label: string
+  value: number
+  suffix: string
+  highlight?: boolean
+}
+
+function StreakCell({ label, value, suffix, highlight }: StreakCellProps): JSX.Element {
+  return (
+    <div>
+      <p className="flex items-baseline gap-2">
+        <span aria-hidden="true" className={`text-base ${highlight ? '' : 'opacity-30 grayscale'}`}>
+          {'\u{1F525}'}
+        </span>
+        <span className="font-mono text-3xl font-semibold tabular-nums">{value}</span>
+        <span className="font-mono text-[10px] uppercase tracking-[0.2em] text-[#0a0a0a]/60">
+          {suffix}
+        </span>
+      </p>
+      <p className="mt-1 font-mono text-[10px] font-bold uppercase tracking-[0.22em] text-[#0a0a0a]/65">
+        {label}
+      </p>
+    </div>
+  )
+}
+
+interface PeriodCellProps {
+  label: string
+  value: number
+  compare: number
+}
+
+function PeriodCell({ label, value, compare }: PeriodCellProps): JSX.Element {
+  return (
+    <div>
+      <p className="flex items-baseline gap-1.5">
+        <span className="font-mono text-3xl font-semibold tabular-nums">
+          {value.toLocaleString('en-US')}
+        </span>
+        <span className="font-mono text-[10px] uppercase tracking-[0.2em] text-[#0a0a0a]/60">
+          reps
+        </span>
+      </p>
+      <p className="mt-1 font-mono text-[10px] font-bold uppercase tracking-[0.22em] text-[#0a0a0a]/65">
+        {label}
+        <span className="ml-2 font-normal normal-case tracking-normal text-[#0a0a0a]/55">
+          vs {compare.toLocaleString('en-US')} prior
+        </span>
+      </p>
+    </div>
+  )
+}
+
+interface SimpleCellProps {
+  label: string
+  value: string
+}
+
+function SimpleCell({ label, value }: SimpleCellProps): JSX.Element {
+  return (
+    <div>
+      <p className="font-mono text-3xl font-semibold tabular-nums">{value}</p>
+      <p className="mt-1 font-mono text-[10px] font-bold uppercase tracking-[0.22em] text-[#0a0a0a]/65">
+        {label}
+      </p>
+    </div>
+  )
+}
+
+/**
+ * Format the average-sets-per-day cell. One decimal place is enough
+ * resolution to differentiate "logged once today" from "logged twice"
+ * without numeric noise; falls back to `—` for the no-data case.
+ */
+function formatAvg(n: number): string {
+  if (!Number.isFinite(n) || n <= 0) return '—'
+  return n.toFixed(1)
+}

--- a/lib/training-facility/weight-room-history.test.ts
+++ b/lib/training-facility/weight-room-history.test.ts
@@ -198,6 +198,18 @@ describe('computeStrengthStreaks', () => {
     ]
     expect(computeStrengthStreaks(sets, PUSHUPS)).toEqual({ current: 0, longest: 0 })
   })
+
+  it('honors the optional `now` arg for the today / yesterday anchor', () => {
+    // Real clock is May 7 2026, but we anchor "today" to Apr 16 — the
+    // current streak should treat Apr 14–16 as fresh, not stale.
+    const now = new Date('2026-04-16T12:00:00')
+    const sets = [
+      set('2026-04-14', 'pushups', 100),
+      set('2026-04-15', 'pushups', 100),
+      set('2026-04-16', 'pushups', 100),
+    ]
+    expect(computeStrengthStreaks(sets, PUSHUPS, now)).toEqual({ current: 3, longest: 3 })
+  })
 })
 
 describe('computeStrengthStats', () => {
@@ -274,5 +286,19 @@ describe('computeStrengthStats', () => {
     const now = new Date('2026-04-16T12:00:00')
     const sets = [set('2026-04-16', 'pushups', 50)]
     expect(computeStrengthStats(sets, [], now)).toEqual([])
+  })
+
+  it('threads `now` into streak math (not just week/month math)', () => {
+    // Real clock is May 7 2026 by the time this PR ran — without
+    // threading `now` into `computeStrengthStreaks`, `current` would
+    // come back 0 because Apr 16 is older than yesterday.
+    const now = new Date('2026-04-16T12:00:00')
+    const sets = [
+      set('2026-04-15', 'pushups', 100),
+      set('2026-04-16', 'pushups', 100),
+    ]
+    const [stats] = computeStrengthStats(sets, [PUSHUPS], now)
+    expect(stats.currentStreak).toBe(2)
+    expect(stats.longestStreak).toBe(2)
   })
 })

--- a/lib/training-facility/weight-room-history.test.ts
+++ b/lib/training-facility/weight-room-history.test.ts
@@ -269,4 +269,10 @@ describe('computeStrengthStats', () => {
     expect(stats[1].color).toBe('#0EA5A1')
     expect(stats[1].thisWeekReps).toBe(30)
   })
+
+  it('returns an empty array when no goals are configured (sets ignored)', () => {
+    const now = new Date('2026-04-16T12:00:00')
+    const sets = [set('2026-04-16', 'pushups', 50)]
+    expect(computeStrengthStats(sets, [], now)).toEqual([])
+  })
 })

--- a/lib/training-facility/weight-room-history.test.ts
+++ b/lib/training-facility/weight-room-history.test.ts
@@ -1,0 +1,272 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+
+import type { ExerciseGoal, StrengthSet } from '@/types/weight-room'
+
+import {
+  buildStrengthHeatmap,
+  computeStrengthStats,
+  computeStrengthStreaks,
+  intensityFromPct,
+} from './weight-room-history'
+
+/**
+ * Local helper — minimal {@link StrengthSet} for a given local date and
+ * exercise. Tests build a synthetic Supabase-shape row without restating
+ * the whole contract per case.
+ */
+function set(dateStr: string, exercise: string, reps: number, hour = 8): StrengthSet {
+  return {
+    id: `${dateStr}-${exercise}-${reps}-${hour}`,
+    logged_at: `${dateStr}T${String(hour).padStart(2, '0')}:00:00`,
+    exercise,
+    reps,
+  }
+}
+
+const PUSHUPS: ExerciseGoal = {
+  exercise: 'pushups',
+  daily_target: 100,
+  color: '#EA580C',
+}
+
+describe('intensityFromPct', () => {
+  it('buckets 0% as level 0', () => {
+    expect(intensityFromPct(0)).toBe(0)
+    expect(intensityFromPct(-0.5)).toBe(0)
+  })
+  it('buckets 1–49% as level 1', () => {
+    expect(intensityFromPct(0.01)).toBe(1)
+    expect(intensityFromPct(0.49)).toBe(1)
+  })
+  it('buckets 50–99% as level 2', () => {
+    expect(intensityFromPct(0.5)).toBe(2)
+    expect(intensityFromPct(0.99)).toBe(2)
+  })
+  it('buckets 100%+ as level 3', () => {
+    expect(intensityFromPct(1)).toBe(3)
+    expect(intensityFromPct(1.5)).toBe(3)
+  })
+})
+
+describe('buildStrengthHeatmap', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('returns 7 rows starting on a Monday', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 3, 15)) // Wed Apr 15
+    const { grid } = buildStrengthHeatmap([], PUSHUPS)
+    expect(grid).toHaveLength(7)
+    expect(grid[0][0].date.getDay()).toBe(1)
+  })
+
+  it('aggregates reps and set counts per local day', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 3, 15))
+    const sets = [
+      set('2026-04-14', 'pushups', 20, 8),
+      set('2026-04-14', 'pushups', 25, 18),
+      set('2026-04-14', 'pullups', 5),
+      set('2026-04-13', 'pushups', 50),
+    ]
+    const { grid } = buildStrengthHeatmap(sets, PUSHUPS)
+    // Match by full year/month/day — the trailing 52-week range covers
+    // both Apr 14 2025 and Apr 14 2026, and only the latter has sets.
+    const dayMatches = (cell: { date: Date }, year: number, month0: number, day: number) =>
+      cell.date.getFullYear() === year &&
+      cell.date.getMonth() === month0 &&
+      cell.date.getDate() === day
+    const apr14 = grid.flat().find((c) => dayMatches(c, 2026, 3, 14))
+    expect(apr14?.reps).toBe(45)
+    expect(apr14?.setCount).toBe(2)
+    expect(apr14?.pct).toBeCloseTo(0.45)
+    const apr13 = grid.flat().find((c) => dayMatches(c, 2026, 3, 13))
+    expect(apr13?.reps).toBe(50)
+    expect(apr13?.pct).toBeCloseTo(0.5)
+  })
+
+  it('ignores sets for other exercises', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 3, 15))
+    const sets = [set('2026-04-14', 'pullups', 30), set('2026-04-14', 'dips', 30)]
+    const { grid } = buildStrengthHeatmap(sets, PUSHUPS)
+    expect(grid.flat().every((c) => c.reps === 0)).toBe(true)
+  })
+
+  it('respects dateFrom / dateTo and clamps insanely wide ranges', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 3, 15))
+    const { grid: small } = buildStrengthHeatmap(
+      [],
+      PUSHUPS,
+      new Date(2026, 3, 1),
+      new Date(2026, 3, 15),
+    )
+    expect(small[0].length).toBeGreaterThanOrEqual(2)
+    expect(small[0].length).toBeLessThanOrEqual(4)
+
+    const { grid: clamped } = buildStrengthHeatmap(
+      [],
+      PUSHUPS,
+      new Date(2018, 0, 1),
+      new Date(2026, 3, 15),
+    )
+    expect(clamped[0].length).toBeLessThanOrEqual(105)
+  })
+
+  it('skips sets with unparseable timestamps', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 3, 15))
+    const sets: StrengthSet[] = [
+      { id: 'bad', logged_at: 'not-a-date', exercise: 'pushups', reps: 50 },
+      set('2026-04-14', 'pushups', 50),
+    ]
+    const { grid } = buildStrengthHeatmap(sets, PUSHUPS)
+    const totalReps = grid.flat().reduce((acc, c) => acc + c.reps, 0)
+    expect(totalReps).toBe(50)
+  })
+
+  it('emits month labels for every visible month', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 3, 15))
+    const { monthLabels } = buildStrengthHeatmap([], PUSHUPS)
+    expect(monthLabels.length).toBeGreaterThan(0)
+    expect(monthLabels.find((l) => l.label === 'Apr')).toBeDefined()
+  })
+})
+
+describe('computeStrengthStreaks', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('returns 0/0 with no sets', () => {
+    expect(computeStrengthStreaks([], PUSHUPS)).toEqual({ current: 0, longest: 0 })
+  })
+
+  it('counts only days that hit the daily target', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-04-16T12:00:00'))
+    // Apr 12: 99 (under), Apr 13: 100, Apr 14: 50+50=100, Apr 15: 80 (under), Apr 16: 200
+    const sets = [
+      set('2026-04-12', 'pushups', 99),
+      set('2026-04-13', 'pushups', 100),
+      set('2026-04-14', 'pushups', 50, 8),
+      set('2026-04-14', 'pushups', 50, 18),
+      set('2026-04-15', 'pushups', 80),
+      set('2026-04-16', 'pushups', 200),
+    ]
+    const result = computeStrengthStreaks(sets, PUSHUPS)
+    // Hit days: 13, 14, 16. Current = 1 (today = 16, yesterday = 15 missed)
+    expect(result.current).toBe(1)
+    // Longest run = 2 (Apr 13–14)
+    expect(result.longest).toBe(2)
+  })
+
+  it('counts yesterday when today is not yet logged', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-04-16T12:00:00'))
+    const sets = [
+      set('2026-04-13', 'pushups', 100),
+      set('2026-04-14', 'pushups', 100),
+      set('2026-04-15', 'pushups', 100),
+    ]
+    const result = computeStrengthStreaks(sets, PUSHUPS)
+    expect(result.current).toBe(3)
+    expect(result.longest).toBe(3)
+  })
+
+  it('current is 0 when last hit-day is older than yesterday', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-04-16T12:00:00'))
+    const sets = [
+      set('2026-04-10', 'pushups', 100),
+      set('2026-04-11', 'pushups', 100),
+    ]
+    const result = computeStrengthStreaks(sets, PUSHUPS)
+    expect(result.current).toBe(0)
+    expect(result.longest).toBe(2)
+  })
+
+  it('ignores sets for other exercises', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-04-16T12:00:00'))
+    const sets = [
+      set('2026-04-15', 'pullups', 100),
+      set('2026-04-16', 'pullups', 100),
+    ]
+    expect(computeStrengthStreaks(sets, PUSHUPS)).toEqual({ current: 0, longest: 0 })
+  })
+})
+
+describe('computeStrengthStats', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('returns zeroed entries for goals with no matching sets', () => {
+    const now = new Date('2026-04-16T12:00:00')
+    const stats = computeStrengthStats([], [PUSHUPS], now)
+    expect(stats).toHaveLength(1)
+    expect(stats[0]).toMatchObject({
+      exercise: 'pushups',
+      color: '#EA580C',
+      dailyTarget: 100,
+      currentStreak: 0,
+      longestStreak: 0,
+      thisWeekReps: 0,
+      lastWeekReps: 0,
+      thisMonthReps: 0,
+      lastMonthReps: 0,
+      avgSetsPerActiveDay: 0,
+      allTimeReps: 0,
+    })
+  })
+
+  it('rolls up reps by ISO week (Mon–Sun) and calendar month', () => {
+    const now = new Date('2026-04-16T12:00:00') // Thu Apr 16, 2026
+    // This week (Mon Apr 13 – Sun Apr 19): 100 + 50 = 150
+    // Last week (Mon Apr 6 – Sun Apr 12): 80
+    // This month (Apr): 100 + 50 + 80 = 230
+    // Last month (Mar): 200
+    const sets = [
+      set('2026-03-15', 'pushups', 200),
+      set('2026-04-08', 'pushups', 80),
+      set('2026-04-13', 'pushups', 100),
+      set('2026-04-16', 'pushups', 50),
+    ]
+    const [stats] = computeStrengthStats(sets, [PUSHUPS], now)
+    expect(stats.thisWeekReps).toBe(150)
+    expect(stats.lastWeekReps).toBe(80)
+    expect(stats.thisMonthReps).toBe(230)
+    expect(stats.lastMonthReps).toBe(200)
+    expect(stats.allTimeReps).toBe(430)
+  })
+
+  it('averages sets across active days only (multi-set days count once)', () => {
+    const now = new Date('2026-04-16T12:00:00')
+    const sets = [
+      set('2026-04-14', 'pushups', 25, 8),
+      set('2026-04-14', 'pushups', 25, 12),
+      set('2026-04-14', 'pushups', 25, 18),
+      set('2026-04-15', 'pushups', 30),
+    ]
+    const [stats] = computeStrengthStats(sets, [PUSHUPS], now)
+    // 4 sets across 2 active days = 2.0 avg
+    expect(stats.avgSetsPerActiveDay).toBe(2)
+  })
+
+  it('returns one entry per goal in input order', () => {
+    const now = new Date('2026-04-16T12:00:00')
+    const goals: ExerciseGoal[] = [
+      PUSHUPS,
+      { exercise: 'pullups', daily_target: 30, color: '#0EA5A1' },
+    ]
+    const sets = [set('2026-04-16', 'pullups', 30), set('2026-04-16', 'pushups', 50)]
+    const stats = computeStrengthStats(sets, goals, now)
+    expect(stats.map((s) => s.exercise)).toEqual(['pushups', 'pullups'])
+    expect(stats[1].color).toBe('#0EA5A1')
+    expect(stats[1].thisWeekReps).toBe(30)
+  })
+})

--- a/lib/training-facility/weight-room-history.ts
+++ b/lib/training-facility/weight-room-history.ts
@@ -230,10 +230,15 @@ export function buildStrengthHeatmap(
  * @param sets every logged set; filtered to `goal.exercise` internally.
  * @param goal the {@link ExerciseGoal} whose `daily_target` defines the
  *   bar to clear.
+ * @param now optional override for the "today" anchor used to decide
+ *   whether `current` includes the most recent hit-day. Defaults to
+ *   `new Date()`. Threaded through from {@link computeStrengthStats}
+ *   so a single fixed clock drives every rollup in one stats payload.
  */
 export function computeStrengthStreaks(
   sets: readonly StrengthSet[],
   goal: ExerciseGoal,
+  now: Date = new Date(),
 ): { current: number; longest: number } {
   // Belt-and-suspenders — same reason as in `buildStrengthHeatmap`.
   const target = Math.max(1, goal.daily_target)
@@ -264,7 +269,7 @@ export function computeStrengthStreaks(
     }
   }
 
-  const today = toDateKey(new Date())
+  const today = toDateKey(now)
   const yesterday = addDays(today, -1)
   const lastDay = hitDays[hitDays.length - 1]
   if (lastDay !== today && lastDay !== yesterday) {
@@ -354,7 +359,7 @@ export function computeStrengthStats(
     }
     const avgSetsPerActiveDay = activeDays.size === 0 ? 0 : validSetCount / activeDays.size
 
-    const streak = computeStrengthStreaks(sets, goal)
+    const streak = computeStrengthStreaks(sets, goal, now)
     return {
       exercise: goal.exercise,
       color: goal.color,

--- a/lib/training-facility/weight-room-history.ts
+++ b/lib/training-facility/weight-room-history.ts
@@ -1,0 +1,367 @@
+import type { ExerciseGoal, StrengthSet } from '@/types/weight-room'
+
+/**
+ * Pure helpers for the Weight Room History View (#81). Mirrors the
+ * cardio-side `heatmap-grid.ts` + `streaks.ts` split: this module owns
+ * the per-exercise daily aggregation, the goal-relative intensity
+ * bucketing, the streak rule (consecutive days hitting the daily goal),
+ * and the period rollups (week / month / all-time) that the stats
+ * panel reads.
+ *
+ * Strength sets carry an ISO `logged_at` timestamp; heatmap and stats
+ * both bucket by *local* calendar day so a set logged at 11pm doesn't
+ * silently roll into the next day.
+ */
+
+/** A single cell in the strength heatmap grid for one exercise. */
+export interface StrengthHeatmapCell {
+  /** Local-time date this cell represents. */
+  date: Date
+  /** Sum of reps logged for this exercise on {@link date}. `0` for empty days. */
+  reps: number
+  /** Number of distinct sets logged on {@link date}. */
+  setCount: number
+  /**
+   * `reps / dailyTarget` — un-clamped, so 100% means "exactly hit the
+   * goal" and 1.5 means "150% of goal". Empty days are `0`.
+   */
+  pct: number
+}
+
+/** Result of {@link buildStrengthHeatmap}. */
+export interface StrengthHeatmapGrid {
+  /** 7-row × N-column grid; row 0 is Monday, row 6 is Sunday. */
+  grid: StrengthHeatmapCell[][]
+  /** First-of-month markers for the column header labels. */
+  monthLabels: { col: number; label: string }[]
+}
+
+/** Per-exercise rollups for the stats panel. */
+export interface StrengthExerciseStats {
+  /** Exercise name (matches {@link ExerciseGoal.exercise}). */
+  exercise: string
+  /** Hex color from the matching {@link ExerciseGoal.color}. */
+  color: string
+  /** Daily target reps from the matching goal. */
+  dailyTarget: number
+  /** Consecutive days (ending today or yesterday) hitting the daily target. */
+  currentStreak: number
+  /** Longest run of consecutive days hitting the daily target, all-time. */
+  longestStreak: number
+  /** Total reps logged this ISO week (Mon–Sun, current). */
+  thisWeekReps: number
+  /** Total reps logged last ISO week (Mon–Sun, previous). */
+  lastWeekReps: number
+  /** Total reps logged in the current calendar month. */
+  thisMonthReps: number
+  /** Total reps logged in the previous calendar month. */
+  lastMonthReps: number
+  /**
+   * Mean sets per *active* day (a day with at least one set) over the
+   * whole logged history. `0` when no sets exist for this exercise.
+   * Active-day denominator (rather than calendar days since first set)
+   * answers "when I train, how many sets do I do" — the question the
+   * Today View's quick-log most directly relates to.
+   */
+  avgSetsPerActiveDay: number
+  /** All-time total reps for this exercise. */
+  allTimeReps: number
+}
+
+const DAY_MS = 86_400_000
+const WEEK_MS = 7 * DAY_MS
+/** Cap at ~2 years to limit DOM node count when a wide range is requested. */
+const MAX_COLS = 104
+
+const MONTH_LABELS = [
+  'Jan',
+  'Feb',
+  'Mar',
+  'Apr',
+  'May',
+  'Jun',
+  'Jul',
+  'Aug',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dec',
+] as const
+
+/** Get the Monday at or before a given local date (00:00 local). */
+function getMondayOf(d: Date): Date {
+  const m = new Date(d.getFullYear(), d.getMonth(), d.getDate())
+  const dow = m.getDay()
+  m.setDate(m.getDate() - (dow === 0 ? 6 : dow - 1))
+  return m
+}
+
+/** Get a `YYYY-MM-DD` local-date key from a Date. */
+function toDateKey(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
+
+/**
+ * Add `n` days to a `YYYY-MM-DD` key, returning a new key. Uses
+ * local-noon as the base so DST transitions don't shift the date.
+ */
+function addDays(dateKey: string, n: number): string {
+  const d = new Date(dateKey + 'T12:00:00')
+  d.setDate(d.getDate() + n)
+  return toDateKey(d)
+}
+
+/**
+ * Bucket reps-as-percent-of-goal into one of four intensity levels for
+ * the heatmap cell color: 0 = empty, 1 = light (1–49%), 2 = medium
+ * (50–99%), 3 = full (100%+). Matches the four-band scheme called out
+ * in the issue body.
+ */
+export function intensityFromPct(pct: number): 0 | 1 | 2 | 3 {
+  if (pct <= 0) return 0
+  if (pct < 0.5) return 1
+  if (pct < 1) return 2
+  return 3
+}
+
+/**
+ * Aggregate one exercise's sets into a 7-row × N-column heatmap. Row 0
+ * is Monday so a year reads top-down as Mon→Sun. The grid spans the
+ * supplied range when both `dateFrom` and `dateTo` are provided;
+ * otherwise it falls back to the trailing 52 weeks ending at the
+ * current week. Capped at ~2 years to keep the DOM small.
+ *
+ * Each cell carries the day's rep total, set count, and `pct = reps /
+ * dailyTarget` so the renderer can pick a color via
+ * {@link intensityFromPct} and a tooltip can read "32 reps (3 sets,
+ * 32% of goal)".
+ *
+ * Sets whose `exercise` doesn't match `goal.exercise` are silently
+ * ignored — call once per exercise.
+ *
+ * @param sets every logged set from {@link import('@/types/weight-room').WeightRoomData.sets};
+ *   the helper filters to the matching exercise.
+ * @param goal the {@link ExerciseGoal} for the target exercise; supplies
+ *   the `daily_target` denominator for `pct`.
+ * @param dateFrom optional inclusive start of the range; clamped to ~2
+ *   years before `dateTo` if longer.
+ * @param dateTo optional inclusive end; defaults to today.
+ */
+export function buildStrengthHeatmap(
+  sets: readonly StrengthSet[],
+  goal: ExerciseGoal,
+  dateFrom?: Date | null,
+  dateTo?: Date | null,
+): StrengthHeatmapGrid {
+  const endMonday = getMondayOf(dateTo ?? new Date())
+  const endDate = new Date(endMonday.getTime() + 6 * DAY_MS)
+
+  let startMonday: Date
+  if (dateFrom) {
+    startMonday = getMondayOf(dateFrom)
+    const maxStart = new Date(endMonday.getTime() - MAX_COLS * WEEK_MS)
+    if (startMonday.getTime() < maxStart.getTime()) {
+      startMonday = maxStart
+    }
+  } else {
+    startMonday = new Date(endMonday.getTime() - 52 * WEEK_MS)
+  }
+
+  // Lookup: local-date key → { reps, setCount } for the matching exercise.
+  const lookup = new Map<string, { reps: number; setCount: number }>()
+  for (const s of sets) {
+    if (s.exercise !== goal.exercise) continue
+    const d = new Date(s.logged_at)
+    if (!Number.isFinite(d.getTime())) continue
+    const key = toDateKey(d)
+    const entry = lookup.get(key)
+    if (entry) {
+      entry.reps += s.reps
+      entry.setCount += 1
+    } else {
+      lookup.set(key, { reps: s.reps, setCount: 1 })
+    }
+  }
+
+  const target = Math.max(1, goal.daily_target)
+  const startMs = startMonday.getTime()
+  const totalCols = Math.floor((endDate.getTime() - startMs) / WEEK_MS) + 1
+  const grid: StrengthHeatmapCell[][] = Array.from({ length: 7 }, () => [])
+  const monthLabels: { col: number; label: string }[] = []
+  let lastMonth = -1
+
+  for (let col = 0; col < totalCols; col++) {
+    for (let row = 0; row < 7; row++) {
+      const date = new Date(startMs + (col * 7 + row) * DAY_MS)
+      const key = toDateKey(date)
+      const entry = lookup.get(key)
+      const reps = entry?.reps ?? 0
+      grid[row].push({
+        date,
+        reps,
+        setCount: entry?.setCount ?? 0,
+        pct: reps / target,
+      })
+
+      if (date.getMonth() !== lastMonth) {
+        lastMonth = date.getMonth()
+        monthLabels.push({ col, label: MONTH_LABELS[date.getMonth()] })
+      }
+    }
+  }
+
+  return { grid, monthLabels }
+}
+
+/**
+ * Compute the "hit-the-goal" streak for one exercise: consecutive
+ * calendar days where the exercise's daily rep total met or exceeded
+ * its `daily_target`. Days below the target — even ones with reps
+ * logged — break the streak. Mirrors the issue body: "consecutive days
+ * hitting goal".
+ *
+ * `current` counts back from today (or yesterday, if today hasn't
+ * crossed the target yet) and is `0` when the most recent goal-hit day
+ * is older than yesterday. `longest` is the all-time best.
+ *
+ * @param sets every logged set; filtered to `goal.exercise` internally.
+ * @param goal the {@link ExerciseGoal} whose `daily_target` defines the
+ *   bar to clear.
+ */
+export function computeStrengthStreaks(
+  sets: readonly StrengthSet[],
+  goal: ExerciseGoal,
+): { current: number; longest: number } {
+  const target = Math.max(1, goal.daily_target)
+  const dailyReps = new Map<string, number>()
+  for (const s of sets) {
+    if (s.exercise !== goal.exercise) continue
+    const d = new Date(s.logged_at)
+    if (!Number.isFinite(d.getTime())) continue
+    const key = toDateKey(d)
+    dailyReps.set(key, (dailyReps.get(key) ?? 0) + s.reps)
+  }
+
+  const hitDays: string[] = []
+  for (const [key, reps] of dailyReps) {
+    if (reps >= target) hitDays.push(key)
+  }
+  if (hitDays.length === 0) return { current: 0, longest: 0 }
+  hitDays.sort()
+
+  let longest = 1
+  let run = 1
+  for (let i = 1; i < hitDays.length; i++) {
+    if (addDays(hitDays[i - 1], 1) === hitDays[i]) {
+      run++
+      if (run > longest) longest = run
+    } else {
+      run = 1
+    }
+  }
+
+  const today = toDateKey(new Date())
+  const yesterday = addDays(today, -1)
+  const lastDay = hitDays[hitDays.length - 1]
+  if (lastDay !== today && lastDay !== yesterday) {
+    return { current: 0, longest }
+  }
+
+  let current = 1
+  for (let i = hitDays.length - 2; i >= 0; i--) {
+    if (addDays(hitDays[i], 1) === hitDays[i + 1]) {
+      current++
+    } else {
+      break
+    }
+  }
+
+  return { current, longest: Math.max(longest, current) }
+}
+
+/**
+ * Sum reps for one exercise across an inclusive local-date window.
+ * Both bounds are date-only — the function compares against each set's
+ * local calendar day, so passing `[Apr 1, Apr 7]` totals everything
+ * logged on Mon–Sun of that week regardless of the time of day.
+ */
+function sumRepsInRange(
+  sets: readonly StrengthSet[],
+  exercise: string,
+  fromKey: string,
+  toKey: string,
+): number {
+  let total = 0
+  for (const s of sets) {
+    if (s.exercise !== exercise) continue
+    const d = new Date(s.logged_at)
+    if (!Number.isFinite(d.getTime())) continue
+    const key = toDateKey(d)
+    if (key >= fromKey && key <= toKey) total += s.reps
+  }
+  return total
+}
+
+/**
+ * Compute every per-exercise rollup the History stats panel needs:
+ * streaks, this/last week reps, this/last month reps, average sets per
+ * active day, and all-time reps. One {@link StrengthExerciseStats}
+ * entry per goal, in the same order as `goals`.
+ *
+ * Week boundaries are ISO (Mon–Sun) so the rollup matches the heatmap's
+ * row layout. Month boundaries are local calendar months. "Average
+ * sets per active day" divides total sets by the number of distinct
+ * days the exercise was performed — a day with multiple sets counts
+ * once in the denominator.
+ *
+ * @param sets every logged set across all exercises.
+ * @param goals the configured exercises; one stats entry per goal.
+ * @param now optional override for the "today" anchor used by the week
+ *   / month / streak math. Defaults to `new Date()`. Tests pass a
+ *   fixed date to make week boundaries deterministic.
+ */
+export function computeStrengthStats(
+  sets: readonly StrengthSet[],
+  goals: readonly ExerciseGoal[],
+  now: Date = new Date(),
+): StrengthExerciseStats[] {
+  const todayMonday = getMondayOf(now)
+  const thisWeekStart = toDateKey(todayMonday)
+  const thisWeekEnd = toDateKey(new Date(todayMonday.getTime() + 6 * DAY_MS))
+  const lastWeekStart = toDateKey(new Date(todayMonday.getTime() - 7 * DAY_MS))
+  const lastWeekEnd = toDateKey(new Date(todayMonday.getTime() - DAY_MS))
+
+  const thisMonthStart = toDateKey(new Date(now.getFullYear(), now.getMonth(), 1))
+  const thisMonthEnd = toDateKey(new Date(now.getFullYear(), now.getMonth() + 1, 0))
+  const lastMonthStart = toDateKey(new Date(now.getFullYear(), now.getMonth() - 1, 1))
+  const lastMonthEnd = toDateKey(new Date(now.getFullYear(), now.getMonth(), 0))
+
+  return goals.map((goal) => {
+    const matching = sets.filter((s) => s.exercise === goal.exercise)
+    const activeDays = new Set<string>()
+    let allTimeReps = 0
+    for (const s of matching) {
+      const d = new Date(s.logged_at)
+      if (!Number.isFinite(d.getTime())) continue
+      activeDays.add(toDateKey(d))
+      allTimeReps += s.reps
+    }
+    const setCount = matching.filter((s) => Number.isFinite(new Date(s.logged_at).getTime())).length
+    const avgSetsPerActiveDay = activeDays.size === 0 ? 0 : setCount / activeDays.size
+
+    const streak = computeStrengthStreaks(sets, goal)
+    return {
+      exercise: goal.exercise,
+      color: goal.color,
+      dailyTarget: goal.daily_target,
+      currentStreak: streak.current,
+      longestStreak: streak.longest,
+      thisWeekReps: sumRepsInRange(sets, goal.exercise, thisWeekStart, thisWeekEnd),
+      lastWeekReps: sumRepsInRange(sets, goal.exercise, lastWeekStart, lastWeekEnd),
+      thisMonthReps: sumRepsInRange(sets, goal.exercise, thisMonthStart, thisMonthEnd),
+      lastMonthReps: sumRepsInRange(sets, goal.exercise, lastMonthStart, lastMonthEnd),
+      avgSetsPerActiveDay,
+      allTimeReps,
+    }
+  })
+}

--- a/lib/training-facility/weight-room-history.ts
+++ b/lib/training-facility/weight-room-history.ts
@@ -183,6 +183,9 @@ export function buildStrengthHeatmap(
     }
   }
 
+  // Belt-and-suspenders: the schema (`WeightRoomGoalRowSchema`) already
+  // enforces a positive integer, but a 0/negative target slipping
+  // through would divide-by-zero or invert the intensity bucket.
   const target = Math.max(1, goal.daily_target)
   const startMs = startMonday.getTime()
   const totalCols = Math.floor((endDate.getTime() - startMs) / WEEK_MS) + 1
@@ -232,6 +235,7 @@ export function computeStrengthStreaks(
   sets: readonly StrengthSet[],
   goal: ExerciseGoal,
 ): { current: number; longest: number } {
+  // Belt-and-suspenders — same reason as in `buildStrengthHeatmap`.
   const target = Math.max(1, goal.daily_target)
   const dailyReps = new Map<string, number>()
   for (const s of sets) {
@@ -340,14 +344,15 @@ export function computeStrengthStats(
     const matching = sets.filter((s) => s.exercise === goal.exercise)
     const activeDays = new Set<string>()
     let allTimeReps = 0
+    let validSetCount = 0
     for (const s of matching) {
       const d = new Date(s.logged_at)
       if (!Number.isFinite(d.getTime())) continue
       activeDays.add(toDateKey(d))
       allTimeReps += s.reps
+      validSetCount += 1
     }
-    const setCount = matching.filter((s) => Number.isFinite(new Date(s.logged_at).getTime())).length
-    const avgSetsPerActiveDay = activeDays.size === 0 ? 0 : setCount / activeDays.size
+    const avgSetsPerActiveDay = activeDays.size === 0 ? 0 : validSetCount / activeDays.size
 
     const streak = computeStrengthStreaks(sets, goal)
     return {


### PR DESCRIPTION
## Summary

Slice 2 of the Weight Room (PRD §7.6, #81). Adds a public route at
`/training-facility/weight-room/history` that renders a GitHub-style
heatmap per configured exercise plus a per-exercise stats panel —
streaks, weekly/monthly rep totals, average sets per active day, and
all-time reps.

Reuses the data layer from #79 (`getWeightRoomDataServer`); no
migrations, no API surface changes. The Today View / scene-link
pieces remain on slices #80 / #82.

Closes #81.

## What landed

| Layer | File | Notes |
| --- | --- | --- |
| Util | `lib/training-facility/weight-room-history.ts` | `buildStrengthHeatmap`, `intensityFromPct`, `computeStrengthStreaks`, `computeStrengthStats`. Mirrors the cardio-side `heatmap-grid.ts` + `streaks.ts` split. |
| Heatmap | `components/training-facility/weight-room/StrengthHeatmap.tsx` | SVG, 7 × 52 grid by default. Cells colored by `reps / daily_target` bucketed into 4 bands (0% / 1–49% / 50–99% / 100%+) and tinted with `goal.color` via `fill-opacity`. Native `<title>` tooltip per cell. |
| Stats | `components/training-facility/weight-room/StrengthStats.tsx` | One cream card per exercise on the dark surface. Editorial mono numerals matching the cardio overview's stat-card style. |
| Page | `app/training-facility/weight-room/history/page.tsx` | Server Component. Reads via `getWeightRoomDataServer`, falls back to the empty-state copy on read failure. Public — RLS already allows anon SELECT on the Weight Room tables. |
| Tests | 3 new test files (34 cases) | All green; full suite at 707/707. |

## Architecture decisions

- **Goal-relative intensity, not raw rep count.** The heatmap's color
  bucket is `reps / daily_target`, so a 50-rep day on a 100-target
  exercise reads the same as a 15-rep day on a 30-target exercise.
  Matches the issue's "Color intensity maps to % of daily goal achieved"
  spec.
- **Stacked per-exercise heatmaps, not a combined toggle.** Reads
  cleanly without UI state, keeps the page a Server Component, and
  matches the issue's primary phrasing ("One heatmap per exercise").
  A toggle / combined view can land later if the Today View ends up
  needing one.
- **`fill-opacity` over per-band hex mixes.** A single hex color from
  `ExerciseGoal.color` drives the whole exercise's heatmap — adding a
  new exercise via the Settings UI doesn't require a palette entry.
- **Streak rule = "consecutive days hitting the daily target."** Days
  with reps logged but below target break the streak. Faithful to the
  issue body; the alternative (any-rep streak) was easier to keep alive
  but less meaningful.
- **Average sets per *active* day, not per calendar day.** Answers
  "when I train, how many sets do I do" — the Today View's quick-log
  question. Calendar-day denominator would punish rest weeks.
- **No `react-router-dom` / cross-view nav.** Slice #82 owns that.
  Page reachable via direct URL; sits behind the same
  `isTrainingFacilityEnabled()` gate as the rest of the area.

## Test plan

- [ ] CI green (Vercel + e2e + CodeRabbit).
- [ ] With seeded data: visit `/training-facility/weight-room/history`
      while signed-out. Should render the page chrome plus per-exercise
      heatmaps (pushups orange, pullups teal) and the stats panel.
- [ ] Hover any populated heatmap cell on desktop — native tooltip
      shows `Apr 14, 2026: 45 reps (2 sets, 45% of pushups goal)`.
      Empty cells show just the date.
- [ ] On mobile (390×844), heatmaps scroll horizontally inside their
      card (the page has \`overflow-x-auto\` per heatmap card) and the
      stats grid stacks single-column.
- [ ] With both tables empty (or read failure) — page renders the
      "No exercises configured yet" empty state with a Settings link.
- [ ] Streak math: log a set ≥ daily target for today; current streak
      shows 1 with the flame in color. Skip a day, log again — current
      resets to 1 but longest persists.
- [ ] \`/training-facility\` env flag off → visiting the route 404s.

## Out of scope

- Today View / activity rings / quick-log — slice #80
- Cross-view nav (header / tab bar between Cardio and Strength) — slice #82
- DateFilter integration on the heatmap — the cardio overview's
  DateFilter could plug in later, but the issue doesn't require it
  and the trailing 52w default reads well on its own.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Weight Room History page displaying a 52-week visual heatmap of training frequency and intensity by exercise goal.
  * Added Statistics cards showing streaks, weekly/monthly totals, average sets per day, and all-time performance metrics by exercise.

* **Tests**
  * Added test coverage for heatmap visualization, statistics display, and underlying data calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->