### PR TITLE
chore(claude): broaden allowlist for ship-issue + screenshots flow

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,10 +1,14 @@
 {
   "permissions": {
     "allow": [
+      "Bash(gh api repos/lucasklawrence/courtfolio/compare/*)",
+      "Bash(gh api repos/lucasklawrence/courtfolio/contents/*)",
+      "Bash(gh api repos/lucasklawrence/courtfolio/git/refs*)",
       "Bash(gh api repos/lucasklawrence/courtfolio/issues/*/comments)",
       "Bash(gh api repos/lucasklawrence/courtfolio/issues/*/comments --jq*)",
       "Bash(gh api repos/lucasklawrence/courtfolio/pulls/*/comments)",
       "Bash(gh api repos/lucasklawrence/courtfolio/pulls/*/comments --jq*)",
+      "Bash(gh api repos/lucasklawrence/courtfolio/pulls/*/comments/*/replies*)",
       "Bash(gh issue close*)",
       "Bash(gh issue comment*)",
       "Bash(gh issue list*)",
@@ -36,7 +40,9 @@
       "Bash(git stash*)",
       "Bash(git status*)",
       "Bash(jq *)",
+      "Bash(mkdir -p*)",
       "Bash(netstat*)",
+      "Bash(npm install --no-audit --no-fund*)",
       "Bash(npm run build)",
       "Bash(npm run dev*)",
       "Bash(npm run import-health*)",


### PR DESCRIPTION
## Summary

Six narrow allowlist additions observed often enough in recent transcripts to be worth pre-approving. Each is bounded — none broaden into arbitrary code execution or destructive ops.

| # | Pattern | Why |
|---|---------|-----|
| 1 | `Bash(mkdir -p*)` | dir creation; idempotent |
| 2 | `Bash(npm install --no-audit --no-fund*)` | fresh-worktree dep install in ship-issue Phase 2 |
| 3 | `Bash(gh api repos/lucasklawrence/courtfolio/pulls/*/comments/*/replies*)` | review-loop replies (pre-approved per memory) |
| 4 | `Bash(gh api repos/lucasklawrence/courtfolio/git/refs*)` | branch ref create/delete for screenshots flow |
| 5 | `Bash(gh api repos/lucasklawrence/courtfolio/contents/*)` | file uploads to the screenshots orphan branch |
| 6 | `Bash(gh api repos/lucasklawrence/courtfolio/compare/*)` | pre-merge staleness check |

Skipped intentionally:
- `gh pr merge*` — memory says destructive ops still require confirmation
- bare `gh api*` — would grant POST/DELETE on any endpoint
- interpreters / package runners / anything in the skill's "never allowlist" list

## Test plan

- [ ] Open the file in `.claude/settings.json` after the squash-merge — six new entries, alphabetized, no key reordering.
- [ ] Run `/ship-issue` on a future task; verify the screenshots flow's `gh api git/refs` and `gh api contents/*` calls don't prompt anymore.

Closes (no issue — driven by `/fewer-permission-prompts`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration settings to enable enhanced GitHub integration and improved development tooling support, including new API permissions and shell command capabilities for better workflow efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->