### PR TITLE
feat(banners): add Snap Ads AI newsletter feature to The Rafters (#236)

### DIFF
--- a/components/banners/BannersClient.tsx
+++ b/components/banners/BannersClient.tsx
@@ -17,6 +17,12 @@ const groupedBanners: BannerSection[] = [
         icon: '🗂️',
         category: 'tech',
       },
+      {
+        year: '2026',
+        title: 'Featured 3× in Snap Ads Internal AI Newsletter',
+        icon: '📰',
+        category: 'tech',
+      },
     ],
   },
   {


### PR DESCRIPTION
## Summary

Adds a new accolade banner to **The Rafters** recognizing being featured **three times** in the Snap Ads team's internal newsletter highlighting AI use and progress.

The banner lands in the existing **💻 Tech** section of `components/banners/BannersClient.tsx`, alongside the other engineering accolades:

```ts
{ year: '2026', title: 'Featured 3× in Snap Ads Internal AI Newsletter', icon: '📰', category: 'tech' }
```

A dedicated "📰 Press & Recognition" section was considered but skipped for now — a single-banner section looks sparse next to the others (4–6 banners each). Easy to split out later once more recognition items accumulate.

## Test plan

- [ ] Visit `/banners` — the new banner appears in the 💻 Tech section, last item, reading **"Featured 3× in Snap Ads Internal AI Newsletter"** with the 📰 icon and **2026** year label
- [ ] Banner styling/sway matches its sibling banners (no visual outlier)
- [ ] No layout regression on the Rafters view at desktop and mobile widths
- [ ] Other sections (Personal, Basketball, Fantasy) render unchanged

Closes #236.
