### PR TITLE
test(training-facility): hardening from #188 follow-ups (#190)

### DIFF
--- a/components/training-facility/gym/WorkoutHeatmap.test.tsx
+++ b/components/training-facility/gym/WorkoutHeatmap.test.tsx
@@ -66,6 +66,36 @@ describe('WorkoutHeatmap', () => {
     expect(fills.some((f) => /234, 88, 12|EA580C/i.test(f))).toBe(true)
   })
 
+  it('positions the legend strip flush with the SVG right edge at MAX_CELL_SIZE', () => {
+    // Regression for #190 item 2 — the original hardcoded `140` offset
+    // clipped the legend off the right edge once the responsive scaling
+    // pushed cells up to `MAX_CELL_SIZE` (28). The PR fix derives
+    // `legendWidth` from the cell stride; this test pins that contract
+    // so a future cell-size knob can't silently re-introduce the clip.
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 3, 15))
+    const { container } = render(<WorkoutHeatmap sessions={[]} cellSize={28} />)
+    const svg = container.querySelector('svg')!
+    const [, , svgWidth] = (svg.getAttribute('viewBox') ?? '').split(' ').map(Number)
+    // The legend `<g>` is the only one whose transform x is computed as
+    // `DAY_LABEL_WIDTH + gridWidth - legendWidth`. Pick it out by finding
+    // the group containing the "More" text.
+    const legendGroup = Array.from(container.querySelectorAll('svg g')).find((g) =>
+      Array.from(g.querySelectorAll('text')).some((t) => t.textContent === 'More'),
+    )
+    expect(legendGroup).toBeDefined()
+    const transform = legendGroup!.getAttribute('transform') ?? ''
+    const match = transform.match(/translate\(([0-9.-]+),\s*([0-9.-]+)\)/)
+    expect(match).not.toBeNull()
+    const legendX = Number(match![1])
+    // Legend width derives from the same constants `WorkoutHeatmap.tsx`
+    // uses: 32 (Less text) + 4 swatches at `cellSize + 1` stride + 4
+    // (gap) + 28 (More text). At cellSize=28, that's 32 + 116 + 4 + 28 = 180.
+    const legendWidth = 32 + 4 * (28 + 1) + 4 + 28
+    expect(legendX + legendWidth).toBeLessThanOrEqual(svgWidth)
+    expect(legendX).toBeGreaterThan(0)
+  })
+
   it('writes a session-count tooltip on populated cells', () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date(2026, 3, 15))

--- a/components/training-facility/gym/WorkoutHeatmap.tsx
+++ b/components/training-facility/gym/WorkoutHeatmap.tsx
@@ -93,6 +93,22 @@ export function WorkoutHeatmap({
   // ResizeObserver fires once (server / first client paint). The
   // explicit `cellSize` prop, if supplied, overrides auto-scale.
   // (#176 slice B follow-up.)
+  //
+  // First-paint flicker trade-off (#190 item 4): the SSR pass and the
+  // initial client paint both render at `DEFAULT_CELL_SIZE = 14`, then
+  // the observer fires and the grid re-renders at the auto-scaled
+  // size. On a fast connection this is a single frame; on a slow one
+  // a viewer briefly sees the small grid before it grows. We accept
+  // this because:
+  //   - The card has a fixed surrounding height, so the re-render is a
+  //     content swap, not a layout shift (CLS budget unaffected).
+  //   - `useLayoutEffect` would tighten the paint but breaks SSR
+  //     (`useLayoutEffect` warns on the server).
+  //   - Pre-computing the width on the server would require threading
+  //     the parent card's measured width through props — extra
+  //     coupling for a single-pixel-flicker benefit.
+  // Revisit if a user reports it or if the heatmap moves into a
+  // surface where layout shift matters.
   const wrapperRef = useRef<HTMLDivElement>(null)
   const [containerWidth, setContainerWidth] = useState<number | null>(null)
   useEffect(() => {

--- a/components/training-facility/gym/lifestyle/lifestyle-chart-props-sync.test.ts
+++ b/components/training-facility/gym/lifestyle/lifestyle-chart-props-sync.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest'
+
+import type {
+  BaseLifestyleTrendChartProps,
+  LifestyleChartProps,
+} from './BaseLifestyleTrendChart'
+
+/**
+ * Compile-time + runtime guard for the two-interface drift risk flagged
+ * by CodeRabbit on #188 and tracked in #190 item 3.
+ *
+ * `LifestyleChartProps` (call-site-facing) and `BaseLifestyleTrendChartProps`
+ * (internal) both live in `BaseLifestyleTrendChart.tsx`. By design,
+ * `LifestyleChartProps === Omit<BaseLifestyleTrendChartProps, 'yLabel' |
+ * 'yTickFormat' | 'emptyMessage' | 'ariaLabel'>`, but the explicit
+ * interface form lets each forwarded prop keep its own JSDoc — at the
+ * cost of two declarations that could drift.
+ *
+ * The type alias below derives the expected forwarded-keys set from the
+ * base interface. If the two interfaces fall out of sync (a new prop
+ * lands on one and not the other, or a key is renamed in one place),
+ * the `Equal<…>` resolution flips to `false` and `_typeCheck` fails to
+ * compile — caught by `npx tsc --noEmit` before this test ever runs.
+ *
+ * The trivial runtime `expect` is there so vitest counts this as a real
+ * test (otherwise `it` with an empty body is a lint smell).
+ */
+
+type ForwardedKeys = Exclude<
+  keyof BaseLifestyleTrendChartProps,
+  'yLabel' | 'yTickFormat' | 'emptyMessage' | 'ariaLabel'
+>
+
+// Mutual `extends` for symmetric equality. A simple `keyof X extends keyof Y`
+// would let extra keys on Y slip through.
+type Equal<A extends string | number | symbol, B extends string | number | symbol> = [A] extends [B]
+  ? [B] extends [A]
+    ? true
+    : false
+  : false
+
+type LifestyleKeysMatchForwarded = Equal<keyof LifestyleChartProps, ForwardedKeys>
+
+const _typeCheck: LifestyleKeysMatchForwarded = true
+void _typeCheck
+
+describe('LifestyleChartProps ↔ BaseLifestyleTrendChartProps', () => {
+  it('keys stay in sync (enforced via the type assertion above)', () => {
+    // If the two interfaces drift, the assignment above will fail tsc.
+    // The runtime expect is here so vitest treats this as a real test.
+    expect(true).toBe(true)
+  })
+})

--- a/components/training-facility/scenes/assets/SceneDoor.test.tsx
+++ b/components/training-facility/scenes/assets/SceneDoor.test.tsx
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+import { render } from '@testing-library/react'
+
+import { SceneDoor } from './SceneDoor'
+
+/**
+ * Smoke coverage for the shared cross-link door (#190 hardening of the
+ * #176 extraction). The two callers (`DoorToCombine`, `DoorToGym`) are
+ * thin wrappers, so anything that reads the same per-call props goes
+ * through this component — verifying href + accessible name + sign
+ * text + focus-ring presence here keeps both call sites honest.
+ *
+ * Renders inside an `<svg>` because `SceneDoor` is composed of SVG
+ * primitives intended to live inside a scene viewBox.
+ */
+describe('SceneDoor', () => {
+  function renderInScene(extraProps: Partial<React.ComponentProps<typeof SceneDoor>> = {}) {
+    return render(
+      <svg viewBox="0 0 1600 800" data-testid="scene">
+        <SceneDoor
+          href="/training-facility/combine"
+          ariaLabel="Walk through the back door into The Combine"
+          signText="→ the combine"
+          x={1300}
+          seedBase={210}
+          {...extraProps}
+        />
+      </svg>,
+    )
+  }
+
+  it('renders a Next link pointed at the supplied href with the accessible label', () => {
+    const { getByRole } = renderInScene()
+    const link = getByRole('link', { name: /walk through the back door into the combine/i })
+    expect(link).toHaveAttribute('href', '/training-facility/combine')
+  })
+
+  it('paints the supplied sign text inside the door group', () => {
+    const { getByText } = renderInScene({ signText: '→ the gym' })
+    expect(getByText('→ the gym')).toBeInTheDocument()
+  })
+
+  it('defaults the floor caption to "back door" when no override is supplied', () => {
+    const { getByText } = renderInScene()
+    expect(getByText('back door')).toBeInTheDocument()
+  })
+
+  it('honors a custom caption when one is supplied', () => {
+    const { getByText, queryByText } = renderInScene({ captionText: 'side entrance' })
+    expect(getByText('side entrance')).toBeInTheDocument()
+    expect(queryByText('back door')).not.toBeInTheDocument()
+  })
+
+  it('includes the focus-visible dashed ring overlay', () => {
+    const { container } = renderInScene()
+    // The focus ring is the only `<rect>` with stroke-dasharray on the
+    // door — locating it via the dasharray attribute keeps the test
+    // resilient to surrounding markup churn.
+    const ring = container.querySelector('rect[stroke-dasharray]')
+    expect(ring).not.toBeNull()
+    // Hidden by default; only the parent `:focus-visible` reveals it.
+    expect(ring).toHaveClass('opacity-0')
+    expect(ring?.getAttribute('class')).toContain('group-focus-visible:opacity-100')
+  })
+
+  it('renders a translucent hover-tint overlay on the inner panel', () => {
+    const { container } = renderInScene()
+    // The overlay is the only `<rect>` carrying `group-hover:opacity-100`.
+    const overlay = container.querySelector('rect.group-hover\\:opacity-100')
+    expect(overlay).not.toBeNull()
+    expect(overlay).toHaveClass('opacity-0')
+  })
+})


### PR DESCRIPTION
## Summary

Closes the 4 non-blocking follow-ups filed as #190 after #188 merged:

- **`SceneDoor` smoke test** (6 cases) — both cross-link doors are thin wrappers, so this single test now covers the shared primitive's href, accessible label, sign text, caption default + override, focus-ring presence, and hover-overlay class.
- **Heatmap legend regression test** — pins the responsive `legendWidth` contract so a future cell-size knob can't silently re-introduce the original "legend clips off the right edge at `MAX_CELL_SIZE`" bug CodeRabbit caught.
- **`LifestyleChartProps` ↔ `BaseLifestyleTrendChartProps` sync test** — structural type-level guard. Adding a prop to one interface and not mirroring it on the other fails `tsc --noEmit`. The runtime `expect` exists just so vitest counts it as a real test.
- **`ResizeObserver` flicker comment** — documents the first-paint trade-off (default cell size on SSR + first client paint, then re-render after the observer fires) so the next reader doesn't have to derive why we didn't reach for `useLayoutEffect`.

## Test plan

- [ ] CI green (Vercel + e2e + CodeRabbit).
- [ ] `npm test` → 812 tests (up from 808): 6 new SceneDoor + 1 new heatmap legend + 1 new sync test.
- [ ] `npx tsc --noEmit` clean.
- [ ] Mentally simulate drift: rename a prop on `BaseLifestyleTrendChartProps` without touching `LifestyleChartProps` — the sync test's `_typeCheck` should fail to compile.

## Out of scope

- No product behavior changes. Tests + one comment only.

Closes #190.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added regression test to verify legend positioning within component bounds.
  * Added test suite for door component rendering, accessibility, and visual overlays.
  * Added type-safety validation to ensure property synchronization in lifestyle charts.

* **Documentation**
  * Expanded documentation on auto-scaling behavior and render optimization trade-offs.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lucasklawrence/courtfolio/pull/191)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->