### PR TITLE
feat(motion): native scroll-driven CSS reveals behind @supports (#208)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -49,3 +49,36 @@ html, body {
 .locker-zone:focus-visible {
   outline: none;
 }
+
+/* ── Scroll-driven reveal ──────────────────────────────────────────────
+   Native fade-up entrance for content sections (e.g. project cards), driven
+   by the element's own progress through the viewport — no JS, no scroll
+   listeners, runs off the main thread.
+
+   Progressive enhancement: the animation only applies in browsers that support
+   scroll-driven timelines AND when the user hasn't requested reduced motion.
+   Anywhere else `.reveal` is inert, so content renders in its natural,
+   fully-visible state — it is never left hidden (no base `opacity: 0`). */
+@keyframes reveal-fade-up {
+  from {
+    opacity: 0;
+    transform: translateY(2rem);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+@supports (animation-timeline: view()) {
+  @media (prefers-reduced-motion: no-preference) {
+    .reveal {
+      animation: reveal-fade-up linear both;
+      animation-timeline: view();
+      /* Begin as the element's top edge enters the viewport and finish once it
+         is 35% of the way across — a quick reveal that settles before the card
+         reaches reading position. */
+      animation-range: entry 0% cover 35%;
+    }
+  }
+}

--- a/components/project-binder/ProjectGallery.tsx
+++ b/components/project-binder/ProjectGallery.tsx
@@ -3,7 +3,6 @@
 import { useSingleColumn } from '@/utils/hooks/useSingleColumn'
 import { TradeCard } from './TradeCard'
 import type { TradeCardProps } from './TradeCard'
-import { tr } from 'framer-motion/client'
 
 const projects: TradeCardProps[] = [
   {
@@ -125,14 +124,20 @@ export const ProjectGallery = () => {
           {/* Left Column */}
           <div className="grid grid-cols-[repeat(auto-fit,minmax(260px,1fr))] gap-6 sm:justify-items-start justify-items-center">
             {leftColumn.map(project => (
-              <TradeCard key={project.slug} {...project} />
+              // `.reveal` fades each card up as it scrolls into view (native
+              // scroll-driven CSS; inert in unsupporting browsers / reduced motion).
+              <div key={project.slug} className="reveal">
+                <TradeCard {...project} />
+              </div>
             ))}
           </div>
 
           {/* Right Column */}
           <div className="grid grid-cols-[repeat(auto-fit,minmax(260px,1fr))] gap-6 sm:justify-items-start justify-items-center">
             {rightColumn.map(project => (
-              <TradeCard key={project.slug} {...project} />
+              <div key={project.slug} className="reveal">
+                <TradeCard {...project} />
+              </div>
             ))}
           </div>
         </div>


### PR DESCRIPTION
## Summary
Adds a reusable **`.reveal`** utility (in `app/globals.css`) that fades content up as it scrolls into view using the native CSS scroll-driven animations spec — `animation-timeline: view()` + `animation-range`. No JS, no scroll listeners, runs off the main thread.

Progressive enhancement by design:
- Gated behind **`@supports (animation-timeline: view())`** — unsupporting browsers (Safari as of 2026) never see the rule.
- Gated behind **`@media (prefers-reduced-motion: no-preference)`** — reduced-motion users never get the animation.
- **No base `opacity: 0`** outside that block, so when the rule doesn't apply, content renders in its natural, fully-visible state — never stuck hidden.

Applied as a first pass to the **`ProjectGallery`** trade cards (each card wrapped in a `.reveal` div), so cards fade up as you scroll the binder. Also drops a stray unused `framer-motion/client` import in that file.

## Why
See `docs/animation-guide.md` §4.1. The reusable utility ships independent of this first surface, so other long-scroll surfaces can adopt `.reveal` in follow-ups.

## Test plan
- [ ] **Chromium/Firefox:** open `/projects`, scroll down → trade cards fade-and-rise into view as they enter the viewport.
- [ ] **Safari (or any browser without scroll-driven support):** open `/projects` → all cards are fully visible immediately (no hidden content, no broken layout).
- [ ] **Reduced motion** (OS setting) in a supporting browser → cards are fully visible immediately, no scroll-linked motion.
- [ ] Card layout (two-column binder grid, centering, the center divider) is unchanged vs. before.
- [ ] `/projects` header + "🏀 Home Court" link still render (e2e `rooms.spec.ts` coverage).

## Verification
- `npx tsc --noEmit` — clean.
- `npm test` — 816/816 passing.
- `npx next build` — compiles, all 31 pages generated. `/projects` First Load JS unchanged at **12.2 kB** → **no new JS bundle cost**. (Pre-existing eslintrc "circular structure" notice is unrelated and non-fatal.)
- E2E: `/projects` coverage asserts the header title + back link (above the fold, not trade cards), so card reveals don't affect it; CI runs the full suite. (`opacity` also doesn't affect Playwright visibility.)

Closes #208.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added scroll-driven reveal animations that fade and slide elements into view as users scroll through the page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->