### PR TITLE
fix(otbeat): make the Supabase test typecheck + add CI typecheck gate

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,0 +1,35 @@
+name: Typecheck
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  typecheck:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          # Read-only job — don't leave the GITHUB_TOKEN in .git/config.
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck
+        # `tsc --noEmit` over the whole repo (tests included). Catches type
+        # regressions that vitest can't — a `.ts` test with broken fixtures
+        # still runs green, but won't compile. This gate is what would have
+        # caught the otbeat test type errors before merge.
+        run: npm run typecheck

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "typecheck": "tsc --noEmit",
     "format": "prettier --write \"**/*.{ts,tsx}\"",
     "optimize:svg": "svgo -rf public/locker-room && svgo -rf public/training-facility && svgo -rf public/contact && svgo -rf public/common",
     "import-health": "node scripts/import-health.mjs",

--- a/scripts/lib/otbeat-supabase.test.ts
+++ b/scripts/lib/otbeat-supabase.test.ts
@@ -10,7 +10,34 @@ import { describe, expect, it } from 'vitest'
 
 import { recordToRow, toStartedAt, upsertOtfSessions } from './otbeat-supabase.mjs'
 
+/** Local alias for the parser's JSDoc record type, for typing fixtures. */
+type OtbeatRecord = import('./otbeat-parser.mjs').OtbeatRecord
+
 const TZ = 'America/Los_Angeles'
+
+/**
+ * Full {@link OtbeatRecord} with every stat field nulled — the realistic
+ * "header-only" shape the parser emits for a class format that reports
+ * only date/time (the parser always assigns every field, `null` when
+ * absent). Keeps the dedupe fixtures terse while satisfying the record's
+ * required-but-nullable properties.
+ */
+function bareRecord(date: string, time: string): OtbeatRecord {
+  return {
+    date,
+    time,
+    coach: null,
+    studio: null,
+    zones_min: null,
+    calories: null,
+    splat: null,
+    avg_hr: null,
+    peak_hr: null,
+    steps: null,
+    treadmill: null,
+    rower: null,
+  }
+}
 
 describe('toStartedAt', () => {
   it('interprets the wall time in Pacific DAYLIGHT time (summer, -07:00)', () => {
@@ -51,8 +78,8 @@ describe('recordToRow', () => {
         avg_hr: 133,
         peak_hr: 164,
         steps: 3508,
-        treadmill: { distance_mi: 1.09 },
-        rower: { distance_m: 2509 },
+        treadmill: { distance_mi: 1.09, time: '11:24' },
+        rower: { distance_m: 2509, time: '7:58' },
       },
       TZ
     )
@@ -76,10 +103,7 @@ describe('recordToRow', () => {
   })
 
   it('nulls out missing zones / blocks', () => {
-    const row = recordToRow(
-      { date: '05/30/2026', time: '9:30AM', zones_min: null, treadmill: null, rower: null },
-      TZ
-    )
+    const row = recordToRow(bareRecord('05/30/2026', '9:30AM'), TZ)
     expect(row.zone_gray_min).toBeNull()
     expect(row.treadmill).toBeNull()
     expect(row.rower).toBeNull()
@@ -87,19 +111,31 @@ describe('recordToRow', () => {
 })
 
 /**
- * Minimal stand-in for the supabase-js client: `from().select()` resolves to
- * the seeded existing keys; `from().upsert()` records what was written.
+ * The fake's public shape — the client param `upsertOtfSessions` expects,
+ * intersected with the `inserted` capture so tests can assert what was
+ * written. Deriving the client type from the function's own parameter
+ * keeps the fake in lockstep with the real signature.
  */
-function fakeClient(existingStartedAt) {
-  const inserted = []
+type FakeClient = Parameters<typeof upsertOtfSessions>[0] & {
+  inserted: Array<Record<string, unknown>>
+}
+
+/**
+ * Minimal stand-in for the supabase-js client: `from().select()` resolves to
+ * the seeded existing keys; `from().upsert()` records what was written. Cast
+ * through `unknown` to the real client type — only the `from`/`select`/
+ * `upsert` surface the upsert path touches is implemented.
+ */
+function fakeClient(existingStartedAt: string[]): FakeClient {
+  const inserted: Array<Record<string, unknown>> = []
   const client = {
     from() {
       return {
         select: async () => ({
-          data: existingStartedAt.map(s => ({ started_at: s })),
+          data: existingStartedAt.map((s) => ({ started_at: s })),
           error: null,
         }),
-        upsert: async rows => {
+        upsert: async (rows: Array<Record<string, unknown>>) => {
           inserted.push(...rows)
           return { error: null }
         },
@@ -107,12 +143,12 @@ function fakeClient(existingStartedAt) {
     },
     inserted,
   }
-  return client
+  return client as unknown as FakeClient
 }
 
 describe('upsertOtfSessions (append-only)', () => {
-  const recA = { date: '06/27/2026', time: '9:30AM', zones_min: null, treadmill: null, rower: null }
-  const recB = { date: '06/25/2026', time: '6:45PM', zones_min: null, treadmill: null, rower: null }
+  const recA = bareRecord('06/27/2026', '9:30AM')
+  const recB = bareRecord('06/25/2026', '6:45PM')
 
   it('inserts only sessions whose started_at is not already present', async () => {
     // recA already in the table; recB is new.


### PR DESCRIPTION
## What

`tsc --noEmit` was **red on `main`** — `scripts/lib/otbeat-supabase.test.ts`
(a strict `.ts` test over the untyped `.mjs` module) had type errors that
`vitest` can't catch, so they merged via #252. This fixes them and adds a CI
gate so it can't recur.

## Diagnosis

The `OtbeatRecord` / `OtbeatTreadmill` / `OtbeatRower` typedefs are **correct** —
`parseOtbeatHtml` assigns *every* record field (`null` when absent) and always
builds a block as `{ distance, time, … }`. So the errors were entirely in the
**test fixtures + fake client**, not the data contract. **No runtime behavior
changes.**

## Changes

**Test (type-only):**
- Complete the minimal fixtures via a typed `bareRecord()` helper (mirrors the
  parser's all-fields-nulled "header-only" output).
- Add the required `time` to the treadmill/rower block fixtures.
- Annotate the fake client and derive its type from
  `Parameters<typeof upsertOtfSessions>[0]`, so it satisfies the real client
  param *and* still exposes `.inserted` for assertions.

**Prevent recurrence:**
- `typecheck` npm script (`tsc --noEmit`) + a **Typecheck** workflow
  (`pull_request` + push to `main`). This is the gate that would have caught the
  original errors. otbeat was the *only* source of errors, so the gate is green
  from its first run — including on this PR.

## Verification

- `npm run typecheck` — clean.
- `vitest run scripts/lib/otbeat-*.test.ts` — 17 pass (logic untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated type-checking to run on pull requests and pushes to the main branch.
  * Added a repository script for running TypeScript checks locally.

* **Tests**
  * Improved test coverage and fixtures for OTbeat-to-Supabase data handling.
  * Strengthened assertions around missing values, mapping behavior, and duplicate-session handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->