### PR TITLE
feat(weight-room): Today View with activity rings + quick log (#80)

### DIFF
--- a/app/training-facility/weight-room/page.tsx
+++ b/app/training-facility/weight-room/page.tsx
@@ -1,0 +1,75 @@
+import { Suspense, type JSX } from 'react'
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+
+import { BackToCourtButton } from '@/components/common/BackToCourtButton'
+import { TodayDataIsland } from '@/components/training-facility/weight-room/TodayDataIsland'
+import { isTrainingFacilityEnabled } from '@/lib/feature-flags'
+
+/**
+ * Weight Room sub-area landing page (#80 — Today View). The activity
+ * rings + quick-log + today's-set list are the centerpiece; admin
+ * viewers get the log form, everyone sees the rings.
+ *
+ * Server Component for the flag gate + chrome only — the data island
+ * is a Client Component because it needs `useSearchParams()` for the
+ * empty-state preview affordance and `getWeightRoomData()` reads
+ * Supabase via the browser client.
+ *
+ * Slice #82 will wire the Weight Room door on the Training Facility
+ * scene + cross-view nav (Today ↔ History ↔ Settings); until then,
+ * this page is reachable via direct URL and the existing settings
+ * link in the header.
+ */
+export default function TrainingFacilityWeightRoomPage(): JSX.Element {
+  if (!isTrainingFacilityEnabled()) notFound()
+
+  return (
+    <div className="relative min-h-svh overflow-hidden bg-[#120d0a] text-[#f7ead9]">
+      <div
+        aria-hidden="true"
+        className="absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(248,214,170,0.16),transparent_30%),linear-gradient(180deg,#241811_0%,#120d0a_55%,#0b0806_100%)]"
+      />
+
+      <div className="relative z-10 mx-auto flex min-h-svh w-full max-w-5xl flex-col gap-10 px-4 py-6 sm:px-6 sm:py-8 lg:px-10">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <BackToCourtButton />
+          <Link
+            href="/training-facility"
+            className="rounded-full border border-white/15 bg-white/5 px-4 py-2 text-xs font-semibold uppercase tracking-[0.28em] text-white/80 transition hover:bg-white/10"
+          >
+            ← Training Facility
+          </Link>
+        </div>
+
+        <header className="text-center sm:text-left">
+          <p className="font-mono text-[11px] uppercase tracking-[0.32em] text-amber-300/80">
+            Training Facility / Weight Room
+          </p>
+          <h1 className="mt-2 text-3xl font-black uppercase tracking-[0.06em] text-[#fff7ec] sm:text-5xl lg:text-6xl">
+            Today
+          </h1>
+          <p className="mx-auto mt-3 max-w-2xl text-sm leading-7 text-[#e8d5be] sm:mx-0 sm:text-base">
+            Grease-the-groove pushups and pullups. The rings track today’s
+            progress against the daily targets; tap a chip to log a set.
+          </p>
+          <div className="mt-4 flex flex-wrap gap-3 sm:justify-start">
+            <Link
+              href="/training-facility/weight-room/settings"
+              className="rounded-full border border-white/15 bg-white/5 px-4 py-2 text-xs font-semibold uppercase tracking-[0.28em] text-white/80 transition hover:bg-white/10"
+            >
+              Settings →
+            </Link>
+          </div>
+        </header>
+
+        {/* Suspense required because the island reads `useSearchParams()`
+            for the `?preview=demo` empty-state affordance. The fallback
+            is null because the island owns its own loading skeleton. */}
+        <Suspense fallback={null}>
+          <TodayDataIsland />
+        </Suspense>
+      </div>
+    </div>
+  )
+}

--- a/components/training-facility/weight-room/ActivityRings.test.tsx
+++ b/components/training-facility/weight-room/ActivityRings.test.tsx
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+import type { ExerciseGoal } from '@/types/weight-room'
+
+import { ActivityRings } from './ActivityRings'
+
+const PUSHUPS: ExerciseGoal = {
+  exercise: 'pushups',
+  daily_target: 100,
+  color: '#EA580C',
+}
+const PULLUPS: ExerciseGoal = {
+  exercise: 'pullups',
+  daily_target: 30,
+  color: '#0EA5A1',
+}
+
+describe('ActivityRings', () => {
+  it('renders one <g> per ring with stable testids', () => {
+    render(
+      <ActivityRings
+        rings={[
+          { goal: PUSHUPS, totalReps: 50 },
+          { goal: PULLUPS, totalReps: 10 },
+        ]}
+      />,
+    )
+    expect(screen.getByTestId('ring-pushups')).toBeInTheDocument()
+    expect(screen.getByTestId('ring-pullups')).toBeInTheDocument()
+  })
+
+  it('shows the primary exercise reps / goal in the center readout', () => {
+    render(<ActivityRings rings={[{ goal: PUSHUPS, totalReps: 75 }]} />)
+    expect(screen.getByText('pushups')).toBeInTheDocument()
+    expect(screen.getByText('75')).toBeInTheDocument()
+    expect(screen.getByText('/ 100')).toBeInTheDocument()
+    expect(screen.getByText('75%')).toBeInTheDocument()
+  })
+
+  it('renders the over-fill raw count but caps the visual ring at 100%', () => {
+    render(<ActivityRings rings={[{ goal: PUSHUPS, totalReps: 125 }]} />)
+    // The over-fill is visible in the readout
+    expect(screen.getByText('125')).toBeInTheDocument()
+    expect(screen.getByText('125%')).toBeInTheDocument()
+
+    // The dashoffset on the progress circle clamps to 0 (full sweep)
+    const ring = screen.getByTestId('ring-pushups')
+    const circles = ring.querySelectorAll('circle')
+    // Second circle is the progress arc (first is the track)
+    expect(circles[1].getAttribute('stroke-dashoffset')).toBe('0')
+  })
+
+  it('renders an empty placeholder when rings is empty', () => {
+    render(<ActivityRings rings={[]} />)
+    expect(screen.getByText(/add a goal in settings/i)).toBeInTheDocument()
+    expect(screen.queryByTestId('activity-rings')).not.toBeInTheDocument()
+  })
+
+  it('exposes an aria-label that summarizes every ring', () => {
+    render(
+      <ActivityRings
+        rings={[
+          { goal: PUSHUPS, totalReps: 50 },
+          { goal: PULLUPS, totalReps: 15 },
+        ]}
+      />,
+    )
+    const svg = screen.getByRole('img')
+    expect(svg).toHaveAttribute(
+      'aria-label',
+      expect.stringContaining('pushups 50 of 100'),
+    )
+    expect(svg).toHaveAttribute(
+      'aria-label',
+      expect.stringContaining('pullups 15 of 30'),
+    )
+  })
+})

--- a/components/training-facility/weight-room/ActivityRings.test.tsx
+++ b/components/training-facility/weight-room/ActivityRings.test.tsx
@@ -76,4 +76,22 @@ describe('ActivityRings', () => {
       expect.stringContaining('pullups 15 of 30'),
     )
   })
+
+  it('renders every configured exercise even when the count is large', () => {
+    // 8 exercises is well over the 6-ring limit the fixed-stroke
+    // dimensions imposed; the auto-fit should shrink stroke/gap so
+    // every ring still renders. Codex flagged the silent-drop behavior
+    // when reviewing #80.
+    const goals: ExerciseGoal[] = Array.from({ length: 8 }, (_, i) => ({
+      exercise: `ex-${i}`,
+      daily_target: 50,
+      color: '#EA580C',
+    }))
+    render(
+      <ActivityRings rings={goals.map((g) => ({ goal: g, totalReps: 25 }))} />,
+    )
+    for (const g of goals) {
+      expect(screen.getByTestId(`ring-${g.exercise}`)).toBeInTheDocument()
+    }
+  })
 })

--- a/components/training-facility/weight-room/ActivityRings.tsx
+++ b/components/training-facility/weight-room/ActivityRings.tsx
@@ -1,0 +1,173 @@
+import type { JSX } from 'react'
+
+import type { ExerciseGoal } from '@/types/weight-room'
+
+/** Per-exercise progress slice consumed by {@link ActivityRings}. */
+export interface RingProgress {
+  /** The configured goal — provides exercise name, target, and color. */
+  goal: ExerciseGoal
+  /** Total reps already logged for the exercise on the current day. */
+  totalReps: number
+}
+
+/** Props for {@link ActivityRings}. */
+export interface ActivityRingsProps {
+  /**
+   * One entry per exercise. The first entry renders as the outer
+   * (largest) ring; subsequent entries shrink inward. The Today View
+   * orders these by goal config so pushups (orange) is outermost and
+   * pullups (teal) sits inside it — the activity-ring metaphor.
+   */
+  rings: readonly RingProgress[]
+  /**
+   * Render size in CSS pixels for the SVG's viewport. Defaults to 256.
+   * The component still scales fluidly via CSS — `size` only sets the
+   * intrinsic viewBox; the consumer can override with Tailwind's
+   * `w-*` / `h-*` classes.
+   */
+  size?: number
+  /**
+   * Optional Tailwind classes appended to the outer wrapper. Lets the
+   * parent place the rings inside its own grid cell without rewriting
+   * the chrome.
+   */
+  className?: string
+}
+
+const RING_STROKE = 14
+const RING_GAP = 4
+const TRACK_OPACITY = 0.18
+
+/**
+ * SVG-based concentric activity rings — the Today View centerpiece
+ * (#80). Each `RingProgress` entry contributes one ring; the first
+ * entry is outermost. Stroke fills proportionally to `totalReps /
+ * goal.daily_target` and clamps at one full revolution (a 110-rep day
+ * stops at the goal visually, but the center text shows the raw
+ * `total / goal` numbers so the over-fill is still visible).
+ *
+ * Goal-hit rings get a subtle drop-shadow glow (the issue's
+ * "completion state: ring glows or pulses when daily goal is hit").
+ * No CSS animation on first paint — the ring fills immediately, which
+ * matches the static screenshot review the test plan calls for. Future
+ * micro-interaction (a pulse on quick-log success) can hang off a
+ * data-attribute toggled by the parent.
+ *
+ * Center text shows the *primary* exercise — the first entry in
+ * `rings`. Ports the spec's "75 / 100" treatment so the ring tells
+ * the at-a-glance story and the number tells the precise one.
+ *
+ * Order matters: the issue calls out outer = pushups (accent), inner
+ * = pullups (secondary). The Today View hands `rings` over already
+ * ordered, so this component just walks the array.
+ */
+export function ActivityRings({
+  rings,
+  size = 256,
+  className = '',
+}: ActivityRingsProps): JSX.Element {
+  const center = size / 2
+  const outerRadius = center - RING_STROKE / 2
+
+  // Empty-state — no goals configured. Rare in practice (the migration
+  // seeds two), but cheap to handle so the page doesn't blow up if
+  // every default goal is deleted via the settings UI.
+  if (rings.length === 0) {
+    return (
+      <div
+        className={`relative flex aspect-square items-center justify-center rounded-full border border-dashed border-white/15 bg-black/30 text-center text-xs text-white/50 ${className}`}
+        style={{ width: size, height: size }}
+      >
+        Add a goal in Settings to start tracking.
+      </div>
+    )
+  }
+
+  const primary = rings[0]
+  const primaryPercentRaw =
+    primary.goal.daily_target > 0 ? primary.totalReps / primary.goal.daily_target : 0
+  const primaryPercentDisplay = Math.round(primaryPercentRaw * 100)
+
+  return (
+    <div
+      className={`relative inline-flex items-center justify-center ${className}`}
+      data-testid="activity-rings"
+    >
+      <svg
+        viewBox={`0 0 ${size} ${size}`}
+        width={size}
+        height={size}
+        role="img"
+        aria-label={`Activity rings: ${rings
+          .map(
+            (r) =>
+              `${r.goal.exercise} ${r.totalReps} of ${r.goal.daily_target}`,
+          )
+          .join(', ')}`}
+        className="block w-full h-auto -rotate-90"
+      >
+        {rings.map((ring, i) => {
+          const radius = outerRadius - i * (RING_STROKE + RING_GAP)
+          if (radius <= RING_STROKE) return null
+          const circumference = 2 * Math.PI * radius
+          const rawPercent =
+            ring.goal.daily_target > 0 ? ring.totalReps / ring.goal.daily_target : 0
+          const clamped = Math.min(1, Math.max(0, rawPercent))
+          const dashOffset = circumference * (1 - clamped)
+          const isHit = rawPercent >= 1
+          return (
+            <g key={ring.goal.exercise} data-testid={`ring-${ring.goal.exercise}`}>
+              <circle
+                cx={center}
+                cy={center}
+                r={radius}
+                fill="none"
+                stroke={ring.goal.color}
+                strokeOpacity={TRACK_OPACITY}
+                strokeWidth={RING_STROKE}
+              />
+              <circle
+                cx={center}
+                cy={center}
+                r={radius}
+                fill="none"
+                stroke={ring.goal.color}
+                strokeWidth={RING_STROKE}
+                strokeLinecap="round"
+                strokeDasharray={circumference}
+                strokeDashoffset={dashOffset}
+                style={
+                  isHit
+                    ? {
+                        filter: `drop-shadow(0 0 6px ${ring.goal.color})`,
+                        transition: 'stroke-dashoffset 600ms ease-out',
+                      }
+                    : { transition: 'stroke-dashoffset 600ms ease-out' }
+                }
+              />
+            </g>
+          )
+        })}
+      </svg>
+      {/* Center readout — anchored to the primary (outermost) exercise.
+          Absolute-positioned over the SVG so the ring sweep stays
+          undisturbed and the SVG itself can rotate (-90deg) without
+          flipping the text. */}
+      <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center text-center">
+        <span className="font-mono text-[10px] uppercase tracking-[0.32em] text-white/55">
+          {primary.goal.exercise}
+        </span>
+        <span className="mt-1 font-mono text-3xl font-semibold tabular-nums text-white sm:text-4xl">
+          {primary.totalReps}
+          <span className="text-white/40"> / {primary.goal.daily_target}</span>
+        </span>
+        <span
+          className="mt-1 font-mono text-[10px] uppercase tracking-[0.22em]"
+          style={{ color: primary.goal.color }}
+        >
+          {primaryPercentDisplay}%
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/components/training-facility/weight-room/ActivityRings.tsx
+++ b/components/training-facility/weight-room/ActivityRings.tsx
@@ -36,7 +36,29 @@ export interface ActivityRingsProps {
 
 const RING_STROKE = 14
 const RING_GAP = 4
+const MIN_RING_STROKE = 4
+const MIN_RING_GAP = 1
 const TRACK_OPACITY = 0.18
+
+/**
+ * Pick `stroke` + `gap` that fit every ring inside the SVG. Defaults to
+ * the generous (`RING_STROKE`, `RING_GAP`) sizes for the common case
+ * (1–5 exercises) and shrinks toward (`MIN_RING_STROKE`, `MIN_RING_GAP`)
+ * as the ring count grows so a settings UI with many exercises (dips,
+ * rows, pistols, etc.) still renders every ring rather than silently
+ * dropping the inner ones to `null`. The 1.6 fudge factor empirically
+ * balances ring thickness vs. inner margin across 1..15 ring counts.
+ */
+function fitRingDimensions(
+  size: number,
+  ringCount: number,
+): { stroke: number; gap: number } {
+  if (ringCount <= 0) return { stroke: RING_STROKE, gap: RING_GAP }
+  const requiredStroke = Math.floor(size / 2 / (ringCount * 1.6))
+  const stroke = Math.max(MIN_RING_STROKE, Math.min(RING_STROKE, requiredStroke))
+  const gap = Math.max(MIN_RING_GAP, Math.min(RING_GAP, Math.floor(stroke * 0.3)))
+  return { stroke, gap }
+}
 
 /**
  * SVG-based concentric activity rings — the Today View centerpiece
@@ -67,7 +89,8 @@ export function ActivityRings({
   className = '',
 }: ActivityRingsProps): JSX.Element {
   const center = size / 2
-  const outerRadius = center - RING_STROKE / 2
+  const { stroke, gap } = fitRingDimensions(size, rings.length)
+  const outerRadius = center - stroke / 2
 
   // Empty-state — no goals configured. Rare in practice (the migration
   // seeds two), but cheap to handle so the page doesn't blow up if
@@ -107,8 +130,12 @@ export function ActivityRings({
         className="block w-full h-auto -rotate-90"
       >
         {rings.map((ring, i) => {
-          const radius = outerRadius - i * (RING_STROKE + RING_GAP)
-          if (radius <= RING_STROKE) return null
+          // Clamp the inner radius to a positive value so the smallest
+          // ring still renders (rather than null-ing out) even when the
+          // settings UI lists many exercises. `fitRingDimensions` already
+          // shrunk stroke/gap to keep this in range — the clamp is a
+          // final defense for pathological counts (>15 exercises).
+          const radius = Math.max(stroke / 2, outerRadius - i * (stroke + gap))
           const circumference = 2 * Math.PI * radius
           const rawPercent =
             ring.goal.daily_target > 0 ? ring.totalReps / ring.goal.daily_target : 0
@@ -124,7 +151,7 @@ export function ActivityRings({
                 fill="none"
                 stroke={ring.goal.color}
                 strokeOpacity={TRACK_OPACITY}
-                strokeWidth={RING_STROKE}
+                strokeWidth={stroke}
               />
               <circle
                 cx={center}
@@ -132,7 +159,7 @@ export function ActivityRings({
                 r={radius}
                 fill="none"
                 stroke={ring.goal.color}
-                strokeWidth={RING_STROKE}
+                strokeWidth={stroke}
                 strokeLinecap="round"
                 strokeDasharray={circumference}
                 strokeDashoffset={dashOffset}

--- a/components/training-facility/weight-room/QuickLog.test.tsx
+++ b/components/training-facility/weight-room/QuickLog.test.tsx
@@ -80,4 +80,28 @@ describe('QuickLog', () => {
     await userEvent.click(screen.getByRole('button', { name: 'Log' }))
     expect(onLog).not.toHaveBeenCalled()
   })
+
+  it('re-seeds the Custom input when lastReps updates while the form is closed', async () => {
+    // Codex called this out for #80: the row stays mounted across logs
+    // (keyed by exercise), so a one-shot useState would show a stale
+    // seed forever. The effect must re-sync customValue when lastReps
+    // changes — but only while the form is closed, so an open edit
+    // isn't yanked out from under the user.
+    const { rerender } = render(
+      <QuickLog
+        goals={[PUSHUPS]}
+        lastReps={{ pushups: 10 }}
+        onLog={vi.fn().mockResolvedValue(undefined)}
+      />,
+    )
+    rerender(
+      <QuickLog
+        goals={[PUSHUPS]}
+        lastReps={{ pushups: 25 }}
+        onLog={vi.fn().mockResolvedValue(undefined)}
+      />,
+    )
+    await userEvent.click(screen.getByRole('button', { name: 'Custom' }))
+    expect(screen.getByLabelText(/reps/i)).toHaveValue(25)
+  })
 })

--- a/components/training-facility/weight-room/QuickLog.test.tsx
+++ b/components/training-facility/weight-room/QuickLog.test.tsx
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import type { ExerciseGoal } from '@/types/weight-room'
+
+import { QuickLog } from './QuickLog'
+
+const PUSHUPS: ExerciseGoal = {
+  exercise: 'pushups',
+  daily_target: 100,
+  color: '#EA580C',
+}
+const PULLUPS: ExerciseGoal = {
+  exercise: 'pullups',
+  daily_target: 30,
+  color: '#0EA5A1',
+}
+
+describe('QuickLog', () => {
+  it('logs a preset rep count with a single click', async () => {
+    const onLog = vi.fn().mockResolvedValue(undefined)
+    render(<QuickLog goals={[PUSHUPS]} onLog={onLog} />)
+    await userEvent.click(screen.getByTestId('quick-log-pushups-10'))
+    expect(onLog).toHaveBeenCalledTimes(1)
+    expect(onLog).toHaveBeenCalledWith({ exercise: 'pushups', reps: 10 })
+  })
+
+  it('renders a card for each goal', () => {
+    render(<QuickLog goals={[PUSHUPS, PULLUPS]} onLog={vi.fn()} />)
+    expect(screen.getByText('pushups')).toBeInTheDocument()
+    expect(screen.getByText('pullups')).toBeInTheDocument()
+    expect(screen.getByTestId('quick-log-pullups-15')).toBeInTheDocument()
+  })
+
+  it('opens the custom form, submits the typed value, and closes', async () => {
+    const onLog = vi.fn().mockResolvedValue(undefined)
+    render(<QuickLog goals={[PUSHUPS]} onLog={onLog} />)
+    const customButtons = screen.getAllByRole('button', { name: 'Custom' })
+    await userEvent.click(customButtons[0])
+    const input = screen.getByLabelText(/reps/i)
+    await userEvent.clear(input)
+    await userEvent.type(input, '17')
+    await userEvent.click(screen.getByRole('button', { name: 'Log' }))
+    expect(onLog).toHaveBeenCalledWith({ exercise: 'pushups', reps: 17 })
+  })
+
+  it('seeds the custom input with lastReps when provided', async () => {
+    render(
+      <QuickLog
+        goals={[PUSHUPS]}
+        lastReps={{ pushups: 22 }}
+        onLog={vi.fn().mockResolvedValue(undefined)}
+      />,
+    )
+    await userEvent.click(screen.getByRole('button', { name: 'Custom' }))
+    expect(screen.getByLabelText(/reps/i)).toHaveValue(22)
+  })
+
+  it('disables every preset while busy', () => {
+    render(<QuickLog goals={[PUSHUPS]} onLog={vi.fn()} busy />)
+    expect(screen.getByTestId('quick-log-pushups-5')).toBeDisabled()
+    expect(screen.getByTestId('quick-log-pushups-25')).toBeDisabled()
+  })
+
+  it('surfaces a thrown error message inline', async () => {
+    const onLog = vi.fn().mockRejectedValue(new Error('FK violation'))
+    render(<QuickLog goals={[PUSHUPS]} onLog={onLog} />)
+    await userEvent.click(screen.getByTestId('quick-log-pushups-10'))
+    expect(await screen.findByRole('alert')).toHaveTextContent(/FK violation/)
+  })
+
+  it('rejects non-positive custom values silently (no submit)', async () => {
+    const onLog = vi.fn()
+    render(<QuickLog goals={[PUSHUPS]} onLog={onLog} />)
+    await userEvent.click(screen.getByRole('button', { name: 'Custom' }))
+    const input = screen.getByLabelText(/reps/i)
+    await userEvent.clear(input)
+    await userEvent.type(input, '0')
+    await userEvent.click(screen.getByRole('button', { name: 'Log' }))
+    expect(onLog).not.toHaveBeenCalled()
+  })
+})

--- a/components/training-facility/weight-room/QuickLog.test.tsx
+++ b/components/training-facility/weight-room/QuickLog.test.tsx
@@ -104,4 +104,34 @@ describe('QuickLog', () => {
     await userEvent.click(screen.getByRole('button', { name: 'Custom' }))
     expect(screen.getByLabelText(/reps/i)).toHaveValue(25)
   })
+
+  it('locks the pending row while a log is in flight', async () => {
+    // CodeRabbit flagged that the pending row's own buttons stayed
+    // enabled, allowing concurrent double-submits on the same exercise.
+    let resolveLog: (() => void) | null = null
+    const onLog = vi.fn().mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveLog = resolve
+        }),
+    )
+    render(<QuickLog goals={[PUSHUPS]} onLog={onLog} />)
+    await userEvent.click(screen.getByTestId('quick-log-pushups-10'))
+    // While the first POST is in flight, the +5 button on the same row
+    // must be disabled too — not just other rows'.
+    expect(screen.getByTestId('quick-log-pushups-5')).toBeDisabled()
+    expect(screen.getByTestId('quick-log-pushups-10')).toBeDisabled()
+    resolveLog?.()
+  })
+
+  it('keeps the Custom form mounted so aria-controls always resolves', () => {
+    render(<QuickLog goals={[PUSHUPS]} onLog={vi.fn()} />)
+    const customButton = screen.getByRole('button', { name: 'Custom' })
+    const controls = customButton.getAttribute('aria-controls')
+    expect(controls).toBeTruthy()
+    // The form is in the DOM regardless of the open/closed state, so the
+    // aria-controls reference resolves to a real node — Codex flagged
+    // the prior conditional render as an ARIA-compliance issue.
+    expect(document.getElementById(controls as string)).not.toBeNull()
+  })
 })

--- a/components/training-facility/weight-room/QuickLog.tsx
+++ b/components/training-facility/weight-room/QuickLog.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useId, useState, type FormEvent, type JSX } from 'react'
+import { useEffect, useId, useState, type FormEvent, type JSX } from 'react'
 
 import type { ExerciseGoal } from '@/types/weight-room'
 
@@ -135,6 +135,16 @@ function QuickLogRow({
   const [customOpen, setCustomOpen] = useState<boolean>(false)
   const seedCustom = lastReps ?? DEFAULT_PRESETS[1]
   const [customValue, setCustomValue] = useState<string>(String(seedCustom))
+
+  // Re-seed the Custom input whenever `lastReps` changes (e.g. after a
+  // successful preset log + parent refetch). The row stays mounted across
+  // logs because it's keyed by exercise, so a one-shot `useState` would
+  // otherwise show a stale seed forever. Skip the reset while the form
+  // is open so the user's in-progress edits don't get yanked out from
+  // under them mid-type.
+  useEffect(() => {
+    if (!customOpen) setCustomValue(String(seedCustom))
+  }, [seedCustom, customOpen])
 
   async function handlePreset(reps: number): Promise<void> {
     await onLog(goal.exercise, reps)

--- a/components/training-facility/weight-room/QuickLog.tsx
+++ b/components/training-facility/weight-room/QuickLog.tsx
@@ -106,7 +106,13 @@ export function QuickLog({
             key={goal.exercise}
             goal={goal}
             lastReps={lastReps[goal.exercise]}
-            disabled={busy || (pendingExercise !== null && pendingExercise !== goal.exercise)}
+            // Disable every row's chips while any request is in flight,
+            // including the row that fired it — without this lock, a
+            // second tap on the pending row before the POST returns
+            // races into a second concurrent write. The visual ring
+            // highlight (`pending`) still distinguishes which row is
+            // resolving; the disable is just functional.
+            disabled={busy || pendingExercise !== null}
             pending={pendingExercise === goal.exercise}
             onLog={handleLog}
           />
@@ -200,33 +206,36 @@ function QuickLogRow({
           Custom
         </button>
       </div>
-      {customOpen ? (
-        <form
-          id={customInputId}
-          onSubmit={handleCustomSubmit}
-          className="mt-3 flex flex-wrap items-center gap-2"
+      {/* Form stays mounted so the Custom button's `aria-controls` always
+          points to a real element. Toggling `hidden` removes it from the
+          accessibility tree and the visual layout when closed; auto-focus
+          fires only when opening (it's a no-op when the input is hidden). */}
+      <form
+        id={customInputId}
+        onSubmit={handleCustomSubmit}
+        hidden={!customOpen}
+        className="mt-3 flex flex-wrap items-center gap-2"
+      >
+        <label className="flex items-center gap-2 text-[12px] text-white/70">
+          <span className="font-mono uppercase tracking-[0.18em]">reps</span>
+          <input
+            type="number"
+            min={1}
+            inputMode="numeric"
+            value={customValue}
+            onChange={(e) => setCustomValue(e.target.value)}
+            autoFocus={customOpen}
+            className="w-24 rounded border border-white/15 bg-black/40 px-2 py-1.5 text-right font-mono text-sm text-white focus:border-amber-300/60 focus:outline-none"
+          />
+        </label>
+        <button
+          type="submit"
+          disabled={disabled || customValue === ''}
+          className="min-h-[40px] rounded-full border border-amber-200/30 bg-amber-200/10 px-4 font-mono text-[11px] uppercase tracking-[0.22em] text-amber-100 transition hover:bg-amber-200/20 disabled:cursor-not-allowed disabled:opacity-40"
         >
-          <label className="flex items-center gap-2 text-[12px] text-white/70">
-            <span className="font-mono uppercase tracking-[0.18em]">reps</span>
-            <input
-              type="number"
-              min={1}
-              inputMode="numeric"
-              value={customValue}
-              onChange={(e) => setCustomValue(e.target.value)}
-              autoFocus
-              className="w-24 rounded border border-white/15 bg-black/40 px-2 py-1.5 text-right font-mono text-sm text-white focus:border-amber-300/60 focus:outline-none"
-            />
-          </label>
-          <button
-            type="submit"
-            disabled={disabled || customValue === ''}
-            className="min-h-[40px] rounded-full border border-amber-200/30 bg-amber-200/10 px-4 font-mono text-[11px] uppercase tracking-[0.22em] text-amber-100 transition hover:bg-amber-200/20 disabled:cursor-not-allowed disabled:opacity-40"
-          >
-            Log
-          </button>
-        </form>
-      ) : null}
+          Log
+        </button>
+      </form>
     </li>
   )
 }

--- a/components/training-facility/weight-room/QuickLog.tsx
+++ b/components/training-facility/weight-room/QuickLog.tsx
@@ -1,0 +1,222 @@
+'use client'
+
+import { useId, useState, type FormEvent, type JSX } from 'react'
+
+import type { ExerciseGoal } from '@/types/weight-room'
+
+/** Props for {@link QuickLog}. */
+export interface QuickLogProps {
+  /**
+   * Goals to render rows for. The Today View passes the full goal
+   * list; this component renders one card per goal so the user can
+   * one-tap log against any configured exercise.
+   */
+  goals: readonly ExerciseGoal[]
+  /**
+   * Last-logged rep count per exercise — used to seed the "Custom"
+   * input with a sensible default. Defaults to {@link DEFAULT_PRESETS}'s
+   * middle value when an exercise has no prior log.
+   */
+  lastReps?: Readonly<Record<string, number | undefined>>
+  /**
+   * Async submit handler. Called once per logged set; the parent is
+   * expected to POST to `/api/admin/weight-room/sets` and then refetch
+   * its data so the rings + set list pick up the new row. Rejects
+   * surface as an inline error message; resolves clear the message.
+   */
+  onLog: (entry: { exercise: string; reps: number }) => Promise<void>
+  /**
+   * `false` while a parent action is in flight (e.g. another quick-log
+   * still resolving). Disables every button so the form can't submit
+   * twice in flight; the parent flips this back when its Promise
+   * settles.
+   */
+  busy?: boolean
+}
+
+/**
+ * Default rep-count chips. Kept short and weighted toward the
+ * common-case "10-ish" so the most frequent action is one tap. The
+ * user can always pick "Custom" for a non-standard count.
+ */
+export const DEFAULT_PRESETS: readonly number[] = [5, 10, 15, 20, 25] as const
+
+/**
+ * Quick-log control for the Today View (#80). Renders one card per
+ * goal with a row of preset chips (`+5 / +10 / …`) and a "Custom"
+ * affordance that opens a numeric input. Hits the issue's "2 taps
+ * max" target — single tap for the common counts, two taps for an
+ * arbitrary value (open custom, type, log).
+ *
+ * The component is presentational: it doesn't talk to Supabase
+ * directly. The parent (TodayView's data island) injects {@link onLog},
+ * which is responsible for the POST + refetch. That keeps the
+ * component testable without mocking fetch and lets the same UI flow
+ * through the demo-fixture path (admin gate stops writes server-side
+ * either way).
+ */
+export function QuickLog({
+  goals,
+  lastReps = {},
+  onLog,
+  busy = false,
+}: QuickLogProps): JSX.Element {
+  const [error, setError] = useState<string | null>(null)
+  const [pendingExercise, setPendingExercise] = useState<string | null>(null)
+
+  async function handleLog(exercise: string, reps: number): Promise<void> {
+    setError(null)
+    setPendingExercise(exercise)
+    try {
+      await onLog({ exercise, reps })
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : `Couldn’t log ${reps} ${exercise}.`,
+      )
+    } finally {
+      setPendingExercise(null)
+    }
+  }
+
+  return (
+    <section
+      aria-label="Quick log"
+      data-testid="quick-log"
+      className="space-y-3"
+    >
+      <div className="flex items-baseline justify-between">
+        <h2 className="font-mono text-[11px] uppercase tracking-[0.32em] text-amber-300/80">
+          Quick log
+        </h2>
+        <span className="font-mono text-[10px] uppercase tracking-[0.22em] text-white/45">
+          One tap · grease the groove
+        </span>
+      </div>
+      {error ? (
+        <p
+          role="alert"
+          className="rounded-lg border border-rose-400/30 bg-rose-950/40 px-3 py-2 font-mono text-[12px] text-rose-200"
+        >
+          {error}
+        </p>
+      ) : null}
+      <ul className="space-y-3">
+        {goals.map((goal) => (
+          <QuickLogRow
+            key={goal.exercise}
+            goal={goal}
+            lastReps={lastReps[goal.exercise]}
+            disabled={busy || (pendingExercise !== null && pendingExercise !== goal.exercise)}
+            pending={pendingExercise === goal.exercise}
+            onLog={handleLog}
+          />
+        ))}
+      </ul>
+    </section>
+  )
+}
+
+interface QuickLogRowProps {
+  goal: ExerciseGoal
+  lastReps: number | undefined
+  disabled: boolean
+  pending: boolean
+  onLog: (exercise: string, reps: number) => Promise<void>
+}
+
+function QuickLogRow({
+  goal,
+  lastReps,
+  disabled,
+  pending,
+  onLog,
+}: QuickLogRowProps): JSX.Element {
+  const customInputId = useId()
+  const [customOpen, setCustomOpen] = useState<boolean>(false)
+  const seedCustom = lastReps ?? DEFAULT_PRESETS[1]
+  const [customValue, setCustomValue] = useState<string>(String(seedCustom))
+
+  async function handlePreset(reps: number): Promise<void> {
+    await onLog(goal.exercise, reps)
+  }
+
+  async function handleCustomSubmit(e: FormEvent<HTMLFormElement>): Promise<void> {
+    e.preventDefault()
+    const reps = Number(customValue)
+    if (!Number.isFinite(reps) || reps <= 0 || !Number.isInteger(reps)) return
+    await onLog(goal.exercise, reps)
+    setCustomOpen(false)
+  }
+
+  return (
+    <li
+      className="rounded-2xl border border-white/10 bg-white/5 p-4"
+      style={{
+        boxShadow: pending ? `inset 0 0 0 1px ${goal.color}55` : undefined,
+      }}
+    >
+      <div className="flex items-baseline justify-between gap-2">
+        <span
+          className="font-mono text-sm font-semibold uppercase tracking-[0.18em]"
+          style={{ color: goal.color }}
+        >
+          {goal.exercise}
+        </span>
+        <span className="font-mono text-[10px] uppercase tracking-[0.22em] text-white/45">
+          target {goal.daily_target}
+        </span>
+      </div>
+      <div className="mt-3 flex flex-wrap gap-2">
+        {DEFAULT_PRESETS.map((reps) => (
+          <button
+            key={reps}
+            type="button"
+            disabled={disabled}
+            onClick={() => void handlePreset(reps)}
+            data-testid={`quick-log-${goal.exercise}-${reps}`}
+            className="min-h-[44px] min-w-[64px] rounded-full border border-white/15 bg-black/30 px-4 font-mono text-sm font-semibold text-white transition hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            +{reps}
+          </button>
+        ))}
+        <button
+          type="button"
+          disabled={disabled}
+          onClick={() => setCustomOpen((v) => !v)}
+          aria-expanded={customOpen}
+          aria-controls={customInputId}
+          className="min-h-[44px] rounded-full border border-white/15 bg-black/30 px-4 font-mono text-sm font-semibold text-white/80 transition hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          Custom
+        </button>
+      </div>
+      {customOpen ? (
+        <form
+          id={customInputId}
+          onSubmit={handleCustomSubmit}
+          className="mt-3 flex flex-wrap items-center gap-2"
+        >
+          <label className="flex items-center gap-2 text-[12px] text-white/70">
+            <span className="font-mono uppercase tracking-[0.18em]">reps</span>
+            <input
+              type="number"
+              min={1}
+              inputMode="numeric"
+              value={customValue}
+              onChange={(e) => setCustomValue(e.target.value)}
+              autoFocus
+              className="w-24 rounded border border-white/15 bg-black/40 px-2 py-1.5 text-right font-mono text-sm text-white focus:border-amber-300/60 focus:outline-none"
+            />
+          </label>
+          <button
+            type="submit"
+            disabled={disabled || customValue === ''}
+            className="min-h-[40px] rounded-full border border-amber-200/30 bg-amber-200/10 px-4 font-mono text-[11px] uppercase tracking-[0.22em] text-amber-100 transition hover:bg-amber-200/20 disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            Log
+          </button>
+        </form>
+      ) : null}
+    </li>
+  )
+}

--- a/components/training-facility/weight-room/SetList.test.tsx
+++ b/components/training-facility/weight-room/SetList.test.tsx
@@ -1,0 +1,96 @@
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import type { ExerciseGoal, StrengthSet } from '@/types/weight-room'
+
+import { SetList } from './SetList'
+
+const PUSHUPS: ExerciseGoal = {
+  exercise: 'pushups',
+  daily_target: 100,
+  color: '#EA580C',
+}
+
+function set(overrides: Partial<StrengthSet> = {}): StrengthSet {
+  return {
+    id: '11111111-1111-1111-1111-111111111111',
+    logged_at: '2026-05-07T09:30:00',
+    exercise: 'pushups',
+    reps: 10,
+    ...overrides,
+  }
+}
+
+describe('SetList', () => {
+  it('renders an empty card when no sets logged today', () => {
+    render(<SetList setsToday={[]} goalsByExercise={{ pushups: PUSHUPS }} />)
+    expect(screen.getByTestId('set-list-empty')).toBeInTheDocument()
+    expect(screen.getByText(/no sets logged yet today/i)).toBeInTheDocument()
+  })
+
+  it('renders one row per logged set with rep count', () => {
+    render(
+      <SetList
+        setsToday={[
+          set({ id: 'a', reps: 10 }),
+          set({ id: 'b', reps: 15 }),
+        ]}
+        goalsByExercise={{ pushups: PUSHUPS }}
+      />,
+    )
+    expect(screen.getByTestId('set-row-a')).toBeInTheDocument()
+    expect(screen.getByTestId('set-row-b')).toBeInTheDocument()
+    expect(screen.getByText('10')).toBeInTheDocument()
+    expect(screen.getByText('15')).toBeInTheDocument()
+  })
+
+  it('shows most recent set first (reverses input order)', () => {
+    render(
+      <SetList
+        setsToday={[
+          set({ id: 'a', reps: 5, logged_at: '2026-05-07T08:00:00' }),
+          set({ id: 'b', reps: 10, logged_at: '2026-05-07T11:00:00' }),
+          set({ id: 'c', reps: 15, logged_at: '2026-05-07T17:00:00' }),
+        ]}
+        goalsByExercise={{ pushups: PUSHUPS }}
+      />,
+    )
+    const rows = screen.getAllByTestId(/set-row-/)
+    expect(rows[0]).toHaveAttribute('data-testid', 'set-row-c')
+    expect(rows[2]).toHaveAttribute('data-testid', 'set-row-a')
+  })
+
+  it('hides delete buttons when onDelete is not provided', () => {
+    render(<SetList setsToday={[set()]} goalsByExercise={{ pushups: PUSHUPS }} />)
+    expect(screen.queryByRole('button', { name: /delete/i })).not.toBeInTheDocument()
+  })
+
+  it('calls onDelete when the trash button is clicked', async () => {
+    const onDelete = vi.fn().mockResolvedValue(undefined)
+    const target = set({ id: 'x', reps: 10 })
+    render(
+      <SetList
+        setsToday={[target]}
+        goalsByExercise={{ pushups: PUSHUPS }}
+        onDelete={onDelete}
+      />,
+    )
+    await userEvent.click(screen.getByRole('button', { name: /delete set of 10 pushups/i }))
+    expect(onDelete).toHaveBeenCalledTimes(1)
+    expect(onDelete).toHaveBeenCalledWith(target)
+  })
+
+  it('surfaces a delete failure inline', async () => {
+    const onDelete = vi.fn().mockRejectedValue(new Error('boom'))
+    render(
+      <SetList
+        setsToday={[set({ id: 'x' })]}
+        goalsByExercise={{ pushups: PUSHUPS }}
+        onDelete={onDelete}
+      />,
+    )
+    await userEvent.click(screen.getByRole('button', { name: /delete/i }))
+    expect(await screen.findByRole('alert')).toHaveTextContent(/boom/)
+  })
+})

--- a/components/training-facility/weight-room/SetList.test.tsx
+++ b/components/training-facility/weight-room/SetList.test.tsx
@@ -93,4 +93,42 @@ describe('SetList', () => {
     await userEvent.click(screen.getByRole('button', { name: /delete/i }))
     expect(await screen.findByRole('alert')).toHaveTextContent(/boom/)
   })
+
+  it('renders per-exercise running total / goal readout above the rows', () => {
+    // Issue #80: "Shows running total vs. goal per exercise". CodeRabbit
+    // flagged the missing readout in review.
+    render(
+      <SetList
+        setsToday={[
+          set({ id: 'a', exercise: 'pushups', reps: 25 }),
+          set({ id: 'b', exercise: 'pushups', reps: 30 }),
+          set({ id: 'c', exercise: 'pullups', reps: 10 }),
+        ]}
+        goalsByExercise={{
+          pushups: PUSHUPS,
+          pullups: { exercise: 'pullups', daily_target: 30, color: '#0EA5A1' },
+        }}
+      />,
+    )
+    const totals = screen.getByTestId('set-list-totals')
+    expect(totals).toHaveTextContent('pushups')
+    expect(totals).toHaveTextContent('55')
+    expect(totals).toHaveTextContent('/ 100')
+    expect(totals).toHaveTextContent('pullups')
+    expect(totals).toHaveTextContent('10')
+    expect(totals).toHaveTextContent('/ 30')
+  })
+
+  it('omits the goal denominator when the exercise has no configured goal', () => {
+    render(
+      <SetList
+        setsToday={[set({ id: 'a', exercise: 'dips', reps: 12 })]}
+        goalsByExercise={{}}
+      />,
+    )
+    const total = screen.getByTestId('set-list-total-dips')
+    expect(total).toHaveTextContent('dips')
+    expect(total).toHaveTextContent('12')
+    expect(total).not.toHaveTextContent('/')
+  })
 })

--- a/components/training-facility/weight-room/SetList.tsx
+++ b/components/training-facility/weight-room/SetList.tsx
@@ -1,0 +1,160 @@
+'use client'
+
+import { useState, type JSX } from 'react'
+
+import type { ExerciseGoal, StrengthSet } from '@/types/weight-room'
+
+/** Props for {@link SetList}. */
+export interface SetListProps {
+  /**
+   * Today's sets, sorted oldest → newest. The list reverses internally
+   * so the most recent set appears at the top — that's the entry the
+   * user usually wants to undo.
+   */
+  setsToday: readonly StrengthSet[]
+  /**
+   * Goals indexed by exercise name. Used to look up display color +
+   * daily target for the running total readout. Missing entries fall
+   * back gracefully to amber + zero target so a deleted goal's leftover
+   * sets still render (rare — the FK has ON DELETE CASCADE so the rows
+   * usually disappear together).
+   */
+  goalsByExercise: Readonly<Record<string, ExerciseGoal | undefined>>
+  /**
+   * Per-row delete handler. Omit to render the list read-only — non-
+   * admin viewers don't see the trash icon. Resolves clear the
+   * pending-row state; rejects surface as an inline error message.
+   */
+  onDelete?: (set: StrengthSet) => Promise<void>
+  /**
+   * `false` while a parent action is in flight. Disables every delete
+   * button so a row can't be dropped twice.
+   */
+  busy?: boolean
+}
+
+/**
+ * Today's logged sets as a timestamped list, with per-row delete for
+ * admin viewers (#80). Mirrors the cardio session log's row layout:
+ * mono timestamps, exercise lane color, rep count tabularly aligned.
+ *
+ * Running per-exercise total renders inline at the top of each
+ * exercise's group so the user can see "you're at 75 / 100 pushups
+ * after these three sets" without scrolling back to the rings. The
+ * group header is sticky-ish — a single header row, not per-set —
+ * because the issue's spec is timestamped *list*, not per-exercise
+ * tabs.
+ */
+export function SetList({
+  setsToday,
+  goalsByExercise,
+  onDelete,
+  busy = false,
+}: SetListProps): JSX.Element {
+  const [error, setError] = useState<string | null>(null)
+  const [pendingId, setPendingId] = useState<string | null>(null)
+
+  async function handleDelete(set: StrengthSet): Promise<void> {
+    if (!onDelete) return
+    setError(null)
+    setPendingId(set.id)
+    try {
+      await onDelete(set)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Couldn’t delete that set.')
+    } finally {
+      setPendingId(null)
+    }
+  }
+
+  if (setsToday.length === 0) {
+    return (
+      <section aria-label="Today’s sets" className="space-y-2" data-testid="set-list-empty">
+        <h2 className="font-mono text-[11px] uppercase tracking-[0.32em] text-amber-300/80">
+          Today
+        </h2>
+        <p className="rounded-2xl border border-dashed border-white/10 bg-black/20 px-4 py-6 text-center text-[13px] text-white/55">
+          No sets logged yet today.
+        </p>
+      </section>
+    )
+  }
+
+  // Most-recent-first for the visible list. Don't mutate the prop.
+  const ordered = [...setsToday].reverse()
+
+  return (
+    <section aria-label="Today’s sets" className="space-y-2" data-testid="set-list">
+      <h2 className="font-mono text-[11px] uppercase tracking-[0.32em] text-amber-300/80">
+        Today
+      </h2>
+      {error ? (
+        <p
+          role="alert"
+          className="rounded-lg border border-rose-400/30 bg-rose-950/40 px-3 py-2 font-mono text-[12px] text-rose-200"
+        >
+          {error}
+        </p>
+      ) : null}
+      <ul className="divide-y divide-white/5 overflow-hidden rounded-2xl border border-white/10 bg-white/5">
+        {ordered.map((s) => {
+          const goal = goalsByExercise[s.exercise]
+          const color = goal?.color ?? '#fbbf24'
+          const isPending = pendingId === s.id
+          return (
+            <li
+              key={s.id}
+              data-testid={`set-row-${s.id}`}
+              className="flex items-center gap-3 px-4 py-3"
+              style={{ opacity: isPending ? 0.5 : 1 }}
+            >
+              <span
+                aria-hidden="true"
+                className="h-2 w-2 shrink-0 rounded-full"
+                style={{ backgroundColor: color }}
+              />
+              <span
+                className="min-w-[80px] font-mono text-sm font-semibold uppercase tracking-[0.18em]"
+                style={{ color }}
+              >
+                {s.exercise}
+              </span>
+              <span className="font-mono text-base font-semibold tabular-nums text-white">
+                {s.reps}
+              </span>
+              <span className="ml-auto font-mono text-[11px] tabular-nums text-white/55">
+                {formatTimeOfDay(s.logged_at)}
+              </span>
+              {onDelete ? (
+                <button
+                  type="button"
+                  aria-label={`Delete set of ${s.reps} ${s.exercise}`}
+                  disabled={busy || isPending}
+                  onClick={() => void handleDelete(s)}
+                  className="rounded-full border border-rose-300/25 bg-rose-300/5 px-3 py-1 font-mono text-[10px] uppercase tracking-[0.22em] text-rose-200 transition hover:bg-rose-300/15 disabled:cursor-not-allowed disabled:opacity-40"
+                >
+                  Delete
+                </button>
+              ) : null}
+            </li>
+          )
+        })}
+      </ul>
+    </section>
+  )
+}
+
+/**
+ * Format an ISO timestamp's time-of-day in the caller's local timezone
+ * (`HH:MM`, 12-hour with am/pm). Returns `'—'` for unparseable input
+ * so the row stays renderable without throwing.
+ */
+function formatTimeOfDay(iso: string): string {
+  const d = new Date(iso)
+  if (!Number.isFinite(d.getTime())) return '—'
+  const hours = d.getHours()
+  const minutes = d.getMinutes().toString().padStart(2, '0')
+  const ampm = hours >= 12 ? 'pm' : 'am'
+  const display = hours % 12 === 0 ? 12 : hours % 12
+  return `${display}:${minutes}${ampm}`
+}

--- a/components/training-facility/weight-room/SetList.tsx
+++ b/components/training-facility/weight-room/SetList.tsx
@@ -83,6 +83,15 @@ export function SetList({
   // Most-recent-first for the visible list. Don't mutate the prop.
   const ordered = [...setsToday].reverse()
 
+  // Per-exercise running totals for the goal-progress readout above the
+  // set rows (issue #80: "Shows running total vs. goal per exercise").
+  // Walk the input array (oldest → newest) once; the list itself
+  // displays newest-first via `ordered`.
+  const totals = new Map<string, number>()
+  for (const s of setsToday) {
+    totals.set(s.exercise, (totals.get(s.exercise) ?? 0) + s.reps)
+  }
+
   return (
     <section aria-label="Today’s sets" className="space-y-2" data-testid="set-list">
       <h2 className="font-mono text-[11px] uppercase tracking-[0.32em] text-amber-300/80">
@@ -95,6 +104,45 @@ export function SetList({
         >
           {error}
         </p>
+      ) : null}
+      {totals.size > 0 ? (
+        <div
+          data-testid="set-list-totals"
+          className="flex flex-wrap gap-3 rounded-2xl border border-white/10 bg-white/5 p-3"
+        >
+          {Array.from(totals.entries()).map(([exercise, total]) => {
+            const goal = goalsByExercise[exercise]
+            const color = goal?.color ?? '#fbbf24'
+            const target = goal?.daily_target
+            return (
+              <span
+                key={exercise}
+                data-testid={`set-list-total-${exercise}`}
+                className="flex items-baseline gap-2 font-mono"
+              >
+                <span
+                  aria-hidden="true"
+                  className="h-2 w-2 rounded-full"
+                  style={{ backgroundColor: color }}
+                />
+                <span
+                  className="text-[10px] font-semibold uppercase tracking-[0.18em]"
+                  style={{ color }}
+                >
+                  {exercise}
+                </span>
+                <span className="text-sm font-semibold tabular-nums text-white">
+                  {total}
+                </span>
+                {target ? (
+                  <span className="text-[10px] uppercase tracking-[0.18em] text-white/50">
+                    / {target}
+                  </span>
+                ) : null}
+              </span>
+            )
+          })}
+        </div>
       ) : null}
       <ul className="divide-y divide-white/5 overflow-hidden rounded-2xl border border-white/10 bg-white/5">
         {ordered.map((s) => {

--- a/components/training-facility/weight-room/StreakBadge.test.tsx
+++ b/components/training-facility/weight-room/StreakBadge.test.tsx
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+import { StreakBadge } from './StreakBadge'
+
+describe('StreakBadge', () => {
+  it('shows the current streak count and exercise label', () => {
+    render(
+      <StreakBadge
+        exercise="pushups"
+        streak={{ current: 5, longest: 12 }}
+        accentColor="#EA580C"
+      />,
+    )
+    expect(screen.getByText('pushups')).toBeInTheDocument()
+    expect(screen.getByText('5')).toBeInTheDocument()
+    expect(screen.getByText('days')).toBeInTheDocument()
+    expect(screen.getByText('12d')).toBeInTheDocument()
+  })
+
+  it('uses the singular "day" label when the current streak is exactly 1', () => {
+    render(<StreakBadge exercise="pushups" streak={{ current: 1, longest: 1 }} />)
+    expect(screen.getByText('day')).toBeInTheDocument()
+    expect(screen.queryByText('days')).not.toBeInTheDocument()
+  })
+
+  it('hides the longest callout when longest is 0', () => {
+    render(<StreakBadge exercise="pushups" streak={{ current: 0, longest: 0 }} />)
+    expect(screen.queryByText(/longest/i)).not.toBeInTheDocument()
+  })
+
+  it('desaturates the flame when current is 0', () => {
+    render(<StreakBadge exercise="pushups" streak={{ current: 0, longest: 5 }} />)
+    const flame = screen.getByText('\u{1F525}')
+    expect(flame.className).toContain('grayscale')
+  })
+
+  it('keeps the flame at full saturation when current > 0', () => {
+    render(<StreakBadge exercise="pushups" streak={{ current: 2, longest: 2 }} />)
+    const flame = screen.getByText('\u{1F525}')
+    expect(flame.className).not.toContain('grayscale')
+  })
+})

--- a/components/training-facility/weight-room/StreakBadge.tsx
+++ b/components/training-facility/weight-room/StreakBadge.tsx
@@ -1,0 +1,74 @@
+import type { JSX } from 'react'
+
+import type { StrengthStreakResult } from '@/lib/training-facility/strength-streaks'
+
+/** Props for {@link StreakBadge}. */
+export interface StreakBadgeProps {
+  /** Display name for the exercise (e.g. `pushups`). Rendered uppercased. */
+  exercise: string
+  /** Active and longest streak counts, from `computeStrengthStreaks`. */
+  streak: StrengthStreakResult
+  /**
+   * Hex color for the active flame's background tint. Pulled from the
+   * exercise's {@link import('@/types/weight-room').ExerciseGoal.color}
+   * so each lane reads as its own visual identity. Falls back to amber
+   * when omitted (matches the rest of the Weight Room chrome).
+   */
+  accentColor?: string
+}
+
+const DEFAULT_ACCENT = '#fbbf24'
+
+/**
+ * Per-exercise streak indicator for the Today View (#80, sub-component
+ * of TodayView). Sibling of the cardio
+ * {@link import('@/components/training-facility/gym/StreakCounter').StreakCounter}
+ * but scaled down to a chip-sized badge — the Today View shows one of
+ * these per exercise alongside the activity rings, so the chrome has
+ * to stay tight.
+ *
+ * The flame goes desaturated when the current streak is 0 so an
+ * inactive run doesn't fight the rest of the page for attention.
+ * Long-streak callout (`+ longest 12d`) only renders when longest > 0
+ * so a freshly-set goal doesn't say "longest 0d".
+ */
+export function StreakBadge({
+  exercise,
+  streak,
+  accentColor = DEFAULT_ACCENT,
+}: StreakBadgeProps): JSX.Element {
+  const isActive = streak.current > 0
+  return (
+    <div
+      data-testid={`streak-badge-${exercise}`}
+      className="flex items-center justify-between gap-3 rounded-2xl border border-white/10 bg-white/5 px-3 py-2"
+    >
+      <div className="flex items-center gap-2">
+        <span
+          aria-hidden="true"
+          className={`text-lg ${isActive ? '' : 'opacity-40 grayscale'}`}
+          style={isActive ? { filter: `drop-shadow(0 0 4px ${accentColor}88)` } : undefined}
+        >
+          {'\u{1F525}'}
+        </span>
+        <div className="flex flex-col leading-none">
+          <span className="font-mono text-[10px] uppercase tracking-[0.22em] text-white/60">
+            {exercise}
+          </span>
+          <span className="mt-0.5 font-mono text-base font-semibold tabular-nums text-white">
+            {streak.current}
+            <span className="ml-1 text-[10px] font-medium uppercase tracking-[0.18em] text-white/55">
+              day{streak.current === 1 ? '' : 's'}
+            </span>
+          </span>
+        </div>
+      </div>
+      {streak.longest > 0 ? (
+        <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-white/45">
+          longest{' '}
+          <span className="font-semibold tabular-nums text-white/80">{streak.longest}d</span>
+        </span>
+      ) : null}
+    </div>
+  )
+}

--- a/components/training-facility/weight-room/TodayDataIsland.tsx
+++ b/components/training-facility/weight-room/TodayDataIsland.tsx
@@ -1,0 +1,303 @@
+'use client'
+
+import { usePathname, useSearchParams } from 'next/navigation'
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type JSX,
+} from 'react'
+
+import { PreviewModeBadge } from '@/components/training-facility/shared/PreviewModeBadge'
+import { PreviewWithSampleDataButton } from '@/components/training-facility/shared/PreviewWithSampleDataButton'
+import { buildWeightRoomDemoData } from '@/constants/weight-room-demo-fixture'
+import { useAdminSession } from '@/lib/auth/use-admin-session'
+import { getWeightRoomData } from '@/lib/data/weight-room'
+import { computeStrengthStreaks } from '@/lib/training-facility/strength-streaks'
+import {
+  filterSetsForDay,
+  toLocalDateKey,
+  totalsByExercise,
+} from '@/lib/training-facility/strength-today'
+import {
+  TRAINING_FACILITY_PREVIEW_PARAM,
+  TRAINING_FACILITY_PREVIEW_VALUE,
+  isPreviewDemoActive,
+} from '@/lib/training-facility/preview-param'
+import type { StrengthSet, WeightRoomData } from '@/types/weight-room'
+
+import { ActivityRings, type RingProgress } from './ActivityRings'
+import { QuickLog } from './QuickLog'
+import { SetList } from './SetList'
+import { StreakBadge } from './StreakBadge'
+
+/**
+ * Owns the Today View's shared {@link WeightRoomData} state and the
+ * write orchestration around the activity rings, quick-log, and
+ * today's-sets list (#80).
+ *
+ * Three branches once the initial fetch settles:
+ *   - real data has anything → render with live data, no preview
+ *   - real data is empty + `?preview=demo` → swap in the demo fixture
+ *     and show {@link PreviewModeBadge}
+ *   - real data is empty + no preview param → show the empty-state
+ *     CTA pointing at `?preview=demo` plus a placeholder card
+ *
+ * Mirror of the Combine + cardio data-island pattern. The page itself
+ * is a Server Component (flag check + chrome) and embeds this island
+ * inside a {@link Suspense} boundary, because `useSearchParams()`
+ * forces dynamic rendering.
+ *
+ * Admin-gated writes: the QuickLog form and SetList delete buttons
+ * only render for admins (per {@link useAdminSession}). Non-admin
+ * viewers see the rings + read-only set list, matching the Combine
+ * page's "form is admin-only" UX.
+ */
+export function TodayDataIsland(): JSX.Element {
+  const [data, setData] = useState<WeightRoomData | null | undefined>(undefined)
+  const [busy, setBusy] = useState<boolean>(false)
+  // Monotonic request id — same pattern as `CombineDataIsland`. Both
+  // mount-time and post-write fetches commit only when the id is still
+  // current, so a slow mount fetch can't clobber fresh post-write data.
+  const requestIdRef = useRef(0)
+
+  useEffect(() => {
+    const id = ++requestIdRef.current
+    getWeightRoomData()
+      .then((d) => {
+        if (id === requestIdRef.current) setData(d)
+      })
+      .catch(() => {
+        if (id === requestIdRef.current) setData(null)
+      })
+    return () => {
+      requestIdRef.current += 1
+    }
+  }, [])
+
+  const refetch = useCallback(async (): Promise<void> => {
+    const id = ++requestIdRef.current
+    try {
+      const d = await getWeightRoomData()
+      if (id === requestIdRef.current) setData(d)
+    } catch {
+      if (id === requestIdRef.current) setData(null)
+    }
+  }, [])
+
+  // Empty-state preview (#80, mirrors #160/#162). The fixture is
+  // generated relative to *now* so today's ring reads partial — the
+  // most informative state for a ring-based UI.
+  const searchParams = useSearchParams()
+  const pathname = usePathname()
+  const previewActive = isPreviewDemoActive(
+    searchParams?.get(TRAINING_FACILITY_PREVIEW_PARAM),
+  )
+  const realIsEmpty =
+    data !== undefined && (data === null || (data.sets.length === 0 && data.goals.length === 0))
+  const isPreviewMode = realIsEmpty && previewActive
+  const showEmptyStateCta = realIsEmpty && !previewActive
+
+  const surfaceData = useMemo<WeightRoomData | null>(() => {
+    if (isPreviewMode) return buildWeightRoomDemoData()
+    if (data === undefined) return null
+    return data
+  }, [data, isPreviewMode])
+
+  const { isAdmin } = useAdminSession()
+
+  // Loading skeleton — keep light, the rings render fast once data lands.
+  if (data === undefined) {
+    return (
+      <div
+        className="rounded-[1.6rem] border border-white/10 bg-black/30 p-10 text-center text-sm text-white/55"
+        data-testid="today-loading"
+      >
+        Loading today’s sets…
+      </div>
+    )
+  }
+
+  // Real-empty + no preview: show the CTA only. Once a real set lands
+  // the page reroutes to the populated branch on next refetch.
+  if (showEmptyStateCta) {
+    return (
+      <div className="space-y-6">
+        <PreviewWithSampleDataButton
+          href={`${pathname}?${TRAINING_FACILITY_PREVIEW_PARAM}=${TRAINING_FACILITY_PREVIEW_VALUE}`}
+          headline="No strength work logged yet"
+          description="Curious what the rings look like populated? Load a sample set to see today’s ring fill, the streak badge, and the timestamped log."
+        />
+        {isAdmin && surfaceData ? (
+          <AdminQuickLog
+            goals={surfaceData.goals}
+            setsToday={[]}
+            busy={busy}
+            setBusy={setBusy}
+            refetch={refetch}
+          />
+        ) : null}
+      </div>
+    )
+  }
+
+  // The fixture branch always passes through `surfaceData`. The
+  // `surfaceData` cannot be null here (we've handled both undefined
+  // and empty branches above).
+  if (!surfaceData) return <></>
+
+  const todayKey = toLocalDateKey(new Date())
+  const setsToday = filterSetsForDay(surfaceData.sets, todayKey)
+  const totals = totalsByExercise(setsToday)
+  const rings: RingProgress[] = surfaceData.goals.map((goal) => ({
+    goal,
+    totalReps: totals.get(goal.exercise) ?? 0,
+  }))
+  const streaks = computeStrengthStreaks(surfaceData.sets, surfaceData.goals)
+  const lastReps = computeLastRepsByExercise(surfaceData.sets)
+  const goalsByExercise = Object.fromEntries(
+    surfaceData.goals.map((g) => [g.exercise, g]),
+  )
+
+  return (
+    <div className="flex flex-col gap-8">
+      {isPreviewMode ? (
+        <PreviewModeBadge description="These rings are illustrative — not Lucas’s real strength logs." />
+      ) : null}
+
+      <div className="grid gap-8 lg:grid-cols-[auto_1fr] lg:items-start">
+        <div className="flex flex-col items-center gap-4">
+          <ActivityRings rings={rings} size={264} className="w-full max-w-[264px]" />
+          <div className="grid w-full max-w-[264px] gap-2">
+            {surfaceData.goals.map((goal) => (
+              <StreakBadge
+                key={goal.exercise}
+                exercise={goal.exercise}
+                streak={streaks[goal.exercise] ?? { current: 0, longest: 0 }}
+                accentColor={goal.color}
+              />
+            ))}
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-6">
+          {isAdmin && !isPreviewMode ? (
+            <AdminQuickLog
+              goals={surfaceData.goals}
+              setsToday={setsToday}
+              busy={busy}
+              setBusy={setBusy}
+              refetch={refetch}
+              lastReps={lastReps}
+            />
+          ) : null}
+          <SetList
+            setsToday={setsToday}
+            goalsByExercise={goalsByExercise}
+            onDelete={
+              isAdmin && !isPreviewMode
+                ? (s) => deleteSet(s, setBusy, refetch)
+                : undefined
+            }
+            busy={busy}
+          />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+interface AdminQuickLogProps {
+  goals: WeightRoomData['goals']
+  setsToday: readonly StrengthSet[]
+  busy: boolean
+  setBusy: (v: boolean) => void
+  refetch: () => Promise<void>
+  lastReps?: Record<string, number>
+}
+
+/**
+ * Admin-only QuickLog wrapper. Owns the POST → refetch handshake so
+ * the parent island can stay declarative; busy state lifts up so the
+ * SetList's delete buttons disable while a quick-log is in flight
+ * (and vice-versa) — prevents racey double-submits.
+ */
+function AdminQuickLog({
+  goals,
+  busy,
+  setBusy,
+  refetch,
+  lastReps,
+}: AdminQuickLogProps): JSX.Element {
+  async function handleLog({
+    exercise,
+    reps,
+  }: {
+    exercise: string
+    reps: number
+  }): Promise<void> {
+    setBusy(true)
+    try {
+      const res = await fetch('/api/admin/weight-room/sets', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ exercise, reps }),
+      })
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { error?: string }
+        throw new Error(body.error ?? `Save failed (${res.status})`)
+      }
+      await refetch()
+    } finally {
+      setBusy(false)
+    }
+  }
+  return <QuickLog goals={goals} lastReps={lastReps} onLog={handleLog} busy={busy} />
+}
+
+/**
+ * Drop one logged set via the admin DELETE endpoint, then refetch so
+ * the rings + list reflect on-disk truth. Confirms with the user
+ * first because the action isn't undoable client-side and undoing it
+ * requires re-logging the set.
+ */
+async function deleteSet(
+  set: StrengthSet,
+  setBusy: (v: boolean) => void,
+  refetch: () => Promise<void>,
+): Promise<void> {
+  const ok = window.confirm(`Delete this set of ${set.reps} ${set.exercise}?`)
+  if (!ok) return
+  setBusy(true)
+  try {
+    const res = await fetch(`/api/admin/weight-room/sets/${set.id}`, {
+      method: 'DELETE',
+    })
+    if (!res.ok) {
+      const body = (await res.json().catch(() => ({}))) as { error?: string }
+      throw new Error(body.error ?? `Delete failed (${res.status})`)
+    }
+    await refetch()
+  } finally {
+    setBusy(false)
+  }
+}
+
+/**
+ * Per-exercise last-logged rep count, used to seed the QuickLog
+ * "Custom" input. Walks the full `sets` array (not just today's) so
+ * the seed survives a midnight rollover.
+ */
+function computeLastRepsByExercise(
+  sets: readonly StrengthSet[],
+): Record<string, number> {
+  const out: Record<string, number> = {}
+  // The data layer returns sets oldest → newest. Walk forward and
+  // overwrite so the final value per exercise is the latest.
+  for (const s of sets) {
+    out[s.exercise] = s.reps
+  }
+  return out
+}

--- a/components/training-facility/weight-room/TodayDataIsland.tsx
+++ b/components/training-facility/weight-room/TodayDataIsland.tsx
@@ -57,6 +57,13 @@ import { StreakBadge } from './StreakBadge'
  */
 export function TodayDataIsland(): JSX.Element {
   const [data, setData] = useState<WeightRoomData | null | undefined>(undefined)
+  // `loadError` is the "fetch threw" branch, distinct from `data === null`
+  // (the "tables are genuinely empty" branch). Without splitting these,
+  // a transient Supabase blip would render the empty-state CTA — which
+  // is misleading at best and could mask a real outage. On refetch
+  // failure we keep the last successful data and surface the error
+  // banner above it instead of nulling the view out.
+  const [loadError, setLoadError] = useState<string | null>(null)
   const [busy, setBusy] = useState<boolean>(false)
   // Monotonic request id — same pattern as `CombineDataIsland`. Both
   // mount-time and post-write fetches commit only when the id is still
@@ -67,10 +74,18 @@ export function TodayDataIsland(): JSX.Element {
     const id = ++requestIdRef.current
     getWeightRoomData()
       .then((d) => {
-        if (id === requestIdRef.current) setData(d)
+        if (id === requestIdRef.current) {
+          setData(d)
+          setLoadError(null)
+        }
       })
-      .catch(() => {
-        if (id === requestIdRef.current) setData(null)
+      .catch((err: unknown) => {
+        if (id === requestIdRef.current) {
+          setLoadError(err instanceof Error ? err.message : 'Failed to load.')
+          // Mount-time failure: there's no prior good data to keep, so
+          // settle `data` to null so the loading skeleton clears.
+          setData((prev) => (prev === undefined ? null : prev))
+        }
       })
     return () => {
       requestIdRef.current += 1
@@ -81,9 +96,17 @@ export function TodayDataIsland(): JSX.Element {
     const id = ++requestIdRef.current
     try {
       const d = await getWeightRoomData()
-      if (id === requestIdRef.current) setData(d)
-    } catch {
-      if (id === requestIdRef.current) setData(null)
+      if (id === requestIdRef.current) {
+        setData(d)
+        setLoadError(null)
+      }
+    } catch (err: unknown) {
+      // Refetch failure: preserve the previously loaded data so the user
+      // doesn't lose their already-rendered view. Surface the error
+      // inline; the next successful refetch clears it.
+      if (id === requestIdRef.current) {
+        setLoadError(err instanceof Error ? err.message : 'Refresh failed.')
+      }
     }
   }, [])
 
@@ -95,8 +118,15 @@ export function TodayDataIsland(): JSX.Element {
   const previewActive = isPreviewDemoActive(
     searchParams?.get(TRAINING_FACILITY_PREVIEW_PARAM),
   )
+  // "Empty" for the Today View means no progress to render — i.e. no
+  // sets logged. Goals on their own are configuration, not progress,
+  // so a freshly-seeded DB with `pushups` + `pullups` goals and zero
+  // sets still counts as empty (mirrors the cardio convention where
+  // `sessions.length === 0` alone triggers the empty branch). Without
+  // this, the seeded goals fool the page into the populated branch and
+  // `?preview=demo` becomes a no-op.
   const realIsEmpty =
-    data !== undefined && (data === null || (data.sets.length === 0 && data.goals.length === 0))
+    data !== undefined && (data === null || data.sets.length === 0)
   const isPreviewMode = realIsEmpty && previewActive
   const showEmptyStateCta = realIsEmpty && !previewActive
 
@@ -121,10 +151,15 @@ export function TodayDataIsland(): JSX.Element {
   }
 
   // Real-empty + no preview: show the CTA only. Once a real set lands
-  // the page reroutes to the populated branch on next refetch.
+  // the page reroutes to the populated branch on next refetch. The
+  // mount-time fetch error case also lands here (data === null and
+  // sets.length === 0 are equivalent here); the inline error banner
+  // tells the user the underlying state is "we couldn't read" not "no
+  // data exists yet."
   if (showEmptyStateCta) {
     return (
       <div className="space-y-6">
+        {loadError ? <LoadErrorBanner message={loadError} /> : null}
         <PreviewWithSampleDataButton
           href={`${pathname}?${TRAINING_FACILITY_PREVIEW_PARAM}=${TRAINING_FACILITY_PREVIEW_VALUE}`}
           headline="No strength work logged yet"
@@ -163,6 +198,7 @@ export function TodayDataIsland(): JSX.Element {
 
   return (
     <div className="flex flex-col gap-8">
+      {loadError ? <LoadErrorBanner message={loadError} /> : null}
       {isPreviewMode ? (
         <PreviewModeBadge description="These rings are illustrative — not Lucas’s real strength logs." />
       ) : null}
@@ -300,4 +336,21 @@ function computeLastRepsByExercise(
     out[s.exercise] = s.reps
   }
   return out
+}
+
+/**
+ * Inline banner that surfaces a load / refetch failure above the
+ * existing UI. Distinct from the empty-state CTA so the user can tell
+ * "we couldn't read" apart from "no data yet."
+ */
+function LoadErrorBanner({ message }: { message: string }): JSX.Element {
+  return (
+    <p
+      role="alert"
+      data-testid="today-load-error"
+      className="rounded-2xl border border-rose-400/30 bg-rose-950/40 px-4 py-3 font-mono text-[12px] text-rose-200"
+    >
+      {message}
+    </p>
+  )
 }

--- a/constants/weight-room-demo-fixture.ts
+++ b/constants/weight-room-demo-fixture.ts
@@ -1,0 +1,146 @@
+/**
+ * Hand-typed sample Weight Room dataset for the Today View's
+ * empty-state preview (#80, sibling of #160 Combine and #162 cardio).
+ * Surfaced when a viewer hits `/training-facility/weight-room?preview=demo`
+ * AND the real fetch returns an empty/null read — gives portfolio
+ * reviewers, first-time visitors, and fresh-clone dev environments a
+ * concrete idea of what the activity rings look like with progress.
+ *
+ * Built as a *function* (not a const) because the Today View is
+ * "today-relative" — we need today's date plus a few days back so the
+ * rings show partial progress now and the streak badge has data to
+ * lean on. The function is invoked at hydration time in the client
+ * data island, so SSR vs client clock drift never lands on the user.
+ *
+ * Hand-typed (not auto-derived from a Zod schema) so a real schema
+ * change in `types/weight-room.ts` surfaces here as a TypeScript error
+ * rather than silently rendering an outdated shape.
+ *
+ * KEEP IN SYNC WITH: `types/weight-room.ts`. If a new required field
+ * lands on `StrengthSet` / `ExerciseGoal`, TypeScript will surface it.
+ */
+
+import type { ExerciseGoal, StrengthSet, WeightRoomData } from '@/types/weight-room'
+
+/** Default goals seeded by the migration; the demo mirrors them. */
+const DEMO_GOALS: ExerciseGoal[] = [
+  { exercise: 'pushups', daily_target: 100, color: '#EA580C' },
+  { exercise: 'pullups', daily_target: 30, color: '#0EA5A1' },
+]
+
+/**
+ * Per-day plan relative to "today". Index 0 = today, 1 = yesterday,
+ * etc. Each day lists `{ exercise, reps[] }` rows; the builder fans
+ * those out into individual `StrengthSet` rows with synthesized ids
+ * and timestamps.
+ *
+ * Today is intentionally *partial* (75/100 pushups, 20/30 pullups) so
+ * the rings render mid-fill — the most representative state for a
+ * "grease the groove" page. The five days before today all hit goal
+ * to feed a current streak; further back has a missed day so the
+ * "longest" streak number is interesting too.
+ */
+const DEMO_DAY_PLAN: Array<{ exercise: string; reps: number[] }>[] = [
+  // 0 — today (partial)
+  [
+    { exercise: 'pushups', reps: [25, 25, 25] },
+    { exercise: 'pullups', reps: [10, 10] },
+  ],
+  // 1 — yesterday (goal hit on both)
+  [
+    { exercise: 'pushups', reps: [25, 25, 25, 25] },
+    { exercise: 'pullups', reps: [10, 10, 10] },
+  ],
+  // 2
+  [
+    { exercise: 'pushups', reps: [30, 30, 25, 25] },
+    { exercise: 'pullups', reps: [10, 10, 10, 5] },
+  ],
+  // 3
+  [
+    { exercise: 'pushups', reps: [25, 25, 25, 25] },
+    { exercise: 'pullups', reps: [10, 10, 10] },
+  ],
+  // 4
+  [
+    { exercise: 'pushups', reps: [20, 20, 20, 20, 20] },
+    { exercise: 'pullups', reps: [8, 8, 8, 6] },
+  ],
+  // 5
+  [
+    { exercise: 'pushups', reps: [25, 25, 25, 25] },
+    { exercise: 'pullups', reps: [10, 10, 10] },
+  ],
+  // 6 — missed day on pullups, hit on pushups (so the pullups streak
+  //      breaks here but pushups keeps a longer all-time longest)
+  [
+    { exercise: 'pushups', reps: [25, 25, 25, 25] },
+    { exercise: 'pullups', reps: [5, 5] },
+  ],
+  // 7
+  [
+    { exercise: 'pushups', reps: [25, 25, 25, 25] },
+    { exercise: 'pullups', reps: [10, 10, 10] },
+  ],
+  // 8
+  [
+    { exercise: 'pushups', reps: [25, 25, 25, 25] },
+    { exercise: 'pullups', reps: [10, 10, 10] },
+  ],
+]
+
+/**
+ * Subtract `n` days from a Date and return an ISO timestamp at the
+ * given hour-of-day. Stays in the caller's local timezone — Today
+ * View math reads everything in local time (per
+ * {@link import('@/lib/training-facility/strength-today').toLocalDateKey})
+ * so the demo's timestamps need to match.
+ */
+function isoDaysAgo(now: Date, daysAgo: number, hour: number, minute = 0): string {
+  const d = new Date(now.getFullYear(), now.getMonth(), now.getDate(), hour, minute, 0, 0)
+  d.setDate(d.getDate() - daysAgo)
+  return d.toISOString()
+}
+
+/**
+ * Build today-relative demo {@link WeightRoomData}. Called from the
+ * client data island when the real read is empty AND the URL has
+ * `?preview=demo`.
+ *
+ * The seed `now` is parameterized so unit tests can pin a specific
+ * "today" — production callers omit it and get system time.
+ *
+ * @param now Optional override; defaults to `new Date()`.
+ */
+export function buildWeightRoomDemoData(now: Date = new Date()): WeightRoomData {
+  const sets: StrengthSet[] = []
+  let counter = 0
+  for (let dayIndex = 0; dayIndex < DEMO_DAY_PLAN.length; dayIndex++) {
+    const rows = DEMO_DAY_PLAN[dayIndex]
+    // Spread the day's sets across waking hours so the timestamps
+    // read like a "grease the groove" cadence rather than a single
+    // session. Hour offsets are deterministic so SetList ordering is
+    // stable across renders.
+    let hour = 7
+    for (const row of rows) {
+      for (const reps of row.reps) {
+        sets.push({
+          id: `demo-${dayIndex}-${counter++}`,
+          logged_at: isoDaysAgo(now, dayIndex, hour, (counter * 7) % 60),
+          exercise: row.exercise,
+          reps,
+        })
+        hour += 2
+        if (hour > 21) hour = 21
+      }
+      hour += 1
+    }
+  }
+  // Sort oldest → newest so the shape matches the live read path.
+  sets.sort((a, b) => (a.logged_at < b.logged_at ? -1 : a.logged_at > b.logged_at ? 1 : 0))
+  return {
+    imported_at: now.toISOString(),
+    sets,
+    goals: DEMO_GOALS,
+  }
+}

--- a/e2e/training-facility-disabled.spec.ts
+++ b/e2e/training-facility-disabled.spec.ts
@@ -3,7 +3,12 @@ import { expect, test } from '@playwright/test'
 import { bypassHomeIntro } from './helpers/intro'
 
 /** Routes that should continue to render the custom 404 while the feature flag is off. */
-const gatedRoutes = ['/training-facility', '/training-facility/gym', '/training-facility/combine']
+const gatedRoutes = [
+  '/training-facility',
+  '/training-facility/gym',
+  '/training-facility/combine',
+  '/training-facility/weight-room',
+]
 
 test.describe('training facility disabled', () => {
   test.beforeEach(async ({ page }) => {

--- a/e2e/training-facility-enabled.spec.ts
+++ b/e2e/training-facility-enabled.spec.ts
@@ -31,4 +31,10 @@ test.describe('training facility enabled', () => {
     await expect(page.getByRole('heading', { name: /^the combine$/i })).toBeVisible()
     await expect(page.getByRole('link', { name: /back to training facility/i })).toBeVisible()
   })
+
+  test('renders the weight room Today View when reached directly', async ({ page }) => {
+    await page.goto('/training-facility/weight-room')
+    await expect(page.getByRole('heading', { name: /^today$/i })).toBeVisible()
+    await expect(page.getByRole('link', { name: /settings/i })).toBeVisible()
+  })
 })

--- a/lib/schemas/weight-room.ts
+++ b/lib/schemas/weight-room.ts
@@ -23,6 +23,19 @@ import type { ExerciseGoal, StrengthSet } from '@/types/weight-room'
 const HEX_COLOR_REGEX = /^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/
 
 /**
+ * Positive-integer Zod check. Inlined as a `.refine` rather than
+ * chaining `.int().positive()` because Turbopack's dev-mode bundler
+ * mis-transpiles `z.number().int()` when this module is pulled into a
+ * client bundle (the Today View's data island in #80 hit this) — the
+ * compiled output references a bare `int` identifier that doesn't
+ * exist. The runtime behavior matches `.int().positive()` precisely.
+ */
+const positiveInt = (): z.ZodType<number> =>
+  z
+    .number()
+    .refine((n) => Number.isInteger(n) && n > 0, 'must be a positive integer')
+
+/**
  * Zod schema for one row of `public.weight_room_sets`. Mirrors the
  * table definition in
  * `supabase/migrations/20260507120000_weight_room_tables.sql`.
@@ -36,7 +49,7 @@ export const WeightRoomSetRowSchema = z
     id: z.string().uuid(),
     logged_at: z.string().min(1, 'logged_at must be an ISO timestamp'),
     exercise: z.string().min(1),
-    reps: z.number().int().positive(),
+    reps: positiveInt(),
   })
   .strict()
 
@@ -51,7 +64,7 @@ export type WeightRoomSetRow = z.infer<typeof WeightRoomSetRowSchema>
 export const WeightRoomGoalRowSchema = z
   .object({
     exercise: z.string().min(1),
-    daily_target: z.number().int().positive(),
+    daily_target: positiveInt(),
     color: z.string().regex(HEX_COLOR_REGEX, 'color must be a hex string like #EA580C'),
   })
   .strict()
@@ -68,7 +81,7 @@ export type WeightRoomGoalRow = z.infer<typeof WeightRoomGoalRowSchema>
 export const WeightRoomSetCreateSchema = z
   .object({
     exercise: z.string().min(1),
-    reps: z.number().int().positive(),
+    reps: positiveInt(),
     logged_at: z.string().min(1).optional(),
   })
   .strict()

--- a/lib/training-facility/strength-streaks.test.ts
+++ b/lib/training-facility/strength-streaks.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { ExerciseGoal, StrengthSet } from '@/types/weight-room'
+
+import { computeStrengthStreaks } from './strength-streaks'
+
+const PUSHUPS: ExerciseGoal = {
+  exercise: 'pushups',
+  daily_target: 100,
+  color: '#EA580C',
+}
+const PULLUPS: ExerciseGoal = {
+  exercise: 'pullups',
+  daily_target: 30,
+  color: '#0EA5A1',
+}
+
+/** Compact set factory — `{ exercise, dayKey, reps }`. */
+function s(exercise: string, dayKey: string, reps: number): StrengthSet {
+  return {
+    id: `${exercise}-${dayKey}-${reps}`,
+    logged_at: `${dayKey}T13:00:00`,
+    exercise,
+    reps,
+  }
+}
+
+describe('computeStrengthStreaks', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('returns 0/0 for every goal when no sets exist', () => {
+    expect(computeStrengthStreaks([], [PUSHUPS, PULLUPS])).toEqual({
+      pushups: { current: 0, longest: 0 },
+      pullups: { current: 0, longest: 0 },
+    })
+  })
+
+  it('counts a 1-day current streak when today hits the goal', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-07T13:00:00'))
+    const result = computeStrengthStreaks([s('pushups', '2026-05-07', 100)], [PUSHUPS])
+    expect(result.pushups).toEqual({ current: 1, longest: 1 })
+  })
+
+  it('does not count under-target days toward the streak', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-07T13:00:00'))
+    const result = computeStrengthStreaks([s('pushups', '2026-05-07', 99)], [PUSHUPS])
+    expect(result.pushups).toEqual({ current: 0, longest: 0 })
+  })
+
+  it('counts consecutive goal-hit calendar days as one run', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-07T13:00:00'))
+    const sets = [
+      s('pushups', '2026-05-04', 100),
+      s('pushups', '2026-05-05', 100),
+      s('pushups', '2026-05-06', 110),
+      s('pushups', '2026-05-07', 100),
+    ]
+    expect(computeStrengthStreaks(sets, [PUSHUPS]).pushups).toEqual({
+      current: 4,
+      longest: 4,
+    })
+  })
+
+  it('sums multiple sets on the same day toward the goal', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-07T13:00:00'))
+    const sets = [
+      s('pushups', '2026-05-07', 40),
+      s('pushups', '2026-05-07', 35),
+      s('pushups', '2026-05-07', 30),
+    ]
+    expect(computeStrengthStreaks(sets, [PUSHUPS]).pushups).toEqual({
+      current: 1,
+      longest: 1,
+    })
+  })
+
+  it('breaks the streak on a missed day', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-07T13:00:00'))
+    const sets = [
+      s('pushups', '2026-05-01', 100),
+      s('pushups', '2026-05-02', 100),
+      s('pushups', '2026-05-03', 100),
+      // missed 5/4 + 5/5
+      s('pushups', '2026-05-06', 100),
+      s('pushups', '2026-05-07', 100),
+    ]
+    const result = computeStrengthStreaks(sets, [PUSHUPS]).pushups
+    expect(result.current).toBe(2)
+    expect(result.longest).toBe(3)
+  })
+
+  it('keeps current at 0 when the latest goal-hit day is older than yesterday', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-07T13:00:00'))
+    const sets = [
+      s('pushups', '2026-05-01', 100),
+      s('pushups', '2026-05-02', 100),
+      s('pushups', '2026-05-03', 100),
+    ]
+    const result = computeStrengthStreaks(sets, [PUSHUPS]).pushups
+    expect(result.current).toBe(0)
+    expect(result.longest).toBe(3)
+  })
+
+  it('counts yesterday-as-current when today has no goal-hit yet', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-07T13:00:00'))
+    const sets = [
+      s('pushups', '2026-05-05', 100),
+      s('pushups', '2026-05-06', 100),
+      s('pushups', '2026-05-07', 50), // not a hit
+    ]
+    const result = computeStrengthStreaks(sets, [PUSHUPS]).pushups
+    expect(result.current).toBe(2)
+    expect(result.longest).toBe(2)
+  })
+
+  it('computes streaks independently per exercise', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-07T13:00:00'))
+    const sets = [
+      s('pushups', '2026-05-06', 100),
+      s('pushups', '2026-05-07', 100),
+      s('pullups', '2026-05-07', 30),
+    ]
+    const result = computeStrengthStreaks(sets, [PUSHUPS, PULLUPS])
+    expect(result.pushups).toEqual({ current: 2, longest: 2 })
+    expect(result.pullups).toEqual({ current: 1, longest: 1 })
+  })
+
+  it('ignores sets whose timestamps cannot be parsed', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-07T13:00:00'))
+    const sets = [
+      { ...s('pushups', '2026-05-07', 100), logged_at: 'not-a-date' },
+      s('pushups', '2026-05-07', 100),
+    ]
+    const result = computeStrengthStreaks(sets, [PUSHUPS]).pushups
+    expect(result.current).toBe(1)
+    expect(result.longest).toBe(1)
+  })
+
+  it('returns 0/0 for goals with non-positive daily_target', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-07T13:00:00'))
+    const broken: ExerciseGoal = { exercise: 'pushups', daily_target: 0, color: '#EA580C' }
+    const sets = [s('pushups', '2026-05-07', 100)]
+    expect(computeStrengthStreaks(sets, [broken]).pushups).toEqual({
+      current: 0,
+      longest: 0,
+    })
+  })
+})

--- a/lib/training-facility/strength-streaks.ts
+++ b/lib/training-facility/strength-streaks.ts
@@ -1,0 +1,138 @@
+import type { ExerciseGoal, StrengthSet } from '@/types/weight-room'
+
+import { toLocalDateKey } from './strength-today'
+
+/**
+ * Per-exercise streak result, mirrored on
+ * {@link import('./streaks').StreakResult} so the UI surfaces can stay
+ * shape-compatible across cardio and weight-room. "Goal hit" here means
+ * the exercise's total reps for the day reached
+ * {@link ExerciseGoal.daily_target} — note that historical changes to
+ * the target aren't tracked, so the streak is computed against today's
+ * configured target across the entire history (best we can do without
+ * a target-history table).
+ */
+export interface StrengthStreakResult {
+  /**
+   * Length in days of the active goal-hit streak ending at today, or
+   * yesterday if today's target hasn't been hit yet. `0` when the most
+   * recent goal-hit day is older than yesterday.
+   */
+  current: number
+  /**
+   * Longest run of consecutive calendar days that hit the goal, ever.
+   * Independent of {@link current}.
+   */
+  longest: number
+}
+
+/**
+ * Add `n` days to a `YYYY-MM-DD` key, returning a new key. Local-noon
+ * base time so DST transitions don't shift the calendar day.
+ */
+function addDays(dateKey: string, n: number): string {
+  const d = new Date(dateKey + 'T12:00:00')
+  d.setDate(d.getDate() + n)
+  return toLocalDateKey(d)
+}
+
+/**
+ * Compute streaks for every configured exercise. Returns a record
+ * keyed by exercise name; exercises with no logged sets (yet) still
+ * appear with `{ current: 0, longest: 0 }` so callers can render a
+ * full row of `StreakBadge`s without juggling fallbacks.
+ *
+ * "Hit the goal" means the exercise's total reps for that calendar
+ * day reach {@link ExerciseGoal.daily_target}. Multiple sets on the
+ * same day sum together; the goal applies to the day, not per-set.
+ *
+ * The "current" streak counts back from today (or yesterday if no
+ * goal-hit set has been logged today yet) and is `0` when the most
+ * recent goal-hit day is older than yesterday — same convention as
+ * {@link import('./streaks').computeStreaks} so the cross-area UX is
+ * coherent.
+ *
+ * @param sets All logged sets, usually `WeightRoomData.sets`.
+ * @param goals All configured exercises, usually `WeightRoomData.goals`.
+ *   Streaks are only computed for goals whose `daily_target > 0`;
+ *   non-positive targets short-circuit to `{ current: 0, longest: 0 }`.
+ */
+export function computeStrengthStreaks(
+  sets: readonly StrengthSet[],
+  goals: readonly ExerciseGoal[],
+): Record<string, StrengthStreakResult> {
+  const result: Record<string, StrengthStreakResult> = {}
+
+  // Bucket reps by exercise → day → running total. Uses Maps to keep
+  // the inner structure ordered insertion-wise; the streak loop sorts
+  // keys explicitly so the input order doesn't matter.
+  const repsByExerciseAndDay = new Map<string, Map<string, number>>()
+  for (const s of sets) {
+    const day = toLocalDateKey(s.logged_at)
+    if (day === '') continue
+    let dayMap = repsByExerciseAndDay.get(s.exercise)
+    if (!dayMap) {
+      dayMap = new Map()
+      repsByExerciseAndDay.set(s.exercise, dayMap)
+    }
+    dayMap.set(day, (dayMap.get(day) ?? 0) + s.reps)
+  }
+
+  const today = toLocalDateKey(new Date())
+  const yesterday = today === '' ? '' : addDays(today, -1)
+
+  for (const goal of goals) {
+    if (goal.daily_target <= 0) {
+      result[goal.exercise] = { current: 0, longest: 0 }
+      continue
+    }
+    const dayMap = repsByExerciseAndDay.get(goal.exercise) ?? new Map<string, number>()
+
+    // "Goal-hit" calendar days, in chronological order.
+    const hitDays: string[] = []
+    for (const [day, total] of dayMap) {
+      if (total >= goal.daily_target) hitDays.push(day)
+    }
+    hitDays.sort()
+
+    if (hitDays.length === 0) {
+      result[goal.exercise] = { current: 0, longest: 0 }
+      continue
+    }
+
+    // Longest run of consecutive goal-hit days, ever.
+    let longest = 1
+    let run = 1
+    for (let i = 1; i < hitDays.length; i++) {
+      if (addDays(hitDays[i - 1], 1) === hitDays[i]) {
+        run++
+        if (run > longest) longest = run
+      } else {
+        run = 1
+      }
+    }
+
+    // Current streak: walk backward from the latest goal-hit day if
+    // it's today or yesterday (matches `computeStreaks`'s rolling-day
+    // grace period).
+    const last = hitDays[hitDays.length - 1]
+    let current = 0
+    if (last === today || last === yesterday) {
+      current = 1
+      for (let i = hitDays.length - 2; i >= 0; i--) {
+        if (addDays(hitDays[i], 1) === hitDays[i + 1]) {
+          current++
+        } else {
+          break
+        }
+      }
+    }
+
+    result[goal.exercise] = {
+      current,
+      longest: Math.max(longest, current),
+    }
+  }
+
+  return result
+}

--- a/lib/training-facility/strength-today.test.ts
+++ b/lib/training-facility/strength-today.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest'
+
+import type { ExerciseGoal, StrengthSet } from '@/types/weight-room'
+
+import {
+  computeRingPercent,
+  filterSetsForDay,
+  sumReps,
+  toLocalDateKey,
+  totalsByExercise,
+} from './strength-today'
+
+/** Helper — assemble a {@link StrengthSet} with sensible defaults. */
+function set(overrides: Partial<StrengthSet> = {}): StrengthSet {
+  return {
+    id: '11111111-1111-1111-1111-111111111111',
+    logged_at: '2026-05-07T13:00:00',
+    exercise: 'pushups',
+    reps: 10,
+    ...overrides,
+  }
+}
+
+const PUSHUPS: ExerciseGoal = {
+  exercise: 'pushups',
+  daily_target: 100,
+  color: '#EA580C',
+}
+
+describe('toLocalDateKey', () => {
+  it('returns YYYY-MM-DD in local time for a parseable timestamp', () => {
+    expect(toLocalDateKey('2026-05-07T13:00:00')).toBe('2026-05-07')
+  })
+
+  it('zero-pads single-digit months and days', () => {
+    expect(toLocalDateKey('2026-01-04T08:00:00')).toBe('2026-01-04')
+  })
+
+  it('returns "" for an unparseable string', () => {
+    expect(toLocalDateKey('not-a-date')).toBe('')
+  })
+
+  it('accepts a Date input directly', () => {
+    const d = new Date('2026-05-07T13:00:00')
+    expect(toLocalDateKey(d)).toBe('2026-05-07')
+  })
+})
+
+describe('filterSetsForDay', () => {
+  it('keeps only sets whose logged_at falls on the day', () => {
+    const sets = [
+      set({ logged_at: '2026-05-07T08:00:00' }),
+      set({ logged_at: '2026-05-07T22:30:00' }),
+      set({ logged_at: '2026-05-06T13:00:00' }),
+    ]
+    expect(filterSetsForDay(sets, '2026-05-07')).toHaveLength(2)
+  })
+
+  it('returns an empty array when dayKey is empty', () => {
+    expect(filterSetsForDay([set()], '')).toEqual([])
+  })
+
+  it('skips sets with unparseable timestamps without throwing', () => {
+    const sets = [
+      set({ logged_at: '2026-05-07T08:00:00' }),
+      set({ logged_at: 'not-a-date' }),
+    ]
+    expect(filterSetsForDay(sets, '2026-05-07')).toHaveLength(1)
+  })
+})
+
+describe('sumReps', () => {
+  it('returns 0 for an empty array', () => {
+    expect(sumReps([])).toBe(0)
+  })
+
+  it('sums reps across all sets', () => {
+    expect(sumReps([set({ reps: 5 }), set({ reps: 12 }), set({ reps: 8 })])).toBe(25)
+  })
+})
+
+describe('totalsByExercise', () => {
+  it('groups reps by exercise key', () => {
+    const totals = totalsByExercise([
+      set({ exercise: 'pushups', reps: 10 }),
+      set({ exercise: 'pushups', reps: 15 }),
+      set({ exercise: 'pullups', reps: 5 }),
+    ])
+    expect(totals.get('pushups')).toBe(25)
+    expect(totals.get('pullups')).toBe(5)
+  })
+
+  it('returns an empty map for no sets', () => {
+    expect(totalsByExercise([]).size).toBe(0)
+  })
+})
+
+describe('computeRingPercent', () => {
+  it('returns the unclamped fraction of the daily target', () => {
+    expect(computeRingPercent(50, PUSHUPS)).toBe(0.5)
+    expect(computeRingPercent(100, PUSHUPS)).toBe(1)
+    expect(computeRingPercent(125, PUSHUPS)).toBe(1.25)
+  })
+
+  it('returns 0 when the daily target is non-positive', () => {
+    expect(
+      computeRingPercent(50, { exercise: 'pushups', daily_target: 0, color: '#000' }),
+    ).toBe(0)
+  })
+
+  it('returns 0 when no reps logged', () => {
+    expect(computeRingPercent(0, PUSHUPS)).toBe(0)
+  })
+})

--- a/lib/training-facility/strength-today.ts
+++ b/lib/training-facility/strength-today.ts
@@ -1,0 +1,105 @@
+import type { ExerciseGoal, StrengthSet } from '@/types/weight-room'
+
+/**
+ * Pure helpers for the Weight Room Today View (#80) — date bucketing,
+ * per-exercise totals, and ring-percent computation. Lives separate
+ * from the React components so the math has unit-test coverage without
+ * any DOM mounted, and so {@link computeRingPercent} can be reused by
+ * the future History View (#81) when it shows "today" alongside the
+ * heatmap.
+ *
+ * All date math runs in the *caller's* local timezone. The Today View
+ * is by definition "what happened on this calendar day" — the user
+ * looking at a phone in Pacific time wants their local midnight
+ * boundary, not UTC's.
+ */
+
+/**
+ * Local-date key (`YYYY-MM-DD`) for an ISO timestamp string or a Date.
+ * Strips off the time-of-day so two sets logged at 06:00 and 23:00 of
+ * the same day collapse to the same key.
+ *
+ * @param input ISO 8601 timestamp string from
+ *   {@link StrengthSet.logged_at}, or a Date already constructed by
+ *   the caller.
+ * @returns `YYYY-MM-DD` in the caller's local timezone, or `''` when
+ *   `input` is unparseable (so callers can use `key === ''` as a skip
+ *   condition without throwing).
+ */
+export function toLocalDateKey(input: string | Date): string {
+  const d = typeof input === 'string' ? new Date(input) : input
+  if (!Number.isFinite(d.getTime())) return ''
+  const yyyy = d.getFullYear().toString().padStart(4, '0')
+  const mm = (d.getMonth() + 1).toString().padStart(2, '0')
+  const dd = d.getDate().toString().padStart(2, '0')
+  return `${yyyy}-${mm}-${dd}`
+}
+
+/**
+ * Filter `sets` down to those logged on a specific local-date key.
+ * Used by the Today View to slice the full sets array (which spans
+ * the whole history) down to just today's logs without re-querying.
+ *
+ * @param sets All logged sets, usually `WeightRoomData.sets`.
+ * @param dayKey `YYYY-MM-DD` key as produced by {@link toLocalDateKey}.
+ *   Pass an empty string to get an empty array back (defensive — keeps
+ *   callers from having to special-case unparseable "now" inputs).
+ */
+export function filterSetsForDay(
+  sets: readonly StrengthSet[],
+  dayKey: string,
+): StrengthSet[] {
+  if (dayKey === '') return []
+  return sets.filter((s) => toLocalDateKey(s.logged_at) === dayKey)
+}
+
+/**
+ * Sum reps across a slice of sets. Trivial helper, but named so call
+ * sites read as intent ("today's total") rather than a generic reduce.
+ *
+ * @param sets Sets to sum — usually one exercise on one day.
+ */
+export function sumReps(sets: readonly StrengthSet[]): number {
+  let total = 0
+  for (const s of sets) total += s.reps
+  return total
+}
+
+/**
+ * Per-exercise rep total for a day. Returns a Map keyed by exercise so
+ * {@link ActivityRings} and {@link QuickLog} can both pull "what's the
+ * current count for pushups?" in O(1) without re-filtering the array.
+ *
+ * @param setsForDay Output of {@link filterSetsForDay}.
+ */
+export function totalsByExercise(
+  setsForDay: readonly StrengthSet[],
+): Map<string, number> {
+  const totals = new Map<string, number>()
+  for (const s of setsForDay) {
+    totals.set(s.exercise, (totals.get(s.exercise) ?? 0) + s.reps)
+  }
+  return totals
+}
+
+/**
+ * Fraction of `goal.daily_target` that today's reps cover. Returned
+ * unclamped — callers that animate a ring usually `Math.min(1, …)` the
+ * stroke offset, but the center-text "75 / 100" surface keeps the raw
+ * value so a 110-rep day reads as "110 / 100" not "100 / 100".
+ *
+ * Returns `0` when `goal.daily_target` is non-positive (defensive
+ * against a future settings UI accepting 0 — the schema currently
+ * enforces `> 0`, but the helper shouldn't `Infinity` if that changes).
+ *
+ * @param totalReps Total reps logged for the exercise today, usually
+ *   sourced from {@link totalsByExercise}.
+ * @param goal The exercise's configured goal.
+ */
+export function computeRingPercent(
+  totalReps: number,
+  goal: ExerciseGoal,
+): number {
+  if (goal.daily_target <= 0) return 0
+  return totalReps / goal.daily_target
+}


### PR DESCRIPTION
## Summary

Builds the primary Weight Room interaction surface (PRD §7.6 / #80 of
the strength-tracker slice). Concentric SVG activity rings act as the
hero (one ring per configured exercise; outer = pushups, inner =
pullups), the quick-log surface gives admins one-tap chip presets +
"Custom" for arbitrary rep counts, and the timestamped set list owns
the per-row delete affordance. A `?preview=demo` empty-state fixture
mirrors the Combine + cardio convention so portfolio reviewers see the
rings populated without an admin account.

The route lands at `/training-facility/weight-room` (the index — slice
#82 will wire the Training Facility door + cross-view nav).

## Architecture decisions

- **Route placement: index, not sub-route.** Today View is what the
  Weight Room defaults to. History (#81) becomes `/history`; Settings
  is already at `/settings`.
- **Quick-log: preset chips + Custom.** `+5 / +10 / +15 / +20 / +25`
  one-tap chips per exercise, with a Custom button that opens an
  inline numeric input seeded by last-logged reps. Hits the issue's
  2-tap target for any count.
- **Admin-gated writes.** Same pattern as the Combine entry form —
  non-admin viewers see rings + read-only set list. Writes funnel
  through the existing `/api/admin/weight-room/sets` POST + `[id]` DELETE.
- **Demo fixture is `now`-relative.** `buildWeightRoomDemoData(new Date())`
  generates today-relative timestamps so today's ring renders mid-fill
  (the most informative ring state) and the streak badges have data.
  Generated client-side at hydration so SSR/CSR clock drift never
  lands on the user.

## What landed

| Layer | File | Notes |
| --- | --- | --- |
| Page | `app/training-facility/weight-room/page.tsx` | Server component for the flag gate + chrome; embeds the data island in a Suspense boundary. |
| Data island | `components/training-facility/weight-room/TodayDataIsland.tsx` | Owns the fetch + write orchestration. Mirrors `CombineDataIsland`'s request-id pattern so a slow mount-time fetch can't clobber post-write data. |
| Centerpiece | `components/training-facility/weight-room/ActivityRings.tsx` | SVG concentric rings, stroke-dashoffset for fill, drop-shadow glow on goal hit. |
| Quick log | `components/training-facility/weight-room/QuickLog.tsx` | Preset chips + Custom input. 44px min touch targets, ARIA-labeled buttons. |
| Set list | `components/training-facility/weight-room/SetList.tsx` | Most-recent-first, per-row delete (admin only), inline error surface. |
| Streak | `components/training-facility/weight-room/StreakBadge.tsx` | Per-exercise flame + count chip. |
| Helpers | `lib/training-facility/strength-{today,streaks}.ts` | Pure date/percent/streak math, both with unit-test coverage. |
| Demo | `constants/weight-room-demo-fixture.ts` | `buildWeightRoomDemoData(now)` — relative timestamps so today's ring populates. |
| E2E | `e2e/training-facility-{enabled,disabled}.spec.ts` | Added `/training-facility/weight-room` to the gated-route list and a render test for the Today header. |

### Drive-by fix

`lib/schemas/weight-room.ts` — rewrote `z.number().int().positive()` to a
`positiveInt()` `.refine` helper. Turbopack's dev-mode bundler
mis-transpiles the chained `.int()` when the schema gets pulled into a
client bundle (the new data island hits this), emitting a bare `int`
identifier that crashes module evaluation at runtime. Same runtime
semantics; works under Turbopack, Webpack, and the production build.

## Test plan

- [ ] CI green (Vercel + e2e + CodeRabbit).
- [ ] **Empty-state CTA.** Visit `/training-facility/weight-room` with no goals/sets — should show "No strength work logged yet" + Preview-with-sample-data button.
- [ ] **Demo fixture.** Click into `?preview=demo` → rings + streaks populate, today's pushups partially filled (75/100), pullups partially filled (20/30), Preview badge visible.
- [ ] **Exit preview.** Click "Exit preview" in the badge → returns to empty-state CTA.
- [ ] **Apply migration locally** (still required from #180 — `supabase db push`), seed at least one goal in Settings.
- [ ] **Quick-log chip.** Sign in as admin → tap `+10` on pushups → ring sweeps to ~10%, the row appears in Today's set list, custom input not opened.
- [ ] **Custom log.** Tap Custom → input seeded with last-logged value → type 17 → Log → row appears with reps=17.
- [ ] **Goal hit.** Log enough reps to cross 100% → ring locks visually at full sweep, center text shows over-fill (e.g. "120 / 100"), drop-shadow glow visible.
- [ ] **Delete a set.** Tap Delete on any row → native confirm → row disappears, ring sweeps back proportionally.
- [ ] **Read-only viewer.** Sign out → quick-log section hides, delete buttons hide, rings + set list still render.
- [ ] **Mobile viewport (`390×844`).** Rings + cards stack single-column; chips stay tappable; nothing overflows.
- [ ] **Streak grace period.** Log < goal today → today's streak should still count yesterday's hit (per `computeStrengthStreaks`).

## Out of scope

- History View / heatmap / aggregate stats — slice #81
- Weight Room door + cross-view nav on the Training Facility scene — slice #82
- Server-side daily aggregation (large-history performance) — premature; the page reads ~one day's worth of sets

Closes #80.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Weight Room training facility with a Today view for strength training
  * Added activity rings visualization showing daily exercise progress toward goals
  * Quick logging of exercises with preset reps or custom entry
  * History view of logged sets with timestamps and delete functionality
  * Exercise streak tracking showing current and longest consecutive days meeting goals
  * Settings link for weight room configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->