### PR TITLE
feat(project-binder): crawlable card links + inert background (#218)

### DIFF
--- a/components/project-binder/LegacyRibbon.tsx
+++ b/components/project-binder/LegacyRibbon.tsx
@@ -5,14 +5,15 @@ import { m } from 'framer-motion'
  * an archived/older project. Bobs gently up and down on an infinite loop.
  *
  * Positioned `absolute`, so it must render inside a `relative` container (the
- * card it badges).
+ * card it badges). `pointer-events-none` so it doesn't intercept clicks meant
+ * for the card's stretched open-detail button beneath it.
  */
 export const LegacyRibbon = () => (
   <m.div
     initial={{ opacity: 0.9, y: 0 }}
     animate={{ opacity: 1, y: [0, 1, 0] }}
     transition={{ repeat: Infinity, duration: 3 }}
-    className="absolute top-0 left-0 z-50"
+    className="absolute top-0 left-0 z-50 pointer-events-none"
   >
     <div className="bg-orange-700 text-white text-[10px] font-bold uppercase px-2 py-0.5 rounded-br-md shadow-sm tracking-wide">
       Legacy

--- a/components/project-binder/ProjectDetail.tsx
+++ b/components/project-binder/ProjectDetail.tsx
@@ -2,7 +2,7 @@
 
 import { m, useReducedMotion } from 'framer-motion'
 import Image from 'next/image'
-import { useEffect, useId, useRef } from 'react'
+import { useEffect, useId, useRef, type RefObject } from 'react'
 import { CARD_MORPH_SPRING, cardLayoutId } from './cardMorph'
 import type { TradeCardProps } from './TradeCard'
 
@@ -12,6 +12,13 @@ type ProjectDetailProps = {
   project: TradeCardProps
   /** Called when the user dismisses the overlay (backdrop click, ✕, or Escape). */
   onClose: () => void
+  /**
+   * Element to return focus to when the dialog closes (the card that opened it).
+   * Captured by {@link ProjectGallery} at click time — `document.activeElement`
+   * can't be used here because the gallery is marked `inert` on open, which
+   * blurs the trigger before this component's effect runs.
+   */
+  returnFocusTo?: RefObject<HTMLElement | null>
 }
 
 /**
@@ -29,7 +36,7 @@ type ProjectDetailProps = {
  * and restores focus to the element that opened it (the originating card) on
  * close.
  */
-export const ProjectDetail = ({ project, onClose }: ProjectDetailProps) => {
+export const ProjectDetail = ({ project, onClose, returnFocusTo }: ProjectDetailProps) => {
   const reduce = useReducedMotion()
   const panelRef = useRef<HTMLDivElement>(null)
   const closeRef = useRef<HTMLButtonElement>(null)
@@ -38,7 +45,8 @@ export const ProjectDetail = ({ project, onClose }: ProjectDetailProps) => {
   // Modal lifecycle: Escape-to-close, body scroll lock, initial focus, a Tab
   // focus trap, and focus restoration to the trigger on unmount.
   useEffect(() => {
-    const trigger = document.activeElement as HTMLElement | null
+    // Fallback only — prefer the gallery-captured trigger (see `returnFocusTo`).
+    const fallbackTrigger = document.activeElement as HTMLElement | null
 
     const onKey = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
@@ -72,9 +80,9 @@ export const ProjectDetail = ({ project, onClose }: ProjectDetailProps) => {
     return () => {
       document.removeEventListener('keydown', onKey)
       document.body.style.overflow = previousOverflow
-      trigger?.focus?.()
+      ;(returnFocusTo?.current ?? fallbackTrigger)?.focus?.()
     }
-  }, [onClose])
+  }, [onClose, returnFocusTo])
 
   const { name, slug, tagline, thumbnailUrl, stack, impact, year, moment, href } = project
 

--- a/components/project-binder/ProjectDetail.tsx
+++ b/components/project-binder/ProjectDetail.tsx
@@ -4,6 +4,7 @@ import { m, useReducedMotion } from 'framer-motion'
 import Image from 'next/image'
 import { useEffect, useId, useRef, type RefObject } from 'react'
 import { CARD_MORPH_SPRING, cardLayoutId } from './cardMorph'
+import { isExternalHref } from './TradeCard'
 import type { TradeCardProps } from './TradeCard'
 
 /** Props for the {@link ProjectDetail} overlay. */
@@ -85,6 +86,8 @@ export const ProjectDetail = ({ project, onClose, returnFocusTo }: ProjectDetail
   }, [onClose, returnFocusTo])
 
   const { name, slug, tagline, thumbnailUrl, stack, impact, year, moment, href } = project
+  // External links open in a new tab (↗); internal routes navigate in place (→).
+  const external = isExternalHref(href)
 
   return (
     // Backdrop doubles as the AnimatePresence child: its opacity exit animation
@@ -143,11 +146,10 @@ export const ProjectDetail = ({ project, onClose, returnFocusTo }: ProjectDetail
         {href && (
           <a
             href={href}
-            target="_blank"
-            rel="noopener noreferrer"
+            {...(external ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
             className="mt-6 inline-block rounded-md bg-yellow-400 px-4 py-2 text-sm font-semibold text-neutral-900 hover:bg-yellow-300 transition"
           >
-            View Project →
+            View Project {external ? '↗' : '→'}
           </a>
         )}
       </m.div>

--- a/components/project-binder/ProjectGallery.tsx
+++ b/components/project-binder/ProjectGallery.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { AnimatePresence } from 'framer-motion'
-import { useRef, useState } from 'react'
+import { useCallback, useRef, useState } from 'react'
 import { useSingleColumn } from '@/utils/hooks/useSingleColumn'
 import { TradeCard } from './TradeCard'
 import type { TradeCardProps } from './TradeCard'
@@ -120,15 +120,20 @@ export const ProjectGallery = () => {
   const [selectedSlug, setSelectedSlug] = useState<string | null>(null)
   const selectedProject = projects.find(project => project.slug === selectedSlug) ?? null
 
-  // The card that opened the overlay, captured at click time so focus can be
-  // restored on close. Must be captured before the gallery is marked `inert`
-  // (which blurs the focused trigger), so we record it here rather than reading
-  // `document.activeElement` from inside the dialog.
+  // The card button that opened the overlay, so focus can be restored to it on
+  // close. The card passes its button element directly (rather than us reading
+  // `document.activeElement`) because Safari/Firefox don't focus a button on
+  // mouse click, and because the gallery is marked `inert` on open — which would
+  // blur the trigger before the dialog could capture it.
   const triggerRef = useRef<HTMLElement | null>(null)
-  const openProject = (slug: string) => {
-    triggerRef.current = document.activeElement as HTMLElement | null
+  const openProject = (slug: string, trigger: HTMLElement) => {
+    triggerRef.current = trigger
     setSelectedSlug(slug)
   }
+  // Stable identity so the dialog's keydown/scroll-lock/focus effect doesn't
+  // re-run (and leak the scroll lock) when the gallery re-renders while open
+  // — e.g. a viewport resize flipping `useSingleColumn`.
+  const closeProject = useCallback(() => setSelectedSlug(null), [])
 
   const mid = Math.ceil(projects.length / 2)
   const leftColumn = projects.slice(0, mid)
@@ -155,7 +160,7 @@ export const ProjectGallery = () => {
               // `.reveal` fades each card up as it scrolls into view (native
               // scroll-driven CSS; inert in unsupporting browsers / reduced motion).
               <div key={project.slug} className="reveal">
-                <TradeCard {...project} onOpen={() => openProject(project.slug)} />
+                <TradeCard {...project} onOpen={trigger => openProject(project.slug, trigger)} />
               </div>
             ))}
           </div>
@@ -164,7 +169,7 @@ export const ProjectGallery = () => {
           <div className="grid grid-cols-[repeat(auto-fit,minmax(260px,1fr))] gap-6 sm:justify-items-start justify-items-center">
             {rightColumn.map(project => (
               <div key={project.slug} className="reveal">
-                <TradeCard {...project} onOpen={() => openProject(project.slug)} />
+                <TradeCard {...project} onOpen={trigger => openProject(project.slug, trigger)} />
               </div>
             ))}
           </div>
@@ -182,7 +187,7 @@ export const ProjectGallery = () => {
           <ProjectDetail
             key={selectedProject.slug}
             project={selectedProject}
-            onClose={() => setSelectedSlug(null)}
+            onClose={closeProject}
             returnFocusTo={triggerRef}
           />
         )}

--- a/components/project-binder/ProjectGallery.tsx
+++ b/components/project-binder/ProjectGallery.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { AnimatePresence } from 'framer-motion'
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import { useSingleColumn } from '@/utils/hooks/useSingleColumn'
 import { TradeCard } from './TradeCard'
 import type { TradeCardProps } from './TradeCard'
@@ -120,13 +120,34 @@ export const ProjectGallery = () => {
   const [selectedSlug, setSelectedSlug] = useState<string | null>(null)
   const selectedProject = projects.find(project => project.slug === selectedSlug) ?? null
 
+  // The card that opened the overlay, captured at click time so focus can be
+  // restored on close. Must be captured before the gallery is marked `inert`
+  // (which blurs the focused trigger), so we record it here rather than reading
+  // `document.activeElement` from inside the dialog.
+  const triggerRef = useRef<HTMLElement | null>(null)
+  const openProject = (slug: string) => {
+    triggerRef.current = document.activeElement as HTMLElement | null
+    setSelectedSlug(slug)
+  }
+
   const mid = Math.ceil(projects.length / 2)
   const leftColumn = projects.slice(0, mid)
   const rightColumn = projects.slice(mid)
 
   return (
     <div className="relative min-h-screen bg-[url('/textures/binder-leather.png')] bg-cover bg-center px-2 sm:px-6 py-12 shadow-[inset_0_0_60px_rgba(0,0,0,0.3)]">
-      <div className="mx-auto w-full max-w-[1600px]">
+      {/*
+       * The card grid is marked `inert` while the detail dialog is open, so the
+       * cards obscured behind the backdrop leave the tab order and the
+       * accessibility tree — completing the dialog's focus trap + aria-modal so
+       * a screen-reader virtual cursor can't wander into the hidden gallery.
+       * (The divider below is decorative and non-interactive, so it's exempt.)
+       */}
+      <div
+        data-testid="gallery-content"
+        inert={selectedProject ? true : undefined}
+        className="mx-auto w-full max-w-[1600px]"
+      >
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6 px-2 sm:px-4">
           {/* Left Column */}
           <div className="grid grid-cols-[repeat(auto-fit,minmax(260px,1fr))] gap-6 sm:justify-items-start justify-items-center">
@@ -134,7 +155,7 @@ export const ProjectGallery = () => {
               // `.reveal` fades each card up as it scrolls into view (native
               // scroll-driven CSS; inert in unsupporting browsers / reduced motion).
               <div key={project.slug} className="reveal">
-                <TradeCard {...project} onOpen={() => setSelectedSlug(project.slug)} />
+                <TradeCard {...project} onOpen={() => openProject(project.slug)} />
               </div>
             ))}
           </div>
@@ -143,7 +164,7 @@ export const ProjectGallery = () => {
           <div className="grid grid-cols-[repeat(auto-fit,minmax(260px,1fr))] gap-6 sm:justify-items-start justify-items-center">
             {rightColumn.map(project => (
               <div key={project.slug} className="reveal">
-                <TradeCard {...project} onOpen={() => setSelectedSlug(project.slug)} />
+                <TradeCard {...project} onOpen={() => openProject(project.slug)} />
               </div>
             ))}
           </div>
@@ -162,6 +183,7 @@ export const ProjectGallery = () => {
             key={selectedProject.slug}
             project={selectedProject}
             onClose={() => setSelectedSlug(null)}
+            returnFocusTo={triggerRef}
           />
         )}
       </AnimatePresence>

--- a/components/project-binder/TradeCard.tsx
+++ b/components/project-binder/TradeCard.tsx
@@ -58,12 +58,24 @@ export type TradeCardProps = {
 /** Props for the {@link TradeCard} component: project data plus the open handler. */
 type TradeCardComponentProps = TradeCardProps & {
   /**
-   * Opens this project's detail overlay. When provided, the whole card becomes a
-   * button; clicking it morphs the card into the `ProjectDetail` panel (the two
-   * are linked by a shared `layoutId`). The `View Project` link lives in that
-   * panel, not on the card.
+   * Opens this project's detail overlay. Drives a full-card stretched button;
+   * clicking anywhere on the card morphs it into the `ProjectDetail` panel (the
+   * two are linked by a shared `layoutId`). Projects with an external `href`
+   * also expose a small "View Project" anchor that navigates instead.
    */
   onOpen?: () => void
+}
+
+/**
+ * True when `href` points off-site (absolute `http(s)` URL) rather than to an
+ * internal route. Only external links get the gallery-level "View Project"
+ * anchor — an outbound, crawlable, middle-clickable link is meaningful for
+ * other sites but not for an internal route like `/`.
+ *
+ * @param href - The project's optional link.
+ */
+function isExternalHref(href: string | undefined): href is string {
+  return !!href && /^https?:\/\//.test(href)
 }
 
 /**
@@ -93,10 +105,12 @@ export const TradeCard: React.FC<TradeCardComponentProps> = ({
   featured = false,
   experimental = false,
   status,
+  href,
   legacy = false,
   onOpen,
 }) => {
   const reduce = useReducedMotion()
+  const showExternalLink = isExternalHref(href)
 
   const rarityClass = featured
     ? 'border-yellow-400'
@@ -105,22 +119,7 @@ export const TradeCard: React.FC<TradeCardComponentProps> = ({
       : 'border-neutral-700'
 
   return (
-    // A div with `role="button"` rather than a real <button>: the card's
-    // content is block-level (heading, paragraphs, absolutely-positioned
-    // overlays), which is invalid inside a <button> (phrasing content only) and
-    // trips React's DOM-nesting validation. role + tabIndex + key handler keeps
-    // it keyboard-operable while preserving valid markup and the inner heading.
     <m.div
-      role="button"
-      tabIndex={0}
-      onClick={onOpen}
-      onKeyDown={event => {
-        if (event.key === 'Enter' || event.key === ' ') {
-          event.preventDefault()
-          onOpen?.()
-        }
-      }}
-      aria-label={`Open ${name} details`}
       // Shared id with the detail panel drives the open/close morph; dropped
       // under reduced motion so the overlay cross-fades instead of morphing.
       layoutId={reduce ? undefined : cardLayoutId(slug)}
@@ -130,10 +129,25 @@ export const TradeCard: React.FC<TradeCardComponentProps> = ({
       }}
       transition={{ type: 'tween', duration: 0.3, layout: CARD_MORPH_SPRING }}
       className={clsx(
-        'relative rounded-xl border p-4 bg-neutral-900 text-white w-full max-w-xs flex flex-col items-center text-left transition-all overflow-hidden cursor-pointer',
+        'relative rounded-xl border p-4 bg-neutral-900 text-white w-full max-w-xs flex flex-col items-center text-left transition-all overflow-hidden',
         rarityClass
       )}
     >
+      {/*
+       * Stretched button = the primary "open detail" target. An empty,
+       * transparent button laid over the whole card keeps the rich card content
+       * (heading, paragraphs, badges) as siblings — not invalid <button>
+       * descendants — and lets the external-link anchor sit above it (z-50) as a
+       * sibling rather than a nested interactive control. Clicking anywhere on
+       * the card except that anchor opens the detail overlay.
+       */}
+      <button
+        type="button"
+        onClick={onOpen}
+        aria-label={`Open ${name} details`}
+        className="absolute inset-0 z-40 cursor-pointer rounded-xl focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-yellow-400"
+      />
+
       {featured && <FoilShineOverlay />}
       {legacy && <LegacyRibbon />}
 
@@ -151,6 +165,22 @@ export const TradeCard: React.FC<TradeCardComponentProps> = ({
         </div>
         <div className="text-yellow-100 text-xs">{moment}</div>
       </div>
+
+      {showExternalLink && (
+        // Sits above the stretched button (z-50) so it receives its own clicks
+        // and navigates instead of opening the overlay. A real <a> in the
+        // initial DOM keeps the outbound project link crawlable and
+        // middle/ctrl-clickable from the gallery.
+        <a
+          href={href}
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label={`View ${name} project (opens in new tab)`}
+          className="relative z-50 mt-4 text-xs text-yellow-300 underline hover:text-yellow-100 transition"
+        >
+          View Project ↗
+        </a>
+      )}
 
       <RarityBadge featured={featured} experimental={experimental} />
 

--- a/components/project-binder/TradeCard.tsx
+++ b/components/project-binder/TradeCard.tsx
@@ -62,19 +62,25 @@ type TradeCardComponentProps = TradeCardProps & {
    * clicking anywhere on the card morphs it into the `ProjectDetail` panel (the
    * two are linked by a shared `layoutId`). Projects with an external `href`
    * also expose a small "View Project" anchor that navigates instead.
+   *
+   * @param trigger - The card's open button, so the caller can restore focus to
+   *   it when the overlay closes. Passed explicitly rather than read from
+   *   `document.activeElement` because Safari/Firefox don't focus a button on
+   *   mouse click.
    */
-  onOpen?: () => void
+  onOpen?: (trigger: HTMLElement) => void
 }
 
 /**
  * True when `href` points off-site (absolute `http(s)` URL) rather than to an
- * internal route. Only external links get the gallery-level "View Project"
- * anchor — an outbound, crawlable, middle-clickable link is meaningful for
- * other sites but not for an internal route like `/`.
+ * internal route. External links open in a new tab and, on the gallery card,
+ * get a crawlable outbound anchor; internal routes (e.g. `/`) navigate in the
+ * same tab and get no card-level anchor. Shared by {@link TradeCard} and the
+ * detail panel so both surfaces apply one link policy.
  *
  * @param href - The project's optional link.
  */
-function isExternalHref(href: string | undefined): href is string {
+export function isExternalHref(href: string | undefined): href is string {
   return !!href && /^https?:\/\//.test(href)
 }
 
@@ -143,7 +149,7 @@ export const TradeCard: React.FC<TradeCardComponentProps> = ({
        */}
       <button
         type="button"
-        onClick={onOpen}
+        onClick={event => onOpen?.(event.currentTarget)}
         aria-label={`Open ${name} details`}
         className="absolute inset-0 z-40 cursor-pointer rounded-xl focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-yellow-400"
       />

--- a/e2e/project-detail.spec.ts
+++ b/e2e/project-detail.spec.ts
@@ -21,6 +21,14 @@ test.describe('project detail overlay', () => {
     await expect(detail.getByRole('link', { name: /view project/i })).toBeVisible()
   })
 
+  test("internal-href project's detail link opens in the same tab", async ({ page }) => {
+    // Courtfolio's href is "/", so the panel link must NOT force a new tab.
+    await page.getByRole('button', { name: /open courtfolio details/i }).click()
+    const link = page.getByTestId('project-detail').getByRole('link', { name: /view project/i })
+    await expect(link).toHaveAttribute('href', '/')
+    expect(await link.getAttribute('target')).toBeNull()
+  })
+
   test('closes on Escape', async ({ page }) => {
     await page.getByRole('button', { name: /open courtfolio details/i }).click()
     await expect(page.getByTestId('project-detail')).toBeVisible()

--- a/e2e/project-detail.spec.ts
+++ b/e2e/project-detail.spec.ts
@@ -40,8 +40,7 @@ test.describe('project detail overlay', () => {
   test('is keyboard operable and restores focus to the card on close', async ({ page }) => {
     const card = page.getByRole('button', { name: /open courtfolio details/i })
 
-    // The card is a div with role="button"; Enter must activate it like a
-    // native button would.
+    // The card's open target is a real (stretched) button; Enter activates it.
     await card.focus()
     await page.keyboard.press('Enter')
     await expect(page.getByTestId('project-detail')).toBeVisible()
@@ -50,5 +49,53 @@ test.describe('project detail overlay', () => {
     await expect(page.getByTestId('project-detail')).toHaveCount(0)
     // Focus returns to the triggering card, not the document body.
     await expect(card).toBeFocused()
+  })
+})
+
+/**
+ * Each project with an EXTERNAL href keeps a real `<a>` on its gallery card —
+ * crawlable and middle/ctrl-clickable — distinct from the card's open-detail
+ * button. Internal-href projects (e.g. Courtfolio → "/") do not get one.
+ */
+test.describe('project gallery outbound links', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/projects')
+    await expect(page.getByTestId('projects-title')).toBeVisible()
+  })
+
+  test('renders a crawlable external link on cards with an external href', async ({ page }) => {
+    const link = page.getByRole('link', { name: /view bars of the day project/i })
+    await expect(link).toHaveAttribute('href', 'https://barsoftheday.com')
+    await expect(link).toHaveAttribute('target', '_blank')
+    await expect(link).toHaveAttribute('rel', /noopener/)
+  })
+
+  test('omits the outbound link for internal-href projects', async ({ page }) => {
+    // Courtfolio's href is "/", so no outbound anchor — only its open-detail button.
+    await expect(page.getByRole('link', { name: /view courtfolio project/i })).toHaveCount(0)
+  })
+})
+
+/**
+ * While the detail dialog is open, the gallery grid behind the backdrop is
+ * marked `inert` so keyboard/AT users can't reach the obscured cards.
+ */
+test.describe('project detail overlay — background inertness', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/projects')
+    await expect(page.getByTestId('projects-title')).toBeVisible()
+  })
+
+  test('toggles inert on the gallery grid with the dialog', async ({ page }) => {
+    const gallery = page.getByTestId('gallery-content')
+    expect(await gallery.getAttribute('inert')).toBeNull()
+
+    await page.getByRole('button', { name: /open courtfolio details/i }).click()
+    await expect(page.getByTestId('project-detail')).toBeVisible()
+    expect(await gallery.getAttribute('inert')).toBe('')
+
+    await page.keyboard.press('Escape')
+    await expect(page.getByTestId('project-detail')).toHaveCount(0)
+    expect(await gallery.getAttribute('inert')).toBeNull()
   })
 })


### PR DESCRIPTION
## Summary

The two non-blocking follow-ups from the card→detail morph (#217).

### 1. Crawlable / middle-clickable outbound links
#217 made the whole card the detail-opener, which dropped the per-card `<a>` to external projects — so those outbound links were no longer crawlable or openable in a new tab from the gallery. This restores a real **`View Project ↗`** anchor on cards whose href is **external** (e.g. `barsoftheday.com`, `flolawrence.life`); internal-href projects (Courtfolio → `/`) don't get one.

To keep the markup valid, the card now uses the **stretched-button pattern**: an empty, transparent `<button>` over the whole card is the "open detail" target, and the anchor is a *sibling above it* (z-50) rather than an interactive control nested inside a `role="button"`. This also lets the native button handle keyboard activation, dropping the manual `onKeyDown`.

### 2. Inert background while the dialog is open
The card grid is now marked **`inert`** while the detail overlay is open, so the obscured cards leave the tab order and the accessibility tree — completing the dialog's existing focus trap + `aria-modal` (a screen-reader virtual cursor can no longer wander into the hidden gallery).

Because `inert` blurs the focused trigger, the opening card is captured at **click time** in `ProjectGallery` and passed to `ProjectDetail` (`returnFocusTo`) for focus restoration, instead of reading `document.activeElement` after open (which would now be `<body>`).

### Tests
Extended `e2e/project-detail.spec.ts`: external-link present + correct `href`/`target`/`rel`; no link for internal-href projects; `inert` toggles on the grid with the dialog. All prior morph/focus tests still pass (816 unit + e2e green).

## Test plan
- [ ] `/projects` — cards for **Bars of the Day** / **Dad Memorial** show a `View Project ↗` link; clicking it opens the external site in a new tab (and **middle-click** opens a new tab).
- [ ] Clicking anywhere else on those cards still opens the **detail morph** (the link doesn't open the overlay; the rest of the card doesn't navigate).
- [ ] **Courtfolio** (internal `/`) shows **no** `View Project ↗` link on the card.
- [ ] Keyboard: Tab reaches both the card (open) and its link; Enter on the card opens the detail, Escape closes and **focus returns to the card**.
- [ ] With the dialog open, Tab stays within the dialog and the background cards are unreachable (grid is `inert`).
- [ ] View source / DevTools: the external `<a href>` is present in the initial gallery DOM (crawlable).

Closes #218.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added external link indicator for project links pointing outside the application.
  * Gallery background is now disabled while viewing project details.

* **Accessibility Improvements**
  * Focus is properly restored when closing project overlays.
  * Enhanced keyboard navigation for project card interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->