### PR TITLE
feat(weight-room): weekly-volume bar chart on History view

### DIFF
--- a/app/training-facility/weight-room/history/page.tsx
+++ b/app/training-facility/weight-room/history/page.tsx
@@ -5,6 +5,7 @@ import { notFound } from 'next/navigation'
 import { BackToCourtButton } from '@/components/common/BackToCourtButton'
 import { StrengthHeatmap } from '@/components/training-facility/weight-room/StrengthHeatmap'
 import { StrengthStats } from '@/components/training-facility/weight-room/StrengthStats'
+import { WeeklyVolumeChart } from '@/components/training-facility/weight-room/WeeklyVolumeChart'
 import { WeightRoomSubNav } from '@/components/training-facility/weight-room/WeightRoomSubNav'
 import { getWeightRoomDataServer } from '@/lib/data/weight-room-server'
 import { isTrainingFacilityEnabled } from '@/lib/feature-flags'
@@ -66,10 +67,9 @@ export default async function WeightRoomHistoryPage(): Promise<JSX.Element> {
             Heatmap &amp; stats
           </h1>
           <p className="mt-3 max-w-xl text-sm leading-7 text-[#e8d5be] sm:text-base">
-            One row per day for the trailing 52 weeks, colored by how
-            close that day got to the daily goal. Hover any cell for the
-            day&rsquo;s breakdown. Stats below summarize the current
-            week, month, and all-time totals.
+            One row per day for the trailing 52 weeks, colored by how close that day got to the
+            daily goal. Hover any cell for the day&rsquo;s breakdown. Stats below summarize the
+            current week, month, and all-time totals.
           </p>
           <WeightRoomSubNav active="history" className="mt-5" />
         </header>
@@ -98,7 +98,7 @@ export default async function WeightRoomHistoryPage(): Promise<JSX.Element> {
               data-testid="weight-room-heatmaps"
               className="mt-10 space-y-8"
             >
-              {goals.map((goal) => (
+              {goals.map(goal => (
                 <article
                   key={goal.exercise}
                   className="rounded-[1.2rem] border border-white/10 bg-white/5 p-5"
@@ -116,6 +116,14 @@ export default async function WeightRoomHistoryPage(): Promise<JSX.Element> {
                   </header>
                   <div className="overflow-x-auto">
                     <StrengthHeatmap sets={sets} goal={goal} />
+                  </div>
+                  <div className="mt-5 border-t border-white/10 pt-4">
+                    <p className="mb-2 font-mono text-[10px] uppercase tracking-[0.22em] text-[#e8d5be]/60">
+                      Weekly volume · last 12 weeks
+                    </p>
+                    <div className="overflow-x-auto">
+                      <WeeklyVolumeChart sets={sets} goal={goal} />
+                    </div>
                   </div>
                 </article>
               ))}

--- a/components/training-facility/weight-room/WeeklyVolumeChart.tsx
+++ b/components/training-facility/weight-room/WeeklyVolumeChart.tsx
@@ -1,0 +1,69 @@
+import type { JSX } from 'react'
+
+import { RoughBar } from '@/components/training-facility/shared/charts'
+import { buildWeeklyVolume } from '@/lib/training-facility/weight-room-history'
+import type { ExerciseGoal, StrengthSet } from '@/types/weight-room'
+
+/** Cream axis ink that reads on the Weight Room's dark card surface. */
+const AXIS_COLOR = 'rgba(247, 234, 217, 0.55)'
+
+/** Props for {@link WeeklyVolumeChart}. */
+export interface WeeklyVolumeChartProps {
+  /**
+   * Every logged set across all exercises; the chart filters down to
+   * {@link goal}'s exercise internally, so callers pass the full
+   * `WeightRoomData.sets` list once per exercise — mirroring
+   * {@link import('./StrengthHeatmap').StrengthHeatmap}.
+   */
+  sets: readonly StrengthSet[]
+  /** The exercise to chart — supplies the bar color and exercise filter. */
+  goal: ExerciseGoal
+  /** Trailing weeks to show, including the current one. Defaults to 12. */
+  weeks?: number
+  /** SVG height in px. Defaults to 220. */
+  height?: number
+}
+
+/**
+ * Weekly rep-volume bar chart for one exercise (#216 follow-up). Sits
+ * beneath that exercise's {@link import('./StrengthHeatmap').StrengthHeatmap}
+ * on the History view: the heatmap shows daily consistency, this shows
+ * the magnitude trend the heatmap's capped color scale can't — "am I
+ * doing more reps per week than I was a quarter ago?".
+ *
+ * A pure Server Component — `buildWeeklyVolume` is a synchronous reduce
+ * and `RoughBar` renders rough.js paths server-side (the generator never
+ * touches the DOM), so no client boundary is needed.
+ *
+ * The SVG is a fixed pixel width sized to the week count so bars stay a
+ * consistent stride; the History page wraps it in `overflow-x-auto` so
+ * the full series scrolls on a phone rather than squashing.
+ */
+export function WeeklyVolumeChart({
+  sets,
+  goal,
+  weeks = 12,
+  height = 220,
+}: WeeklyVolumeChartProps): JSX.Element {
+  const points = buildWeeklyVolume(sets, goal, weeks)
+  // ~56px per bar keeps the M/D labels from colliding; the 96px pad
+  // covers the left y-axis gutter and right margin.
+  const width = Math.max(480, points.length * 56 + 96)
+  const weeklyGoal = Math.max(1, goal.daily_target) * 7
+
+  return (
+    <RoughBar
+      data={points}
+      x={p => p.label}
+      y={p => p.reps}
+      width={width}
+      height={height}
+      fill={goal.color}
+      stroke={goal.color}
+      axisColor={AXIS_COLOR}
+      yLabel="reps"
+      ariaLabel={`${goal.exercise} weekly volume over the last ${points.length} weeks (weekly goal ${weeklyGoal} reps)`}
+      emptyMessage="No sets logged yet"
+    />
+  )
+}

--- a/lib/training-facility/weight-room-history.test.ts
+++ b/lib/training-facility/weight-room-history.test.ts
@@ -4,6 +4,7 @@ import type { ExerciseGoal, StrengthSet } from '@/types/weight-room'
 
 import {
   buildStrengthHeatmap,
+  buildWeeklyVolume,
   computeStrengthStats,
   computeStrengthStreaks,
   intensityFromPct,
@@ -77,11 +78,11 @@ describe('buildStrengthHeatmap', () => {
       cell.date.getFullYear() === year &&
       cell.date.getMonth() === month0 &&
       cell.date.getDate() === day
-    const apr14 = grid.flat().find((c) => dayMatches(c, 2026, 3, 14))
+    const apr14 = grid.flat().find(c => dayMatches(c, 2026, 3, 14))
     expect(apr14?.reps).toBe(45)
     expect(apr14?.setCount).toBe(2)
     expect(apr14?.pct).toBeCloseTo(0.45)
-    const apr13 = grid.flat().find((c) => dayMatches(c, 2026, 3, 13))
+    const apr13 = grid.flat().find(c => dayMatches(c, 2026, 3, 13))
     expect(apr13?.reps).toBe(50)
     expect(apr13?.pct).toBeCloseTo(0.5)
   })
@@ -91,7 +92,7 @@ describe('buildStrengthHeatmap', () => {
     vi.setSystemTime(new Date(2026, 3, 15))
     const sets = [set('2026-04-14', 'pullups', 30), set('2026-04-14', 'dips', 30)]
     const { grid } = buildStrengthHeatmap(sets, PUSHUPS)
-    expect(grid.flat().every((c) => c.reps === 0)).toBe(true)
+    expect(grid.flat().every(c => c.reps === 0)).toBe(true)
   })
 
   it('respects dateFrom / dateTo and clamps insanely wide ranges', () => {
@@ -101,7 +102,7 @@ describe('buildStrengthHeatmap', () => {
       [],
       PUSHUPS,
       new Date(2026, 3, 1),
-      new Date(2026, 3, 15),
+      new Date(2026, 3, 15)
     )
     expect(small[0].length).toBeGreaterThanOrEqual(2)
     expect(small[0].length).toBeLessThanOrEqual(4)
@@ -110,7 +111,7 @@ describe('buildStrengthHeatmap', () => {
       [],
       PUSHUPS,
       new Date(2018, 0, 1),
-      new Date(2026, 3, 15),
+      new Date(2026, 3, 15)
     )
     expect(clamped[0].length).toBeLessThanOrEqual(105)
   })
@@ -132,7 +133,74 @@ describe('buildStrengthHeatmap', () => {
     vi.setSystemTime(new Date(2026, 3, 15))
     const { monthLabels } = buildStrengthHeatmap([], PUSHUPS)
     expect(monthLabels.length).toBeGreaterThan(0)
-    expect(monthLabels.find((l) => l.label === 'Apr')).toBeDefined()
+    expect(monthLabels.find(l => l.label === 'Apr')).toBeDefined()
+  })
+})
+
+describe('buildWeeklyVolume', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('emits exactly `weeks` columns ending with the current week', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 3, 15)) // Wed Apr 15
+    const points = buildWeeklyVolume([], PUSHUPS, 8)
+    expect(points).toHaveLength(8)
+    // Every column opens on a Monday, oldest → newest.
+    expect(points.every(p => p.weekStart.getDay() === 1)).toBe(true)
+    for (let i = 1; i < points.length; i++) {
+      expect(points[i].weekStart.getTime()).toBeGreaterThan(points[i - 1].weekStart.getTime())
+    }
+    // Last column is the week containing "now" (Mon Apr 13 2026).
+    const last = points[points.length - 1]
+    expect(last.weekStart.getMonth()).toBe(3)
+    expect(last.weekStart.getDate()).toBe(13)
+    expect(last.label).toBe('4/13')
+  })
+
+  it('sums reps and counts sets per ISO week, bucketing by Monday', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 3, 15))
+    const sets = [
+      set('2026-04-13', 'pushups', 40), // Mon — same week as...
+      set('2026-04-15', 'pushups', 30), // ...Wed
+      set('2026-04-06', 'pushups', 50), // prior week (Mon Apr 6)
+    ]
+    const points = buildWeeklyVolume(sets, PUSHUPS, 4)
+    const current = points.find(p => p.weekKey === '2026-04-13')
+    expect(current?.reps).toBe(70)
+    expect(current?.setCount).toBe(2)
+    const prior = points.find(p => p.weekKey === '2026-04-06')
+    expect(prior?.reps).toBe(50)
+    expect(prior?.setCount).toBe(1)
+  })
+
+  it('back-fills weeks with no sets as zero', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 3, 15))
+    const points = buildWeeklyVolume([set('2026-04-13', 'pushups', 40)], PUSHUPS, 4)
+    const empties = points.filter(p => p.reps === 0)
+    expect(empties).toHaveLength(3)
+    expect(points.reduce((acc, p) => acc + p.reps, 0)).toBe(40)
+  })
+
+  it('ignores other exercises and unparseable timestamps', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 3, 15))
+    const sets: StrengthSet[] = [
+      set('2026-04-13', 'pullups', 30),
+      { id: 'bad', logged_at: 'not-a-date', exercise: 'pushups', reps: 99 },
+      set('2026-04-13', 'pushups', 25),
+    ]
+    const points = buildWeeklyVolume(sets, PUSHUPS, 4)
+    expect(points.reduce((acc, p) => acc + p.reps, 0)).toBe(25)
+  })
+
+  it('clamps a sub-1 week count to a single column', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 3, 15))
+    expect(buildWeeklyVolume([], PUSHUPS, 0)).toHaveLength(1)
   })
 })
 
@@ -180,10 +248,7 @@ describe('computeStrengthStreaks', () => {
   it('current is 0 when last hit-day is older than yesterday', () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-04-16T12:00:00'))
-    const sets = [
-      set('2026-04-10', 'pushups', 100),
-      set('2026-04-11', 'pushups', 100),
-    ]
+    const sets = [set('2026-04-10', 'pushups', 100), set('2026-04-11', 'pushups', 100)]
     const result = computeStrengthStreaks(sets, PUSHUPS)
     expect(result.current).toBe(0)
     expect(result.longest).toBe(2)
@@ -192,10 +257,7 @@ describe('computeStrengthStreaks', () => {
   it('ignores sets for other exercises', () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-04-16T12:00:00'))
-    const sets = [
-      set('2026-04-15', 'pullups', 100),
-      set('2026-04-16', 'pullups', 100),
-    ]
+    const sets = [set('2026-04-15', 'pullups', 100), set('2026-04-16', 'pullups', 100)]
     expect(computeStrengthStreaks(sets, PUSHUPS)).toEqual({ current: 0, longest: 0 })
   })
 
@@ -277,7 +339,7 @@ describe('computeStrengthStats', () => {
     ]
     const sets = [set('2026-04-16', 'pullups', 30), set('2026-04-16', 'pushups', 50)]
     const stats = computeStrengthStats(sets, goals, now)
-    expect(stats.map((s) => s.exercise)).toEqual(['pushups', 'pullups'])
+    expect(stats.map(s => s.exercise)).toEqual(['pushups', 'pullups'])
     expect(stats[1].color).toBe('#0EA5A1')
     expect(stats[1].thisWeekReps).toBe(30)
   })
@@ -293,10 +355,7 @@ describe('computeStrengthStats', () => {
     // threading `now` into `computeStrengthStreaks`, `current` would
     // come back 0 because Apr 16 is older than yesterday.
     const now = new Date('2026-04-16T12:00:00')
-    const sets = [
-      set('2026-04-15', 'pushups', 100),
-      set('2026-04-16', 'pushups', 100),
-    ]
+    const sets = [set('2026-04-15', 'pushups', 100), set('2026-04-16', 'pushups', 100)]
     const [stats] = computeStrengthStats(sets, [PUSHUPS], now)
     expect(stats.currentStreak).toBe(2)
     expect(stats.longestStreak).toBe(2)

--- a/lib/training-facility/weight-room-history.ts
+++ b/lib/training-facility/weight-room-history.ts
@@ -36,6 +36,25 @@ export interface StrengthHeatmapGrid {
   monthLabels: { col: number; label: string }[]
 }
 
+/**
+ * One week's rep total for a single exercise — the datum behind a bar
+ * in the History view's weekly-volume chart (#216 follow-up). Buckets
+ * are ISO weeks (Mon–Sun), matching the heatmap's row layout and the
+ * stats panel's `thisWeek`/`lastWeek` rollups.
+ */
+export interface WeeklyVolumePoint {
+  /** Monday (00:00 local) that opens this ISO week. */
+  weekStart: Date
+  /** `YYYY-MM-DD` of {@link weekStart} — a stable, unique band key. */
+  weekKey: string
+  /** Short `M/D` x-axis label derived from {@link weekStart}. */
+  label: string
+  /** Total reps logged for this exercise across the week. `0` for empty weeks. */
+  reps: number
+  /** Number of distinct sets logged across the week. */
+  setCount: number
+}
+
 /** Per-exercise rollups for the stats panel. */
 export interface StrengthExerciseStats {
   /** Exercise name (matches {@link ExerciseGoal.exercise}). */
@@ -151,7 +170,7 @@ export function buildStrengthHeatmap(
   sets: readonly StrengthSet[],
   goal: ExerciseGoal,
   dateFrom?: Date | null,
-  dateTo?: Date | null,
+  dateTo?: Date | null
 ): StrengthHeatmapGrid {
   const endMonday = getMondayOf(dateTo ?? new Date())
   const endDate = new Date(endMonday.getTime() + 6 * DAY_MS)
@@ -238,7 +257,7 @@ export function buildStrengthHeatmap(
 export function computeStrengthStreaks(
   sets: readonly StrengthSet[],
   goal: ExerciseGoal,
-  now: Date = new Date(),
+  now: Date = new Date()
 ): { current: number; longest: number } {
   const dailyReps = new Map<string, number>()
   for (const s of sets) {
@@ -268,7 +287,7 @@ export function computeStrengthStreaks(
 function streakFromDailyReps(
   dailyReps: ReadonlyMap<string, number>,
   dailyTarget: number,
-  now: Date,
+  now: Date
 ): { current: number; longest: number } {
   // Belt-and-suspenders — same reason as in `buildStrengthHeatmap`.
   const target = Math.max(1, dailyTarget)
@@ -337,7 +356,7 @@ function streakFromDailyReps(
 export function computeStrengthStats(
   sets: readonly StrengthSet[],
   goals: readonly ExerciseGoal[],
-  now: Date = new Date(),
+  now: Date = new Date()
 ): StrengthExerciseStats[] {
   const todayMonday = getMondayOf(now)
   const thisWeekStart = toDateKey(todayMonday)
@@ -350,7 +369,7 @@ export function computeStrengthStats(
   const lastMonthStart = toDateKey(new Date(now.getFullYear(), now.getMonth() - 1, 1))
   const lastMonthEnd = toDateKey(new Date(now.getFullYear(), now.getMonth(), 0))
 
-  return goals.map((goal) => {
+  return goals.map(goal => {
     const dailyReps = new Map<string, number>()
     let allTimeReps = 0
     let validSetCount = 0
@@ -398,4 +417,69 @@ export function computeStrengthStats(
       allTimeReps,
     }
   })
+}
+
+/**
+ * Roll one exercise's sets into a trailing run of weekly rep totals —
+ * the data behind the History view's weekly-volume bar chart. Where the
+ * heatmap answers "did I show up?" at daily granularity, this answers
+ * "is my weekly volume trending up?" at a magnitude the heatmap's
+ * capped color scale can't show.
+ *
+ * Weeks are ISO (Monday-anchored) so a bar lines up with the heatmap's
+ * columns and the stats panel's week rollups. The series always spans
+ * exactly `weeks` columns ending with the current week, back-filling
+ * empty weeks with `0` so a training gap reads as a visible trough
+ * rather than a missing bar. Sets whose `exercise` doesn't match
+ * `goal.exercise` are ignored — call once per exercise.
+ *
+ * @param sets every logged set from {@link import('@/types/weight-room').WeightRoomData.sets};
+ *   the helper filters to the matching exercise.
+ * @param goal the {@link ExerciseGoal} for the target exercise.
+ * @param weeks number of trailing weeks to emit, including the current
+ *   one. Floored to an integer and clamped to a minimum of 1. Defaults
+ *   to 12 (a quarter) — short enough that every bar can carry a legible
+ *   date label.
+ * @param now optional override for the "current week" anchor. Defaults
+ *   to `new Date()`; tests pass a fixed date for determinism.
+ */
+export function buildWeeklyVolume(
+  sets: readonly StrengthSet[],
+  goal: ExerciseGoal,
+  weeks = 12,
+  now: Date = new Date()
+): WeeklyVolumePoint[] {
+  const span = Math.max(1, Math.floor(weeks))
+  const currentMonday = getMondayOf(now)
+  const startMs = currentMonday.getTime() - (span - 1) * WEEK_MS
+
+  // weekKey (Monday YYYY-MM-DD) → reps + set tallies for this exercise.
+  const lookup = new Map<string, { reps: number; setCount: number }>()
+  for (const s of sets) {
+    if (s.exercise !== goal.exercise) continue
+    const d = new Date(s.logged_at)
+    if (!Number.isFinite(d.getTime())) continue
+    const key = toDateKey(getMondayOf(d))
+    const entry = lookup.get(key) ?? { reps: 0, setCount: 0 }
+    entry.reps += s.reps
+    entry.setCount += 1
+    lookup.set(key, entry)
+  }
+
+  const points: WeeklyVolumePoint[] = []
+  for (let i = 0; i < span; i++) {
+    // Snap each generated week back through getMondayOf so a DST hour
+    // shift in the raw ms arithmetic can't land the key on a Sunday.
+    const weekStart = getMondayOf(new Date(startMs + i * WEEK_MS))
+    const weekKey = toDateKey(weekStart)
+    const entry = lookup.get(weekKey)
+    points.push({
+      weekStart,
+      weekKey,
+      label: `${weekStart.getMonth() + 1}/${weekStart.getDate()}`,
+      reps: entry?.reps ?? 0,
+      setCount: entry?.setCount ?? 0,
+    })
+  }
+  return points
 }


### PR DESCRIPTION
## What

Adds a **weekly rep-volume bar chart** beneath each exercise's heatmap on the Weight Room History view.

The 52-week heatmap already answers *"did I show up?"* at daily granularity, but its color scale caps at "≥100% of goal" — so it can't show the magnitude trend. This chart answers *"is my weekly volume trending up?"*, surfacing ramps and gaps the heatmap flattens.

| Before | After |
|--------|-------|
| Heatmap (daily consistency) + stats cards | + per-exercise weekly-volume bars under each heatmap |

Rendered against real data (late-May pushup ramp, ~600 → ~250 reps/week):

_See screenshot in the review thread._

## How

- **`buildWeeklyVolume()`** (`lib/training-facility/weight-room-history.ts`) — ISO-week (Monday-anchored) rep rollups for one exercise, back-filling empty weeks with `0` so training gaps render as visible troughs rather than missing bars. Mirrors `buildStrengthHeatmap`'s exercise-filter and bad-timestamp guards; weeks are snapped through `getMondayOf` so a DST hour-shift can't land a key on a Sunday.
- **`WeeklyVolumeChart`** — pure Server Component wrapping the existing `RoughBar` primitive (rough.js generator is SSR-safe, no DOM), colored per-exercise with cream axis ink for the dark card. Wrapped in `overflow-x-auto` on the page so the series scrolls on mobile, matching the heatmap treatment.
- Window defaults to **12 weeks** (a quarter) — short enough that every bar carries a legible `M/D` label.

## Design choice

The chart lives **inside each exercise's card** (heatmap = consistency, bars = magnitude, grouped per exercise) rather than in a separate section. Trivial to relocate if a "all heatmaps, then all charts" layout reads better.

## Testing

- 5 new unit tests: column count, Monday bucketing, zero back-fill, exercise/bad-timestamp filtering, sub-1 week clamp. **27/27 pass.**
- Typecheck clean for changed files.
- Verified live against Supabase data in a local training-facility build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
