### PR TITLE
chore(ci): add Dependabot config for npm + github-actions (#238)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+  # Application dependencies (single-package repo — singular `directory: /`,
+  # not multi-directory globs, which can trip frozen-lockfile installs).
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      # Fold minor/patch bumps into one weekly PR to keep the noise down;
+      # majors stay ungrouped so each gets its own review.
+      npm-minor-patch:
+        update-types:
+          - minor
+          - patch
+
+  # GitHub Actions used by the workflows in .github/workflows.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      # All action bumps land in a single weekly PR.
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

Adds `.github/dependabot.yml` so dependency and GitHub Actions updates land as automated, CI-gated PRs instead of manually. Dependabot also surfaces known security advisories — the push for this branch already flagged **20 open vulnerabilities** (9 high, 9 moderate, 2 low) on `main`, so the security-update PRs will have immediate work to do.

Two ecosystems, both detected in this repo:

- **npm** (root `package.json`) — minor/patch bumps grouped into one weekly PR to keep noise down; majors stay ungrouped so each gets its own review. `open-pull-requests-limit: 10`.
- **github-actions** (`.github/workflows/{unit,playwright}.yml`) — all action bumps grouped into a single weekly PR.

Singular `directory: /` per the issue note (single-package repo) — multi-directory globs can produce frozen-lockfile failures on shared deps.

## Test plan

- [ ] CI green (config-only; no app code touched).
- [ ] After merge: Insights → Dependency graph → Dependabot shows no config errors.
- [ ] Dependabot opens its first grouped update PR(s) (and security PRs against the 20 flagged advisories).

## Notes

- Workflow actions are currently pinned to major tags (`actions/checkout@v4`, `actions/setup-node@v4`), which the github-actions updater bumps fine. SHA-pinning (the issue's optional hardening suggestion) is left as a separate follow-up.

Closes #238.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured automated dependency updates to regularly update npm packages and GitHub Actions, ensuring the project stays current with the latest compatible versions for improved security and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->