### PR TITLE
perf(court): pause FreeRoamPlayer rAF loop when off-screen (#212)

### DIFF
--- a/components/court/FreeRoamPlayer.tsx
+++ b/components/court/FreeRoamPlayer.tsx
@@ -149,10 +149,15 @@ export function FreeRoamPlayer({
 
   // ── Unified game loop ──────────────────────────────────────────────
   // Single RAF loop handles both keyboard and click-to-move with delta time,
-  // so movement speed is consistent regardless of frame rate.
+  // so movement speed is consistent regardless of frame rate. An
+  // IntersectionObserver starts/stops the loop so it burns no frames while the
+  // court is scrolled off-screen, and it also pauses with the tab.
   useEffect(() => {
+    const svg = boundsRef.current
     let prevTime = performance.now()
     let wasMoving = false
+    let running = false
+    let onScreen = true
 
     const tick = (now: number) => {
       const dt = Math.min((now - prevTime) / 1000, 0.1) // cap to prevent teleporting after tab-away
@@ -237,8 +242,46 @@ export function FreeRoamPlayer({
       gameLoopRef.current = requestAnimationFrame(tick)
     }
 
-    gameLoopRef.current = requestAnimationFrame(tick)
-    return () => cancelAnimationFrame(gameLoopRef.current)
+    const start = () => {
+      if (running) return
+      running = true
+      // Reset the clock so the first frame after a pause produces a small dt
+      // instead of "time since the loop last ran".
+      prevTime = performance.now()
+      gameLoopRef.current = requestAnimationFrame(tick)
+    }
+
+    const stop = () => {
+      if (!running) return
+      running = false
+      cancelAnimationFrame(gameLoopRef.current)
+    }
+
+    // Run only while the court is on-screen and the tab is foregrounded.
+    const sync = () => {
+      if (onScreen && !document.hidden) start()
+      else stop()
+    }
+
+    let observer: IntersectionObserver | null = null
+    if (svg && typeof IntersectionObserver !== 'undefined') {
+      observer = new IntersectionObserver(entries => {
+        onScreen = entries.some(entry => entry.isIntersecting)
+        sync()
+      })
+      observer.observe(svg)
+    } else {
+      // Nothing to observe (or unsupported) — fall back to the tab-visibility gate.
+      sync()
+    }
+
+    document.addEventListener('visibilitychange', sync)
+
+    return () => {
+      observer?.disconnect()
+      document.removeEventListener('visibilitychange', sync)
+      stop()
+    }
   }, [boundsRef, x, y])
 
   // Idle shooting pose — triggers after player stands still for a while.


### PR DESCRIPTION
## Summary
`FreeRoamPlayer`'s `requestAnimationFrame` game loop ran continuously, even when the court was scrolled out of view — wasted CPU/battery on long pages. This gates the loop on visibility:

- An **`IntersectionObserver`** on the court SVG (`boundsRef`) starts the loop when the court enters the viewport and stops it (`cancelAnimationFrame`) when it's fully off-screen — so no frames are burned while it's not visible.
- A **`visibilitychange`** listener pauses the loop when the tab is backgrounded and resumes it on refocus (only if the court is also on-screen).
- On every resume, **`prevTime` is reset** so the first post-pause frame produces a small `dt` rather than "time since the loop last ran" (the existing `Math.min(dt, 0.1)` cap was the safety net; this makes it clean).
- If `IntersectionObserver` is unavailable, it falls back to the tab-visibility gate (loop runs whenever the page is visible) — no behavior loss.

Position lives in motion values that aren't touched while paused, so resuming never teleports the player.

## Why
See `docs/animation-guide.md` §2.5. rAF auto-pauses in background tabs but keeps ticking when the element is merely scrolled away; an observer-gated loop is the idiomatic fix.

## Test plan
- [ ] On the home court, scroll the court fully out of view → in DevTools Performance, confirm the rAF loop stops ticking (no `FreeRoamPlayer` frame work).
- [ ] Scroll back → loop resumes; the player responds to WASD/arrows and click-to-move immediately, **no teleport / position jump**.
- [ ] Background the tab for a few seconds, refocus → no teleport, movement resumes normally.
- [ ] Keyboard movement, click-to-move, facing flip, walk-cycle sprite swap, and the idle shooting pose all still behave as before.
- [ ] Reduced-motion / normal both unaffected (this change doesn't alter animation, only loop scheduling).

## Verification
- `npx tsc --noEmit` — clean.
- `npm test` — 816/816 passing.
- `npx next build` — compiles, all 31 pages generated. (Pre-existing eslintrc "circular structure" notice is unrelated and non-fatal.)
- E2E not run locally: this is an internal loop-scheduling change — no DOM/route/testid change, and no Playwright test drives player movement; CI runs the full e2e suite on this PR. jsdom unit env lacks `IntersectionObserver`, which the fallback path handles.

Closes #212.