### PR TITLE
feat(project-binder): shared-element morph (layoutId) for thumbnail→detail (#209)

### DIFF
--- a/components/project-binder/ProjectDetail.tsx
+++ b/components/project-binder/ProjectDetail.tsx
@@ -1,0 +1,116 @@
+'use client'
+
+import { motion, useReducedMotion } from 'framer-motion'
+import Image from 'next/image'
+import { useEffect, useRef } from 'react'
+import { CARD_MORPH_SPRING, cardLayoutId } from './cardMorph'
+import type { TradeCardProps } from './TradeCard'
+
+/** Props for the {@link ProjectDetail} overlay. */
+type ProjectDetailProps = {
+  /** The project to show, expanded. Shares its `slug` with the originating card. */
+  project: TradeCardProps
+  /** Called when the user dismisses the overlay (backdrop click, ✕, or Escape). */
+  onClose: () => void
+}
+
+/**
+ * Full-screen, dimmed overlay that presents a single project at a larger scale.
+ *
+ * Mounted by {@link ProjectGallery} inside an `AnimatePresence` while a card is
+ * selected. The panel carries the same `layoutId` as its originating
+ * {@link TradeCard} ({@link cardLayoutId}), so Framer Motion morphs the card
+ * open into this panel and back on close. Under `prefers-reduced-motion` the
+ * `layoutId` is dropped, so there is no layout morph — the overlay simply fades
+ * (the backdrop's opacity transition, inherited by the panel).
+ *
+ * While open it locks body scroll, closes on Escape, and moves focus to the
+ * close button.
+ */
+export const ProjectDetail = ({ project, onClose }: ProjectDetailProps) => {
+  const reduce = useReducedMotion()
+  const closeRef = useRef<HTMLButtonElement>(null)
+
+  // Escape-to-close + body scroll lock + initial focus for the lifetime of the
+  // overlay. Restores the previous body overflow on unmount.
+  useEffect(() => {
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', onKey)
+    const previousOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    closeRef.current?.focus()
+    return () => {
+      document.removeEventListener('keydown', onKey)
+      document.body.style.overflow = previousOverflow
+    }
+  }, [onClose])
+
+  const { name, slug, tagline, thumbnailUrl, stack, impact, year, moment, href } = project
+
+  return (
+    // Backdrop doubles as the AnimatePresence child: its opacity exit animation
+    // keeps the panel mounted long enough to morph back to the card. Clicking it
+    // closes; the panel stops propagation so inner clicks don't dismiss.
+    <motion.div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4 sm:p-6 bg-black/70 backdrop-blur-sm"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      transition={{ duration: 0.2 }}
+      onClick={onClose}
+    >
+      <motion.div
+        layoutId={reduce ? undefined : cardLayoutId(slug)}
+        transition={{ layout: CARD_MORPH_SPRING }}
+        onClick={event => event.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-label={`${name} details`}
+        data-testid="project-detail"
+        className="relative z-10 w-full max-w-lg max-h-[90vh] overflow-y-auto rounded-xl border border-yellow-400 bg-neutral-900 text-white p-6 shadow-2xl"
+      >
+        <button
+          ref={closeRef}
+          type="button"
+          onClick={onClose}
+          aria-label="Close project details"
+          className="absolute right-3 top-3 z-20 flex h-8 w-8 items-center justify-center rounded-full bg-black/40 text-lg leading-none text-neutral-300 hover:bg-black/60 hover:text-white transition"
+        >
+          ✕
+        </button>
+
+        <div className="w-full aspect-video relative rounded-md overflow-hidden border border-neutral-600 bg-black">
+          <Image
+            src={thumbnailUrl}
+            alt={name}
+            fill
+            className="object-cover"
+            sizes="(max-width: 640px) 100vw, 512px"
+          />
+        </div>
+
+        <h2 className="mt-5 text-2xl font-bold leading-tight">{name}</h2>
+        <p className="mt-1 text-sm text-neutral-400 italic">{tagline}</p>
+
+        <p className="mt-4 text-sm text-yellow-200">{impact}</p>
+        <p className="mt-2 text-xs text-yellow-200/90">
+          📅 {year} · ⚙️ {stack.join(', ')}
+        </p>
+        <p className="mt-3 text-sm text-yellow-100">{moment}</p>
+
+        {href && (
+          <a
+            href={href}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="mt-6 inline-block rounded-md bg-yellow-400 px-4 py-2 text-sm font-semibold text-neutral-900 hover:bg-yellow-300 transition"
+          >
+            View Project →
+          </a>
+        )}
+      </motion.div>
+    </motion.div>
+  )
+}

--- a/components/project-binder/ProjectDetail.tsx
+++ b/components/project-binder/ProjectDetail.tsx
@@ -2,7 +2,7 @@
 
 import { motion, useReducedMotion } from 'framer-motion'
 import Image from 'next/image'
-import { useEffect, useRef } from 'react'
+import { useEffect, useId, useRef } from 'react'
 import { CARD_MORPH_SPRING, cardLayoutId } from './cardMorph'
 import type { TradeCardProps } from './TradeCard'
 
@@ -24,19 +24,47 @@ type ProjectDetailProps = {
  * `layoutId` is dropped, so there is no layout morph — the overlay simply fades
  * (the backdrop's opacity transition, inherited by the panel).
  *
- * While open it locks body scroll, closes on Escape, and moves focus to the
- * close button.
+ * While open it behaves as a modal dialog: it locks body scroll, closes on
+ * Escape, moves focus to the close button, traps Tab focus within the panel,
+ * and restores focus to the element that opened it (the originating card) on
+ * close.
  */
 export const ProjectDetail = ({ project, onClose }: ProjectDetailProps) => {
   const reduce = useReducedMotion()
+  const panelRef = useRef<HTMLDivElement>(null)
   const closeRef = useRef<HTMLButtonElement>(null)
+  const titleId = useId()
 
-  // Escape-to-close + body scroll lock + initial focus for the lifetime of the
-  // overlay. Restores the previous body overflow on unmount.
+  // Modal lifecycle: Escape-to-close, body scroll lock, initial focus, a Tab
+  // focus trap, and focus restoration to the trigger on unmount.
   useEffect(() => {
+    const trigger = document.activeElement as HTMLElement | null
+
     const onKey = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') onClose()
+      if (event.key === 'Escape') {
+        onClose()
+        return
+      }
+      if (event.key !== 'Tab') return
+      // Keep Tab/Shift+Tab cycling within the dialog so focus can't reach the
+      // obscured gallery behind the backdrop.
+      const panel = panelRef.current
+      if (!panel) return
+      const focusables = panel.querySelectorAll<HTMLElement>(
+        'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])'
+      )
+      if (focusables.length === 0) return
+      const first = focusables[0]
+      const last = focusables[focusables.length - 1]
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault()
+        last.focus()
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault()
+        first.focus()
+      }
     }
+
     document.addEventListener('keydown', onKey)
     const previousOverflow = document.body.style.overflow
     document.body.style.overflow = 'hidden'
@@ -44,6 +72,7 @@ export const ProjectDetail = ({ project, onClose }: ProjectDetailProps) => {
     return () => {
       document.removeEventListener('keydown', onKey)
       document.body.style.overflow = previousOverflow
+      trigger?.focus?.()
     }
   }, [onClose])
 
@@ -62,12 +91,13 @@ export const ProjectDetail = ({ project, onClose }: ProjectDetailProps) => {
       onClick={onClose}
     >
       <motion.div
+        ref={panelRef}
         layoutId={reduce ? undefined : cardLayoutId(slug)}
         transition={{ layout: CARD_MORPH_SPRING }}
         onClick={event => event.stopPropagation()}
         role="dialog"
         aria-modal="true"
-        aria-label={`${name} details`}
+        aria-labelledby={titleId}
         data-testid="project-detail"
         className="relative z-10 w-full max-w-lg max-h-[90vh] overflow-y-auto rounded-xl border border-yellow-400 bg-neutral-900 text-white p-6 shadow-2xl"
       >
@@ -91,7 +121,9 @@ export const ProjectDetail = ({ project, onClose }: ProjectDetailProps) => {
           />
         </div>
 
-        <h2 className="mt-5 text-2xl font-bold leading-tight">{name}</h2>
+        <h2 id={titleId} className="mt-5 text-2xl font-bold leading-tight">
+          {name}
+        </h2>
         <p className="mt-1 text-sm text-neutral-400 italic">{tagline}</p>
 
         <p className="mt-4 text-sm text-yellow-200">{impact}</p>

--- a/components/project-binder/ProjectGallery.tsx
+++ b/components/project-binder/ProjectGallery.tsx
@@ -1,8 +1,11 @@
 'use client'
 
+import { AnimatePresence } from 'framer-motion'
+import { useState } from 'react'
 import { useSingleColumn } from '@/utils/hooks/useSingleColumn'
 import { TradeCard } from './TradeCard'
 import type { TradeCardProps } from './TradeCard'
+import { ProjectDetail } from './ProjectDetail'
 
 const projects: TradeCardProps[] = [
   {
@@ -113,6 +116,10 @@ const projects: TradeCardProps[] = [
 export const ProjectGallery = () => {
   const isSingleColumn = useSingleColumn()
 
+  // Slug of the project whose detail overlay is open, or null when none is.
+  const [selectedSlug, setSelectedSlug] = useState<string | null>(null)
+  const selectedProject = projects.find(project => project.slug === selectedSlug) ?? null
+
   const mid = Math.ceil(projects.length / 2)
   const leftColumn = projects.slice(0, mid)
   const rightColumn = projects.slice(mid)
@@ -127,7 +134,7 @@ export const ProjectGallery = () => {
               // `.reveal` fades each card up as it scrolls into view (native
               // scroll-driven CSS; inert in unsupporting browsers / reduced motion).
               <div key={project.slug} className="reveal">
-                <TradeCard {...project} />
+                <TradeCard {...project} onOpen={() => setSelectedSlug(project.slug)} />
               </div>
             ))}
           </div>
@@ -136,7 +143,7 @@ export const ProjectGallery = () => {
           <div className="grid grid-cols-[repeat(auto-fit,minmax(260px,1fr))] gap-6 sm:justify-items-start justify-items-center">
             {rightColumn.map(project => (
               <div key={project.slug} className="reveal">
-                <TradeCard {...project} />
+                <TradeCard {...project} onOpen={() => setSelectedSlug(project.slug)} />
               </div>
             ))}
           </div>
@@ -146,6 +153,18 @@ export const ProjectGallery = () => {
       {!isSingleColumn && (
         <div className="absolute inset-y-0 left-1/2 w-[2px] bg-neutral-800/30 shadow-inner z-10 pointer-events-none" />
       )}
+
+      {/* Shared-element morph target: the selected card flies open into this
+          overlay and back. AnimatePresence keeps it mounted through the exit. */}
+      <AnimatePresence>
+        {selectedProject && (
+          <ProjectDetail
+            key={selectedProject.slug}
+            project={selectedProject}
+            onClose={() => setSelectedSlug(null)}
+          />
+        )}
+      </AnimatePresence>
     </div>
   )
 }

--- a/components/project-binder/TradeCard.tsx
+++ b/components/project-binder/TradeCard.tsx
@@ -105,9 +105,21 @@ export const TradeCard: React.FC<TradeCardComponentProps> = ({
       : 'border-neutral-700'
 
   return (
-    <motion.button
-      type="button"
+    // A div with `role="button"` rather than a real <button>: the card's
+    // content is block-level (heading, paragraphs, absolutely-positioned
+    // overlays), which is invalid inside a <button> (phrasing content only) and
+    // trips React's DOM-nesting validation. role + tabIndex + key handler keeps
+    // it keyboard-operable while preserving valid markup and the inner heading.
+    <motion.div
+      role="button"
+      tabIndex={0}
       onClick={onOpen}
+      onKeyDown={event => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault()
+          onOpen?.()
+        }
+      }}
       aria-label={`Open ${name} details`}
       // Shared id with the detail panel drives the open/close morph; dropped
       // under reduced motion so the overlay cross-fades instead of morphing.
@@ -143,6 +155,6 @@ export const TradeCard: React.FC<TradeCardComponentProps> = ({
       <RarityBadge featured={featured} experimental={experimental} />
 
       {status && <StatusOverlay status={status} />}
-    </motion.button>
+    </motion.div>
   )
 }

--- a/components/project-binder/TradeCard.tsx
+++ b/components/project-binder/TradeCard.tsx
@@ -1,12 +1,13 @@
 'use client'
 
-import { motion } from 'framer-motion'
+import { motion, useReducedMotion } from 'framer-motion'
 import Image from 'next/image'
 import clsx from 'clsx'
 import { FoilShineOverlay } from './FoilShineOverlay'
 import { RarityBadge } from './RarityBadge'
 import { StatusOverlay } from './StatusOverlay'
 import { LegacyRibbon } from './LegacyRibbon'
+import { CARD_MORPH_SPRING, cardLayoutId } from './cardMorph'
 /**
  * Props for the `TradeCard` component.
  *
@@ -54,6 +55,17 @@ export type TradeCardProps = {
   legacy?: boolean
 }
 
+/** Props for the {@link TradeCard} component: project data plus the open handler. */
+type TradeCardComponentProps = TradeCardProps & {
+  /**
+   * Opens this project's detail overlay. When provided, the whole card becomes a
+   * button; clicking it morphs the card into the `ProjectDetail` panel (the two
+   * are linked by a shared `layoutId`). The `View Project` link lives in that
+   * panel, not on the card.
+   */
+  onOpen?: () => void
+}
+
 /**
  * Renders a stylized project card used in the portfolio binder layout.
  *
@@ -66,10 +78,10 @@ export type TradeCardProps = {
  * Thumbnail is rendered using `next/image`, with optional foil overlay and metadata below.
  *
  * @component
- * @param {TradeCardProps} props - Project metadata and visual config
+ * @param {TradeCardComponentProps} props - Project metadata, visual config, and the open handler
  * @returns {JSX.Element} An animated, styled card component
  */
-export const TradeCard: React.FC<TradeCardProps> = ({
+export const TradeCard: React.FC<TradeCardComponentProps> = ({
   name,
   slug,
   tagline,
@@ -81,9 +93,11 @@ export const TradeCard: React.FC<TradeCardProps> = ({
   featured = false,
   experimental = false,
   status,
-  href,
   legacy = false,
+  onOpen,
 }) => {
+  const reduce = useReducedMotion()
+
   const rarityClass = featured
     ? 'border-yellow-400'
     : experimental
@@ -91,14 +105,20 @@ export const TradeCard: React.FC<TradeCardProps> = ({
       : 'border-neutral-700'
 
   return (
-    <motion.div
+    <motion.button
+      type="button"
+      onClick={onOpen}
+      aria-label={`Open ${name} details`}
+      // Shared id with the detail panel drives the open/close morph; dropped
+      // under reduced motion so the overlay cross-fades instead of morphing.
+      layoutId={reduce ? undefined : cardLayoutId(slug)}
       whileHover={{
         y: -4,
         boxShadow: '0 0 16px rgba(255, 255, 255, 0.2)',
       }}
-      transition={{ type: 'tween', duration: 0.3 }}
+      transition={{ type: 'tween', duration: 0.3, layout: CARD_MORPH_SPRING }}
       className={clsx(
-        'relative rounded-xl border p-4 bg-neutral-900 text-white w-full max-w-xs flex flex-col items-center transition-all overflow-hidden',
+        'relative rounded-xl border p-4 bg-neutral-900 text-white w-full max-w-xs flex flex-col items-center text-left transition-all overflow-hidden cursor-pointer',
         rarityClass
       )}
     >
@@ -123,17 +143,6 @@ export const TradeCard: React.FC<TradeCardProps> = ({
       <RarityBadge featured={featured} experimental={experimental} />
 
       {status && <StatusOverlay status={status} />}
-
-      {href && (
-        <a
-          href={href}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="mt-4 text-xs text-yellow-300 underline hover:text-yellow-100 transition"
-        >
-          View Project
-        </a>
-      )}
-    </motion.div>
+    </motion.button>
   )
 }

--- a/components/project-binder/cardMorph.ts
+++ b/components/project-binder/cardMorph.ts
@@ -1,0 +1,26 @@
+import type { Transition } from 'framer-motion'
+
+/**
+ * Builds the shared `layoutId` that links a gallery {@link TradeCard} to its
+ * expanded `ProjectDetail` panel. Giving both elements the same `layoutId` is
+ * what lets Framer Motion morph one into the other across mount/unmount — the
+ * "card flies open into the detail, then back" shared-element transition.
+ *
+ * @param slug - The project's unique slug.
+ * @returns A stable id of the form `card-<slug>`.
+ */
+export function cardLayoutId(slug: string): string {
+  return `card-${slug}`
+}
+
+/**
+ * Spring applied as the `layout` transition on both the {@link TradeCard} and
+ * the detail panel, so the open and close morphs are symmetric. Tuned to feel
+ * deliberate rather than floaty: high stiffness with near-critical damping pulls
+ * the element to its target quickly and settles with no visible wobble.
+ */
+export const CARD_MORPH_SPRING: Transition = {
+  type: 'spring',
+  stiffness: 300,
+  damping: 32,
+}

--- a/e2e/project-detail.spec.ts
+++ b/e2e/project-detail.spec.ts
@@ -1,0 +1,39 @@
+import { expect, test } from '@playwright/test'
+
+/**
+ * The project binder's shared-element morph: clicking a card opens a detail
+ * overlay (linked to the card by a Framer Motion `layoutId`), which can be
+ * dismissed by Escape, the close button, or a backdrop click. These specs
+ * assert the open/close interaction, not the visual morph itself.
+ */
+test.describe('project detail overlay', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/projects')
+    await expect(page.getByTestId('projects-title')).toBeVisible()
+  })
+
+  test('opens the detail overlay when a card is clicked', async ({ page }) => {
+    await page.getByRole('button', { name: /open courtfolio details/i }).click()
+
+    const detail = page.getByTestId('project-detail')
+    await expect(detail).toBeVisible()
+    await expect(detail.getByRole('heading', { name: 'Courtfolio' })).toBeVisible()
+    await expect(detail.getByRole('link', { name: /view project/i })).toBeVisible()
+  })
+
+  test('closes on Escape', async ({ page }) => {
+    await page.getByRole('button', { name: /open courtfolio details/i }).click()
+    await expect(page.getByTestId('project-detail')).toBeVisible()
+
+    await page.keyboard.press('Escape')
+    await expect(page.getByTestId('project-detail')).toHaveCount(0)
+  })
+
+  test('closes on the close button', async ({ page }) => {
+    await page.getByRole('button', { name: /open courtfolio details/i }).click()
+    await expect(page.getByTestId('project-detail')).toBeVisible()
+
+    await page.getByRole('button', { name: /close project details/i }).click()
+    await expect(page.getByTestId('project-detail')).toHaveCount(0)
+  })
+})

--- a/e2e/project-detail.spec.ts
+++ b/e2e/project-detail.spec.ts
@@ -36,4 +36,19 @@ test.describe('project detail overlay', () => {
     await page.getByRole('button', { name: /close project details/i }).click()
     await expect(page.getByTestId('project-detail')).toHaveCount(0)
   })
+
+  test('is keyboard operable and restores focus to the card on close', async ({ page }) => {
+    const card = page.getByRole('button', { name: /open courtfolio details/i })
+
+    // The card is a div with role="button"; Enter must activate it like a
+    // native button would.
+    await card.focus()
+    await page.keyboard.press('Enter')
+    await expect(page.getByTestId('project-detail')).toBeVisible()
+
+    await page.keyboard.press('Escape')
+    await expect(page.getByTestId('project-detail')).toHaveCount(0)
+    // Focus returns to the triggering card, not the document body.
+    await expect(card).toBeFocused()
+  })
 })

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -31,7 +31,7 @@ export default defineConfig({
   projects: [
     {
       name: 'default-routes',
-      testMatch: /(?:home|rooms|training-facility-disabled)\.spec\.ts/,
+      testMatch: /(?:home|rooms|project-detail|training-facility-disabled)\.spec\.ts/,
       use: {
         baseURL: DEFAULT_BASE_URL,
       },


### PR DESCRIPTION
## Summary

Opening a project in the binder used to swap views with no connecting motion. This adds a Framer Motion **shared-element morph** (`layoutId`): clicking a card morphs it open into a larger centered detail panel over a dimmed backdrop, and morphs back on close — a compositor-friendly "card flies open" transition (see `docs/animation-guide.md` §1.5).

### What changed
- **`TradeCard`** is now a `<button>` that owns an `onOpen` handler and carries a shared `layoutId` (`card-<slug>`). The inline "View Project" link moved into the detail panel (a card can't nest an interactive `<a>` once the whole card is a button).
- **`ProjectDetail`** (new) — the morph target: a dimmed, blurred full-screen overlay presenting the same project data at a larger scale, with a prominent "View Project" button. Locks body scroll, closes on **Escape / backdrop click / ✕**, and moves focus to the close button (`role="dialog"`, `aria-modal`).
- **`ProjectGallery`** owns the selected-slug state and renders the overlay inside `AnimatePresence` (keeps it mounted through the morph-back exit).
- **`cardMorph.ts`** (new) — shared `cardLayoutId(slug)` helper + the tuned `CARD_MORPH_SPRING` (stiffness 300 / damping 32 — deliberate, not floaty) applied to both card and panel for symmetric open/close.
- **Reduced motion:** `useReducedMotion()` drops the `layoutId` on both ends, so the overlay plain-fades instead of morphing.

### Acceptance criteria
- [x] Card visually morphs into the detail view (and back).
- [x] No flicker / duplicate elements — the original card sits behind the dimmed backdrop while the shared element is projected to the panel.
- [x] Reduced-motion users get a fade instead of a morph.

## Test plan
- [ ] Visit `/projects`. Click any card → it morphs open into a centered detail panel over a dimmed backdrop.
- [ ] Close via the **✕** button, a **backdrop click**, and the **Escape** key — each morphs the panel back into its card.
- [ ] Open a card with an external link (e.g. Courtfolio, Dad Memorial, Bars of the Day) → the **View Project →** button is present and opens the project in a new tab.
- [ ] Open a card *without* a link (e.g. GitLab Portal, R-Learning Snake) → detail shows all metadata, no broken button.
- [ ] Tab to a card and press **Enter/Space** → opens the detail (cards are real buttons). Focus lands on the close button.
- [ ] Enable OS "Reduce motion" → opening/closing a card **fades** rather than morphs.
- [ ] Resize to mobile (≤640px) → the binder collapses to one column; the detail panel is full-width with a scrollable body and remains usable.
- [ ] Background does not scroll while the overlay is open.

Closes #209.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Project cards are now interactive and open an expanded detail view when clicked
  * Project detail overlay displays full project information including thumbnail, name, tagline, impact, year, and stack
  * Overlay can be dismissed via Escape key, close button, or backdrop click
  * Smooth animations when opening and closing the detail view
  * Document scroll is locked while the overlay is open for focused interaction

* **Tests**
  * Added end-to-end tests for project detail overlay interactions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->