### PR TITLE
feat(weight-room): day picker for backdating QuickLog sets (#202)

### DIFF
--- a/components/training-facility/weight-room/LogDataIsland.tsx
+++ b/components/training-facility/weight-room/LogDataIsland.tsx
@@ -6,12 +6,15 @@ import { getWeightRoomData } from '@/lib/data/weight-room'
 import { computeStrengthStreaks } from '@/lib/training-facility/strength-streaks'
 import {
   filterSetsForDay,
+  formatDayLabel,
+  localNoonIsoForDay,
   toLocalDateKey,
   totalsByExercise,
 } from '@/lib/training-facility/strength-today'
 import type { StrengthSet, WeightRoomData } from '@/types/weight-room'
 
 import { ActivityRings, type RingProgress } from './ActivityRings'
+import { LogDayPicker } from './LogDayPicker'
 import { QuickLog } from './QuickLog'
 import { SetList } from './SetList'
 import { StreakBadge } from './StreakBadge'
@@ -20,8 +23,14 @@ import { StreakBadge } from './StreakBadge'
  * Admin Log View data island (#197). Owns the strength dataset that
  * powers the dashboard-style admin page at
  * `/training-facility/weight-room/log` — activity rings, streak
- * badges, the QuickLog form, and today's SetList live here behind a
- * single `getWeightRoomData()` read.
+ * badges, the QuickLog form, and the selected day's SetList live here
+ * behind a single `getWeightRoomData()` read.
+ *
+ * The view is day-addressable (#202): a {@link LogDayPicker} above the
+ * grid defaults to today, and selecting a past day flips rings, totals,
+ * and the set list to that day while stamping newly logged sets onto it
+ * (local noon, via `logged_at`). Streak badges always show the all-time
+ * computation regardless of the selected day.
  *
  * Always renders the admin-only surfaces (quick-log form + set-list
  * delete buttons) because the parent page is already admin-gated by
@@ -40,6 +49,12 @@ export function LogDataIsland(): JSX.Element {
   // transient Supabase blip from masquerading as "no data yet."
   const [loadError, setLoadError] = useState<string | null>(null)
   const [busy, setBusy] = useState<boolean>(false)
+  // Day the whole view is pointed at (#202) — rings, totals, SetList,
+  // and the `logged_at` of newly logged sets all follow this key. Lazy
+  // initializer so "today" is computed once at mount, not every render.
+  const [selectedDay, setSelectedDay] = useState<string>(() =>
+    toLocalDateKey(new Date()),
+  )
   const requestIdRef = useRef(0)
 
   useEffect(() => {
@@ -99,8 +114,12 @@ export function LogDataIsland(): JSX.Element {
   // render in their empty state.
   const surfaceData: WeightRoomData = data ?? { goals: [], sets: [], imported_at: '' }
   const todayKey = toLocalDateKey(new Date())
-  const setsToday = filterSetsForDay(surfaceData.sets, todayKey)
-  const totals = totalsByExercise(setsToday)
+  // After a midnight rollover `selectedDay` (set at mount) lags
+  // `todayKey` — that's intentional: the view stays on the day the
+  // admin was logging against, now flagged as a backfill by the picker.
+  const isBackfilling = selectedDay !== todayKey
+  const setsForDay = filterSetsForDay(surfaceData.sets, selectedDay)
+  const totals = totalsByExercise(setsForDay)
   const rings: RingProgress[] = surfaceData.goals.map((goal) => ({
     goal,
     totalReps: totals.get(goal.exercise) ?? 0,
@@ -113,6 +132,12 @@ export function LogDataIsland(): JSX.Element {
   return (
     <div className="flex flex-col gap-8">
       {loadError ? <LoadErrorBanner message={loadError} /> : null}
+
+      <LogDayPicker
+        selectedDay={selectedDay}
+        todayKey={todayKey}
+        onSelectDay={setSelectedDay}
+      />
 
       <div className="grid gap-8 lg:grid-cols-[auto_1fr] lg:items-start">
         <div className="flex flex-col items-center gap-4">
@@ -134,7 +159,19 @@ export function LogDataIsland(): JSX.Element {
             <QuickLog
               goals={surfaceData.goals}
               lastReps={lastReps}
-              onLog={({ exercise, reps }) => logSet(exercise, reps, setBusy, refetch)}
+              onLog={({ exercise, reps }) =>
+                logSet(
+                  exercise,
+                  reps,
+                  // Backfills stamp local noon of the selected day; same-day
+                  // logs omit logged_at so the API keeps its now() default
+                  // (real time-of-day on the set row). `|| undefined` guards
+                  // the '' unparseable-key fallback.
+                  isBackfilling ? localNoonIsoForDay(selectedDay) || undefined : undefined,
+                  setBusy,
+                  refetch,
+                )
+              }
               busy={busy}
             />
           ) : (
@@ -150,10 +187,11 @@ export function LogDataIsland(): JSX.Element {
             </p>
           )}
           <SetList
-            setsToday={setsToday}
+            setsToday={setsForDay}
             goalsByExercise={goalsByExercise}
             onDelete={(s) => deleteSet(s, setBusy, refetch)}
             busy={busy}
+            dayLabel={isBackfilling ? formatDayLabel(selectedDay) || selectedDay : 'Today'}
           />
         </div>
       </div>
@@ -163,10 +201,15 @@ export function LogDataIsland(): JSX.Element {
 
 /**
  * POST a new strength set, then refetch so rings + list reflect on-disk truth.
+ *
+ * @param loggedAt Optional ISO timestamp for backdated sets (#202).
+ *   Omitted for same-day logs so the API's `now()` default stamps the
+ *   real time-of-day.
  */
 async function logSet(
   exercise: string,
   reps: number,
+  loggedAt: string | undefined,
   setBusy: (v: boolean) => void,
   refetch: () => Promise<void>,
 ): Promise<void> {
@@ -175,7 +218,9 @@ async function logSet(
     const res = await fetch('/api/admin/weight-room/sets', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ exercise, reps }),
+      body: JSON.stringify(
+        loggedAt ? { exercise, reps, logged_at: loggedAt } : { exercise, reps },
+      ),
     })
     if (!res.ok) {
       const body = (await res.json().catch(() => ({}))) as { error?: string }

--- a/components/training-facility/weight-room/LogDataIsland.tsx
+++ b/components/training-facility/weight-room/LogDataIsland.tsx
@@ -114,9 +114,11 @@ export function LogDataIsland(): JSX.Element {
   // render in their empty state.
   const surfaceData: WeightRoomData = data ?? { goals: [], sets: [], imported_at: '' }
   const todayKey = toLocalDateKey(new Date())
-  // After a midnight rollover `selectedDay` (set at mount) lags
-  // `todayKey` — that's intentional: the view stays on the day the
-  // admin was logging against, now flagged as a backfill by the picker.
+  // Display-only backfill flag. After a midnight rollover `selectedDay`
+  // (set at mount) lags `todayKey` — that's intentional: the view stays
+  // on the day the admin was logging against, now flagged as a backfill
+  // by the picker. The *write* path recomputes this at tap time inside
+  // onLog so a stale render closure can't stamp the wrong day.
   const isBackfilling = selectedDay !== todayKey
   const setsForDay = filterSetsForDay(surfaceData.sets, selectedDay)
   const totals = totalsByExercise(setsForDay)
@@ -159,19 +161,27 @@ export function LogDataIsland(): JSX.Element {
             <QuickLog
               goals={surfaceData.goals}
               lastReps={lastReps}
-              onLog={({ exercise, reps }) =>
-                logSet(
+              onLog={({ exercise, reps }) => {
+                // Recompute "today" at tap time rather than reusing the
+                // render-scoped isBackfilling — a page left mounted across
+                // local midnight would otherwise have a stale closure and
+                // silently stamp the set with the new day's now() while
+                // the view still shows the previous day (Codex P2 on
+                // #228). Backfills stamp local noon of the selected day;
+                // same-day logs omit logged_at so the API keeps its now()
+                // default (real time-of-day on the set row). `|| undefined`
+                // guards the '' unparseable-key fallback.
+                const isBackfillAtTap = selectedDay !== toLocalDateKey(new Date())
+                return logSet(
                   exercise,
                   reps,
-                  // Backfills stamp local noon of the selected day; same-day
-                  // logs omit logged_at so the API keeps its now() default
-                  // (real time-of-day on the set row). `|| undefined` guards
-                  // the '' unparseable-key fallback.
-                  isBackfilling ? localNoonIsoForDay(selectedDay) || undefined : undefined,
+                  isBackfillAtTap
+                    ? localNoonIsoForDay(selectedDay) || undefined
+                    : undefined,
                   setBusy,
                   refetch,
                 )
-              }
+              }}
               busy={busy}
             />
           ) : (

--- a/components/training-facility/weight-room/LogDayPicker.test.tsx
+++ b/components/training-facility/weight-room/LogDayPicker.test.tsx
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { LogDayPicker } from './LogDayPicker'
+
+const TODAY = '2026-06-04'
+const PAST = '2026-05-25'
+
+describe('LogDayPicker', () => {
+  it('renders a date input capped at today', () => {
+    render(
+      <LogDayPicker selectedDay={TODAY} todayKey={TODAY} onSelectDay={vi.fn()} />,
+    )
+    const input = screen.getByTestId('log-day-input')
+    expect(input).toHaveValue(TODAY)
+    expect(input).toHaveAttribute('max', TODAY)
+  })
+
+  it('hides the reset chip and indicator when viewing today', () => {
+    render(
+      <LogDayPicker selectedDay={TODAY} todayKey={TODAY} onSelectDay={vi.fn()} />,
+    )
+    expect(screen.queryByTestId('log-day-reset')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('log-day-indicator')).not.toBeInTheDocument()
+  })
+
+  it('forwards a picked past day to onSelectDay', () => {
+    const onSelectDay = vi.fn()
+    render(
+      <LogDayPicker selectedDay={TODAY} todayKey={TODAY} onSelectDay={onSelectDay} />,
+    )
+    fireEvent.change(screen.getByTestId('log-day-input'), {
+      target: { value: PAST },
+    })
+    expect(onSelectDay).toHaveBeenCalledWith(PAST)
+  })
+
+  it('swallows future dates and cleared input', () => {
+    const onSelectDay = vi.fn()
+    render(
+      <LogDayPicker selectedDay={TODAY} todayKey={TODAY} onSelectDay={onSelectDay} />,
+    )
+    const input = screen.getByTestId('log-day-input')
+    fireEvent.change(input, { target: { value: '2026-06-05' } })
+    fireEvent.change(input, { target: { value: '' } })
+    expect(onSelectDay).not.toHaveBeenCalled()
+  })
+
+  it('shows a viewing indicator while backfilling', () => {
+    render(
+      <LogDayPicker selectedDay={PAST} todayKey={TODAY} onSelectDay={vi.fn()} />,
+    )
+    const indicator = screen.getByTestId('log-day-indicator')
+    // 2026-05-25 is a Monday.
+    expect(indicator).toHaveTextContent(/Mon/)
+    expect(indicator).toHaveTextContent(/logged to this day/)
+  })
+
+  it('resets to today via the Back to today chip', async () => {
+    const onSelectDay = vi.fn()
+    render(
+      <LogDayPicker selectedDay={PAST} todayKey={TODAY} onSelectDay={onSelectDay} />,
+    )
+    await userEvent.click(screen.getByRole('button', { name: /back to today/i }))
+    expect(onSelectDay).toHaveBeenCalledWith(TODAY)
+  })
+})

--- a/components/training-facility/weight-room/LogDayPicker.test.tsx
+++ b/components/training-facility/weight-room/LogDayPicker.test.tsx
@@ -44,6 +44,9 @@ describe('LogDayPicker', () => {
     const input = screen.getByTestId('log-day-input')
     fireEvent.change(input, { target: { value: '2026-06-05' } })
     fireEvent.change(input, { target: { value: '' } })
+    // 5-digit year would defeat the lexicographic future-date compare if
+    // the shape weren't pinned first.
+    fireEvent.change(input, { target: { value: '10000-01-01' } })
     expect(onSelectDay).not.toHaveBeenCalled()
   })
 

--- a/components/training-facility/weight-room/LogDayPicker.tsx
+++ b/components/training-facility/weight-room/LogDayPicker.tsx
@@ -63,10 +63,11 @@ export function LogDayPicker({
         max={todayKey}
         onChange={(e) => {
           const next = e.target.value
-          // Ignore a cleared input and (typed) future dates — the
-          // controlled value snaps the input back to the last valid
-          // day. Lexicographic compare is safe on YYYY-MM-DD keys.
-          if (next === '' || next > todayKey) return
+          // Ignore anything that isn't a strict YYYY-MM-DD key (cleared
+          // input, exotic 5+-digit years) and typed future dates — the
+          // controlled value snaps the input back to the last valid day.
+          // Lexicographic compare is safe once the shape is pinned.
+          if (!/^\d{4}-\d{2}-\d{2}$/.test(next) || next > todayKey) return
           onSelectDay(next)
         }}
         data-testid="log-day-input"

--- a/components/training-facility/weight-room/LogDayPicker.tsx
+++ b/components/training-facility/weight-room/LogDayPicker.tsx
@@ -1,0 +1,97 @@
+'use client'
+
+import { useId, type JSX } from 'react'
+
+import { formatDayLabel } from '@/lib/training-facility/strength-today'
+
+/** Props for {@link LogDayPicker}. */
+export interface LogDayPickerProps {
+  /**
+   * Currently selected `YYYY-MM-DD` day key. The Log view's rings,
+   * set list, and new-set `logged_at` all follow this value.
+   */
+  selectedDay: string
+  /**
+   * Today's `YYYY-MM-DD` key in the viewer's local timezone. Doubles
+   * as the date input's `max` (no logging into the future) and as the
+   * reference for "are we backfilling?" — the reset chip and the
+   * viewing indicator only render when `selectedDay !== todayKey`.
+   */
+  todayKey: string
+  /**
+   * Called with the new `YYYY-MM-DD` key when the user picks a date or
+   * taps "Back to today". Never called with an empty or future value —
+   * the component swallows those instead of forwarding them.
+   */
+  onSelectDay: (dayKey: string) => void
+}
+
+/**
+ * Sticky day selector for the admin Log view (#202). Defaults to today;
+ * picking a past day switches the whole view (rings, totals, set list)
+ * to that day and stamps newly logged sets onto it, so a workout done
+ * yesterday can be filed under yesterday instead of polluting today's
+ * rings.
+ *
+ * Native `<input type="date">` so mobile gets the platform date picker
+ * for free. `max` blocks future days in the picker UI; typed future
+ * dates are dropped in the change handler as well.
+ */
+export function LogDayPicker({
+  selectedDay,
+  todayKey,
+  onSelectDay,
+}: LogDayPickerProps): JSX.Element {
+  const inputId = useId()
+  const isBackfilling = selectedDay !== todayKey
+
+  return (
+    <div
+      data-testid="log-day-picker"
+      className="flex flex-wrap items-center gap-x-4 gap-y-2 rounded-2xl border border-white/10 bg-white/5 px-4 py-3"
+    >
+      <label
+        htmlFor={inputId}
+        className="font-mono text-[11px] uppercase tracking-[0.32em] text-amber-300/80"
+      >
+        Logging day
+      </label>
+      <input
+        id={inputId}
+        type="date"
+        value={selectedDay}
+        max={todayKey}
+        onChange={(e) => {
+          const next = e.target.value
+          // Ignore a cleared input and (typed) future dates — the
+          // controlled value snaps the input back to the last valid
+          // day. Lexicographic compare is safe on YYYY-MM-DD keys.
+          if (next === '' || next > todayKey) return
+          onSelectDay(next)
+        }}
+        data-testid="log-day-input"
+        className="rounded border border-white/15 bg-black/40 px-2 py-1.5 font-mono text-sm text-white [color-scheme:dark] focus:border-amber-300/60 focus:outline-none"
+      />
+      {isBackfilling ? (
+        <>
+          <button
+            type="button"
+            onClick={() => onSelectDay(todayKey)}
+            data-testid="log-day-reset"
+            className="min-h-[40px] rounded-full border border-amber-200/30 bg-amber-200/10 px-4 font-mono text-[11px] uppercase tracking-[0.22em] text-amber-100 transition hover:bg-amber-200/20"
+          >
+            Back to today
+          </button>
+          <p
+            role="status"
+            data-testid="log-day-indicator"
+            className="basis-full font-mono text-[12px] text-amber-200/90"
+          >
+            Viewing {formatDayLabel(selectedDay)} — new sets will be logged
+            to this day.
+          </p>
+        </>
+      ) : null}
+    </div>
+  )
+}

--- a/components/training-facility/weight-room/SetList.test.tsx
+++ b/components/training-facility/weight-room/SetList.test.tsx
@@ -119,6 +119,31 @@ describe('SetList', () => {
     expect(totals).toHaveTextContent('/ 30')
   })
 
+  it('headlines a custom dayLabel when viewing a backfill day', () => {
+    render(
+      <SetList
+        setsToday={[set()]}
+        goalsByExercise={{ pushups: PUSHUPS }}
+        dayLabel="Mon, May 25"
+      />,
+    )
+    expect(
+      screen.getByRole('heading', { name: 'Mon, May 25' }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('region', { name: /sets logged on Mon, May 25/i }),
+    ).toBeInTheDocument()
+  })
+
+  it('adapts the empty-state copy to the backfill day', () => {
+    render(
+      <SetList setsToday={[]} goalsByExercise={{}} dayLabel="Mon, May 25" />,
+    )
+    expect(
+      screen.getByText(/no sets logged on Mon, May 25/i),
+    ).toBeInTheDocument()
+  })
+
   it('omits the goal denominator when the exercise has no configured goal', () => {
     render(
       <SetList

--- a/components/training-facility/weight-room/SetList.tsx
+++ b/components/training-facility/weight-room/SetList.tsx
@@ -7,9 +7,11 @@ import type { ExerciseGoal, StrengthSet } from '@/types/weight-room'
 /** Props for {@link SetList}. */
 export interface SetListProps {
   /**
-   * Today's sets, sorted oldest → newest. The list reverses internally
-   * so the most recent set appears at the top — that's the entry the
-   * user usually wants to undo.
+   * The displayed day's sets (today by default, or a backfill day when
+   * the Log view's day picker is set to the past — see {@link dayLabel}),
+   * sorted oldest → newest. The list reverses internally so the most
+   * recent set appears at the top — that's the entry the user usually
+   * wants to undo.
    */
   setsToday: readonly StrengthSet[]
   /**
@@ -31,6 +33,12 @@ export interface SetListProps {
    * button so a row can't be dropped twice.
    */
   busy?: boolean
+  /**
+   * Heading for the list — `'Today'` (the default) or a formatted past
+   * day like `'Mon, May 25'` when the Log view is backfilling (#202).
+   * Also adjusts the empty-state copy and the section's accessible name.
+   */
+  dayLabel?: string
 }
 
 /**
@@ -50,9 +58,13 @@ export function SetList({
   goalsByExercise,
   onDelete,
   busy = false,
+  dayLabel = 'Today',
 }: SetListProps): JSX.Element {
   const [error, setError] = useState<string | null>(null)
   const [pendingId, setPendingId] = useState<string | null>(null)
+
+  const isToday = dayLabel === 'Today'
+  const sectionLabel = isToday ? 'Today’s sets' : `Sets logged on ${dayLabel}`
 
   async function handleDelete(set: StrengthSet): Promise<void> {
     if (!onDelete) return
@@ -69,12 +81,12 @@ export function SetList({
 
   if (setsToday.length === 0) {
     return (
-      <section aria-label="Today’s sets" className="space-y-2" data-testid="set-list-empty">
+      <section aria-label={sectionLabel} className="space-y-2" data-testid="set-list-empty">
         <h2 className="font-mono text-[11px] uppercase tracking-[0.32em] text-amber-300/80">
-          Today
+          {dayLabel}
         </h2>
         <p className="rounded-2xl border border-dashed border-white/10 bg-black/20 px-4 py-6 text-center text-[13px] text-white/55">
-          No sets logged yet today.
+          {isToday ? 'No sets logged yet today.' : `No sets logged on ${dayLabel}.`}
         </p>
       </section>
     )
@@ -93,9 +105,9 @@ export function SetList({
   }
 
   return (
-    <section aria-label="Today’s sets" className="space-y-2" data-testid="set-list">
+    <section aria-label={sectionLabel} className="space-y-2" data-testid="set-list">
       <h2 className="font-mono text-[11px] uppercase tracking-[0.32em] text-amber-300/80">
-        Today
+        {dayLabel}
       </h2>
       {error ? (
         <p

--- a/lib/training-facility/strength-today.test.ts
+++ b/lib/training-facility/strength-today.test.ts
@@ -5,6 +5,8 @@ import type { ExerciseGoal, StrengthSet } from '@/types/weight-room'
 import {
   computeRingPercent,
   filterSetsForDay,
+  formatDayLabel,
+  localNoonIsoForDay,
   sumReps,
   toLocalDateKey,
   totalsByExercise,
@@ -110,5 +112,46 @@ describe('computeRingPercent', () => {
 
   it('returns 0 when no reps logged', () => {
     expect(computeRingPercent(0, PUSHUPS)).toBe(0)
+  })
+})
+
+describe('localNoonIsoForDay', () => {
+  it('round-trips back to the same local day key', () => {
+    // The exact UTC string depends on the test runner's timezone; the
+    // contract is "this instant buckets onto the requested day."
+    expect(toLocalDateKey(localNoonIsoForDay('2026-05-25'))).toBe('2026-05-25')
+  })
+
+  it('stamps local noon, not midnight', () => {
+    const d = new Date(localNoonIsoForDay('2026-05-25'))
+    expect(d.getHours()).toBe(12)
+    expect(d.getMinutes()).toBe(0)
+  })
+
+  it('returns "" for a non-day-key string', () => {
+    expect(localNoonIsoForDay('not-a-date')).toBe('')
+    expect(localNoonIsoForDay('2026-05-25T08:00:00')).toBe('')
+    expect(localNoonIsoForDay('')).toBe('')
+  })
+
+  it('returns "" for component overflow instead of rolling the date', () => {
+    // new Date(2026, 1, 31) would silently roll to March 3.
+    expect(localNoonIsoForDay('2026-02-31')).toBe('')
+  })
+})
+
+describe('formatDayLabel', () => {
+  it('formats weekday, month, and day', () => {
+    // 2026-05-25 is a Monday. Exact strings are locale-dependent; assert
+    // on the en-US pieces the CI/dev environments produce.
+    const label = formatDayLabel('2026-05-25')
+    expect(label).toContain('Mon')
+    expect(label).toContain('May')
+    expect(label).toContain('25')
+  })
+
+  it('returns "" for an unparseable key', () => {
+    expect(formatDayLabel('not-a-date')).toBe('')
+    expect(formatDayLabel('2026-02-31')).toBe('')
   })
 })

--- a/lib/training-facility/strength-today.ts
+++ b/lib/training-facility/strength-today.ts
@@ -103,3 +103,68 @@ export function computeRingPercent(
   if (goal.daily_target <= 0) return 0
   return totalReps / goal.daily_target
 }
+
+/**
+ * Strict `YYYY-MM-DD` shape produced by {@link toLocalDateKey} and the
+ * native `<input type="date">` value. Anchored so a stray timestamp
+ * (`2026-05-25T08:00`) doesn't silently parse as a day key.
+ */
+const DAY_KEY_REGEX = /^(\d{4})-(\d{2})-(\d{2})$/
+
+/**
+ * Parse a `YYYY-MM-DD` day key into a Date at *local noon* of that day.
+ * Component-wise rather than `new Date(dayKey)` — the Date constructor
+ * treats a bare date string as UTC midnight, which lands on the
+ * *previous* local day in negative-offset timezones.
+ *
+ * @returns The local-noon Date, or `null` when `dayKey` isn't a valid
+ *   calendar day (bad shape, or component overflow like `2026-02-31`
+ *   that would silently roll into March).
+ */
+function parseDayKeyToLocalNoon(dayKey: string): Date | null {
+  const match = DAY_KEY_REGEX.exec(dayKey)
+  if (!match) return null
+  const [, yyyy, mm, dd] = match
+  const d = new Date(Number(yyyy), Number(mm) - 1, Number(dd), 12, 0, 0)
+  if (!Number.isFinite(d.getTime()) || toLocalDateKey(d) !== dayKey) return null
+  return d
+}
+
+/**
+ * ISO timestamp for *local noon* of a `YYYY-MM-DD` day key. Used when
+ * backdating a QuickLog set (#202): stamping the set at the middle of
+ * the day keeps it inside the intended calendar day for any plausible
+ * timezone the data is later viewed in, instead of straddling a
+ * midnight boundary the way a 00:00 stamp would.
+ *
+ * @param dayKey `YYYY-MM-DD` key as produced by {@link toLocalDateKey}
+ *   or an `<input type="date">` value.
+ * @returns ISO 8601 UTC timestamp of the day's local noon, or `''` when
+ *   `dayKey` isn't a valid day key (so callers can fall back to the
+ *   server-side `now()` default instead of throwing).
+ */
+export function localNoonIsoForDay(dayKey: string): string {
+  const d = parseDayKeyToLocalNoon(dayKey)
+  return d ? d.toISOString() : ''
+}
+
+/**
+ * Human-readable label for a `YYYY-MM-DD` day key — e.g. `"Mon, May 25"`
+ * in the caller's locale. Used by the Log view's day-picker indicator
+ * and SetList heading when viewing a backfill day (#202). Year is
+ * omitted: the date input next to the label already shows it, and
+ * backfills more than a few days old are rare.
+ *
+ * @param dayKey `YYYY-MM-DD` key as produced by {@link toLocalDateKey}.
+ * @returns Locale-formatted weekday + date, or `''` when `dayKey` is
+ *   unparseable.
+ */
+export function formatDayLabel(dayKey: string): string {
+  const d = parseDayKeyToLocalNoon(dayKey)
+  if (!d) return ''
+  return d.toLocaleDateString(undefined, {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+  })
+}


### PR DESCRIPTION
## Summary

The Log view (`/training-facility/weight-room/log`) always stamped sets at `now()`, so a workout logged the morning after landed on the wrong day's rings (#202's motivating case: 5/25 sets had to be inserted via SQL).

- **New `LogDayPicker`** above the dashboard grid — native `<input type="date">` (capped at today) plus a "Back to today" reset chip and a "Viewing Mon, May 25 — new sets will be logged to this day" indicator when backfilling.
- **The whole view follows the selected day** — rings, per-exercise totals, and the SetList all switch to the chosen day, so a backfilled set is immediately visible (and deletable) on the day it landed.
- **Backdated sets stamp local noon** of the selected day via the existing optional `logged_at` field on `POST /api/admin/weight-room/sets` — middle-of-day keeps the set inside the intended calendar day across timezone boundaries. Same-day logs still omit `logged_at`, so the server's `now()` default preserves real time-of-day.
- `SetList` gains a `dayLabel` prop (heading, empty-state copy, accessible name). `QuickLog` is untouched — the island's `onLog` closure injects the timestamp.
- New helpers `localNoonIsoForDay` / `formatDayLabel` in `lib/training-facility/strength-today.ts`, with unit tests (day-key validation rejects overflow like `2026-02-31`).

No API or schema changes — the backend already accepted `logged_at`.

## Test plan

- [ ] Sign in as admin, open `/training-facility/weight-room/log` — view defaults to today, rings/SetList unchanged from before.
- [ ] Log a set with a preset chip — lands on today with real time-of-day in the SetList row.
- [ ] Set the date picker to a past day — rings/totals/SetList flip to that day, indicator + "Back to today" chip appear.
- [ ] Log a set on the past day — it appears in that day's list stamped 12:00pm, and the day's rings update; History heatmap shows it on the right day.
- [ ] Delete the backfilled set from that day's list — works as before.
- [ ] Tap "Back to today" — view returns to today; today's rings unaffected by the backfill.
- [ ] Try picking a future date — the input caps at today.

Closes #202.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin log view: pick a specific day to view and log sets; UI shows which day is active.
  * Backfilled logs include a local-noon timestamp; same-day logs remain unchanged.
  * Lists and empty-state messages adapt to an optional day label (e.g., “Mon, May 25”).

* **Tests**
  * Added coverage for the date picker, day labeling, backfill behavior, and new date utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->