### PR TITLE
docs(skills): pin Get-Date to the PowerShell tool in log-workout

### DIFF
--- a/.claude/skills/log-workout/SKILL.md
+++ b/.claude/skills/log-workout/SKILL.md
@@ -82,14 +82,20 @@ invent a near-duplicate key.
 
 ### 2. Get local time
 
-Run PowerShell to get the current local time **with UTC offset** — needed both
-to stamp `logged_at` correctly and to compute the day window in step 5:
+Get the current local time **with UTC offset** — needed both to stamp
+`logged_at` correctly and to compute the day window in step 5. `Get-Date` is a
+PowerShell cmdlet, so on Windows you **must** invoke it with the `PowerShell`
+tool, **not** the `Bash` tool — `bash` routes to `/usr/bin/bash` where
+`Get-Date` is `command not found` (exit 127). Use the `PowerShell` tool with:
 
-```
+```powershell
 Get-Date -Format "yyyy-MM-ddTHH:mm:ssK"
 ```
 
 (e.g. `2026-05-28T18:36:59-07:00`).
+
+On a POSIX shell instead, the equivalent via the `Bash` tool is
+`date +%Y-%m-%dT%H:%M:%S%:z`.
 
 ### 3. Determine `logged_at`
 

--- a/.claude/skills/log-workout/SKILL.md
+++ b/.claude/skills/log-workout/SKILL.md
@@ -94,8 +94,11 @@ Get-Date -Format "yyyy-MM-ddTHH:mm:ssK"
 
 (e.g. `2026-05-28T18:36:59-07:00`).
 
-On a POSIX shell instead, the equivalent via the `Bash` tool is
-`date +%Y-%m-%dT%H:%M:%S%:z`.
+On a POSIX shell instead, get the equivalent via the `Bash` tool with
+`date +%Y-%m-%dT%H:%M:%S%z | sed -E 's/([+-][0-9]{2})([0-9]{2})$/\1:\2/'`. The
+`sed` step inserts the colon in the offset (`-0700` → `-07:00`); don't use GNU's
+`%:z` specifier directly — BSD/macOS `date` doesn't support it and would emit a
+literal `%:z`.
 
 ### 3. Determine `logged_at`
 


### PR DESCRIPTION
## What

Step 2 of the `log-workout` skill (Get local time) said "Run PowerShell" but showed a bare `Get-Date -Format ...` snippet without naming which harness tool to use.

## Why

On Windows, both shells are present. A bare `Get-Date` is easy to misroute to the **Bash** tool, where `/usr/bin/bash` reports `Get-Date: command not found` (exit 127) — which is exactly what happened logging the 6/2 set before the retry through the PowerShell tool succeeded.

## Change

- Make the **PowerShell tool** a hard requirement on Windows and call out the exact failure mode (exit 127).
- Add a POSIX fallback (`date +%Y-%m-%dT%H:%M:%S%:z`) for the Bash tool on macOS/Linux, so the skill still works where `Get-Date` doesn't exist.

Docs-only change to a skill file; no runtime code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Documentation
* Clarified Step 2 of the "log-workout" instructions to specify the correct shell/tool for getting local time and added updated command examples for PowerShell and POSIX shells, including a note about portability differences across platforms to prevent command failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->