### PR TITLE
chore(ci): enforce coverage thresholds, harden playwright checkout (#225)

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -14,6 +14,9 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          # Read-only job — don't leave the GITHUB_TOKEN in .git/config.
+          persist-credentials: false
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -27,5 +27,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Run unit tests
-        run: npm test
+      - name: Run unit tests with coverage thresholds
+        # `test:coverage` (not plain `npm test`) so the per-path
+        # `lines >= 80` thresholds in vitest.config.ts actually gate PRs
+        # instead of applying only to local --coverage runs (#225).
+        run: npm run test:coverage

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -50,10 +50,13 @@ export default defineConfig({
         // "scoped to the modules added during the Training Facility build."
         'constants/playerSize.ts',
         'constants/tourSteps.ts',
-        // Pure demo-data blobs with no logic to cover; counting their
-        // 0% lines dragged constants/** below the 80% gate (#225, #227).
-        'constants/training-facility-demo-fixture.ts',
-        'constants/weight-room-demo-fixture.ts',
+        // Demo/preview fixtures, excluded by policy rather than because
+        // they're logic-free (buildWeightRoomDemoData() does real date
+        // math): they only feed admin-preview / empty-state surfaces, so
+        // their lines aren't worth gating. Counting the uncovered
+        // weight-room fixture's 0% dragged constants/** below the 80%
+        // gate (#225; #227 misnames it "training-facility-demo-fixture").
+        'constants/*-demo-fixture.ts',
       ],
       thresholds: {
         'lib/**': { lines: 80 },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -50,6 +50,10 @@ export default defineConfig({
         // "scoped to the modules added during the Training Facility build."
         'constants/playerSize.ts',
         'constants/tourSteps.ts',
+        // Pure demo-data blobs with no logic to cover; counting their
+        // 0% lines dragged constants/** below the 80% gate (#225, #227).
+        'constants/training-facility-demo-fixture.ts',
+        'constants/weight-room-demo-fixture.ts',
       ],
       thresholds: {
         'lib/**': { lines: 80 },


### PR DESCRIPTION
## Summary

Both follow-ups from #223's review:

- **`playwright.yml` checkout hardened** — same `persist-credentials: false` the unit workflow already had (read-only job; no reason to leave the `GITHUB_TOKEN` in `.git/config`).
- **Coverage thresholds now gate PRs.** The Unit tests workflow runs `npm run test:coverage` instead of plain `npm test`, so the per-path `lines >= 80` thresholds from #104 are enforced rather than local-only advisory. Coverage adds negligible runtime (v8 provider; suite stays ~25-45s).
- To make the gate green, demo/preview fixtures (`constants/*-demo-fixture.ts` — cardio, combine, weight-room) are excluded from coverage **by policy**: they only feed preview/empty-state surfaces. The uncovered weight-room fixture's 0% lines had dragged `constants/**` to ~57%. This also clears the pre-existing local `test:coverage` failure tracked in #227 (whose third checkbox misnames the file as `training-facility-demo-fixture.ts` — flagged by Codex in review, fixed to the real paths in 706edde).

`constants/**` still measures the tested modules (`benchmarks.ts`, `hr-zones.ts`, `movement.ts`), so the 80% gate there remains live.

## Test plan

- [ ] CI "Unit tests" check on this PR is green and its log shows the coverage table + no threshold error.
- [ ] `npm run test:coverage` passes locally (previously failed on `constants/**`).
- [ ] Playwright E2E check still green after the checkout change.

Closes #225.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reduced credential persistence during CI checkout to limit GitHub token exposure
  * Enforced test coverage checks in CI by running coverage-aware test commands for pull requests
  * Excluded demo fixture modules from coverage reporting to improve accuracy of coverage metrics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->