### PR TITLE
feat(telemetry): auth-failure domain event + /resume e2e coverage (#227)

### DIFF
--- a/app/auth/callback/route.test.ts
+++ b/app/auth/callback/route.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+import { GET } from './route'
+
+/**
+ * Tests the magic-link callback's redirect + telemetry contract (#227).
+ * Both failure branches return 3xx redirects, which the `withTelemetry`
+ * wrapper labels `status='ok'` — so each must also emit an
+ * `auth_callback_failed` domain event with a low-cardinality reason
+ * (never the Supabase error message) for the App-health dashboard.
+ *
+ * Sibling pattern: `app/auth/sign-out/route.test.ts`.
+ */
+
+const exchangeMock = vi.fn()
+const emitEventMock = vi.fn()
+
+vi.mock('@/lib/supabase/server', () => ({
+  createServerSupabaseClient: async () => ({
+    auth: { exchangeCodeForSession: (code: string) => exchangeMock(code) },
+  }),
+}))
+
+vi.mock('@/lib/telemetry/client', () => ({
+  emitEvent: (...args: unknown[]) => emitEventMock(...args),
+  flush: vi.fn(),
+}))
+
+beforeEach(() => {
+  exchangeMock.mockReset()
+  emitEventMock.mockReset()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+function makeRequest(query = ''): NextRequest {
+  return new NextRequest(`http://localhost/auth/callback${query}`)
+}
+
+/** The `auth_callback_failed` emissions captured by the telemetry mock. */
+function failureEvents(): unknown[][] {
+  return emitEventMock.mock.calls.filter(([name]) => name === 'auth_callback_failed')
+}
+
+describe('GET /auth/callback', () => {
+  it('redirects to next and emits no failure event on success', async () => {
+    exchangeMock.mockResolvedValueOnce({ error: null })
+
+    const res = await GET(makeRequest('?code=abc&next=/locker-room'))
+
+    expect(res.status).toBe(307)
+    expect(res.headers.get('location')).toBe('http://localhost/locker-room')
+    expect(failureEvents()).toHaveLength(0)
+  })
+
+  it('redirects to login and emits reason=missing_code when ?code= is absent', async () => {
+    const res = await GET(makeRequest())
+
+    expect(res.status).toBe(307)
+    expect(res.headers.get('location')).toBe(
+      'http://localhost/admin/login?error=missing_code',
+    )
+    expect(failureEvents()).toEqual([
+      ['auth_callback_failed', { status: 'error', attributes: { reason: 'missing_code' } }],
+    ])
+    expect(exchangeMock).not.toHaveBeenCalled()
+  })
+
+  it('redirects to login and emits reason=exchange_failed when the code exchange errors', async () => {
+    exchangeMock.mockResolvedValueOnce({
+      error: { message: 'invalid request: both auth code and code verifier should be non-empty' },
+    })
+
+    const res = await GET(makeRequest('?code=expired'))
+
+    expect(res.status).toBe(307)
+    expect(res.headers.get('location')).toContain('/admin/login?error=')
+    // The reason is the fixed bucket, never the Supabase message — error
+    // messages can carry user input and must not reach telemetry.
+    expect(failureEvents()).toEqual([
+      ['auth_callback_failed', { status: 'error', attributes: { reason: 'exchange_failed' } }],
+    ])
+  })
+
+  it('sanitizes an absolute ?next= to / on success', async () => {
+    exchangeMock.mockResolvedValueOnce({ error: null })
+
+    const res = await GET(makeRequest('?code=abc&next=https://evil.example'))
+
+    expect(res.headers.get('location')).toBe('http://localhost/')
+  })
+})

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -6,11 +6,14 @@
  *
  * Failure modes redirect to `/admin/login?error=...` so the user sees
  * a visible message instead of a blank page or a stale stuck state.
+ * Each failure also emits an `auth_callback_failed` domain event so the
+ * App-health dashboard can see failed exchanges despite the 3xx (#227).
  */
 
 import { NextResponse, type NextRequest } from 'next/server'
 
 import { createServerSupabaseClient } from '@/lib/supabase/server'
+import { emitEvent } from '@/lib/telemetry/client'
 import { withTelemetry } from '@/lib/telemetry/with-telemetry'
 
 /**
@@ -29,18 +32,37 @@ async function handleGET(request: NextRequest): Promise<NextResponse> {
   const next = sanitizeNext(url.searchParams.get('next'))
 
   if (!code) {
+    emitAuthCallbackFailed('missing_code')
     return NextResponse.redirect(new URL('/admin/login?error=missing_code', request.url))
   }
 
   const supabase = await createServerSupabaseClient()
   const { error } = await supabase.auth.exchangeCodeForSession(code)
   if (error) {
+    emitAuthCallbackFailed('exchange_failed')
     return NextResponse.redirect(
       new URL(`/admin/login?error=${encodeURIComponent(error.message)}`, request.url)
     )
   }
 
   return NextResponse.redirect(new URL(next, request.url))
+}
+
+/**
+ * Domain event for a failed magic-link exchange (#227). The wrapper's
+ * per-request health event can't see these — the failure path returns a
+ * 3xx redirect, which it labels `status='ok'` — so dashboards chart
+ * `auth_callback_failed` directly instead of parsing redirect targets.
+ *
+ * @param reason Low-cardinality failure bucket. Never the Supabase
+ *   error message — messages can embed user input (PII rule, see
+ *   {@link withTelemetry}).
+ */
+function emitAuthCallbackFailed(reason: 'missing_code' | 'exchange_failed'): void {
+  emitEvent('auth_callback_failed', {
+    status: 'error',
+    attributes: { reason },
+  })
 }
 
 /** `handleGET` wrapped with one-event-per-request telemetry (#220). */

--- a/e2e/resume.spec.ts
+++ b/e2e/resume.spec.ts
@@ -1,0 +1,27 @@
+import { expect, test } from '@playwright/test'
+
+/**
+ * Smoke coverage for the resume download route (#220 / #227). The PDF
+ * itself is a static asset; `/resume` exists purely so the server can
+ * count downloads before redirecting. These tests pin the redirect
+ * contract and that the user-facing link actually routes through it —
+ * a link pointed back at the bare PDF would silently stop counting.
+ */
+
+test.describe('resume download route', () => {
+  test('GET /resume 307-redirects to the static PDF', async ({ request }) => {
+    const res = await request.get('/resume', { maxRedirects: 0 })
+
+    expect(res.status()).toBe(307)
+    // Location may come back absolute; compare the path only.
+    expect(new URL(res.headers()['location']).pathname).toBe('/LucasLawrenceResume.pdf')
+  })
+
+  test('the contact-page resume link routes through /resume', async ({ page }) => {
+    await page.goto('/contact')
+
+    await expect(
+      page.getByRole('link', { name: /view full resume \(pdf\)/i }),
+    ).toHaveAttribute('href', '/resume')
+  })
+})

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -31,7 +31,7 @@ export default defineConfig({
   projects: [
     {
       name: 'default-routes',
-      testMatch: /(?:home|rooms|project-detail|training-facility-disabled)\.spec\.ts/,
+      testMatch: /(?:home|rooms|project-detail|resume|training-facility-disabled)\.spec\.ts/,
       use: {
         baseURL: DEFAULT_BASE_URL,
       },


### PR DESCRIPTION
## Summary

Closes out #227's two shippable items (the coverage gate was done in #231; the vendored-client swap is blocked on an external publish and split out to #232):

- **Failed magic-link exchanges are now visible in telemetry.** Both failure branches of `GET /auth/callback` (missing `?code=`, failed code exchange) emit an `auth_callback_failed` domain event with `status: 'error'` and a low-cardinality `reason` bucket (`missing_code` / `exchange_failed`) — never the Supabase error message, per the PII rule. The wrapper's per-request health event is untouched; it labels the 3xx redirects `ok`, which is exactly why a separate domain event was needed. New unit tests (`app/auth/callback/route.test.ts`, sibling to the sign-out tests) pin the redirect + telemetry contract, including `?next=` sanitization.
- **`/resume` e2e coverage.** New `e2e/resume.spec.ts` asserts `GET /resume` 307-redirects to `/LucasLawrenceResume.pdf` and the contact-page link routes through `/resume` (a link pointed back at the bare PDF would silently stop counting downloads). Note: `playwright.config.ts`'s `testMatch` is an explicit allowlist — `resume` had to be added or the spec would silently never run.

## Test plan

- [ ] CI green (unit incl. 4 new callback tests; e2e incl. 2 new resume tests).
- [ ] Hit `<preview>/auth/callback` (no code) — lands on `/admin/login?error=missing_code`.
- [ ] Hit `<preview>/resume` — downloads/opens the PDF via redirect.
- [ ] After merge: `auth_callback_failed` rows appear in the telemetry pipeline when a stale magic link is clicked (prod-only signal; preview lacks the Pub/Sub creds).

Closes #227.

🤖 Generated with [Claude Code](https://claude.com/claude-code)