### PR TITLE
chore(weight-room): stable set ordering + announced backfill indicator (#229)

### DIFF
--- a/components/training-facility/weight-room/LogDayPicker.test.tsx
+++ b/components/training-facility/weight-room/LogDayPicker.test.tsx
@@ -17,12 +17,16 @@ describe('LogDayPicker', () => {
     expect(input).toHaveAttribute('max', TODAY)
   })
 
-  it('hides the reset chip and indicator when viewing today', () => {
+  it('hides the reset chip and empties the indicator when viewing today', () => {
     render(
       <LogDayPicker selectedDay={TODAY} todayKey={TODAY} onSelectDay={vi.fn()} />,
     )
     expect(screen.queryByTestId('log-day-reset')).not.toBeInTheDocument()
-    expect(screen.queryByTestId('log-day-indicator')).not.toBeInTheDocument()
+    // The live region stays mounted (so AT announces the text swap, #229)
+    // but is empty and visually hidden while viewing today.
+    const indicator = screen.getByTestId('log-day-indicator')
+    expect(indicator).toBeEmptyDOMElement()
+    expect(indicator).toHaveClass('sr-only')
   })
 
   it('forwards a picked past day to onSelectDay', () => {

--- a/components/training-facility/weight-room/LogDayPicker.tsx
+++ b/components/training-facility/weight-room/LogDayPicker.tsx
@@ -36,6 +36,10 @@ export interface LogDayPickerProps {
  * Native `<input type="date">` so mobile gets the platform date picker
  * for free. `max` blocks future days in the picker UI; typed future
  * dates are dropped in the change handler as well.
+ *
+ * The backfill indicator is a permanently-mounted `role="status"` live
+ * region whose text swaps with the mode (#229) — conditional mounting
+ * would skip the screen-reader announcement on most AT.
  */
 export function LogDayPicker({
   selectedDay,
@@ -74,25 +78,33 @@ export function LogDayPicker({
         className="rounded border border-white/15 bg-black/40 px-2 py-1.5 font-mono text-sm text-white [color-scheme:dark] focus:border-amber-300/60 focus:outline-none"
       />
       {isBackfilling ? (
-        <>
-          <button
-            type="button"
-            onClick={() => onSelectDay(todayKey)}
-            data-testid="log-day-reset"
-            className="min-h-[40px] rounded-full border border-amber-200/30 bg-amber-200/10 px-4 font-mono text-[11px] uppercase tracking-[0.22em] text-amber-100 transition hover:bg-amber-200/20"
-          >
-            Back to today
-          </button>
-          <p
-            role="status"
-            data-testid="log-day-indicator"
-            className="basis-full font-mono text-[12px] text-amber-200/90"
-          >
-            Viewing {formatDayLabel(selectedDay)} — new sets will be logged
-            to this day.
-          </p>
-        </>
+        <button
+          type="button"
+          onClick={() => onSelectDay(todayKey)}
+          data-testid="log-day-reset"
+          className="min-h-[40px] rounded-full border border-amber-200/30 bg-amber-200/10 px-4 font-mono text-[11px] uppercase tracking-[0.22em] text-amber-100 transition hover:bg-amber-200/20"
+        >
+          Back to today
+        </button>
       ) : null}
+      {/* Permanently-mounted live region (#229): a role="status" element
+          that enters the DOM already populated often isn't announced, so
+          the node stays mounted and only its text swaps. sr-only keeps
+          the empty state out of the visual layout without removing it
+          from the accessibility tree. */}
+      <p
+        role="status"
+        data-testid="log-day-indicator"
+        className={
+          isBackfilling
+            ? 'basis-full font-mono text-[12px] text-amber-200/90'
+            : 'sr-only'
+        }
+      >
+        {isBackfilling
+          ? `Viewing ${formatDayLabel(selectedDay)} — new sets will be logged to this day.`
+          : null}
+      </p>
     </div>
   )
 }

--- a/lib/data/weight-room-shared.ts
+++ b/lib/data/weight-room-shared.ts
@@ -60,8 +60,18 @@ const WeightRoomGoalRowsSchema = z.array(WeightRoomGoalRowSchema)
 export async function assembleWeightRoomData(
   supabase: SupabaseClient,
 ): Promise<WeightRoomData | null> {
+  // Secondary sort keys make ties deterministic (#229): backdated sets
+  // all stamp local noon of their day, so `logged_at` alone left their
+  // relative order unstable between fetches. `updated_at` resolves ties
+  // by insertion order (sets have no update path), and `id` backstops
+  // same-transaction inserts whose `updated_at` also collides.
   const [setsRes, goalsRes] = await Promise.all([
-    supabase.from(SETS_TABLE).select(SETS_COLUMNS).order('logged_at', { ascending: true }),
+    supabase
+      .from(SETS_TABLE)
+      .select(SETS_COLUMNS)
+      .order('logged_at', { ascending: true })
+      .order('updated_at', { ascending: true })
+      .order('id', { ascending: true }),
     supabase.from(GOALS_TABLE).select(GOALS_COLUMNS).order('exercise', { ascending: true }),
   ])
 

--- a/lib/data/weight-room.test.ts
+++ b/lib/data/weight-room.test.ts
@@ -11,9 +11,23 @@ import { getWeightRoomData } from './weight-room'
  * Sibling pattern: `lib/data/cardio.test.ts`.
  */
 
-interface FakeQuery {
+/** Stubbed PostgREST result a {@link FakeQuery} resolves with when awaited. */
+interface FakeResult {
+  data: Array<Record<string, unknown>> | null
+  error: unknown
+}
+
+/**
+ * Chainable + awaitable fake of the Supabase query builder. `select`/
+ * `order` return the builder itself (so multi-key `.order().order()`
+ * chains work, #229) and awaiting it resolves with {@link FakeQuery.result}
+ * — mirroring the real builder, which is a thenable.
+ */
+interface FakeQuery extends PromiseLike<FakeResult> {
   select: ReturnType<typeof vi.fn>
   order: ReturnType<typeof vi.fn>
+  /** Result the await resolves with; {@link stubTable} overwrites it. */
+  result: FakeResult
 }
 
 const queriesByTable: Record<string, FakeQuery> = {}
@@ -22,9 +36,13 @@ const fromMock = vi.fn((table: string): FakeQuery => {
     const query: FakeQuery = {
       select: vi.fn(),
       order: vi.fn(),
+      result: { data: [], error: null },
+      then(onFulfilled, onRejected) {
+        return Promise.resolve(this.result).then(onFulfilled, onRejected)
+      },
     }
     query.select.mockReturnValue(query)
-    query.order.mockResolvedValue({ data: [], error: null })
+    query.order.mockReturnValue(query)
     queriesByTable[table] = query
   }
   return queriesByTable[table]
@@ -52,8 +70,7 @@ function stubTable(
   error: unknown = null,
 ): void {
   const query = fromMock(table)
-  query.order.mockReset()
-  query.order.mockResolvedValue({ data, error })
+  query.result = { data, error }
 }
 
 describe('getWeightRoomData', () => {
@@ -68,14 +85,18 @@ describe('getWeightRoomData', () => {
     expect(fromMock).toHaveBeenCalledWith('weight_room_goals')
   })
 
-  it('orders sets by logged_at ascending and goals by exercise ascending', async () => {
+  it('orders sets by logged_at with deterministic tie-breakers, goals by exercise', async () => {
     stubTable('weight_room_sets', [])
     stubTable('weight_room_goals', [])
     await getWeightRoomData()
 
-    expect(queriesByTable.weight_room_sets.order).toHaveBeenCalledWith('logged_at', {
-      ascending: true,
-    })
+    // Backdated sets share an identical noon logged_at (#229), so the
+    // query must chain updated_at + id to keep tie order stable.
+    expect(queriesByTable.weight_room_sets.order.mock.calls).toEqual([
+      ['logged_at', { ascending: true }],
+      ['updated_at', { ascending: true }],
+      ['id', { ascending: true }],
+    ])
     expect(queriesByTable.weight_room_goals.order).toHaveBeenCalledWith('exercise', {
       ascending: true,
     })


### PR DESCRIPTION
## Summary

Both follow-ups from the #228 review:

- **Deterministic set ordering.** Backdated sets all stamp local noon, so `ORDER BY logged_at` alone left same-day backfills in unstable relative order between fetches (SetList rows could swap). The sets query in `assembleWeightRoomData` now chains `updated_at` (insertion order — sets have no update path) and `id` as tie-breakers. The test fake for the Supabase builder became a chainable thenable to mirror the real builder.
- **Announced backfill indicator.** `LogDayPicker`'s `role="status"` live region was conditionally mounted, and live regions that enter the DOM already populated are often skipped by screen readers. It's now permanently mounted — text swaps with the mode, `sr-only` keeps the empty state out of the visual layout without leaving the accessibility tree. No visual change in either mode.

## Test plan

- [ ] `/training-facility/weight-room/log` as admin: pick a past day, log 2–3 sets — reload a few times and confirm their order in the list stays put.
- [ ] Visual spot-check: picker looks identical to before in both today and backfill modes (the live region is invisible when empty).
- [ ] With a screen reader (optional): toggling to a past day announces "Viewing <day> — new sets will be logged to this day."

Closes #229.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accessibility for the weight room log day picker by ensuring the status indicator is always present in the DOM, toggling visibility as needed.
  * Fixed ordering of weight room entries to ensure consistent, deterministic results when multiple entries share the same date.

* **Tests**
  * Updated test coverage for the log day picker and weight room data ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->