### PR TITLE
feat(weight-room): rotating monthly focus + load tracking (#255)

### DIFF
--- a/app/api/admin/weight-room/monthly-focus/[id]/route.test.ts
+++ b/app/api/admin/weight-room/monthly-focus/[id]/route.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextResponse } from 'next/server'
+
+import { DELETE } from './route'
+
+/**
+ * Tests for `DELETE /api/admin/weight-room/monthly-focus/[id]` (#255).
+ * Auth gate + Supabase service-role client mocked; the delete chain ends
+ * in `.maybeSingle()` so a missing row resolves `{ data: null }` → 404.
+ */
+
+const requireAdminMock = vi.fn()
+vi.mock('@/lib/auth/require-admin', () => ({
+  requireAdmin: () => requireAdminMock(),
+}))
+
+const maybeSingleMock = vi.fn()
+const supabaseChain = {
+  from: vi.fn(() => supabaseChain),
+  delete: vi.fn(() => supabaseChain),
+  eq: vi.fn(() => supabaseChain),
+  select: vi.fn(() => supabaseChain),
+  maybeSingle: vi.fn(() => maybeSingleMock()),
+}
+vi.mock('@/lib/supabase/admin', () => ({
+  createAdminSupabaseClient: () => supabaseChain,
+}))
+
+const VALID_ID = '33333333-3333-4333-8333-333333333333'
+
+beforeEach(() => {
+  requireAdminMock.mockReset()
+  maybeSingleMock.mockReset()
+  supabaseChain.from.mockClear()
+  supabaseChain.delete.mockClear()
+  supabaseChain.eq.mockClear()
+  supabaseChain.select.mockClear()
+  supabaseChain.maybeSingle.mockClear()
+  supabaseChain.from.mockReturnValue(supabaseChain)
+  supabaseChain.delete.mockReturnValue(supabaseChain)
+  supabaseChain.eq.mockReturnValue(supabaseChain)
+  supabaseChain.select.mockReturnValue(supabaseChain)
+  supabaseChain.maybeSingle.mockImplementation(() => maybeSingleMock())
+})
+
+function ctx(id: string): { params: Promise<{ id: string }> } {
+  return { params: Promise.resolve({ id }) }
+}
+
+describe('DELETE /api/admin/weight-room/monthly-focus/[id]', () => {
+  it('returns 401 when not signed in', async () => {
+    requireAdminMock.mockResolvedValueOnce({
+      ok: false,
+      response: NextResponse.json({ error: 'Sign in required.' }, { status: 401 }),
+    })
+    const res = await DELETE({} as never, ctx(VALID_ID))
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 400 for a non-UUID id', async () => {
+    requireAdminMock.mockResolvedValue({ ok: true, email: 'a@b.com' })
+    const res = await DELETE({} as never, ctx('not-a-uuid'))
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 404 when no focus matches the id', async () => {
+    requireAdminMock.mockResolvedValue({ ok: true, email: 'a@b.com' })
+    maybeSingleMock.mockResolvedValueOnce({ data: null, error: null })
+    const res = await DELETE({} as never, ctx(VALID_ID))
+    expect(res.status).toBe(404)
+  })
+
+  it('returns 500 on an unexpected Supabase error', async () => {
+    requireAdminMock.mockResolvedValue({ ok: true, email: 'a@b.com' })
+    maybeSingleMock.mockResolvedValueOnce({ data: null, error: { message: 'boom' } })
+    const res = await DELETE({} as never, ctx(VALID_ID))
+    expect(res.status).toBe(500)
+  })
+
+  it('returns 200 with the deleted row on success', async () => {
+    requireAdminMock.mockResolvedValue({ ok: true, email: 'a@b.com' })
+    maybeSingleMock.mockResolvedValueOnce({ data: { id: VALID_ID, exercise: 'shrugs' }, error: null })
+    const res = await DELETE({} as never, ctx(VALID_ID))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toEqual({ id: VALID_ID, exercise: 'shrugs' })
+    expect(supabaseChain.eq).toHaveBeenCalledWith('id', VALID_ID)
+  })
+})

--- a/app/api/admin/weight-room/monthly-focus/[id]/route.ts
+++ b/app/api/admin/weight-room/monthly-focus/[id]/route.ts
@@ -1,0 +1,79 @@
+/**
+ * Admin-only item endpoint for Weight Room monthly-focus deletion (#255).
+ * Sibling of the collection POST — same admin gate, same service-role
+ * client. Removes a queued/active focus from the roadmap.
+ *
+ * Only the `weight_room_monthly_focus` row is deleted; the `kind: 'focus'`
+ * goal anchor and any logged sets are intentionally left in place so the
+ * exercise's history survives removing it from the rotation. (Pruning the
+ * orphaned anchor is a possible follow-up.)
+ */
+
+import { NextResponse, type NextRequest } from 'next/server'
+
+import { requireAdmin } from '@/lib/auth/require-admin'
+import { createAdminSupabaseClient } from '@/lib/supabase/admin'
+import { withTelemetry } from '@/lib/telemetry/with-telemetry'
+
+interface Context {
+  params: Promise<{ id: string }>
+}
+
+/**
+ * Loose UUID guard — keeps the 400 (malformed id, a client bug) vs 404
+ * (valid-but-missing id) distinction clean before hitting Postgres.
+ */
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+/**
+ * Delete one monthly focus by `id`.
+ *
+ * Status codes:
+ * - 200 — deleted (response body echoes the removed row)
+ * - 400 — `id` is not a valid UUID
+ * - 401 — not signed in
+ * - 403 — not on the allowlist
+ * - 404 — no focus exists for `id`
+ * - 500 — unexpected Supabase error
+ *
+ * @param _request Unused — DELETE has no body. Required by the Next.js
+ *   handler signature.
+ * @param ctx Next.js route context; `ctx.params.id` is the focus row's
+ *   UUID primary key parsed from the URL segment.
+ * @throws when Supabase env vars are missing (misconfigured deploy).
+ *   Domain failures are returned as JSON responses, not thrown.
+ */
+async function handleDELETE(_request: NextRequest, ctx: Context): Promise<NextResponse> {
+  const auth = await requireAdmin()
+  if (!auth.ok) return auth.response
+
+  const { id } = await ctx.params
+  if (!UUID_REGEX.test(id)) {
+    return NextResponse.json({ error: 'id must be a UUID.' }, { status: 400 })
+  }
+
+  const supabase = createAdminSupabaseClient()
+  const { data, error } = await supabase
+    .from('weight_room_monthly_focus')
+    .delete()
+    .eq('id', id)
+    .select()
+    .maybeSingle()
+
+  if (error) {
+    return NextResponse.json(
+      { error: `Failed to delete monthly focus: ${error.message}` },
+      { status: 500 },
+    )
+  }
+  if (!data) {
+    return NextResponse.json({ error: `No monthly focus for id '${id}'.` }, { status: 404 })
+  }
+  return NextResponse.json(data, { status: 200 })
+}
+
+/** `handleDELETE` wrapped with one-event-per-request telemetry (#220). */
+export const DELETE = withTelemetry(
+  'DELETE /api/admin/weight-room/monthly-focus/[id]',
+  handleDELETE,
+)

--- a/app/api/admin/weight-room/monthly-focus/route.test.ts
+++ b/app/api/admin/weight-room/monthly-focus/route.test.ts
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextResponse } from 'next/server'
+
+import { POST } from './route'
+
+/**
+ * Tests for `POST /api/admin/weight-room/monthly-focus` (#255). Auth gate
+ * + Supabase service-role client are mocked. The route does two writes —
+ * a `kind: 'focus'` goal-anchor upsert (awaited directly) and a focus-row
+ * insert (`.insert().select().single()`) — so the mock resolves those two
+ * call shapes independently.
+ */
+
+const requireAdminMock = vi.fn()
+vi.mock('@/lib/auth/require-admin', () => ({
+  requireAdmin: () => requireAdminMock(),
+}))
+
+const upsertResultMock = vi.fn()
+const singleMock = vi.fn()
+const supabaseChain = {
+  from: vi.fn(() => supabaseChain),
+  upsert: vi.fn(() => upsertResultMock()),
+  insert: vi.fn(() => supabaseChain),
+  select: vi.fn(() => supabaseChain),
+  single: vi.fn(() => singleMock()),
+}
+vi.mock('@/lib/supabase/admin', () => ({
+  createAdminSupabaseClient: () => supabaseChain,
+}))
+
+const validFocus = {
+  exercise: 'shrugs',
+  daily_target: 100,
+  color: '#C9A268',
+  start_date: '2026-07-01',
+  end_date: '2026-07-31',
+}
+
+beforeEach(() => {
+  requireAdminMock.mockReset()
+  upsertResultMock.mockReset()
+  singleMock.mockReset()
+  supabaseChain.from.mockClear()
+  supabaseChain.upsert.mockClear()
+  supabaseChain.insert.mockClear()
+  supabaseChain.select.mockClear()
+  supabaseChain.single.mockClear()
+  supabaseChain.from.mockReturnValue(supabaseChain)
+  supabaseChain.upsert.mockImplementation(() => upsertResultMock())
+  supabaseChain.insert.mockReturnValue(supabaseChain)
+  supabaseChain.select.mockReturnValue(supabaseChain)
+  supabaseChain.single.mockImplementation(() => singleMock())
+  // Happy-path defaults; individual tests override.
+  upsertResultMock.mockResolvedValue({ error: null })
+  singleMock.mockResolvedValue({ data: { id: 'f1', ...validFocus, target_kind: 'reps' }, error: null })
+})
+
+function makeRequest(body: unknown): Request {
+  return new Request('http://localhost/api/admin/weight-room/monthly-focus', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: typeof body === 'string' ? body : JSON.stringify(body),
+  })
+}
+
+describe('POST /api/admin/weight-room/monthly-focus', () => {
+  it('returns 401 when not signed in', async () => {
+    requireAdminMock.mockResolvedValueOnce({
+      ok: false,
+      response: NextResponse.json({ error: 'Sign in required.' }, { status: 401 }),
+    })
+    const res = await POST(makeRequest(validFocus) as never)
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 400 when color is not a hex string', async () => {
+    requireAdminMock.mockResolvedValue({ ok: true, email: 'a@b.com' })
+    const res = await POST(makeRequest({ ...validFocus, color: 'tan' }) as never)
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 when end_date precedes start_date', async () => {
+    requireAdminMock.mockResolvedValue({ ok: true, email: 'a@b.com' })
+    const res = await POST(
+      makeRequest({ ...validFocus, start_date: '2026-07-31', end_date: '2026-07-01' }) as never,
+    )
+    expect(res.status).toBe(400)
+  })
+
+  it('rejects unknown extra fields via Zod .strict()', async () => {
+    requireAdminMock.mockResolvedValue({ ok: true, email: 'a@b.com' })
+    const res = await POST(makeRequest({ ...validFocus, sneaky: 1 }) as never)
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 500 when the goal-anchor upsert fails', async () => {
+    requireAdminMock.mockResolvedValue({ ok: true, email: 'a@b.com' })
+    upsertResultMock.mockResolvedValueOnce({ error: { code: 'XX001', message: 'boom' } })
+    const res = await POST(makeRequest(validFocus) as never)
+    expect(res.status).toBe(500)
+    const body = await res.json()
+    expect(body.error).toMatch(/anchor focus goal/i)
+  })
+
+  it('returns 500 when the focus insert fails', async () => {
+    requireAdminMock.mockResolvedValue({ ok: true, email: 'a@b.com' })
+    singleMock.mockResolvedValueOnce({ data: null, error: { code: 'XX001', message: 'nope' } })
+    const res = await POST(makeRequest(validFocus) as never)
+    expect(res.status).toBe(500)
+  })
+
+  it('anchors a kind=focus goal without clobbering existing goals, then inserts the focus', async () => {
+    requireAdminMock.mockResolvedValue({ ok: true, email: 'a@b.com' })
+    const res = await POST(makeRequest(validFocus) as never)
+    expect(res.status).toBe(201)
+
+    // Anchor upsert: kind 'focus', ignoreDuplicates so an existing
+    // permanent goal isn't flipped.
+    expect(supabaseChain.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({ exercise: 'shrugs', kind: 'focus', daily_target: 100 }),
+      { onConflict: 'exercise', ignoreDuplicates: true },
+    )
+    // Focus insert defaults target_kind to 'reps'.
+    expect(supabaseChain.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        exercise: 'shrugs',
+        target_kind: 'reps',
+        start_date: '2026-07-01',
+        end_date: '2026-07-31',
+      }),
+    )
+  })
+
+  it('lowercases the exercise name on write', async () => {
+    requireAdminMock.mockResolvedValue({ ok: true, email: 'a@b.com' })
+    await POST(makeRequest({ ...validFocus, exercise: 'Shrugs' }) as never)
+    expect(supabaseChain.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({ exercise: 'shrugs' }),
+      expect.anything(),
+    )
+  })
+})

--- a/app/api/admin/weight-room/monthly-focus/route.ts
+++ b/app/api/admin/weight-room/monthly-focus/route.ts
@@ -1,0 +1,117 @@
+/**
+ * Admin-only collection endpoint for Weight Room monthly focuses (#255).
+ *
+ * Lets the admin queue a "grease the groove" exercise of the month
+ * without a seed migration — the Up Next roadmap reads straight from
+ * `weight_room_monthly_focus`. RLS on that table permits SELECT only, so
+ * writes funnel through this gate via the service-role client.
+ *
+ * Each create does two writes: it first ensures a `kind: 'focus'` goal
+ * anchor exists for the exercise (so set logging satisfies the
+ * `weight_room_sets.exercise` FK and the rings/rollup reuse existing
+ * machinery), then inserts the focus row. The anchor upsert uses
+ * `ignoreDuplicates` so it never clobbers an exercise that already has a
+ * goal (e.g. a permanent pushups goal stays permanent).
+ *
+ * Pair with `[id]/route.ts` for DELETE.
+ */
+
+import { NextResponse, type NextRequest } from 'next/server'
+import { ZodError } from 'zod'
+
+import { requireAdmin } from '@/lib/auth/require-admin'
+import { WeightRoomMonthlyFocusCreateSchema } from '@/lib/schemas/weight-room'
+import { createAdminSupabaseClient } from '@/lib/supabase/admin'
+import { withTelemetry } from '@/lib/telemetry/with-telemetry'
+
+/**
+ * Create a monthly focus. Body must conform to
+ * {@link WeightRoomMonthlyFocusCreateSchema} — `exercise` (lowercased),
+ * `daily_target`, `color`, `start_date`, `end_date` required;
+ * `target_kind` defaults to `'reps'`.
+ *
+ * Status codes:
+ * - 201 — created (response echoes the focus row)
+ * - 400 — payload failed Zod validation or wasn't valid JSON
+ * - 401 — not signed in
+ * - 403 — signed in but email not on the allowlist
+ * - 500 — unexpected Supabase error (anchor upsert or focus insert)
+ *
+ * @param request Incoming JSON request whose body matches
+ *   {@link WeightRoomMonthlyFocusCreateSchema}.
+ * @throws when Supabase env vars are missing (misconfigured deploy).
+ *   Domain failures are returned as JSON responses, not thrown.
+ */
+async function handlePOST(request: NextRequest): Promise<NextResponse> {
+  const auth = await requireAdmin()
+  if (!auth.ok) return auth.response
+
+  let payload: unknown
+  try {
+    payload = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Body must be valid JSON.' }, { status: 400 })
+  }
+
+  let focus
+  try {
+    focus = WeightRoomMonthlyFocusCreateSchema.parse(payload)
+  } catch (err) {
+    if (err instanceof ZodError) {
+      return NextResponse.json(
+        { error: 'Validation failed.', issues: err.flatten() },
+        { status: 400 },
+      )
+    }
+    throw err
+  }
+
+  const supabase = createAdminSupabaseClient()
+
+  // 1. Ensure the goal anchor exists. ignoreDuplicates leaves an existing
+  //    goal untouched so we never flip a permanent exercise to 'focus'.
+  const now = new Date().toISOString()
+  const { error: anchorError } = await supabase.from('weight_room_goals').upsert(
+    {
+      exercise: focus.exercise,
+      daily_target: focus.daily_target,
+      color: focus.color,
+      kind: 'focus',
+      updated_at: now,
+    },
+    { onConflict: 'exercise', ignoreDuplicates: true },
+  )
+  if (anchorError) {
+    return NextResponse.json(
+      { error: `Failed to anchor focus goal: ${anchorError.message}` },
+      { status: 500 },
+    )
+  }
+
+  // 2. Insert the focus row.
+  const { data, error } = await supabase
+    .from('weight_room_monthly_focus')
+    .insert({
+      exercise: focus.exercise,
+      daily_target: focus.daily_target,
+      target_kind: focus.target_kind,
+      color: focus.color,
+      start_date: focus.start_date,
+      end_date: focus.end_date,
+      updated_at: now,
+    })
+    .select()
+    .single()
+
+  if (error) {
+    return NextResponse.json(
+      { error: `Failed to create monthly focus: ${error.message}` },
+      { status: 500 },
+    )
+  }
+
+  return NextResponse.json(data, { status: 201 })
+}
+
+/** `handlePOST` wrapped with one-event-per-request telemetry (#220). */
+export const POST = withTelemetry('POST /api/admin/weight-room/monthly-focus', handlePOST)

--- a/components/training-facility/weight-room/LogDataIsland.tsx
+++ b/components/training-facility/weight-room/LogDataIsland.tsx
@@ -112,7 +112,12 @@ export function LogDataIsland(): JSX.Element {
   // mount-fetch failure that settled the state to null). Either way,
   // surface the form so the admin can add their first set; the rings
   // render in their empty state.
-  const surfaceData: WeightRoomData = data ?? { goals: [], sets: [], imported_at: '' }
+  const surfaceData: WeightRoomData = data ?? {
+    goals: [],
+    sets: [],
+    imported_at: '',
+    monthly_focus: [],
+  }
   const todayKey = toLocalDateKey(new Date())
   // Display-only backfill flag. After a midnight rollover `selectedDay`
   // (set at mount) lags `todayKey` — that's intentional: the view stays

--- a/components/training-facility/weight-room/LogDataIsland.tsx
+++ b/components/training-facility/weight-room/LogDataIsland.tsx
@@ -3,6 +3,12 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type JSX } from 'react'
 
 import { getWeightRoomData } from '@/lib/data/weight-room'
+import {
+  activeFocusForDay,
+  computeFocusAdherence,
+  computeFocusLoadStats,
+  upcomingFocuses,
+} from '@/lib/training-facility/monthly-focus'
 import { computeStrengthStreaks } from '@/lib/training-facility/strength-streaks'
 import {
   filterSetsForDay,
@@ -11,13 +17,15 @@ import {
   toLocalDateKey,
   totalsByExercise,
 } from '@/lib/training-facility/strength-today'
-import type { StrengthSet, WeightRoomData } from '@/types/weight-room'
+import type { MonthlyFocus, StrengthSet, WeightRoomData } from '@/types/weight-room'
 
 import { ActivityRings, type RingProgress } from './ActivityRings'
 import { LogDayPicker } from './LogDayPicker'
+import { MonthlyFocusCard } from './MonthlyFocusCard'
 import { QuickLog } from './QuickLog'
 import { SetList } from './SetList'
 import { StreakBadge } from './StreakBadge'
+import { UpcomingFocusStrip } from './UpcomingFocusStrip'
 
 /**
  * Admin Log View data island (#197). Owns the strength dataset that
@@ -127,14 +135,33 @@ export function LogDataIsland(): JSX.Element {
   const isBackfilling = selectedDay !== todayKey
   const setsForDay = filterSetsForDay(surfaceData.sets, selectedDay)
   const totals = totalsByExercise(setsForDay)
-  const rings: RingProgress[] = surfaceData.goals.map((goal) => ({
+
+  // The focus active on the *viewed* day (#255). A `kind: 'focus'` goal
+  // only earns a ring / streak / quick-log button while its window
+  // covers the day, so a finished or future focus doesn't leave a stale
+  // empty ring. Permanent goals always show.
+  const activeFocus = activeFocusForDay(surfaceData.monthly_focus, selectedDay)
+  const visibleGoals = surfaceData.goals.filter(
+    (goal) => goal.kind !== 'focus' || goal.exercise === activeFocus?.exercise,
+  )
+  const upcoming = upcomingFocuses(surfaceData.monthly_focus, todayKey)
+
+  const rings: RingProgress[] = visibleGoals.map((goal) => ({
     goal,
     totalReps: totals.get(goal.exercise) ?? 0,
   }))
-  const streaks = computeStrengthStreaks(surfaceData.sets, surfaceData.goals)
+  const streaks = computeStrengthStreaks(surfaceData.sets, visibleGoals)
+  // SetList color/label lookup spans *all* goals (incl. inactive focuses)
+  // so a backfilled out-of-window set still resolves its exercise.
   const goalsByExercise = Object.fromEntries(
     surfaceData.goals.map((g) => [g.exercise, g]),
   )
+
+  // Focus card inputs: today's progress in the focus's own unit (reps or
+  // distinct sets), plus windowed adherence and load stats.
+  const focusCard = activeFocus
+    ? buildFocusCardProps(activeFocus, setsForDay, surfaceData.sets)
+    : null
 
   return (
     <div className="flex flex-col gap-8">
@@ -146,11 +173,13 @@ export function LogDataIsland(): JSX.Element {
         onSelectDay={setSelectedDay}
       />
 
+      <UpcomingFocusStrip focuses={upcoming} />
+
       <div className="grid gap-8 lg:grid-cols-[auto_1fr] lg:items-start">
-        <div className="flex flex-col items-center gap-4">
+        <div className="flex w-full max-w-[264px] flex-col items-center gap-4">
           <ActivityRings rings={rings} size={264} className="w-full max-w-[264px]" />
-          <div className="grid w-full max-w-[264px] gap-2">
-            {surfaceData.goals.map((goal) => (
+          <div className="grid w-full gap-2">
+            {visibleGoals.map((goal) => (
               <StreakBadge
                 key={goal.exercise}
                 exercise={goal.exercise}
@@ -159,12 +188,20 @@ export function LogDataIsland(): JSX.Element {
               />
             ))}
           </div>
+          {focusCard ? (
+            <MonthlyFocusCard
+              focus={focusCard.focus}
+              todayProgress={focusCard.todayProgress}
+              adherence={focusCard.adherence}
+              loadStats={focusCard.loadStats}
+            />
+          ) : null}
         </div>
 
         <div className="flex flex-col gap-6">
-          {surfaceData.goals.length > 0 ? (
+          {visibleGoals.length > 0 ? (
             <QuickLog
-              goals={surfaceData.goals}
+              goals={visibleGoals}
               lastReps={lastReps}
               onLog={({ exercise, reps }) => {
                 // Recompute "today" at tap time rather than reusing the
@@ -288,6 +325,39 @@ function computeLastRepsByExercise(
     out[s.exercise] = s.reps
   }
   return out
+}
+
+/**
+ * Assemble {@link MonthlyFocusCard} inputs for the active focus: today's
+ * progress in the focus's own unit (total reps, or distinct-set count
+ * for a `sets` target), plus windowed adherence and load stats computed
+ * over the full set history.
+ *
+ * @param focus The focus active on the viewed day.
+ * @param setsForDay Sets already filtered to the viewed day.
+ * @param allSets The full set log, for window-spanning adherence + load.
+ */
+function buildFocusCardProps(
+  focus: MonthlyFocus,
+  setsForDay: readonly StrengthSet[],
+  allSets: readonly StrengthSet[],
+): {
+  focus: MonthlyFocus
+  todayProgress: number
+  adherence: ReturnType<typeof computeFocusAdherence>
+  loadStats: ReturnType<typeof computeFocusLoadStats>
+} {
+  const focusSetsToday = setsForDay.filter((s) => s.exercise === focus.exercise)
+  const todayProgress =
+    focus.target_kind === 'sets'
+      ? focusSetsToday.length
+      : focusSetsToday.reduce((n, s) => n + s.reps, 0)
+  return {
+    focus,
+    todayProgress,
+    adherence: computeFocusAdherence(focus, allSets),
+    loadStats: computeFocusLoadStats(focus, allSets),
+  }
 }
 
 function LoadErrorBanner({ message }: { message: string }): JSX.Element {

--- a/components/training-facility/weight-room/MonthlyFocusCard.test.tsx
+++ b/components/training-facility/weight-room/MonthlyFocusCard.test.tsx
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+import type { FocusAdherence, FocusLoadStats } from '@/lib/training-facility/monthly-focus'
+import type { MonthlyFocus } from '@/types/weight-room'
+
+import { MonthlyFocusCard } from './MonthlyFocusCard'
+
+const FOCUS: MonthlyFocus = {
+  id: 'f1',
+  exercise: 'shrugs',
+  daily_target: 100,
+  target_kind: 'reps',
+  color: '#C9A268',
+  start_date: '2026-07-01',
+  end_date: '2026-07-31',
+}
+
+const ADHERENCE: FocusAdherence = {
+  daysInWindow: 31,
+  daysElapsed: 5,
+  daysHit: 4,
+  currentStreak: 1,
+  percent: 0.8,
+}
+
+const WEIGHTED_LOAD: FocusLoadStats = {
+  topSetLbs: 120,
+  avgLoadLbs: 105,
+  tonnageLbs: 5800,
+  weightedSets: 6,
+}
+
+const BODYWEIGHT_LOAD: FocusLoadStats = {
+  topSetLbs: null,
+  avgLoadLbs: null,
+  tonnageLbs: 0,
+  weightedSets: 0,
+}
+
+describe('MonthlyFocusCard', () => {
+  it('shows the focus label, exercise, and today progress against the target', () => {
+    render(
+      <MonthlyFocusCard
+        focus={FOCUS}
+        todayProgress={60}
+        adherence={ADHERENCE}
+        loadStats={WEIGHTED_LOAD}
+      />,
+    )
+    expect(screen.getByText('Focus of the Month')).toBeInTheDocument()
+    expect(screen.getByText('shrugs')).toBeInTheDocument()
+    expect(screen.getByText('60')).toBeInTheDocument()
+    expect(screen.getByText(/\/ 100 reps today/)).toBeInTheDocument()
+  })
+
+  it('renders windowed adherence (day, days-hit, streak)', () => {
+    render(
+      <MonthlyFocusCard
+        focus={FOCUS}
+        todayProgress={60}
+        adherence={ADHERENCE}
+        loadStats={BODYWEIGHT_LOAD}
+      />,
+    )
+    expect(screen.getByText('5/31')).toBeInTheDocument()
+    expect(screen.getByText('4')).toBeInTheDocument()
+    expect(screen.getByText('1d')).toBeInTheDocument()
+  })
+
+  it('shows load stats only when the focus has weighted sets', () => {
+    const { rerender } = render(
+      <MonthlyFocusCard
+        focus={FOCUS}
+        todayProgress={100}
+        adherence={ADHERENCE}
+        loadStats={WEIGHTED_LOAD}
+      />,
+    )
+    expect(screen.getByText('Top set')).toBeInTheDocument()
+    expect(screen.getByText('120 lb')).toBeInTheDocument()
+    expect(screen.getByText('5,800 lb')).toBeInTheDocument()
+
+    rerender(
+      <MonthlyFocusCard
+        focus={FOCUS}
+        todayProgress={100}
+        adherence={ADHERENCE}
+        loadStats={BODYWEIGHT_LOAD}
+      />,
+    )
+    expect(screen.queryByText('Top set')).not.toBeInTheDocument()
+  })
+
+  it('marks the daily target as met when today progress reaches it', () => {
+    render(
+      <MonthlyFocusCard
+        focus={FOCUS}
+        todayProgress={100}
+        adherence={ADHERENCE}
+        loadStats={BODYWEIGHT_LOAD}
+      />,
+    )
+    expect(screen.getByTitle('Daily target met')).toBeInTheDocument()
+  })
+
+  it('labels the unit as "sets" for a sets-based target', () => {
+    render(
+      <MonthlyFocusCard
+        focus={{ ...FOCUS, target_kind: 'sets', daily_target: 5 }}
+        todayProgress={3}
+        adherence={ADHERENCE}
+        loadStats={BODYWEIGHT_LOAD}
+      />,
+    )
+    expect(screen.getByText(/\/ 5 sets today/)).toBeInTheDocument()
+  })
+})

--- a/components/training-facility/weight-room/MonthlyFocusCard.tsx
+++ b/components/training-facility/weight-room/MonthlyFocusCard.tsx
@@ -1,0 +1,110 @@
+import type { JSX } from 'react'
+
+import type { FocusAdherence, FocusLoadStats } from '@/lib/training-facility/monthly-focus'
+import type { MonthlyFocus } from '@/types/weight-room'
+
+/** Props for {@link MonthlyFocusCard}. */
+export interface MonthlyFocusCardProps {
+  /** The active focus to display (caller resolves it via `activeFocusForDay`). */
+  focus: MonthlyFocus
+  /**
+   * The focus exercise's total for the viewed day — reps when
+   * `focus.target_kind === 'reps'`, distinct sets when `'sets'`. Drives
+   * the "today" progress readout against {@link MonthlyFocus.daily_target}.
+   */
+  todayProgress: number
+  /** Windowed adherence from `computeFocusAdherence`. */
+  adherence: FocusAdherence
+  /** Load summary from `computeFocusLoadStats`; metrics are null when bodyweight. */
+  loadStats: FocusLoadStats
+}
+
+/** Round to one decimal and strip a trailing `.0` so 95.0 reads "95". */
+function trim1(n: number): string {
+  return n.toFixed(1).replace(/\.0$/, '')
+}
+
+/**
+ * "Focus of the Month" card for the Weight Room Log View (#255). Surfaces
+ * the active "grease the groove" campaign: today's progress toward the
+ * daily target, windowed adherence (day N of the month, days hit, current
+ * streak), and — for weighted focuses like shrugs — load stats (top set,
+ * average load, tonnage).
+ *
+ * Renders nothing about load when the focus is bodyweight
+ * (`loadStats.weightedSets === 0`), so a calisthenics focus doesn't show
+ * an empty "0 lbs" strip. The focus color tints the accent chrome so the
+ * card reads as its own lane alongside the permanent rings.
+ */
+export function MonthlyFocusCard({
+  focus,
+  todayProgress,
+  adherence,
+  loadStats,
+}: MonthlyFocusCardProps): JSX.Element {
+  const unit = focus.target_kind === 'sets' ? 'sets' : 'reps'
+  const metGoal = todayProgress >= focus.daily_target
+  const dayOfWindow = Math.min(adherence.daysElapsed, adherence.daysInWindow)
+  const hasLoad = loadStats.weightedSets > 0
+
+  return (
+    <div
+      data-testid={`monthly-focus-${focus.exercise}`}
+      className="flex flex-col gap-4 rounded-[1.4rem] border border-white/10 bg-white/5 p-5"
+      style={{ boxShadow: `inset 3px 0 0 0 ${focus.color}` }}
+    >
+      <div className="flex items-center justify-between gap-3">
+        <span className="font-mono text-[10px] uppercase tracking-[0.28em] text-white/55">
+          Focus of the Month
+        </span>
+        <span
+          className="font-mono text-[10px] font-semibold uppercase tracking-[0.2em]"
+          style={{ color: focus.color }}
+        >
+          {focus.exercise}
+        </span>
+      </div>
+
+      {/* Today's progress toward the daily target. */}
+      <div className="flex items-baseline gap-2">
+        <span className="font-mono text-3xl font-semibold tabular-nums text-white">
+          {todayProgress}
+        </span>
+        <span className="font-mono text-sm text-white/55">
+          / {focus.daily_target} {unit} today
+        </span>
+        {metGoal ? (
+          <span aria-hidden="true" className="ml-auto text-lg" title="Daily target met">
+            {'✅'}
+          </span>
+        ) : null}
+      </div>
+
+      {/* Windowed adherence. */}
+      <dl className="grid grid-cols-3 gap-3 text-center">
+        <FocusStat label="Day" value={`${dayOfWindow}/${adherence.daysInWindow}`} />
+        <FocusStat label="Days hit" value={`${adherence.daysHit}`} />
+        <FocusStat label="Streak" value={`${adherence.currentStreak}d`} />
+      </dl>
+
+      {/* Load stats — only for weighted focuses. */}
+      {hasLoad ? (
+        <dl className="grid grid-cols-3 gap-3 border-t border-white/10 pt-4 text-center">
+          <FocusStat label="Top set" value={`${trim1(loadStats.topSetLbs ?? 0)} lb`} />
+          <FocusStat label="Avg load" value={`${trim1(loadStats.avgLoadLbs ?? 0)} lb`} />
+          <FocusStat label="Tonnage" value={`${loadStats.tonnageLbs.toLocaleString()} lb`} />
+        </dl>
+      ) : null}
+    </div>
+  )
+}
+
+/** Single labelled stat cell inside the focus card's grids. */
+function FocusStat({ label, value }: { label: string; value: string }): JSX.Element {
+  return (
+    <div className="flex flex-col gap-1">
+      <dd className="font-mono text-base font-semibold tabular-nums text-white">{value}</dd>
+      <dt className="font-mono text-[9px] uppercase tracking-[0.18em] text-white/45">{label}</dt>
+    </div>
+  )
+}

--- a/components/training-facility/weight-room/UpcomingFocusStrip.test.tsx
+++ b/components/training-facility/weight-room/UpcomingFocusStrip.test.tsx
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+import type { MonthlyFocus } from '@/types/weight-room'
+
+import { UpcomingFocusStrip } from './UpcomingFocusStrip'
+
+const SHRUGS: MonthlyFocus = {
+  id: 'f1',
+  exercise: 'shrugs',
+  daily_target: 100,
+  target_kind: 'reps',
+  color: '#C9A268',
+  start_date: '2026-07-01',
+  end_date: '2026-07-31',
+}
+
+const CALVES: MonthlyFocus = {
+  id: 'f2',
+  exercise: 'calf-raises',
+  daily_target: 150,
+  target_kind: 'reps',
+  color: '#0EA5A1',
+  start_date: '2026-08-01',
+  end_date: '2026-08-31',
+}
+
+describe('UpcomingFocusStrip', () => {
+  it('renders nothing when there are no upcoming focuses', () => {
+    const { container } = render(<UpcomingFocusStrip focuses={[]} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('lists each upcoming focus with its exercise and month', () => {
+    render(<UpcomingFocusStrip focuses={[SHRUGS, CALVES]} />)
+    expect(screen.getByText('Up Next')).toBeInTheDocument()
+    expect(screen.getByTestId('upcoming-focus-shrugs')).toBeInTheDocument()
+    expect(screen.getByTestId('upcoming-focus-calf-raises')).toBeInTheDocument()
+    // Month label derived from start_date (locale-formatted; assert the year is present).
+    expect(screen.getByTestId('upcoming-focus-shrugs').textContent).toMatch(/2026/)
+  })
+})

--- a/components/training-facility/weight-room/UpcomingFocusStrip.tsx
+++ b/components/training-facility/weight-room/UpcomingFocusStrip.tsx
@@ -1,0 +1,59 @@
+import type { JSX } from 'react'
+
+import type { MonthlyFocus } from '@/types/weight-room'
+
+/** Props for {@link UpcomingFocusStrip}. */
+export interface UpcomingFocusStripProps {
+  /**
+   * Upcoming focuses, soonest first — caller resolves via
+   * `upcomingFocuses`. The strip renders nothing when this is empty.
+   */
+  focuses: readonly MonthlyFocus[]
+}
+
+/**
+ * Format a focus's start date as a short month label (e.g. `Jul 2026`)
+ * for the "Up Next" chips. Parses at local noon so the bare
+ * `YYYY-MM-DD` doesn't shift a month boundary in negative-offset zones.
+ */
+function focusMonthLabel(focus: MonthlyFocus): string {
+  const d = new Date(focus.start_date + 'T12:00:00')
+  if (!Number.isFinite(d.getTime())) return focus.start_date
+  return d.toLocaleDateString(undefined, { month: 'short', year: 'numeric' })
+}
+
+/**
+ * "Up Next" roadmap strip for the Weight Room Log View (#255). Lists the
+ * queued "grease the groove" focuses so the rotation is visible before it
+ * starts — answering "what's coming after this month?". Renders `null`
+ * when nothing is queued, so the caller can drop it in unconditionally.
+ */
+export function UpcomingFocusStrip({ focuses }: UpcomingFocusStripProps): JSX.Element | null {
+  if (focuses.length === 0) return null
+
+  return (
+    <div
+      data-testid="upcoming-focus-strip"
+      className="flex flex-wrap items-center gap-2 rounded-2xl border border-white/10 bg-black/20 px-4 py-3"
+    >
+      <span className="font-mono text-[10px] uppercase tracking-[0.24em] text-white/45">
+        Up Next
+      </span>
+      {focuses.map((focus) => (
+        <span
+          key={focus.id}
+          data-testid={`upcoming-focus-${focus.exercise}`}
+          className="flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1"
+        >
+          <span aria-hidden="true" className="h-2 w-2 rounded-full" style={{ background: focus.color }} />
+          <span className="font-mono text-[11px] font-semibold uppercase tracking-[0.14em] text-white/80">
+            {focus.exercise}
+          </span>
+          <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-white/45">
+            {focusMonthLabel(focus)}
+          </span>
+        </span>
+      ))}
+    </div>
+  )
+}

--- a/constants/weight-room-demo-fixture.ts
+++ b/constants/weight-room-demo-fixture.ts
@@ -142,5 +142,10 @@ export function buildWeightRoomDemoData(now: Date = new Date()): WeightRoomData 
     imported_at: now.toISOString(),
     sets,
     goals: DEMO_GOALS,
+    // The empty-state preview demonstrates the permanent rings; a
+    // monthly focus (#255) is date-windowed and would only render in
+    // its month, so the demo leaves it empty rather than faking an
+    // always-active campaign.
+    monthly_focus: [],
   }
 }

--- a/lib/data/weight-room-shared.ts
+++ b/lib/data/weight-room-shared.ts
@@ -3,7 +3,9 @@ import { z } from 'zod'
 
 import {
   WeightRoomGoalRowSchema,
+  WeightRoomMonthlyFocusRowSchema,
   WeightRoomSetRowSchema,
+  focusRowToMonthlyFocus,
   goalRowToExerciseGoal,
   setRowToStrengthSet,
 } from '@/lib/schemas/weight-room'
@@ -22,13 +24,17 @@ import type { WeightRoomData } from '@/types/weight-room'
 
 const SETS_TABLE = 'weight_room_sets'
 const GOALS_TABLE = 'weight_room_goals'
+const FOCUS_TABLE = 'weight_room_monthly_focus'
 
 /** Whitelisted column lists for each table; `updated_at` rides along for `imported_at` computation. */
-const SETS_COLUMNS = 'id, logged_at, exercise, reps, updated_at'
-const GOALS_COLUMNS = 'exercise, daily_target, color, updated_at'
+const SETS_COLUMNS = 'id, logged_at, exercise, reps, weight_lbs, updated_at'
+const GOALS_COLUMNS = 'exercise, daily_target, color, kind, updated_at'
+const FOCUS_COLUMNS =
+  'id, exercise, daily_target, target_kind, color, start_date, end_date, updated_at'
 
 const WeightRoomSetRowsSchema = z.array(WeightRoomSetRowSchema)
 const WeightRoomGoalRowsSchema = z.array(WeightRoomGoalRowSchema)
+const WeightRoomMonthlyFocusRowsSchema = z.array(WeightRoomMonthlyFocusRowSchema)
 
 /**
  * Fetch the full Weight Room dataset from Supabase using the supplied
@@ -65,7 +71,7 @@ export async function assembleWeightRoomData(
   // relative order unstable between fetches. `updated_at` resolves ties
   // by insertion order (sets have no update path), and `id` backstops
   // same-transaction inserts whose `updated_at` also collides.
-  const [setsRes, goalsRes] = await Promise.all([
+  const [setsRes, goalsRes, focusRes] = await Promise.all([
     supabase
       .from(SETS_TABLE)
       .select(SETS_COLUMNS)
@@ -73,6 +79,9 @@ export async function assembleWeightRoomData(
       .order('updated_at', { ascending: true })
       .order('id', { ascending: true }),
     supabase.from(GOALS_TABLE).select(GOALS_COLUMNS).order('exercise', { ascending: true }),
+    // Newest window first so the "Upcoming"/roadmap UI can slice from
+    // the head without re-sorting.
+    supabase.from(FOCUS_TABLE).select(FOCUS_COLUMNS).order('start_date', { ascending: false }),
   ])
 
   if (setsRes.error) {
@@ -81,15 +90,23 @@ export async function assembleWeightRoomData(
   if (goalsRes.error) {
     throw new Error(`Failed to load weight room goals: ${goalsRes.error.message}`)
   }
+  if (focusRes.error) {
+    throw new Error(`Failed to load weight room monthly focus: ${focusRes.error.message}`)
+  }
 
   const setsRaw = (setsRes.data ?? []) as unknown as Array<Record<string, unknown>>
   const goalsRaw = (goalsRes.data ?? []) as unknown as Array<Record<string, unknown>>
+  const focusRaw = (focusRes.data ?? []) as unknown as Array<Record<string, unknown>>
 
   // Compute imported_at before stripping `updated_at` — that column lives
   // on every row but isn't part of the row-shape schema (`.strict()`
   // would reject it).
-  const importedAt = computeImportedAt([setsRaw, goalsRaw])
+  const importedAt = computeImportedAt([setsRaw, goalsRaw, focusRaw])
 
+  // A monthly focus can't exist without its `kind: 'focus'` goal anchor
+  // (FK), so sets+goals empty still means "no data" — focus is implied
+  // empty. Keeping the original two-table condition preserves the
+  // pre-baseline null contract.
   if (setsRaw.length === 0 && goalsRaw.length === 0) {
     return null
   }
@@ -102,11 +119,18 @@ export async function assembleWeightRoomData(
   if (!goalsParsed.success) {
     throw new Error(`weight_room_goals failed schema validation: ${goalsParsed.error.message}`)
   }
+  const focusParsed = WeightRoomMonthlyFocusRowsSchema.safeParse(focusRaw.map(stripUpdatedAt))
+  if (!focusParsed.success) {
+    throw new Error(
+      `weight_room_monthly_focus failed schema validation: ${focusParsed.error.message}`,
+    )
+  }
 
   return {
     imported_at: importedAt,
     sets: setsParsed.data.map(setRowToStrengthSet),
     goals: goalsParsed.data.map(goalRowToExerciseGoal),
+    monthly_focus: focusParsed.data.map(focusRowToMonthlyFocus),
   }
 }
 

--- a/lib/data/weight-room.test.ts
+++ b/lib/data/weight-room.test.ts
@@ -148,6 +148,76 @@ describe('getWeightRoomData', () => {
         { exercise: 'pushups', daily_target: 100, color: '#EA580C' },
         { exercise: 'pullups', daily_target: 30, color: '#0EA5A1' },
       ],
+      monthly_focus: [],
+    })
+  })
+
+  it('assembles weighted sets, focus goals, and the monthly-focus roadmap (#255)', async () => {
+    stubTable('weight_room_sets', [
+      {
+        id: '22222222-2222-4222-8222-222222222222',
+        logged_at: '2026-07-01T08:00:00Z',
+        exercise: 'shrugs',
+        reps: 20,
+        weight_lbs: 100,
+        updated_at: '2026-07-01T08:00:01Z',
+      },
+    ])
+    stubTable('weight_room_goals', [
+      {
+        exercise: 'shrugs',
+        daily_target: 100,
+        color: '#C9A268',
+        kind: 'focus',
+        updated_at: '2026-07-01T08:00:00Z',
+      },
+    ])
+    stubTable('weight_room_monthly_focus', [
+      {
+        id: '33333333-3333-4333-8333-333333333333',
+        exercise: 'shrugs',
+        daily_target: 100,
+        target_kind: 'reps',
+        color: '#C9A268',
+        start_date: '2026-07-01',
+        end_date: '2026-07-31',
+        updated_at: '2026-07-01T08:00:00Z',
+      },
+    ])
+
+    const data = await getWeightRoomData()
+    expect(data?.sets).toEqual([
+      {
+        id: '22222222-2222-4222-8222-222222222222',
+        logged_at: '2026-07-01T08:00:00Z',
+        exercise: 'shrugs',
+        reps: 20,
+        weight_lbs: 100,
+      },
+    ])
+    expect(data?.goals).toEqual([
+      { exercise: 'shrugs', daily_target: 100, color: '#C9A268', kind: 'focus' },
+    ])
+    expect(data?.monthly_focus).toEqual([
+      {
+        id: '33333333-3333-4333-8333-333333333333',
+        exercise: 'shrugs',
+        daily_target: 100,
+        target_kind: 'reps',
+        color: '#C9A268',
+        start_date: '2026-07-01',
+        end_date: '2026-07-31',
+      },
+    ])
+  })
+
+  it('orders the monthly-focus roadmap by start_date descending (newest window first)', async () => {
+    stubTable('weight_room_sets', [])
+    stubTable('weight_room_goals', [])
+    await getWeightRoomData()
+
+    expect(queriesByTable.weight_room_monthly_focus.order).toHaveBeenCalledWith('start_date', {
+      ascending: false,
     })
   })
 

--- a/lib/schemas/weight-room.ts
+++ b/lib/schemas/weight-room.ts
@@ -12,7 +12,7 @@
 
 import { z } from 'zod'
 
-import type { ExerciseGoal, StrengthSet } from '@/types/weight-room'
+import type { ExerciseGoal, MonthlyFocus, StrengthSet } from '@/types/weight-room'
 
 /**
  * Hex-color regex used for the per-exercise display token. Loose enough
@@ -21,6 +21,23 @@ import type { ExerciseGoal, StrengthSet } from '@/types/weight-room'
  * settings UI shouldn't require a schema bump.
  */
 const HEX_COLOR_REGEX = /^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/
+
+/**
+ * `YYYY-MM-DD` calendar-date regex for the monthly-focus window columns
+ * (#255). PostgREST renders a Postgres `date` as this bare string (no
+ * time, no zone), so the focus schema validates the shape rather than
+ * round-tripping through `Date` (which would reintroduce a UTC-midnight
+ * timezone hazard).
+ */
+const DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/
+
+/**
+ * Optional non-negative load in pounds for a set (#255). Accepts a
+ * number, `null` (PostgREST emits `null` for bodyweight sets where the
+ * column is unset), or absent — normalized to absent by the row
+ * converter so {@link StrengthSet.weight_lbs} stays `number | undefined`.
+ */
+const optionalWeightLbs = () => z.number().nonnegative().nullable().optional()
 
 /**
  * Positive-integer Zod check. Inlined as a `.refine` rather than
@@ -72,6 +89,7 @@ export const WeightRoomSetRowSchema = z
     logged_at: z.string().min(1, 'logged_at must be an ISO timestamp'),
     exercise: z.string().min(1),
     reps: positiveInt(),
+    weight_lbs: optionalWeightLbs(),
   })
   .strict()
 
@@ -88,6 +106,11 @@ export const WeightRoomGoalRowSchema = z
     exercise: z.string().min(1),
     daily_target: positiveInt(),
     color: z.string().regex(HEX_COLOR_REGEX, 'color must be a hex string like #EA580C'),
+    // Optional + nullable so pre-#255 rows (and fixtures) without the
+    // column still validate; the DB column is NOT NULL DEFAULT
+    // 'permanent', so live rows always carry it. Absent → treated as
+    // 'permanent' by the row converter.
+    kind: z.enum(['permanent', 'focus']).nullable().optional(),
   })
   .strict()
 
@@ -140,6 +163,9 @@ export function setRowToStrengthSet(row: WeightRoomSetRow): StrengthSet {
     logged_at: row.logged_at,
     exercise: row.exercise,
     reps: row.reps,
+    // Normalize null/absent to absent so StrengthSet.weight_lbs stays
+    // `number | undefined` (bodyweight sets omit the field entirely).
+    ...(row.weight_lbs != null ? { weight_lbs: row.weight_lbs } : {}),
   }
 }
 
@@ -153,5 +179,72 @@ export function goalRowToExerciseGoal(row: WeightRoomGoalRow): ExerciseGoal {
     exercise: row.exercise,
     daily_target: row.daily_target,
     color: row.color,
+    // Absent/null → omit so it defaults to 'permanent' at read sites
+    // (pre-#255 goals and fixtures never carry kind).
+    ...(row.kind != null ? { kind: row.kind } : {}),
+  }
+}
+
+/**
+ * Zod schema for one row of `public.weight_room_monthly_focus` (#255).
+ * Mirrors the table in
+ * `supabase/migrations/20260628120000_weight_room_monthly_focus.sql`.
+ *
+ * `start_date` / `end_date` are bare `YYYY-MM-DD` strings (PostgREST's
+ * rendering of a Postgres `date`), validated by shape rather than
+ * parsed to a `Date` to avoid a UTC-midnight timezone shift.
+ */
+export const WeightRoomMonthlyFocusRowSchema = z
+  .object({
+    id: z.string().uuid(),
+    exercise: z.string().min(1),
+    daily_target: positiveInt(),
+    target_kind: z.enum(['reps', 'sets']),
+    color: z.string().regex(HEX_COLOR_REGEX, 'color must be a hex string like #C9A268'),
+    start_date: z.string().regex(DATE_REGEX, 'start_date must be YYYY-MM-DD'),
+    end_date: z.string().regex(DATE_REGEX, 'end_date must be YYYY-MM-DD'),
+  })
+  .strict()
+
+/** Validated `weight_room_monthly_focus` row inferred from {@link WeightRoomMonthlyFocusRowSchema}. */
+export type WeightRoomMonthlyFocusRow = z.infer<typeof WeightRoomMonthlyFocusRowSchema>
+
+/**
+ * Request-body schema for the monthly-focus admin route (#255).
+ * Lowercases `exercise` (same anti-duplicate reasoning as
+ * {@link exerciseWriteField}) and defaults `target_kind` to `'reps'`.
+ */
+export const WeightRoomMonthlyFocusCreateSchema = z
+  .object({
+    exercise: exerciseWriteField(),
+    daily_target: positiveInt(),
+    target_kind: z.enum(['reps', 'sets']).default('reps'),
+    color: z.string().regex(HEX_COLOR_REGEX, 'color must be a hex string like #C9A268'),
+    start_date: z.string().regex(DATE_REGEX, 'start_date must be YYYY-MM-DD'),
+    end_date: z.string().regex(DATE_REGEX, 'end_date must be YYYY-MM-DD'),
+  })
+  .strict()
+  .refine((v) => v.end_date >= v.start_date, {
+    message: 'end_date must be on or after start_date',
+    path: ['end_date'],
+  })
+
+/** Validated body of the monthly-focus admin route. */
+export type WeightRoomMonthlyFocusCreate = z.infer<typeof WeightRoomMonthlyFocusCreateSchema>
+
+/**
+ * Translate a validated `weight_room_monthly_focus` row into the public
+ * {@link MonthlyFocus} shape. Pass-through; sibling-symmetric with
+ * {@link setRowToStrengthSet} / {@link goalRowToExerciseGoal}.
+ */
+export function focusRowToMonthlyFocus(row: WeightRoomMonthlyFocusRow): MonthlyFocus {
+  return {
+    id: row.id,
+    exercise: row.exercise,
+    daily_target: row.daily_target,
+    target_kind: row.target_kind,
+    color: row.color,
+    start_date: row.start_date,
+    end_date: row.end_date,
   }
 }

--- a/lib/training-facility/monthly-focus.test.ts
+++ b/lib/training-facility/monthly-focus.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, it } from 'vitest'
+
+import type { MonthlyFocus, StrengthSet } from '@/types/weight-room'
+
+import {
+  activeFocusForDay,
+  computeFocusAdherence,
+  computeFocusLoadStats,
+  isFocusActiveOnDay,
+  upcomingFocuses,
+} from './monthly-focus'
+
+/**
+ * Unit tests for the monthly-focus helpers (#255). All dates use local
+ * construction (`new Date(y, mIndex, d, …)`) so the local-timezone day
+ * bucketing in `toLocalDateKey` matches the `YYYY-MM-DD` window keys.
+ */
+
+const JULY_SHRUGS: MonthlyFocus = {
+  id: '33333333-3333-4333-8333-333333333333',
+  exercise: 'shrugs',
+  daily_target: 100,
+  target_kind: 'reps',
+  color: '#C9A268',
+  start_date: '2026-07-01',
+  end_date: '2026-07-31',
+}
+
+const AUGUST_CALVES: MonthlyFocus = {
+  id: '44444444-4444-4444-8444-444444444444',
+  exercise: 'calf-raises',
+  daily_target: 150,
+  target_kind: 'reps',
+  color: '#0EA5A1',
+  start_date: '2026-08-01',
+  end_date: '2026-08-31',
+}
+
+/** Build a set on a given local calendar day at noon (stable bucketing). */
+function setOn(
+  exercise: string,
+  year: number,
+  monthIndex: number,
+  day: number,
+  reps: number,
+  weight_lbs?: number,
+): StrengthSet {
+  return {
+    id: `${exercise}-${year}-${monthIndex}-${day}-${reps}-${weight_lbs ?? 'bw'}`,
+    logged_at: new Date(year, monthIndex, day, 12, 0, 0).toISOString(),
+    exercise,
+    reps,
+    ...(weight_lbs != null ? { weight_lbs } : {}),
+  }
+}
+
+describe('isFocusActiveOnDay', () => {
+  it('is inclusive on both window boundaries', () => {
+    expect(isFocusActiveOnDay(JULY_SHRUGS, '2026-07-01')).toBe(true)
+    expect(isFocusActiveOnDay(JULY_SHRUGS, '2026-07-31')).toBe(true)
+    expect(isFocusActiveOnDay(JULY_SHRUGS, '2026-07-15')).toBe(true)
+  })
+
+  it('is false outside the window and for an empty day key', () => {
+    expect(isFocusActiveOnDay(JULY_SHRUGS, '2026-06-30')).toBe(false)
+    expect(isFocusActiveOnDay(JULY_SHRUGS, '2026-08-01')).toBe(false)
+    expect(isFocusActiveOnDay(JULY_SHRUGS, '')).toBe(false)
+  })
+})
+
+describe('activeFocusForDay', () => {
+  it('returns the focus whose window covers the day', () => {
+    expect(activeFocusForDay([JULY_SHRUGS, AUGUST_CALVES], '2026-07-10')).toEqual(JULY_SHRUGS)
+    expect(activeFocusForDay([JULY_SHRUGS, AUGUST_CALVES], '2026-08-10')).toEqual(AUGUST_CALVES)
+  })
+
+  it('returns null when no window covers the day', () => {
+    expect(activeFocusForDay([JULY_SHRUGS, AUGUST_CALVES], '2026-09-01')).toBeNull()
+    expect(activeFocusForDay([], '2026-07-10')).toBeNull()
+  })
+
+  it('prefers the most recently started focus when windows overlap', () => {
+    const replacement: MonthlyFocus = {
+      ...JULY_SHRUGS,
+      id: 'replacement',
+      exercise: 'heavy-shrugs',
+      start_date: '2026-07-15',
+      end_date: '2026-07-31',
+    }
+    expect(activeFocusForDay([JULY_SHRUGS, replacement], '2026-07-20')).toEqual(replacement)
+  })
+})
+
+describe('upcomingFocuses', () => {
+  it('returns focuses starting after the day, soonest first', () => {
+    const result = upcomingFocuses([AUGUST_CALVES, JULY_SHRUGS], '2026-06-15')
+    expect(result.map((f) => f.exercise)).toEqual(['shrugs', 'calf-raises'])
+  })
+
+  it('excludes active and past focuses', () => {
+    // On a July day, July is active (not upcoming) and only August remains.
+    expect(upcomingFocuses([JULY_SHRUGS, AUGUST_CALVES], '2026-07-10').map((f) => f.exercise)).toEqual(
+      ['calf-raises'],
+    )
+  })
+
+  it('returns empty for an empty day key', () => {
+    expect(upcomingFocuses([JULY_SHRUGS], '')).toEqual([])
+  })
+})
+
+describe('computeFocusAdherence', () => {
+  it('reports nothing elapsed before the window opens', () => {
+    const a = computeFocusAdherence(JULY_SHRUGS, [], new Date(2026, 5, 20, 9, 0, 0))
+    expect(a).toEqual({
+      daysInWindow: 31,
+      daysElapsed: 0,
+      daysHit: 0,
+      currentStreak: 0,
+      percent: 0,
+    })
+  })
+
+  it('counts hit days and the current streak partway through the window (reps kind)', () => {
+    // Window opens 7/1. "Today" = 7/5 → 5 days elapsed. Hit goal (100
+    // reps) on 7/1, 7/2, 7/3, missed 7/4 (only 50), hit 7/5.
+    const sets: StrengthSet[] = [
+      setOn('shrugs', 2026, 6, 1, 100, 95),
+      setOn('shrugs', 2026, 6, 2, 60, 95),
+      setOn('shrugs', 2026, 6, 2, 40, 95),
+      setOn('shrugs', 2026, 6, 3, 100, 100),
+      setOn('shrugs', 2026, 6, 4, 50, 100),
+      setOn('shrugs', 2026, 6, 5, 100, 100),
+    ]
+    const a = computeFocusAdherence(JULY_SHRUGS, sets, new Date(2026, 6, 5, 18, 0, 0))
+    expect(a.daysInWindow).toBe(31)
+    expect(a.daysElapsed).toBe(5)
+    expect(a.daysHit).toBe(4) // 7/1, 7/2 (60+40), 7/3, 7/5
+    expect(a.currentStreak).toBe(1) // 7/5 hit, 7/4 missed breaks it
+    expect(a.percent).toBeCloseTo(4 / 5)
+  })
+
+  it('ignores sets for other exercises and outside the window', () => {
+    const sets: StrengthSet[] = [
+      setOn('shrugs', 2026, 6, 1, 100),
+      setOn('pushups', 2026, 6, 1, 100), // wrong exercise
+      setOn('shrugs', 2026, 5, 30, 100), // before window
+    ]
+    const a = computeFocusAdherence(JULY_SHRUGS, sets, new Date(2026, 6, 1, 18, 0, 0))
+    expect(a.daysElapsed).toBe(1)
+    expect(a.daysHit).toBe(1)
+  })
+
+  it('clamps elapsed to the window length once the month is over', () => {
+    const a = computeFocusAdherence(JULY_SHRUGS, [], new Date(2026, 8, 15, 9, 0, 0))
+    expect(a.daysElapsed).toBe(31)
+    expect(a.daysInWindow).toBe(31)
+  })
+
+  it('supports a sets-based target', () => {
+    const setsFocus: MonthlyFocus = { ...JULY_SHRUGS, target_kind: 'sets', daily_target: 3 }
+    const sets: StrengthSet[] = [
+      setOn('shrugs', 2026, 6, 1, 10),
+      setOn('shrugs', 2026, 6, 1, 10),
+      setOn('shrugs', 2026, 6, 1, 10), // 3 sets on 7/1 → hit
+    ]
+    const a = computeFocusAdherence(setsFocus, sets, new Date(2026, 6, 1, 18, 0, 0))
+    expect(a.daysHit).toBe(1)
+    expect(a.currentStreak).toBe(1)
+  })
+})
+
+describe('computeFocusLoadStats', () => {
+  it('summarizes top set, average load, and tonnage over weighted sets', () => {
+    const sets: StrengthSet[] = [
+      setOn('shrugs', 2026, 6, 1, 20, 100),
+      setOn('shrugs', 2026, 6, 1, 20, 110),
+      setOn('shrugs', 2026, 6, 2, 15, 120),
+    ]
+    const stats = computeFocusLoadStats(JULY_SHRUGS, sets)
+    expect(stats.topSetLbs).toBe(120)
+    expect(stats.weightedSets).toBe(3)
+    expect(stats.avgLoadLbs).toBeCloseTo((100 + 110 + 120) / 3)
+    expect(stats.tonnageLbs).toBe(20 * 100 + 20 * 110 + 15 * 120) // 5800
+  })
+
+  it('returns null load metrics for a bodyweight focus', () => {
+    const sets: StrengthSet[] = [setOn('shrugs', 2026, 6, 1, 20)]
+    const stats = computeFocusLoadStats(JULY_SHRUGS, sets)
+    expect(stats).toEqual({
+      topSetLbs: null,
+      avgLoadLbs: null,
+      tonnageLbs: 0,
+      weightedSets: 0,
+    })
+  })
+
+  it('excludes sets outside the window and other exercises', () => {
+    const sets: StrengthSet[] = [
+      setOn('shrugs', 2026, 6, 1, 20, 100),
+      setOn('shrugs', 2026, 7, 1, 20, 200), // August, out of window
+      setOn('pushups', 2026, 6, 1, 20, 50), // wrong exercise
+    ]
+    const stats = computeFocusLoadStats(JULY_SHRUGS, sets)
+    expect(stats.weightedSets).toBe(1)
+    expect(stats.tonnageLbs).toBe(2000)
+  })
+})

--- a/lib/training-facility/monthly-focus.ts
+++ b/lib/training-facility/monthly-focus.ts
@@ -1,0 +1,246 @@
+import type { MonthlyFocus, StrengthSet } from '@/types/weight-room'
+
+import { toLocalDateKey } from './strength-today'
+
+/**
+ * Pure helpers for the "grease the groove" monthly focus (#255) — which
+ * focus is active on a given day, which are still upcoming, windowed
+ * adherence, and load stats for weighted focuses. Kept separate from the
+ * React surfaces so the date/window math is unit-tested without a DOM,
+ * mirroring `strength-today.ts` / `strength-streaks.ts`.
+ *
+ * All window math compares bare `YYYY-MM-DD` keys. PostgREST renders a
+ * Postgres `date` in that canonical form, and `toLocalDateKey` produces
+ * it for set timestamps, so lexicographic string comparison is exactly
+ * chronological comparison — no `Date` parsing (and no UTC-midnight
+ * timezone hazard) needed for the inclusive `start <= day <= end` test.
+ */
+
+/**
+ * Whether a focus window covers `dayKey` (inclusive on both ends).
+ *
+ * @param focus The focus whose `[start_date, end_date]` window to test.
+ * @param dayKey `YYYY-MM-DD` key, e.g. from {@link toLocalDateKey}. An
+ *   empty string (unparseable "today") is never in-window.
+ */
+export function isFocusActiveOnDay(focus: MonthlyFocus, dayKey: string): boolean {
+  if (dayKey === '') return false
+  return focus.start_date <= dayKey && dayKey <= focus.end_date
+}
+
+/**
+ * The single focus active on `dayKey`, or `null` if none. When more than
+ * one window overlaps the day (not expected — focuses are meant to be a
+ * non-overlapping monthly rotation), the one that started most recently
+ * wins, so a deliberately-overlapping replacement takes precedence.
+ *
+ * @param focuses All configured focuses, usually `WeightRoomData.monthly_focus`.
+ * @param dayKey `YYYY-MM-DD` key for the viewed day.
+ */
+export function activeFocusForDay(
+  focuses: readonly MonthlyFocus[],
+  dayKey: string,
+): MonthlyFocus | null {
+  let active: MonthlyFocus | null = null
+  for (const focus of focuses) {
+    if (!isFocusActiveOnDay(focus, dayKey)) continue
+    if (active === null || focus.start_date > active.start_date) {
+      active = focus
+    }
+  }
+  return active
+}
+
+/**
+ * Focuses whose window starts strictly after `dayKey`, soonest first.
+ * Powers the Today View "Upcoming" strip — the roadmap of what's queued.
+ *
+ * @param focuses All configured focuses, usually `WeightRoomData.monthly_focus`.
+ * @param dayKey `YYYY-MM-DD` key for the viewed day. An empty string
+ *   yields an empty list (defensive against an unparseable clock).
+ */
+export function upcomingFocuses(
+  focuses: readonly MonthlyFocus[],
+  dayKey: string,
+): MonthlyFocus[] {
+  if (dayKey === '') return []
+  return focuses
+    .filter((focus) => focus.start_date > dayKey)
+    .sort((a, b) => (a.start_date < b.start_date ? -1 : a.start_date > b.start_date ? 1 : 0))
+}
+
+/**
+ * Add `n` days to a `YYYY-MM-DD` key, returning a new key. Local-noon
+ * base time so DST transitions don't shift the calendar day. Same helper
+ * shape as `strength-streaks.addDays`.
+ */
+function addDays(dateKey: string, n: number): string {
+  const d = new Date(dateKey + 'T12:00:00')
+  d.setDate(d.getDate() + n)
+  return toLocalDateKey(d)
+}
+
+/**
+ * Inclusive day count between two `YYYY-MM-DD` keys (`end - start + 1`),
+ * or `0` when `end` precedes `start`. Walks the calendar via
+ * {@link addDays} so month boundaries and DST are handled correctly.
+ */
+function inclusiveDaySpan(startKey: string, endKey: string): number {
+  if (endKey < startKey) return 0
+  let count = 1
+  let cursor = startKey
+  while (cursor < endKey) {
+    cursor = addDays(cursor, 1)
+    count++
+  }
+  return count
+}
+
+/**
+ * Per-day target attainment for one focus, restricted to its window up
+ * to "today". A day counts as hit when the day's logged volume reaches
+ * {@link MonthlyFocus.daily_target} — interpreted as total reps for
+ * `target_kind: 'reps'` or distinct logged sets for `'sets'`.
+ */
+export interface FocusAdherence {
+  /** Total calendar days in the focus window `[start_date, end_date]`. */
+  daysInWindow: number
+  /**
+   * Days from `start_date` through the earlier of today and `end_date`,
+   * inclusive. `0` before the window starts; equals `daysInWindow` once
+   * the window has fully elapsed. The denominator for {@link percent}.
+   */
+  daysElapsed: number
+  /** Count of elapsed days whose volume met the daily target. */
+  daysHit: number
+  /**
+   * Consecutive hit days ending on the most recent elapsed day (today,
+   * or `end_date` if the window is over). `0` if the latest elapsed day
+   * was missed.
+   */
+  currentStreak: number
+  /** `daysHit / daysElapsed`, or `0` when no day has elapsed yet. */
+  percent: number
+}
+
+/**
+ * Compute windowed adherence for a focus from the full set log.
+ *
+ * @param focus The focus to score.
+ * @param sets All logged sets, usually `WeightRoomData.sets`; filtered to
+ *   this focus's `exercise` and window internally.
+ * @param now Clock for "today" (local). Defaults to `new Date()`; pass
+ *   the viewer's clock from server-rendered surfaces so UTC doesn't
+ *   disagree with their timezone (#197).
+ */
+export function computeFocusAdherence(
+  focus: MonthlyFocus,
+  sets: readonly StrengthSet[],
+  now: Date = new Date(),
+): FocusAdherence {
+  const daysInWindow = inclusiveDaySpan(focus.start_date, focus.end_date)
+  const today = toLocalDateKey(now)
+
+  // Last elapsed day = min(today, end_date); nothing elapsed if today is
+  // before the window opens.
+  const lastElapsed =
+    today === '' || today < focus.start_date
+      ? ''
+      : today < focus.end_date
+        ? today
+        : focus.end_date
+
+  if (lastElapsed === '') {
+    return { daysInWindow, daysElapsed: 0, daysHit: 0, currentStreak: 0, percent: 0 }
+  }
+
+  const daysElapsed = inclusiveDaySpan(focus.start_date, lastElapsed)
+
+  // Bucket this focus's in-window volume by day.
+  const volumeByDay = new Map<string, number>()
+  for (const s of sets) {
+    if (s.exercise !== focus.exercise) continue
+    const day = toLocalDateKey(s.logged_at)
+    if (day === '' || day < focus.start_date || day > lastElapsed) continue
+    const increment = focus.target_kind === 'sets' ? 1 : s.reps
+    volumeByDay.set(day, (volumeByDay.get(day) ?? 0) + increment)
+  }
+
+  const hit = (day: string): boolean => (volumeByDay.get(day) ?? 0) >= focus.daily_target
+
+  let daysHit = 0
+  for (const total of volumeByDay.values()) {
+    if (total >= focus.daily_target) daysHit++
+  }
+
+  // Current streak walks backward from the last elapsed day.
+  let currentStreak = 0
+  let cursor = lastElapsed
+  while (cursor >= focus.start_date && hit(cursor)) {
+    currentStreak++
+    cursor = addDays(cursor, -1)
+  }
+
+  return {
+    daysInWindow,
+    daysElapsed,
+    daysHit,
+    currentStreak,
+    percent: daysElapsed === 0 ? 0 : daysHit / daysElapsed,
+  }
+}
+
+/**
+ * Load summary for a weighted focus, across all of its in-window sets.
+ * All `null`/`0` when the focus is bodyweight (no set carries a
+ * `weight_lbs`).
+ */
+export interface FocusLoadStats {
+  /** Heaviest single set's load in lbs, or `null` if no weighted sets. */
+  topSetLbs: number | null
+  /**
+   * Mean load across weighted sets in lbs (unrounded), or `null` if
+   * none. Only sets that carry a `weight_lbs` count toward the average —
+   * an unweighted warmup set doesn't drag it down.
+   */
+  avgLoadLbs: number | null
+  /** Total tonnage = Σ `reps × weight_lbs` over weighted sets, in lbs. */
+  tonnageLbs: number
+  /** Number of in-window sets that carried a load. */
+  weightedSets: number
+}
+
+/**
+ * Compute load stats for a focus from the full set log, restricted to
+ * the focus's `exercise` and `[start_date, end_date]` window.
+ *
+ * @param focus The focus to summarize.
+ * @param sets All logged sets, usually `WeightRoomData.sets`.
+ */
+export function computeFocusLoadStats(
+  focus: MonthlyFocus,
+  sets: readonly StrengthSet[],
+): FocusLoadStats {
+  let topSetLbs: number | null = null
+  let loadSum = 0
+  let tonnageLbs = 0
+  let weightedSets = 0
+
+  for (const s of sets) {
+    if (s.exercise !== focus.exercise) continue
+    const day = toLocalDateKey(s.logged_at)
+    if (day === '' || day < focus.start_date || day > focus.end_date) continue
+    if (s.weight_lbs == null) continue
+    weightedSets++
+    loadSum += s.weight_lbs
+    tonnageLbs += s.reps * s.weight_lbs
+    if (topSetLbs === null || s.weight_lbs > topSetLbs) topSetLbs = s.weight_lbs
+  }
+
+  return {
+    topSetLbs,
+    avgLoadLbs: weightedSets === 0 ? null : loadSum / weightedSets,
+    tonnageLbs,
+    weightedSets,
+  }
+}

--- a/supabase/migrations/20260628120000_weight_room_monthly_focus.sql
+++ b/supabase/migrations/20260628120000_weight_room_monthly_focus.sql
@@ -1,0 +1,90 @@
+-- Weight Room "grease the groove" monthly focus (#255). Extends the
+-- strength model (#79, `20260507120000_weight_room_tables.sql`) with a
+-- *rotating exercise of the month* — pick one accessory movement, do it
+-- every day for a month, then rotate. Adds three things:
+--
+--   * weight_room_monthly_focus — the rotation roadmap. One row per
+--     campaign (exercise + month window + daily target + color). Powers
+--     the Today View "Focus of the Month" ring and the "Upcoming" strip.
+--     A dedicated table (not a date-window on weight_room_goals) so
+--     future-dated and past campaigns live apart from the permanent
+--     pushups/pullups goals instead of cluttering that list.
+--   * weight_room_sets.weight_lbs — optional per-set load, so weighted
+--     focuses (shrugs, carries, …) record the weight used. Null for
+--     bodyweight movements; mirrors the cardio model's nullable metrics.
+--   * weight_room_goals.kind — 'permanent' vs 'focus'. A focus needs a
+--     matching goals row so set-logging satisfies the
+--     weight_room_sets.exercise FK and reuses all existing ring/rollup
+--     math, but the Today View must only render a focus ring while its
+--     window is live (no stale, permanently-empty shrugs ring in August).
+--     `kind` lets the read layer tell the two apart.
+--
+-- RLS mirrors weight_room_goals / weight_room_sets: anon + authenticated
+-- SELECT only; writes go through the service-role key via admin-gated API
+-- routes. All DDL is idempotent so re-applying on a fresh dev project (or
+-- after a branch reset) is a safe no-op.
+
+-- 1. Per-set load. Nullable: existing rows and all bodyweight sets stay null.
+alter table public.weight_room_sets
+  add column if not exists weight_lbs numeric check (weight_lbs >= 0);
+
+comment on column public.weight_room_sets.weight_lbs is
+  'Optional external load in pounds for this set (e.g. weighted shrugs). Null = bodyweight (pushups, pullups). Used by the monthly-focus load stats: top set, avg load, tonnage = sum(reps * weight_lbs).';
+
+-- 2. Permanent vs focus goals. Existing rows default to 'permanent' so the
+--    pushups/pullups rings are unchanged.
+alter table public.weight_room_goals
+  add column if not exists kind text not null default 'permanent'
+    check (kind in ('permanent', 'focus'));
+
+comment on column public.weight_room_goals.kind is
+  'Whether this goal is a permanent daily ring (''permanent'') or the anchor row for a time-boxed monthly focus (''focus'', see weight_room_monthly_focus). The Today View always renders permanent goals but renders focus goals only while their focus window covers the viewed day.';
+
+-- 3. The rotation roadmap.
+create table if not exists public.weight_room_monthly_focus (
+  id uuid primary key default gen_random_uuid(),
+  exercise text not null references public.weight_room_goals(exercise) on delete cascade,
+  daily_target integer not null check (daily_target > 0),
+  target_kind text not null default 'reps' check (target_kind in ('reps', 'sets')),
+  color text not null,
+  start_date date not null,
+  end_date date not null check (end_date >= start_date),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+comment on table public.weight_room_monthly_focus is
+  '"Grease the groove" monthly focus roadmap (#255). One row per time-boxed campaign: an exercise done daily for the [start_date, end_date] window with its own daily_target and color. Past / active / upcoming rows coexist; "upcoming" = start_date > today. The matching weight_room_goals row (kind=''focus'', same exercise) anchors set logging and the daily ring rollup. target_kind ''reps'' fills the ring on rep total; ''sets'' (modeled, unused for July) would fill on distinct-set count.';
+
+-- Roadmap is almost always scanned ordered by window; one set of months.
+create index if not exists weight_room_monthly_focus_start_date_idx
+  on public.weight_room_monthly_focus (start_date desc);
+
+alter table public.weight_room_monthly_focus enable row level security;
+
+do $$
+begin
+  create policy "anon and authenticated can read weight room monthly focus"
+    on public.weight_room_monthly_focus
+    for select
+    to anon, authenticated
+    using (true);
+exception when duplicate_object then null;
+end $$;
+
+-- 4. Seed the first focus: shrugs, July 2026, 100 reps/day, hardwood-tan.
+--    The goals anchor row (kind='focus') must exist first to satisfy the
+--    monthly-focus FK and to let shrug sets log + roll up like any other
+--    exercise. hardwood-tan (#C9A268) is the chartPalette basketball-floor
+--    maple token — distinct from pushup rim-orange and pullup teal.
+insert into public.weight_room_goals (exercise, daily_target, color, kind)
+values ('shrugs', 100, '#C9A268', 'focus')
+on conflict (exercise) do nothing;
+
+insert into public.weight_room_monthly_focus
+  (exercise, daily_target, target_kind, color, start_date, end_date)
+select 'shrugs', 100, 'reps', '#C9A268', date '2026-07-01', date '2026-07-31'
+where not exists (
+  select 1 from public.weight_room_monthly_focus
+  where exercise = 'shrugs' and start_date = date '2026-07-01'
+);

--- a/types/weight-room.ts
+++ b/types/weight-room.ts
@@ -25,6 +25,14 @@ export interface StrengthSet {
   exercise: string
   /** Rep count for this single set. Always positive (DB CHECK enforces). */
   reps: number
+  /**
+   * Optional external load in pounds for this set — e.g. weighted
+   * shrugs in a monthly focus (#255). Absent for bodyweight movements
+   * (pushups, pullups). Feeds the load stats (top set, avg load,
+   * tonnage = Σ reps×weight); never part of the daily-ring rollup,
+   * which is rep-based.
+   */
+  weight_lbs?: number
 }
 
 /**
@@ -48,6 +56,54 @@ export interface ExerciseGoal {
    * require a code change.
    */
   color: string
+  /**
+   * Whether this is a permanent daily ring or the anchor row for a
+   * time-boxed monthly focus (#255). Absent is treated as
+   * `'permanent'` (every pre-#255 goal). A `'focus'` goal is rendered
+   * on the Today View only while its {@link MonthlyFocus} window covers
+   * the viewed day, so a finished focus doesn't leave a stale empty
+   * ring. Mirrors `weight_room_goals.kind`.
+   */
+  kind?: 'permanent' | 'focus'
+}
+
+/**
+ * One "grease the groove" monthly focus (#255) — a time-boxed campaign
+ * to do an accessory movement every day for a month, then rotate.
+ * Mirrors a row of `public.weight_room_monthly_focus`. The roadmap is
+ * the full list (past, active, upcoming); "upcoming" = a focus whose
+ * {@link MonthlyFocus.start_date} is after today.
+ *
+ * A focus shares its `exercise` with a `kind: 'focus'`
+ * {@link ExerciseGoal} so its sets log and roll up through the exact
+ * same machinery as permanent exercises.
+ */
+export interface MonthlyFocus {
+  /** UUID primary key, generated server-side. */
+  id: string
+  /**
+   * Exercise name (e.g. `shrugs`). Foreign-keyed to the matching
+   * `kind: 'focus'` {@link ExerciseGoal.exercise} that anchors logging.
+   */
+  exercise: string
+  /**
+   * Target for the daily ring during the focus window. Interpreted per
+   * {@link MonthlyFocus.target_kind}: reps/day or distinct sets/day.
+   */
+  daily_target: number
+  /**
+   * Whether {@link MonthlyFocus.daily_target} counts reps (`'reps'`,
+   * the default — ring fills on rep total) or distinct logged sets
+   * (`'sets'`). `'sets'` is modeled but unused until a future focus
+   * needs it.
+   */
+  target_kind: 'reps' | 'sets'
+  /** Hex color for the focus's ring/strip (e.g. `#C9A268`). */
+  color: string
+  /** Inclusive first day of the focus window, `YYYY-MM-DD` local date. */
+  start_date: string
+  /** Inclusive last day of the focus window, `YYYY-MM-DD` local date. */
+  end_date: string
 }
 
 /**
@@ -68,4 +124,10 @@ export interface WeightRoomData {
   sets: StrengthSet[]
   /** Every configured exercise goal, ordered by exercise name. */
   goals: ExerciseGoal[]
+  /**
+   * "Grease the groove" monthly focuses (#255), ordered newest window
+   * first. Empty when none are configured. Includes past, active, and
+   * upcoming focuses — callers slice by date against today.
+   */
+  monthly_focus: MonthlyFocus[]
 }


### PR DESCRIPTION
## What

Implements the rotating **"grease the groove" exercise of the month** (#255) — a
time-boxed accessory movement you do daily for a month, then rotate — seeded with
**shrugs for July 2026** (100 reps/day), plus an **"Up Next"** roadmap of queued
focuses. Also adds **per-set load tracking** so weighted focuses record the weight
used.

Closes #255.

## Why this shape

- **Dedicated `weight_room_monthly_focus` table** for the roadmap (past / active /
  upcoming) so future-dated campaigns don't clutter the permanent pushups/pullups
  goals — chosen specifically because the "see upcoming" view needs a clean
  forward-looking list.
- **Roll-up is untouched.** `weight_lbs` and the focus relationship are per-set /
  per-goal attributes, not new ring keys, so the rep-based daily-ring math is
  unchanged. A `kind: 'focus'` goal anchors logging (satisfies the
  `weight_room_sets.exercise` FK) and reuses all existing rollup/streak machinery.
- **No stale rings.** A focus goal only earns a ring / streak / quick-log button
  while its window covers the viewed day, so July's shrugs ring disappears on
  Aug 1 instead of sitting permanently empty.

## Commits

1. **Data model + load tracking** — migration (`weight_room_monthly_focus`,
   `weight_room_sets.weight_lbs`, `weight_room_goals.kind`, RLS, seeded July
   shrugs + its `kind=focus` anchor); types; Zod row/create schemas; data-layer
   assembly.
2. **Logic** — `monthly-focus.ts`: active/upcoming resolution, windowed adherence
   (days-hit / streak / %), load stats (top set, avg, tonnage). 16 unit tests.
3. **UI** — `MonthlyFocusCard` (today progress + adherence + load) and
   `UpcomingFocusStrip` ("Up Next" chips) wired into the Log View, with
   window-aware ring filtering. 12 component tests.

## Tests

- Full weight-room suite green: **380 passed**, `tsc` clean for all touched files.
- Note: `tsc` reports pre-existing errors in `scripts/lib/otbeat-supabase.test.ts`
  (from #252, commit `25be9fe`) — unrelated to this PR; flagging separately.

## Today's behavior

As of 6/28, **shrugs shows in "Up Next" (Jul 2026)** and flips to the active
"Focus of the Month" card on July 1.

## Follow-ups (not in this PR)

- [ ] Admin route to **create/edit** monthly focuses (queue August+ without a
      seed migration). Today the roadmap is seeded via migration only.
- [ ] Apply the migration to the live Supabase project so the seeded focus appears
      on the deployed site.
- [ ] `log-workout` MCP skill: parse weighted sets (`"3x10 shrugs @ 100lb"`) to set
      `weight_lbs` (tracked on #255 / #254).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added monthly focus tracking in the Weight Room, including upcoming focus chips and a “Focus of the Month” card.
  * The log view now highlights the active focus and shows progress, adherence, and load stats when applicable.
  * Added support for tracking optional set load and focus-specific goal types.

* **Bug Fixes**
  * Improved date handling for monthly focus windows to avoid timezone boundary issues.
  * Focus progress now updates more accurately across overlapping or inactive focus periods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->