### PR TITLE
feat(gym): OrangeTheory (otf_sessions) detail view (#256)

### DIFF
--- a/app/training-facility/gym/otf/page.tsx
+++ b/app/training-facility/gym/otf/page.tsx
@@ -1,0 +1,20 @@
+import { notFound } from 'next/navigation'
+
+import { OtfDetailView } from '@/components/training-facility/gym/OtfDetailView'
+import { isTrainingFacilityEnabled } from '@/lib/feature-flags'
+
+/**
+ * OrangeTheory detail view (#256) — studio-class data from the OTbeat
+ * ingestion pipeline (#251). Reachable from the OrangeTheory signpost on the
+ * Gym scene; gated behind the Training Facility feature flag for staged
+ * rollout, matching the sibling treadmill/track/stair pages.
+ *
+ * No `<Suspense>` boundary here (unlike the cardio detail pages) because
+ * `OtfDetailView` doesn't read `useSearchParams()` — it owns its own loading
+ * panel and fetches client-side from a mount effect.
+ */
+export default function TrainingFacilityGymOtfPage() {
+  if (!isTrainingFacilityEnabled()) notFound()
+
+  return <OtfDetailView />
+}

--- a/components/training-facility/gym/OtfDetailView.test.tsx
+++ b/components/training-facility/gym/OtfDetailView.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { OtfData } from '@/types/otf'
+
+import { OtfDetailView } from './OtfDetailView'
+
+/**
+ * Render tests for the OTF detail view (#256). `getOtfData` is mocked and the
+ * heavy SVG chart children are stubbed to `null`, so the tests focus on the
+ * branch decisions (loading → data, empty state, error panel) rather than
+ * chart geometry. Sibling pattern: `StairDetailView.test.tsx`.
+ */
+
+const getOtfDataMock = vi.fn()
+
+vi.mock('@/lib/data', () => ({ getOtfData: () => getOtfDataMock() }))
+vi.mock('./OtfZoneBars', () => ({ OtfZoneBars: () => null }))
+vi.mock('@/components/training-facility/shared/charts/RoughLine', () => ({ RoughLine: () => null }))
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/training-facility/gym/otf',
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), prefetch: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+}))
+
+const DATA: OtfData = {
+  imported_at: '2026-06-30T07:53:00+00:00',
+  sessions: [
+    {
+      started_at: '2026-06-27T16:30:00+00:00',
+      coach: 'Mara Magistad',
+      studio: 'Marina Del Rey, CA',
+      splat: 15,
+      calories: 776,
+      avg_hr: 133,
+      peak_hr: 164,
+      zones_min: { gray: 1, blue: 11, green: 29, orange: 14, red: 1 },
+      treadmill: { distance_mi: 1.09, time: '16:44' },
+      rower: { distance_m: 2509, time: '13:54' },
+    },
+  ],
+}
+
+beforeEach(() => {
+  getOtfDataMock.mockReset()
+})
+
+describe('OtfDetailView', () => {
+  it('always renders the header and a link back to the Gym', () => {
+    getOtfDataMock.mockResolvedValue(DATA)
+    render(<OtfDetailView />)
+    expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /the gym/i })).toHaveAttribute(
+      'href',
+      '/training-facility/gym'
+    )
+  })
+
+  it('renders the highlights strip and session log once data loads', async () => {
+    getOtfDataMock.mockResolvedValue(DATA)
+    render(<OtfDetailView />)
+    await waitFor(() => expect(screen.getByText('Mara Magistad')).toBeInTheDocument())
+    // Highlights strip (unique tile label) + the session-log heading.
+    expect(screen.getByText('Total splat')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: /classes/i })).toBeInTheDocument()
+    // Splat value appears in both the tile and the table; just assert presence.
+    expect(screen.getAllByText('15').length).toBeGreaterThan(0)
+  })
+
+  it('shows the empty state when there are no sessions', async () => {
+    getOtfDataMock.mockResolvedValue(null)
+    render(<OtfDetailView />)
+    await waitFor(() =>
+      expect(screen.getByText(/no orangetheory classes yet/i)).toBeInTheDocument()
+    )
+  })
+
+  it('shows the error panel when the load throws', async () => {
+    getOtfDataMock.mockRejectedValue(new Error('boom'))
+    render(<OtfDetailView />)
+    await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent(/boom/))
+  })
+})

--- a/components/training-facility/gym/OtfDetailView.tsx
+++ b/components/training-facility/gym/OtfDetailView.tsx
@@ -1,0 +1,547 @@
+'use client'
+
+import Link from 'next/link'
+import { Fragment, useEffect, useMemo, useRef, useState, type JSX } from 'react'
+
+import { BackToCourtButton } from '@/components/common/BackToCourtButton'
+import { RoughLine } from '@/components/training-facility/shared/charts/RoughLine'
+import { chartPalette } from '@/components/training-facility/shared/charts/palette'
+import { defaultMargin } from '@/components/training-facility/shared/charts/types'
+import {
+  DateFilter,
+  rangeForPreset,
+  type DateRange,
+} from '@/components/training-facility/shared/DateFilter'
+import { getOtfData } from '@/lib/data'
+import {
+  OTF_ZONES,
+  aggregateOtfZoneMinutes,
+  earliestOtfDate,
+  filterOtfSessionsInRange,
+  formatOtfDate,
+  otfHighlights,
+  otfMetricTrend,
+  type OtfTrendPoint,
+} from '@/lib/training-facility/otf'
+import type { OtfData, OtfRower, OtfSession, OtfTreadmill } from '@/types/otf'
+
+import { OtfZoneBars } from './OtfZoneBars'
+
+const CHART_HEIGHT = 280
+const MIN_CHART_WIDTH = 280
+const DEFAULT_CHART_WIDTH = 560
+const EARLIEST_FALLBACK = new Date(2026, 0, 1)
+const FONT_FAMILY = "'Patrick Hand', system-ui, sans-serif"
+
+/** Empty dataset used while loading resolves to "no sessions yet" instead of spinning forever. */
+const EMPTY_OTF: OtfData = { imported_at: '', sessions: [] }
+
+/**
+ * OrangeTheory detail view (#256) — renders the `otf_sessions` data the
+ * OTbeat ingestion pipeline (#251) feeds into Supabase. Sibling of the
+ * cardio Gym detail views (`TreadmillDetailView` et al.): same dark-arena
+ * shell, `DateFilter`, `ChartCard` chrome, and loading/error panels, with
+ * OTF-specific charts — minutes-in-zone bars (gray→red) and splat / calorie
+ * / avg-HR trend lines — plus an expandable session log surfacing each
+ * class's treadmill and rower performance blocks.
+ */
+export function OtfDetailView(): JSX.Element {
+  const [data, setData] = useState<OtfData | null>(null)
+  const [loadError, setLoadError] = useState<Error | null>(null)
+  const [range, setRange] = useState<DateRange>(() => rangeForPreset('ALL', EARLIEST_FALLBACK))
+  const [chartWidth, setChartWidth] = useState(DEFAULT_CHART_WIDTH)
+  const cardSizerRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    getOtfData()
+      .then(otf => {
+        if (cancelled) return
+        // `getOtfData()` resolves to `null` when `otf_sessions` is empty;
+        // substitute an empty dataset so we land on the empty state rather
+        // than the perpetual loading panel.
+        setData(otf ?? EMPTY_OTF)
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return
+        setLoadError(err instanceof Error ? err : new Error(String(err)))
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  useEffect(() => {
+    const node = cardSizerRef.current
+    if (!node || typeof ResizeObserver === 'undefined') return
+    const observer = new ResizeObserver(entries => {
+      for (const entry of entries) {
+        const next = Math.max(MIN_CHART_WIDTH, Math.floor(entry.contentRect.width))
+        setChartWidth(prev => (prev === next ? prev : next))
+      }
+    })
+    observer.observe(node)
+    return () => observer.disconnect()
+  }, [])
+
+  const earliest = useMemo(
+    () => (data ? (earliestOtfDate(data.sessions) ?? EARLIEST_FALLBACK) : EARLIEST_FALLBACK),
+    [data]
+  )
+
+  const sessions = useMemo(
+    () => (data ? filterOtfSessionsInRange(data.sessions, range) : []),
+    [data, range]
+  )
+  const buckets = useMemo(() => aggregateOtfZoneMinutes(sessions), [sessions])
+  const splatTrend = useMemo(() => otfMetricTrend(sessions, 'splat'), [sessions])
+  const calorieTrend = useMemo(() => otfMetricTrend(sessions, 'calories'), [sessions])
+  const hrTrend = useMemo(() => otfMetricTrend(sessions, 'avg_hr'), [sessions])
+  const highlights = useMemo(() => otfHighlights(sessions), [sessions])
+
+  const hasAnySessions = !!data && data.sessions.length > 0
+
+  return (
+    <div className="relative min-h-svh overflow-hidden bg-[#120d0a] text-[#f7ead9]">
+      <div
+        aria-hidden="true"
+        className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(249,115,22,0.12),transparent_30%),linear-gradient(180deg,#241811_0%,#120d0a_52%,#0b0806_100%)]"
+      />
+
+      <div className="relative z-10 mx-auto flex min-h-svh w-full max-w-5xl flex-col px-6 py-8 sm:px-8 lg:px-12">
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <BackToCourtButton />
+          <Link
+            href="/training-facility/gym"
+            className="rounded-full border border-white/15 bg-white/5 px-4 py-2 text-xs font-semibold uppercase tracking-[0.28em] text-white/80 transition hover:bg-white/10"
+          >
+            ← The Gym
+          </Link>
+        </div>
+
+        <header className="mt-12">
+          <div className="text-xs font-semibold uppercase tracking-[0.38em] text-[#f97316]">
+            OrangeTheory
+          </div>
+          <h1 className="mt-3 text-4xl font-black uppercase tracking-[0.08em] text-[#fff7ec] sm:text-5xl">
+            Splat points, zones, and the row-tread grind
+          </h1>
+          <p className="mt-4 max-w-2xl text-sm leading-7 text-[#e8d5be] sm:text-base">
+            Every studio class, straight from the OTbeat summary emails — time in each HR zone,
+            splat and calorie trends, and the treadmill + rower splits underneath each session.
+            Scoped to the date range.
+          </p>
+        </header>
+
+        <div className="mt-8">
+          <DateFilter earliestDate={earliest} defaultPreset="ALL" onChange={setRange} />
+        </div>
+
+        {loadError ? (
+          <ErrorPanel error={loadError} />
+        ) : !data ? (
+          <LoadingPanel />
+        ) : !hasAnySessions ? (
+          <EmptyState />
+        ) : (
+          <>
+            <HighlightStrip highlights={highlights} />
+
+            <div className="mt-8 grid gap-6 lg:grid-cols-2">
+              <ChartCard
+                title="Minutes in zone"
+                helper="Total minutes per OTbeat HR zone across the filtered window."
+              >
+                <div ref={cardSizerRef}>
+                  <OtfZoneBars
+                    buckets={buckets}
+                    width={chartWidth}
+                    height={CHART_HEIGHT}
+                    fontFamily={FONT_FAMILY}
+                  />
+                </div>
+              </ChartCard>
+
+              <ChartCard
+                title="Splat points per class"
+                helper="Minutes in the orange + red zones. One point per class."
+              >
+                <OtfTrendChart
+                  data={splatTrend}
+                  width={chartWidth}
+                  yLabel="Splat"
+                  ariaLabel="Splat points per class over time"
+                  emptyMessage="No splat data in range"
+                />
+              </ChartCard>
+            </div>
+
+            <div className="mt-6 grid gap-6 lg:grid-cols-2">
+              <ChartCard
+                title="Calories per class"
+                helper="Total calories burned, one point per class."
+              >
+                <OtfTrendChart
+                  data={calorieTrend}
+                  width={chartWidth}
+                  yLabel="Calories"
+                  ariaLabel="Calories per class over time"
+                  emptyMessage="No calorie data in range"
+                />
+              </ChartCard>
+
+              <ChartCard title="Average heart rate" helper="Mean HR per class, BPM.">
+                <OtfTrendChart
+                  data={hrTrend}
+                  width={chartWidth}
+                  yLabel="Avg HR"
+                  ariaLabel="Average heart rate per class over time"
+                  emptyMessage="No heart-rate data in range"
+                />
+              </ChartCard>
+            </div>
+
+            <SessionLogTable sessions={sessions} range={range} />
+          </>
+        )}
+      </div>
+    </div>
+  )
+}
+
+/** Shared trend-line chart — `RoughLine` over `{date, value}` points with the OTF font/tick style. */
+function OtfTrendChart({
+  data,
+  width,
+  yLabel,
+  ariaLabel,
+  emptyMessage,
+}: {
+  data: OtfTrendPoint[]
+  width: number
+  yLabel: string
+  ariaLabel: string
+  emptyMessage: string
+}): JSX.Element {
+  return (
+    <RoughLine<OtfTrendPoint>
+      data={data}
+      x={p => p.date}
+      y={p => p.value}
+      width={width}
+      height={CHART_HEIGHT}
+      margin={defaultMargin}
+      fontFamily={FONT_FAMILY}
+      yLabel={yLabel}
+      yTickFormat={v => `${Math.round(v)}`}
+      ariaLabel={ariaLabel}
+      emptyMessage={emptyMessage}
+    />
+  )
+}
+
+/** Headline stat tiles for the active range. */
+function HighlightStrip({
+  highlights,
+}: {
+  highlights: ReturnType<typeof otfHighlights>
+}): JSX.Element {
+  const tiles: Array<{ label: string; value: string }> = [
+    { label: 'Classes', value: `${highlights.classes}` },
+    { label: 'Total splat', value: `${highlights.totalSplat}` },
+    { label: 'Avg splat', value: highlights.avgSplat.toFixed(1) },
+    { label: 'Best splat', value: `${highlights.bestSplat}` },
+    { label: 'Total calories', value: highlights.totalCalories.toLocaleString() },
+    { label: 'Best calories', value: highlights.bestCalories.toLocaleString() },
+  ]
+  return (
+    <dl className="mt-8 grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6">
+      {tiles.map(t => (
+        <div
+          key={t.label}
+          className="rounded-2xl border border-white/10 bg-black/25 px-4 py-3 text-center"
+        >
+          <dt className="font-mono text-[0.65rem] uppercase tracking-[0.18em] text-white/55">
+            {t.label}
+          </dt>
+          <dd className="mt-1 text-2xl font-black text-[#f97316]">{t.value}</dd>
+        </div>
+      ))}
+    </dl>
+  )
+}
+
+interface ChartCardProps {
+  title: string
+  helper: string
+  children: JSX.Element
+}
+
+/** Cream chart card chrome — mirrors the inline `ChartCard` in the cardio detail views. */
+function ChartCard({ title, helper, children }: ChartCardProps): JSX.Element {
+  return (
+    <section className="rounded-[1.6rem] border border-white/10 bg-[#f5f1e6] p-5 text-[#0a0a0a] shadow-[0_18px_46px_rgba(0,0,0,0.34)]">
+      <header className="mb-2 flex flex-wrap items-baseline justify-between gap-3">
+        <h2 className="font-mono text-xs font-bold uppercase tracking-[0.24em] text-[#0a0a0a]">
+          {title}
+        </h2>
+      </header>
+      <p className="mb-4 text-xs leading-5 text-[#404040]">{helper}</p>
+      <div className="overflow-x-auto">{children}</div>
+    </section>
+  )
+}
+
+interface SessionLogTableProps {
+  sessions: readonly OtfSession[]
+  range: DateRange
+}
+
+/** Per-class log with rows expandable to the treadmill + rower performance blocks. */
+function SessionLogTable({ sessions, range }: SessionLogTableProps): JSX.Element {
+  // Newest first.
+  const rows = useMemo(() => sessions.slice().reverse(), [sessions])
+  const [expandedKey, setExpandedKey] = useState<string | null>(null)
+
+  return (
+    <section className="mt-8 rounded-[1.6rem] border border-white/10 bg-black/25 p-5">
+      <header className="mb-3 flex flex-wrap items-baseline justify-between gap-3">
+        <h2 className="font-mono text-xs font-bold uppercase tracking-[0.24em] text-white/80">
+          Classes
+        </h2>
+        <p className="text-xs text-white/55">
+          {sessions.length === 0 ? 'No classes in range' : `${sessions.length} in range`}
+          <span className="ml-2 text-white/35">
+            ({formatBound(range.start)} → {formatBound(range.end)})
+          </span>
+        </p>
+      </header>
+      {rows.length === 0 ? (
+        <p className="px-2 py-6 text-center text-sm text-white/55">
+          No OrangeTheory classes in the selected range.
+        </p>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full min-w-[720px] border-separate border-spacing-y-1 text-left text-sm">
+            <thead className="text-xs uppercase tracking-[0.18em] text-white/55">
+              <tr>
+                <th scope="col" className="px-3 py-2 font-semibold">
+                  Date
+                </th>
+                <th scope="col" className="px-3 py-2 font-semibold">
+                  Coach
+                </th>
+                <th scope="col" className="px-3 py-2 font-semibold">
+                  Splat
+                </th>
+                <th scope="col" className="px-3 py-2 font-semibold">
+                  Calories
+                </th>
+                <th scope="col" className="px-3 py-2 font-semibold">
+                  Avg HR
+                </th>
+                <th scope="col" className="px-3 py-2 font-semibold">
+                  Peak HR
+                </th>
+                <th scope="col" className="px-3 py-2 font-semibold">
+                  <span className="sr-only">Expand</span>
+                </th>
+              </tr>
+            </thead>
+            <tbody className="text-[#f7ead9]">
+              {rows.map((s, i) => {
+                const rowKey = `${s.started_at}-${i}`
+                const expandable = !!s.treadmill || !!s.rower || !!s.zones_min
+                const isExpanded = expandedKey === rowKey
+                const toggle = () => {
+                  if (!expandable) return
+                  setExpandedKey(isExpanded ? null : rowKey)
+                }
+                return (
+                  <Fragment key={rowKey}>
+                    <tr
+                      className={`rounded-md bg-white/5 align-middle ${
+                        expandable
+                          ? 'cursor-pointer transition hover:bg-white/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/60'
+                          : ''
+                      }`}
+                      {...(expandable
+                        ? {
+                            role: 'button',
+                            tabIndex: 0,
+                            'aria-expanded': isExpanded,
+                            onClick: toggle,
+                            onKeyDown: (e: React.KeyboardEvent<HTMLTableRowElement>) => {
+                              if (e.key === 'Enter' || e.key === ' ') {
+                                e.preventDefault()
+                                toggle()
+                              }
+                            },
+                          }
+                        : {})}
+                    >
+                      <td className="rounded-l-md px-3 py-2 font-mono">{formatOtfDate(s)}</td>
+                      <td className="px-3 py-2">{s.coach ?? '—'}</td>
+                      <td className="px-3 py-2 font-mono text-[#f97316]">{numCell(s.splat)}</td>
+                      <td className="px-3 py-2 font-mono">{numCell(s.calories)}</td>
+                      <td className="px-3 py-2 font-mono">{numCell(s.avg_hr)}</td>
+                      <td className="px-3 py-2 font-mono">{numCell(s.peak_hr)}</td>
+                      <td className="rounded-r-md px-3 py-2 text-right font-mono text-white/45">
+                        {expandable ? (isExpanded ? '▾' : '▸') : ''}
+                      </td>
+                    </tr>
+                    {isExpanded && expandable && (
+                      <tr>
+                        <td colSpan={7} className="px-3 pb-3">
+                          <ExpandedSession session={s} />
+                        </td>
+                      </tr>
+                    )}
+                  </Fragment>
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  )
+}
+
+/** Expanded row body: zone minutes plus the treadmill and rower performance blocks. */
+function ExpandedSession({ session }: { session: OtfSession }): JSX.Element {
+  // Capture into a local so the truthiness narrowing carries into the `.map`
+  // callback (a property access doesn't stay narrowed across the closure).
+  const zones = session.zones_min
+  return (
+    <div className="grid gap-4 rounded-xl bg-black/30 p-4 text-xs sm:grid-cols-3">
+      <div>
+        <p className="mb-2 font-mono uppercase tracking-[0.18em] text-white/55">Zones</p>
+        {zones ? (
+          <ul className="space-y-1">
+            {OTF_ZONES.map(z => (
+              <li key={z.key} className="flex items-center gap-2">
+                <span
+                  aria-hidden="true"
+                  className="inline-block h-2.5 w-2.5 rounded-sm"
+                  style={{ backgroundColor: z.color }}
+                />
+                <span className="text-white/70">{z.shortLabel}</span>
+                <span className="ml-auto font-mono text-white/90">{zones[z.key]}m</span>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="text-white/45">No zone data.</p>
+        )}
+      </div>
+      <StatBlock title="Treadmill" rows={treadmillRows(session.treadmill)} />
+      <StatBlock title="Rower" rows={rowerRows(session.rower)} />
+    </div>
+  )
+}
+
+/** A labeled stat list used by the treadmill / rower blocks. Renders a placeholder when absent. */
+function StatBlock({
+  title,
+  rows,
+}: {
+  title: string
+  rows: Array<[string, string]> | null
+}): JSX.Element {
+  return (
+    <div>
+      <p className="mb-2 font-mono uppercase tracking-[0.18em] text-white/55">{title}</p>
+      {rows ? (
+        <dl className="space-y-1">
+          {rows.map(([label, value]) => (
+            <div key={label} className="flex items-center justify-between gap-2">
+              <dt className="text-white/60">{label}</dt>
+              <dd className="font-mono text-white/90">{value}</dd>
+            </div>
+          ))}
+        </dl>
+      ) : (
+        <p className="text-white/45">Not in this class format.</p>
+      )}
+    </div>
+  )
+}
+
+/** Format the treadmill block into label/value pairs, or `null` when absent. */
+function treadmillRows(t: OtfTreadmill | undefined): Array<[string, string]> | null {
+  if (!t) return null
+  const rows: Array<[string, string]> = [
+    ['Distance', `${t.distance_mi} mi`],
+    ['Time', t.time],
+  ]
+  if (t.avg_pace) rows.push(['Avg pace', `${t.avg_pace}/mi`])
+  if (t.fastest_pace) rows.push(['Best pace', `${t.fastest_pace}/mi`])
+  if (t.avg_mph !== undefined) rows.push(['Avg speed', `${t.avg_mph} mph`])
+  if (t.avg_incline !== undefined) rows.push(['Avg incline', `${t.avg_incline}%`])
+  if (t.elevation_ft !== undefined) rows.push(['Elevation', `${t.elevation_ft} ft`])
+  return rows
+}
+
+/** Format the rower block into label/value pairs, or `null` when absent. */
+function rowerRows(r: OtfRower | undefined): Array<[string, string]> | null {
+  if (!r) return null
+  const rows: Array<[string, string]> = [
+    ['Distance', `${r.distance_m} m`],
+    ['Time', r.time],
+  ]
+  if (r.split_500m) rows.push(['Avg /500m', r.split_500m])
+  if (r.best_split_500m) rows.push(['Best /500m', r.best_split_500m])
+  if (r.avg_watt !== undefined) rows.push(['Avg watts', `${r.avg_watt}`])
+  if (r.avg_spm !== undefined) rows.push(['Avg SPM', `${r.avg_spm}`])
+  return rows
+}
+
+/** Render a numeric cell, rounding to a whole number, or an em dash when absent. */
+function numCell(value: number | undefined): string {
+  return typeof value === 'number' ? `${Math.round(value)}` : '—'
+}
+
+/** `YYYY-MM-DD` for a date-range bound. */
+function formatBound(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(
+    d.getDate()
+  ).padStart(2, '0')}`
+}
+
+function LoadingPanel(): JSX.Element {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="mt-10 rounded-[1.6rem] border border-white/10 bg-black/25 p-8 text-center text-sm text-white/65"
+    >
+      Loading OrangeTheory data…
+    </div>
+  )
+}
+
+function EmptyState(): JSX.Element {
+  return (
+    <div className="mt-10 rounded-[1.6rem] border border-white/10 bg-black/25 p-8 text-center text-sm leading-6 text-white/65">
+      <p className="font-semibold uppercase tracking-[0.18em] text-white/80">
+        No OrangeTheory classes yet
+      </p>
+      <p className="mt-2 text-white/55">
+        Sessions land here automatically each week as the OTbeat summary emails are ingested.
+      </p>
+    </div>
+  )
+}
+
+function ErrorPanel({ error }: { error: Error }): JSX.Element {
+  return (
+    <div
+      role="alert"
+      className="mt-10 rounded-[1.6rem] border border-red-400/30 bg-red-950/40 p-6 text-sm leading-6 text-red-100"
+    >
+      <p className="font-semibold uppercase tracking-[0.18em]">Could not load OrangeTheory data</p>
+      <p className="mt-2 text-red-100/80">{error.message}</p>
+    </div>
+  )
+}

--- a/components/training-facility/gym/OtfDetailView.tsx
+++ b/components/training-facility/gym/OtfDetailView.tsx
@@ -18,7 +18,10 @@ import {
   aggregateOtfZoneMinutes,
   earliestOtfDate,
   filterOtfSessionsInRange,
+  formatMmss,
   formatOtfDate,
+  mmssToSeconds,
+  otfBlockTrend,
   otfHighlights,
   otfMetricTrend,
   type OtfTrendPoint,
@@ -115,6 +118,22 @@ export function OtfDetailView(): JSX.Element {
   const splatTrend = useMemo(() => otfMetricTrend(sessions, 'splat'), [sessions])
   const calorieTrend = useMemo(() => otfMetricTrend(sessions, 'calories'), [sessions])
   const hrTrend = useMemo(() => otfMetricTrend(sessions, 'avg_hr'), [sessions])
+  const treadDistanceTrend = useMemo(
+    () => otfBlockTrend(sessions, 'treadmill', t => t.distance_mi),
+    [sessions]
+  )
+  const treadPaceTrend = useMemo(
+    () => otfBlockTrend(sessions, 'treadmill', t => mmssToSeconds(t.avg_pace)),
+    [sessions]
+  )
+  const rowerDistanceTrend = useMemo(
+    () => otfBlockTrend(sessions, 'rower', r => r.distance_m),
+    [sessions]
+  )
+  const rowerSplitTrend = useMemo(
+    () => otfBlockTrend(sessions, 'rower', r => mmssToSeconds(r.split_500m)),
+    [sessions]
+  )
   const highlights = useMemo(() => otfHighlights(sessions), [sessions])
 
   const hasAnySessions = !!data && data.sessions.length > 0
@@ -224,6 +243,56 @@ export function OtfDetailView(): JSX.Element {
               </ChartCard>
             </div>
 
+            <SectionLabel>Treadmill</SectionLabel>
+            <div className="mt-4 grid gap-6 lg:grid-cols-2">
+              <ChartCard title="Distance per class" helper="Treadmill miles per class.">
+                <OtfTrendChart
+                  data={treadDistanceTrend}
+                  width={chartWidth}
+                  yLabel="Miles"
+                  yTickFormat={v => v.toFixed(2)}
+                  ariaLabel="Treadmill distance per class over time"
+                  emptyMessage="No treadmill distance in range"
+                />
+              </ChartCard>
+              <ChartCard
+                title="Avg pace"
+                helper="Average treadmill pace per mile — lower is faster."
+              >
+                <OtfTrendChart
+                  data={treadPaceTrend}
+                  width={chartWidth}
+                  yLabel="min/mi"
+                  yTickFormat={formatMmss}
+                  ariaLabel="Treadmill average pace over time"
+                  emptyMessage="No treadmill pace in range"
+                />
+              </ChartCard>
+            </div>
+
+            <SectionLabel>Rower</SectionLabel>
+            <div className="mt-4 grid gap-6 lg:grid-cols-2">
+              <ChartCard title="Distance per class" helper="Rower meters per class.">
+                <OtfTrendChart
+                  data={rowerDistanceTrend}
+                  width={chartWidth}
+                  yLabel="Meters"
+                  ariaLabel="Rower distance per class over time"
+                  emptyMessage="No rower distance in range"
+                />
+              </ChartCard>
+              <ChartCard title="500m split" helper="Average time per 500m — lower is faster.">
+                <OtfTrendChart
+                  data={rowerSplitTrend}
+                  width={chartWidth}
+                  yLabel="/500m"
+                  yTickFormat={formatMmss}
+                  ariaLabel="Rower 500m split over time"
+                  emptyMessage="No rower split in range"
+                />
+              </ChartCard>
+            </div>
+
             <SessionLogTable sessions={sessions} range={range} />
           </>
         )}
@@ -239,12 +308,15 @@ function OtfTrendChart({
   yLabel,
   ariaLabel,
   emptyMessage,
+  yTickFormat,
 }: {
   data: OtfTrendPoint[]
   width: number
   yLabel: string
   ariaLabel: string
   emptyMessage: string
+  /** Optional y-axis tick formatter (e.g. `formatMmss` for pace/split). Defaults to whole numbers. */
+  yTickFormat?: (value: number) => string
 }): JSX.Element {
   return (
     <RoughLine<OtfTrendPoint>
@@ -256,10 +328,19 @@ function OtfTrendChart({
       margin={defaultMargin}
       fontFamily={FONT_FAMILY}
       yLabel={yLabel}
-      yTickFormat={v => `${Math.round(v)}`}
+      yTickFormat={yTickFormat ?? (v => `${Math.round(v)}`)}
       ariaLabel={ariaLabel}
       emptyMessage={emptyMessage}
     />
+  )
+}
+
+/** Small orange divider label for the machine-specific chart groups. */
+function SectionLabel({ children }: { children: string }): JSX.Element {
+  return (
+    <h2 className="mt-10 font-mono text-sm font-bold uppercase tracking-[0.28em] text-[#f97316]">
+      {children}
+    </h2>
   )
 }
 

--- a/components/training-facility/gym/OtfDetailView.tsx
+++ b/components/training-facility/gym/OtfDetailView.tsx
@@ -134,6 +134,14 @@ export function OtfDetailView(): JSX.Element {
     () => otfBlockTrend(sessions, 'rower', r => mmssToSeconds(r.split_500m)),
     [sessions]
   )
+  const treadInclineTrend = useMemo(
+    () => otfBlockTrend(sessions, 'treadmill', t => t.avg_incline),
+    [sessions]
+  )
+  const rowerWattsTrend = useMemo(
+    () => otfBlockTrend(sessions, 'rower', r => r.avg_watt),
+    [sessions]
+  )
   const highlights = useMemo(() => otfHighlights(sessions), [sessions])
 
   const hasAnySessions = !!data && data.sessions.length > 0
@@ -268,6 +276,19 @@ export function OtfDetailView(): JSX.Element {
                   emptyMessage="No treadmill pace in range"
                 />
               </ChartCard>
+              <ChartCard
+                title="Avg incline"
+                helper="Average treadmill incline — context for pace (a slow mile may be a steep one)."
+              >
+                <OtfTrendChart
+                  data={treadInclineTrend}
+                  width={chartWidth}
+                  yLabel="Incline %"
+                  yTickFormat={v => v.toFixed(1)}
+                  ariaLabel="Treadmill average incline over time"
+                  emptyMessage="No treadmill incline in range"
+                />
+              </ChartCard>
             </div>
 
             <SectionLabel>Rower</SectionLabel>
@@ -289,6 +310,18 @@ export function OtfDetailView(): JSX.Element {
                   yTickFormat={formatMmss}
                   ariaLabel="Rower 500m split over time"
                   emptyMessage="No rower split in range"
+                />
+              </ChartCard>
+              <ChartCard
+                title="Avg watts"
+                helper="Average rower power output — higher is stronger."
+              >
+                <OtfTrendChart
+                  data={rowerWattsTrend}
+                  width={chartWidth}
+                  yLabel="Watts"
+                  ariaLabel="Rower average wattage over time"
+                  emptyMessage="No rower wattage in range"
                 />
               </ChartCard>
             </div>

--- a/components/training-facility/gym/OtfDetailView.tsx
+++ b/components/training-facility/gym/OtfDetailView.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import Link from 'next/link'
-import { Fragment, useEffect, useMemo, useRef, useState, type JSX } from 'react'
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState, type JSX } from 'react'
 
 import { BackToCourtButton } from '@/components/common/BackToCourtButton'
 import { RoughLine } from '@/components/training-facility/shared/charts/RoughLine'
@@ -50,7 +50,30 @@ export function OtfDetailView(): JSX.Element {
   const [loadError, setLoadError] = useState<Error | null>(null)
   const [range, setRange] = useState<DateRange>(() => rangeForPreset('ALL', EARLIEST_FALLBACK))
   const [chartWidth, setChartWidth] = useState(DEFAULT_CHART_WIDTH)
-  const cardSizerRef = useRef<HTMLDivElement>(null)
+
+  // The chart wrapper mounts only after data arrives (it lives inside the data
+  // branch), so observe it via a callback ref. A mount effect would run while
+  // the node is still null and never attach, freezing the width at the default.
+  const observerRef = useRef<ResizeObserver | null>(null)
+  const measureChart = useCallback((node: HTMLDivElement | null) => {
+    observerRef.current?.disconnect()
+    if (!node || typeof ResizeObserver === 'undefined') return
+    const observer = new ResizeObserver(entries => {
+      for (const entry of entries) {
+        const next = Math.max(MIN_CHART_WIDTH, Math.floor(entry.contentRect.width))
+        setChartWidth(prev => (prev === next ? prev : next))
+      }
+    })
+    observer.observe(node)
+    observerRef.current = observer
+  }, [])
+
+  // Track manual range edits so the post-load re-anchor doesn't stomp them.
+  const userAdjustedRange = useRef(false)
+  const handleRangeChange = useCallback((next: DateRange) => {
+    userAdjustedRange.current = true
+    setRange(next)
+  }, [])
 
   useEffect(() => {
     let cancelled = false
@@ -71,23 +94,18 @@ export function OtfDetailView(): JSX.Element {
     }
   }, [])
 
-  useEffect(() => {
-    const node = cardSizerRef.current
-    if (!node || typeof ResizeObserver === 'undefined') return
-    const observer = new ResizeObserver(entries => {
-      for (const entry of entries) {
-        const next = Math.max(MIN_CHART_WIDTH, Math.floor(entry.contentRect.width))
-        setChartWidth(prev => (prev === next ? prev : next))
-      }
-    })
-    observer.observe(node)
-    return () => observer.disconnect()
-  }, [])
-
   const earliest = useMemo(
     () => (data ? (earliestOtfDate(data.sessions) ?? EARLIEST_FALLBACK) : EARLIEST_FALLBACK),
     [data]
   )
+
+  // Re-anchor the default "All" range once the real earliest session date is
+  // known — the dataset loads after mount, so the mount-time range was built
+  // from EARLIEST_FALLBACK. Skipped after the user picks a range.
+  useEffect(() => {
+    if (userAdjustedRange.current || !data) return
+    setRange(rangeForPreset('ALL', earliest))
+  }, [earliest, data])
 
   const sessions = useMemo(
     () => (data ? filterOtfSessionsInRange(data.sessions, range) : []),
@@ -134,7 +152,12 @@ export function OtfDetailView(): JSX.Element {
         </header>
 
         <div className="mt-8">
-          <DateFilter earliestDate={earliest} defaultPreset="ALL" onChange={setRange} />
+          <DateFilter
+            key={earliest.getTime()}
+            earliestDate={earliest}
+            defaultPreset="ALL"
+            onChange={handleRangeChange}
+          />
         </div>
 
         {loadError ? (
@@ -152,7 +175,7 @@ export function OtfDetailView(): JSX.Element {
                 title="Minutes in zone"
                 helper="Total minutes per OTbeat HR zone across the filtered window."
               >
-                <div ref={cardSizerRef}>
+                <div ref={measureChart}>
                   <OtfZoneBars
                     buckets={buckets}
                     width={chartWidth}

--- a/components/training-facility/gym/OtfZoneBars.tsx
+++ b/components/training-facility/gym/OtfZoneBars.tsx
@@ -80,8 +80,12 @@ export function OtfZoneBars({
     offset: (xScale(b.shortLabel) ?? 0) + xScale.bandwidth() / 2,
   }))
 
+  // Format with the scale's own precision rather than `Math.round`, so a small
+  // range whose nice ticks are fractional doesn't collapse to duplicate labels
+  // (e.g. 0m / 1m / 1m). Whole-minute ranges still read as plain integers.
+  const formatYTick = yScale.tickFormat(5)
   const yTicks: AxisTick[] = yScale.ticks(5).map(tick => ({
-    value: `${Math.round(tick)}m`,
+    value: `${formatYTick(tick)}m`,
     offset: yScale(tick),
   }))
 

--- a/components/training-facility/gym/OtfZoneBars.tsx
+++ b/components/training-facility/gym/OtfZoneBars.tsx
@@ -1,0 +1,157 @@
+import type { JSX } from 'react'
+import { scaleBand, scaleLinear } from 'd3-scale'
+
+import { Axis, EmptyChart, type AxisTick } from '@/components/training-facility/shared/charts/axes'
+import { chartPalette } from '@/components/training-facility/shared/charts/palette'
+import {
+  drawableToPaths,
+  getGenerator,
+} from '@/components/training-facility/shared/charts/rough-svg'
+import {
+  resolveMargin,
+  type ChartCommonProps,
+} from '@/components/training-facility/shared/charts/types'
+import type { OtfZoneBucket } from '@/lib/training-facility/otf'
+
+/** Props for {@link OtfZoneBars}. */
+export interface OtfZoneBarsProps extends ChartCommonProps {
+  /** Pre-aggregated zone buckets (gray → red, in canonical order). */
+  buckets: readonly OtfZoneBucket[]
+  /** Inner padding between bars (0–1). Defaults to 0.25. */
+  padding?: number
+}
+
+/**
+ * Minutes-in-zone bar chart for the OrangeTheory Gym view — five bars
+ * (gray/blue/green/orange/red), each tinted with the zone's brand color,
+ * heights driven by total minutes in that zone across the filtered window.
+ *
+ * Sibling of `HrZoneBars` (the cardio Z1–Z5 chart). The shared `RoughBar`
+ * primitive only takes one `fill`, so this inlines a renderer that asks
+ * rough.js for one rectangle per bucket using `bucket.color`. OTF data is
+ * already in minutes, so the y-axis needs no seconds→minutes switch.
+ */
+export function OtfZoneBars({
+  buckets,
+  width,
+  height,
+  margin,
+  padding = 0.25,
+  roughness = 1.4,
+  seed = 4,
+  fontFamily = 'inherit',
+  axisColor = chartPalette.inkBlack,
+  className,
+  ariaLabel = 'Minutes in heart-rate zone',
+  ariaLabelledBy,
+  emptyMessage = 'No zone data in range',
+}: OtfZoneBarsProps): JSX.Element {
+  const m = resolveMargin(margin)
+  const innerW = width - m.left - m.right
+  const innerH = height - m.top - m.bottom
+
+  const totalMinutes = buckets.reduce((acc, b) => acc + b.minutes, 0)
+  if (totalMinutes === 0) {
+    return (
+      <EmptyChart
+        width={width}
+        height={height}
+        message={emptyMessage}
+        fontFamily={fontFamily}
+        className={className}
+        ariaLabel={ariaLabel}
+        ariaLabelledBy={ariaLabelledBy}
+      />
+    )
+  }
+
+  const xScale = scaleBand<string>()
+    .domain(buckets.map(b => b.shortLabel))
+    .range([0, innerW])
+    .padding(padding)
+
+  const yMax = Math.max(0, ...buckets.map(b => b.minutes))
+  const yScale = scaleLinear().domain([0, yMax]).nice().range([innerH, 0])
+
+  const gen = getGenerator()
+
+  const xTicks: AxisTick[] = buckets.map(b => ({
+    value: b.shortLabel,
+    offset: (xScale(b.shortLabel) ?? 0) + xScale.bandwidth() / 2,
+  }))
+
+  const yTicks: AxisTick[] = yScale.ticks(5).map(tick => ({
+    value: `${Math.round(tick)}m`,
+    offset: yScale(tick),
+  }))
+
+  return (
+    <svg
+      width={width}
+      height={height}
+      className={className}
+      role="img"
+      aria-label={ariaLabelledBy ? undefined : ariaLabel}
+      aria-labelledby={ariaLabelledBy}
+    >
+      {ariaLabel && !ariaLabelledBy && <title>{ariaLabel}</title>}
+      <g transform={`translate(${m.left},${m.top})`}>
+        <Axis
+          orientation="bottom"
+          position={innerH}
+          start={0}
+          end={innerW}
+          ticks={xTicks}
+          label="Zone"
+          color={axisColor}
+          fontFamily={fontFamily}
+          roughness={roughness}
+          seed={seed + 100}
+        />
+        <Axis
+          orientation="left"
+          position={0}
+          start={0}
+          end={innerH}
+          ticks={yTicks}
+          label="Minutes"
+          color={axisColor}
+          fontFamily={fontFamily}
+          roughness={roughness}
+          seed={seed + 200}
+        />
+        {buckets.map((b, i) => {
+          const bx = xScale(b.shortLabel) ?? 0
+          const bw = xScale.bandwidth()
+          // Zero buckets collapse entirely (no 1px baseline) — an OTF class
+          // legitimately logs zero minutes in some zones and a stub bar would
+          // read as "a little time here" when there was none.
+          const bh = b.minutes > 0 ? Math.max(innerH - yScale(b.minutes), 1) : 0
+          if (bh === 0) return null
+          const by = innerH - bh
+          const rect = gen.rectangle(bx, by, bw, bh, {
+            fill: b.color,
+            fillStyle: 'hachure',
+            fillWeight: 2,
+            hachureGap: 5,
+            stroke: chartPalette.inkBlack,
+            strokeWidth: 1.5,
+            roughness,
+            seed: seed + 1000 + i,
+          })
+          return drawableToPaths(rect).map((p, j) => (
+            <path
+              key={`otfzone-${b.key}-${j}`}
+              d={p.d}
+              stroke={p.stroke}
+              strokeWidth={p.strokeWidth}
+              fill={p.fill ?? 'none'}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          ))
+        })}
+      </g>
+    </svg>
+  )
+}

--- a/components/training-facility/scenes/GymScene.tsx
+++ b/components/training-facility/scenes/GymScene.tsx
@@ -7,12 +7,7 @@ import {
   pickLatestVo2max,
 } from '@/lib/training-facility/wall-fixtures'
 
-import {
-  HardwoodFloor,
-  SCENE_PALETTE,
-  SceneDefs,
-  WallBand,
-} from './scene-primitives'
+import { HardwoodFloor, SCENE_PALETTE, SceneDefs, WallBand } from './scene-primitives'
 import { Basketball, SweatTowel, WaterBottle } from './assets/character-props'
 import {
   BenchWithTablet,
@@ -32,6 +27,9 @@ const FLOOR_TOP = 600
 /** Cap matches the existing painted polylines so chart geometry stays stable between empty and populated states. */
 const HR_SPARKLINE_LIMIT = 9
 const VO2_TREND_LIMIT = 7
+
+/** Hand-marked font for the OrangeTheory signpost, matching the scene's other captions. */
+const SIGN_FONT = "'Patrick Hand', system-ui, sans-serif"
 
 /** Props for {@link GymScene}. */
 export interface GymSceneProps {
@@ -74,13 +72,7 @@ export function GymScene({ cardioData = null }: GymSceneProps = {}) {
       <SceneDefs />
 
       <WallBand width={VIEWBOX_WIDTH} height={FLOOR_TOP} />
-      <rect
-        x={0}
-        y={0}
-        width={VIEWBOX_WIDTH}
-        height={FLOOR_TOP}
-        fill="url(#sceneSpotlight)"
-      />
+      <rect x={0} y={0} width={VIEWBOX_WIDTH} height={FLOOR_TOP} fill="url(#sceneSpotlight)" />
 
       {/*
         Indoor-track group — same hover/focus pattern as the treadmill and
@@ -117,11 +109,7 @@ export function GymScene({ cardioData = null }: GymSceneProps = {}) {
         />
       </Link>
 
-      <HardwoodFloor
-        y={FLOOR_TOP}
-        height={VIEWBOX_HEIGHT - FLOOR_TOP}
-        width={VIEWBOX_WIDTH}
-      />
+      <HardwoodFloor y={FLOOR_TOP} height={VIEWBOX_HEIGHT - FLOOR_TOP} width={VIEWBOX_WIDTH} />
 
       {/* Wall fixtures (back-most) */}
       <HrMonitor bpm={hr?.bpm} sparkline={hr?.series} />
@@ -229,6 +217,89 @@ export function GymScene({ cardioData = null }: GymSceneProps = {}) {
         mark="H₂O"
         seed={920}
       />
+
+      {/*
+        OrangeTheory signpost — the "lighter" entry chosen for #256 instead of
+        a bespoke equipment asset. A freestanding floor placard in the empty
+        left-foreground, using the same group hover/focus overlay pattern as
+        the equipment links. A bespoke OTF equipment illustration can replace
+        it later (tracked as a follow-up).
+      */}
+      <Link
+        href="/training-facility/gym/otf"
+        aria-label="Open the OrangeTheory detail view"
+        className="group focus:outline-none"
+      >
+        {/* Base shadow + post */}
+        <ellipse cx={67} cy={858} rx={42} ry={7} fill={SCENE_PALETTE.ink} opacity={0.5} />
+        <rect x={62} y={718} width={10} height={138} fill={SCENE_PALETTE.hardwoodDark} />
+        {/* Placard */}
+        <rect
+          x={20}
+          y={628}
+          width={94}
+          height={98}
+          rx={6}
+          fill={SCENE_PALETTE.creamBright}
+          stroke={SCENE_PALETTE.ink}
+          strokeWidth={3}
+        />
+        <text
+          x={67}
+          y={668}
+          textAnchor="middle"
+          fill={SCENE_PALETTE.rim}
+          fontFamily={SIGN_FONT}
+          fontSize={34}
+          fontWeight={700}
+        >
+          OTF
+        </text>
+        <text
+          x={67}
+          y={690}
+          textAnchor="middle"
+          fill={SCENE_PALETTE.inkSoft}
+          fontFamily={SIGN_FONT}
+          fontSize={11}
+          letterSpacing={1}
+        >
+          orangetheory
+        </text>
+        <text
+          x={67}
+          y={712}
+          textAnchor="middle"
+          fill={SCENE_PALETTE.inkSoft}
+          fontFamily={SIGN_FONT}
+          fontSize={15}
+          fontWeight={700}
+        >
+          studio →
+        </text>
+        {/* Hover tint */}
+        <rect
+          x={18}
+          y={620}
+          width={94}
+          height={245}
+          fill={SCENE_PALETTE.creamBright}
+          className="opacity-0 transition-opacity group-hover:opacity-10 group-focus-visible:opacity-15"
+        />
+        {/* Focus ring */}
+        <rect
+          x={18}
+          y={620}
+          width={94}
+          height={245}
+          fill="none"
+          stroke={SCENE_PALETTE.rim}
+          strokeWidth={4}
+          strokeDasharray="6 4"
+          rx={6}
+          className="opacity-0 transition-opacity group-focus-visible:opacity-100"
+        />
+      </Link>
 
       <DoorToCombine />
     </svg>

--- a/lib/data/index.ts
+++ b/lib/data/index.ts
@@ -18,6 +18,7 @@
  */
 
 export { getCardioData } from './cardio';
+export { getOtfData } from './otf';
 export {
   getMovementBenchmarks,
   logBenchmark,

--- a/lib/data/otf-server.ts
+++ b/lib/data/otf-server.ts
@@ -1,0 +1,19 @@
+import 'server-only'
+
+import { createServerSupabaseClient } from '@/lib/supabase/server'
+import type { OtfData } from '@/types/otf'
+
+import { assembleOtfData } from './otf-shared'
+
+/**
+ * Server-side OrangeTheory dataset reader (SSR / Server Components). Wraps
+ * the shared {@link assembleOtfData} helper with the request-scoped server
+ * Supabase client. Mirrors `getCardioDataServer` in `lib/data/cardio-server.ts`.
+ *
+ * @throws See {@link assembleOtfData}. Server callers typically
+ *   `.catch(() => null)` and render the empty state.
+ */
+export async function getOtfDataServer(): Promise<OtfData | null> {
+  const supabase = await createServerSupabaseClient()
+  return assembleOtfData(supabase)
+}

--- a/lib/data/otf-shared.ts
+++ b/lib/data/otf-shared.ts
@@ -1,0 +1,119 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { z } from 'zod'
+
+import { OtfSessionRowSchema, otfRowToSession } from '@/lib/schemas/otf'
+import type { OtfData } from '@/types/otf'
+
+/**
+ * Pure OTF-read helper shared between the browser entry (`lib/data/otf.ts`)
+ * and the server entry (`lib/data/otf-server.ts`). Like its cardio sibling
+ * (`lib/data/cardio-shared.ts`), this module imports neither Supabase client
+ * — only the entry files do — so importing `assembleOtfData` from a Server
+ * Component doesn't drag the browser client into the server bundle (or vice
+ * versa).
+ */
+
+/** Supabase table backing the OrangeTheory Gym view (#256). */
+const SESSIONS_TABLE = 'otf_sessions'
+
+/**
+ * Whitelisted columns for `otf_sessions`. Kept in sync by hand with
+ * {@link OtfSessionRowSchema} (which is `.strict()`), so a column added to
+ * the table without updating the schema fails loudly instead of leaking to
+ * the view. `updated_at` is pulled to compute `imported_at`, then stripped
+ * before validation.
+ */
+const SESSIONS_COLUMNS =
+  'started_at, coach, studio, calories, splat, steps, avg_hr, peak_hr, ' +
+  'zone_gray_min, zone_blue_min, zone_green_min, zone_orange_min, zone_red_min, ' +
+  'treadmill, rower, updated_at'
+
+/** Array form of {@link OtfSessionRowSchema} for validating the full read. */
+const OtfSessionRowsSchema = z.array(OtfSessionRowSchema)
+
+/**
+ * Fetch the full OrangeTheory dataset from Supabase using the supplied
+ * client. Shared between `getOtfData` (browser) and `getOtfDataServer`
+ * (server) so the read shape, column whitelist, and validation can't drift.
+ *
+ * Returns `null` when the table is empty — preserves the same "no data yet"
+ * contract the cardio views use, so the OTF view can fall back to an empty
+ * render / empty-state branch.
+ *
+ * `imported_at` is `MAX(updated_at)` across the rows. Lexicographic string
+ * compare is safe because PostgREST serializes every `timestamptz` in the
+ * same canonical UTC form, so the strings sort by actual time.
+ *
+ * @param supabase Browser or server SSR client (both anon role; otf RLS
+ *   allows anon SELECT).
+ * @throws when the Supabase query fails (network / misconfig / RLS
+ *   regression) or when row-shape validation fails. Callers usually
+ *   downgrade this to an empty render.
+ */
+export async function assembleOtfData(supabase: SupabaseClient): Promise<OtfData | null> {
+  const res = await supabase
+    .from(SESSIONS_TABLE)
+    .select(SESSIONS_COLUMNS)
+    .order('started_at', { ascending: true })
+
+  if (res.error) {
+    throw new Error(`Failed to load OTF sessions: ${res.error.message}`)
+  }
+
+  const raw = (res.data ?? []) as unknown as Array<Record<string, unknown>>
+  if (raw.length === 0) {
+    // Preserves the null-on-empty contract the view's empty-state handles.
+    return null
+  }
+
+  const importedAt = computeImportedAt(raw)
+
+  const parsed = OtfSessionRowsSchema.safeParse(raw.map(stripNulls).map(stripUpdatedAt))
+  if (!parsed.success) {
+    throw new Error(`otf_sessions failed schema validation: ${parsed.error.message}`)
+  }
+
+  return {
+    imported_at: importedAt,
+    sessions: parsed.data.map(otfRowToSession),
+  }
+}
+
+/**
+ * Postgres returns `null` for omitted optional columns, but the row schema
+ * declares optional fields with `.optional()` (no `.nullable()`). Map `null`
+ * → absent so Zod parses Supabase rows the same way it parses the importer's
+ * absent-key payloads.
+ */
+function stripNulls(row: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(row)) {
+    if (value !== null) out[key] = value
+  }
+  return out
+}
+
+/**
+ * Drop the `updated_at` audit column before Zod-parsing — the row schema is
+ * `.strict()` and would reject it — but only after {@link computeImportedAt}
+ * has read it off the raw row.
+ */
+function stripUpdatedAt(row: Record<string, unknown>): Record<string, unknown> {
+  if (!('updated_at' in row)) return row
+  const { updated_at: _ignored, ...rest } = row
+  return rest
+}
+
+/**
+ * Determine `imported_at` from the latest `updated_at` across the rows.
+ * Returns `''` when no row carries an `updated_at`. Lexicographic compare is
+ * valid on PostgREST's canonical UTC `timestamptz` serialization.
+ */
+function computeImportedAt(rows: Array<Record<string, unknown>>): string {
+  let latest = ''
+  for (const row of rows) {
+    const value = row.updated_at
+    if (typeof value === 'string' && value > latest) latest = value
+  }
+  return latest
+}

--- a/lib/data/otf.test.ts
+++ b/lib/data/otf.test.ts
@@ -1,0 +1,171 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { getOtfData } from './otf'
+
+/**
+ * Tests for the OTF data-access wrapper (#256). Mocks
+ * `getBrowserSupabaseClient` and tracks the chained `from(...).select().order()`
+ * call so each assertion can stub the `otf_sessions` result independently.
+ *
+ * Sibling pattern: `lib/data/cardio.test.ts`.
+ */
+
+interface FakeQuery {
+  select: ReturnType<typeof vi.fn>
+  order: ReturnType<typeof vi.fn>
+}
+
+const queriesByTable: Record<string, FakeQuery> = {}
+const fromMock = vi.fn((table: string): FakeQuery => {
+  if (!queriesByTable[table]) {
+    const query: FakeQuery = { select: vi.fn(), order: vi.fn() }
+    query.select.mockReturnValue(query)
+    query.order.mockResolvedValue({ data: [], error: null })
+    queriesByTable[table] = query
+  }
+  return queriesByTable[table]
+})
+const browserClientMock = { from: fromMock }
+
+vi.mock('@/lib/supabase/browser', () => ({
+  getBrowserSupabaseClient: () => browserClientMock,
+}))
+
+beforeEach(() => {
+  for (const key of Object.keys(queriesByTable)) delete queriesByTable[key]
+  fromMock.mockClear()
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+/** Stub the `otf_sessions` query result. See the cardio test for the tautology gotcha around `fromMock.mockClear()`. */
+function stubSessions(data: Array<Record<string, unknown>> | null, error: unknown = null): void {
+  const query = fromMock('otf_sessions')
+  query.order.mockReset()
+  query.order.mockResolvedValue({ data, error })
+}
+
+const FULL_ROW = {
+  started_at: '2026-06-27T16:30:00+00:00',
+  coach: 'Mara Magistad',
+  studio: 'Marina Del Rey, CA',
+  calories: 776,
+  splat: 15,
+  steps: 3508,
+  avg_hr: 133,
+  peak_hr: 164,
+  zone_gray_min: 1,
+  zone_blue_min: 11,
+  zone_green_min: 29,
+  zone_orange_min: 14,
+  zone_red_min: 1,
+  treadmill: { distance_mi: 1.09, time: '16:44', avg_mph: 3.9 },
+  rower: { distance_m: 2509, time: '13:54', avg_spm: 30.2 },
+  updated_at: '2026-06-30T07:53:00+00:00',
+}
+
+describe('getOtfData', () => {
+  it('returns null when otf_sessions is empty', async () => {
+    stubSessions([])
+    fromMock.mockClear()
+    await expect(getOtfData()).resolves.toBeNull()
+    expect(fromMock).toHaveBeenCalledWith('otf_sessions')
+  })
+
+  it('orders sessions by started_at ascending', async () => {
+    stubSessions([])
+    await getOtfData()
+    expect(queriesByTable.otf_sessions.order).toHaveBeenCalledWith('started_at', {
+      ascending: true,
+    })
+  })
+
+  it('assembles OtfData and folds zone columns into zones_min', async () => {
+    stubSessions([FULL_ROW])
+    const data = await getOtfData()
+    expect(data).toEqual({
+      imported_at: '2026-06-30T07:53:00+00:00',
+      sessions: [
+        {
+          started_at: '2026-06-27T16:30:00+00:00',
+          coach: 'Mara Magistad',
+          studio: 'Marina Del Rey, CA',
+          calories: 776,
+          splat: 15,
+          steps: 3508,
+          avg_hr: 133,
+          peak_hr: 164,
+          zones_min: { gray: 1, blue: 11, green: 29, orange: 14, red: 1 },
+          treadmill: { distance_mi: 1.09, time: '16:44', avg_mph: 3.9 },
+          rower: { distance_m: 2509, time: '13:54', avg_spm: 30.2 },
+        },
+      ],
+    })
+  })
+
+  it('omits zones_min / treadmill / rower when null (belt-malfunction anomaly)', async () => {
+    stubSessions([
+      {
+        started_at: '2026-05-30T16:30:00+00:00',
+        coach: 'Jacob Buckenmeyer',
+        studio: 'Marina Del Rey, CA',
+        calories: 4,
+        splat: 0,
+        steps: null,
+        avg_hr: 94,
+        peak_hr: 95,
+        zone_gray_min: null,
+        zone_blue_min: null,
+        zone_green_min: null,
+        zone_orange_min: null,
+        zone_red_min: null,
+        treadmill: null,
+        rower: null,
+        updated_at: '2026-05-30T17:00:00+00:00',
+      },
+    ])
+    const data = await getOtfData()
+    expect(data?.sessions[0]).not.toHaveProperty('zones_min')
+    expect(data?.sessions[0]).not.toHaveProperty('treadmill')
+    expect(data?.sessions[0]).not.toHaveProperty('rower')
+    expect(data?.sessions[0]).not.toHaveProperty('steps')
+    expect(data?.sessions[0]).toEqual({
+      started_at: '2026-05-30T16:30:00+00:00',
+      coach: 'Jacob Buckenmeyer',
+      studio: 'Marina Del Rey, CA',
+      calories: 4,
+      splat: 0,
+      avg_hr: 94,
+      peak_hr: 95,
+    })
+  })
+
+  it('takes imported_at from the latest updated_at', async () => {
+    stubSessions([
+      {
+        ...FULL_ROW,
+        started_at: '2026-06-01T00:00:00+00:00',
+        updated_at: '2026-06-01T00:00:00+00:00',
+      },
+      {
+        ...FULL_ROW,
+        started_at: '2026-06-27T16:30:00+00:00',
+        updated_at: '2026-06-30T07:53:00+00:00',
+      },
+    ])
+    const data = await getOtfData()
+    expect(data?.imported_at).toBe('2026-06-30T07:53:00+00:00')
+  })
+
+  it('throws a descriptive error when the query fails', async () => {
+    stubSessions(null, { message: 'JWT expired' })
+    await expect(getOtfData()).rejects.toThrow(/Failed to load OTF sessions: JWT expired/)
+  })
+
+  it('throws when a row fails schema validation (unknown column)', async () => {
+    stubSessions([{ ...FULL_ROW, bogus_col: 1 }])
+    await expect(getOtfData()).rejects.toThrow(/otf_sessions failed schema validation/)
+  })
+})

--- a/lib/data/otf.ts
+++ b/lib/data/otf.ts
@@ -1,0 +1,17 @@
+import { getBrowserSupabaseClient } from '@/lib/supabase/browser'
+import type { OtfData } from '@/types/otf'
+
+import { assembleOtfData } from './otf-shared'
+
+/**
+ * Browser-side OrangeTheory dataset reader. Wraps the shared
+ * {@link assembleOtfData} helper with the cached browser Supabase client.
+ * The OTF detail view (`OtfDetailView`) calls this from a client effect; an
+ * SSR caller would use `getOtfDataServer` in `lib/data/otf-server.ts`.
+ *
+ * @throws See {@link assembleOtfData} — Supabase query or row-shape
+ *   validation failures. Callers usually downgrade this to an empty render.
+ */
+export async function getOtfData(): Promise<OtfData | null> {
+  return assembleOtfData(getBrowserSupabaseClient())
+}

--- a/lib/schemas/otf.test.ts
+++ b/lib/schemas/otf.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest'
+
+import { OtfSessionRowSchema, otfRowToSession } from './otf'
+
+/**
+ * Tests for the OTF row schema + row→session mapper (#256). Sibling pattern:
+ * `lib/schemas/cardio.test.ts`.
+ */
+
+describe('OtfSessionRowSchema', () => {
+  it('accepts a full row', () => {
+    const row = {
+      started_at: '2026-06-27T16:30:00+00:00',
+      coach: 'Mara Magistad',
+      studio: 'Marina Del Rey, CA',
+      calories: 776,
+      splat: 15,
+      steps: 3508,
+      avg_hr: 133,
+      peak_hr: 164,
+      zone_gray_min: 1,
+      zone_blue_min: 11,
+      zone_green_min: 29,
+      zone_orange_min: 14,
+      zone_red_min: 1,
+      treadmill: { distance_mi: 1.09, time: '16:44', avg_mph: 3.9 },
+      rower: { distance_m: 2509, time: '13:54', avg_spm: 30.2 },
+    }
+    expect(OtfSessionRowSchema.safeParse(row).success).toBe(true)
+  })
+
+  it('accepts a minimal row (started_at only)', () => {
+    expect(OtfSessionRowSchema.safeParse({ started_at: '2026-06-27T16:30:00+00:00' }).success).toBe(
+      true
+    )
+  })
+
+  it('rejects an unknown column (.strict)', () => {
+    expect(
+      OtfSessionRowSchema.safeParse({ started_at: '2026-06-27T16:30:00+00:00', bogus: 1 }).success
+    ).toBe(false)
+  })
+
+  it('rejects a negative numeric', () => {
+    expect(
+      OtfSessionRowSchema.safeParse({ started_at: '2026-06-27T16:30:00+00:00', calories: -1 })
+        .success
+    ).toBe(false)
+  })
+
+  it('rejects an empty started_at', () => {
+    expect(OtfSessionRowSchema.safeParse({ started_at: '' }).success).toBe(false)
+  })
+})
+
+describe('otfRowToSession', () => {
+  it('folds the zone columns into zones_min and passes the jsonb blocks through', () => {
+    const session = otfRowToSession({
+      started_at: '2026-06-27T16:30:00+00:00',
+      coach: 'Mara Magistad',
+      zone_gray_min: 1,
+      zone_blue_min: 11,
+      zone_green_min: 29,
+      zone_orange_min: 14,
+      zone_red_min: 1,
+      treadmill: { distance_mi: 1.09, time: '16:44' },
+    })
+    expect(session).toEqual({
+      started_at: '2026-06-27T16:30:00+00:00',
+      coach: 'Mara Magistad',
+      zones_min: { gray: 1, blue: 11, green: 29, orange: 14, red: 1 },
+      treadmill: { distance_mi: 1.09, time: '16:44' },
+    })
+  })
+
+  it('omits zones_min when no zone column is present', () => {
+    const session = otfRowToSession({ started_at: '2026-05-30T16:30:00+00:00', calories: 4 })
+    expect(session).not.toHaveProperty('zones_min')
+    expect(session).toEqual({ started_at: '2026-05-30T16:30:00+00:00', calories: 4 })
+  })
+
+  it('defaults missing zones to 0 when at least one is present', () => {
+    const session = otfRowToSession({ started_at: '2026-06-27T16:30:00+00:00', zone_orange_min: 5 })
+    expect(session.zones_min).toEqual({ gray: 0, blue: 0, green: 0, orange: 5, red: 0 })
+  })
+})

--- a/lib/schemas/otf.ts
+++ b/lib/schemas/otf.ts
@@ -1,0 +1,126 @@
+/**
+ * Pure (isomorphic) Zod schemas for the `otf_sessions` Supabase row
+ * contract (#256).
+ *
+ * One table backs the OrangeTheory Gym view: `public.otf_sessions`
+ * (`supabase/migrations/20260628120000_otf_sessions.sql`). These schemas
+ * are the single source of truth for what the data layer
+ * (`lib/data/otf-shared.ts`) accepts on read; the static interfaces in
+ * `types/otf.ts` mirror them for IDE ergonomics.
+ *
+ * Sibling pattern: `lib/schemas/cardio.ts`.
+ *
+ * KEEP IN SYNC WITH: `scripts/lib/otbeat-supabase.mjs` (`recordToRow`
+ * writes the snake_case columns read back here) and `types/otf.ts`.
+ */
+
+import { z } from 'zod'
+
+import type { OtfSession } from '@/types/otf'
+
+/**
+ * Treadmill JSONB block. Non-strict (extra keys stripped, not rejected) so
+ * a future parser field doesn't break reads before the schema catches up.
+ */
+export const OtfTreadmillSchema = z.object({
+  distance_mi: z.number(),
+  time: z.string(),
+  avg_mph: z.number().optional(),
+  max_mph: z.number().optional(),
+  avg_incline: z.number().optional(),
+  max_incline: z.number().optional(),
+  avg_pace: z.string().optional(),
+  fastest_pace: z.string().optional(),
+  elevation_ft: z.number().optional(),
+})
+
+/** Rower JSONB block. Non-strict, same rationale as {@link OtfTreadmillSchema}. */
+export const OtfRowerSchema = z.object({
+  distance_m: z.number(),
+  time: z.string(),
+  avg_watt: z.number().optional(),
+  max_watt: z.number().optional(),
+  avg_kmh: z.number().optional(),
+  max_kmh: z.number().optional(),
+  split_500m: z.string().optional(),
+  best_split_500m: z.string().optional(),
+  avg_spm: z.number().optional(),
+})
+
+/**
+ * Zod schema for one row of `public.otf_sessions`.
+ *
+ * - `started_at` is the ISO 8601 class-start timestamp and the primary key.
+ * - Zone minutes are five explicit `zone_*_min` columns (queryable without
+ *   unpacking JSONB), mirroring `cardio_sessions`' zone columns.
+ * - `treadmill` / `rower` are JSONB blocks, validated by the schemas above.
+ * - Optional fields use `.optional()` (not `.nullable()`): Postgres `NULL`
+ *   is mapped to absent by `stripNulls()` in the data layer before
+ *   validation, so the schema only ever sees a value or `undefined`.
+ * - `.strict()` so a column added to the table without updating this
+ *   schema/whitelist fails loudly rather than leaking through.
+ */
+export const OtfSessionRowSchema = z
+  .object({
+    started_at: z.string().min(1, 'started_at must be an ISO timestamp'),
+    coach: z.string().optional(),
+    studio: z.string().optional(),
+    calories: z.number().nonnegative().optional(),
+    splat: z.number().nonnegative().optional(),
+    steps: z.number().nonnegative().optional(),
+    avg_hr: z.number().nonnegative().optional(),
+    peak_hr: z.number().nonnegative().optional(),
+    zone_gray_min: z.number().nonnegative().optional(),
+    zone_blue_min: z.number().nonnegative().optional(),
+    zone_green_min: z.number().nonnegative().optional(),
+    zone_orange_min: z.number().nonnegative().optional(),
+    zone_red_min: z.number().nonnegative().optional(),
+    treadmill: OtfTreadmillSchema.optional(),
+    rower: OtfRowerSchema.optional(),
+  })
+  .strict()
+
+/** Validated `otf_sessions` row inferred from {@link OtfSessionRowSchema}. */
+export type OtfSessionRow = z.infer<typeof OtfSessionRowSchema>
+
+/**
+ * Translate a validated `otf_sessions` row (flat `zone_*_min` columns) into
+ * the consumed {@link OtfSession} shape (nested `zones_min` map). Applied by
+ * the data layer on read.
+ *
+ * Zone minutes are folded into a single `zones_min` object only when at
+ * least one zone column is present; a session with no zone block omits
+ * `zones_min` entirely rather than rendering as five zeros (matches the
+ * `sessionRowToCardioSession` convention).
+ */
+export function otfRowToSession(row: OtfSessionRow): OtfSession {
+  const session: OtfSession = { started_at: row.started_at }
+  if (row.coach !== undefined) session.coach = row.coach
+  if (row.studio !== undefined) session.studio = row.studio
+  if (row.calories !== undefined) session.calories = row.calories
+  if (row.splat !== undefined) session.splat = row.splat
+  if (row.steps !== undefined) session.steps = row.steps
+  if (row.avg_hr !== undefined) session.avg_hr = row.avg_hr
+  if (row.peak_hr !== undefined) session.peak_hr = row.peak_hr
+
+  const zones = {
+    gray: row.zone_gray_min,
+    blue: row.zone_blue_min,
+    green: row.zone_green_min,
+    orange: row.zone_orange_min,
+    red: row.zone_red_min,
+  }
+  if ((Object.values(zones) as Array<number | undefined>).some(v => v !== undefined)) {
+    session.zones_min = {
+      gray: zones.gray ?? 0,
+      blue: zones.blue ?? 0,
+      green: zones.green ?? 0,
+      orange: zones.orange ?? 0,
+      red: zones.red ?? 0,
+    }
+  }
+
+  if (row.treadmill !== undefined) session.treadmill = row.treadmill
+  if (row.rower !== undefined) session.rower = row.rower
+  return session
+}

--- a/lib/training-facility/otf.test.ts
+++ b/lib/training-facility/otf.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest'
+
+import type { OtfSession } from '@/types/otf'
+
+import {
+  aggregateOtfZoneMinutes,
+  earliestOtfDate,
+  filterOtfSessionsInRange,
+  formatOtfDate,
+  otfHighlights,
+  otfMetricTrend,
+} from './otf'
+
+/** Tiny session factory for the helper tests. */
+function mk(started_at: string, extra: Partial<OtfSession> = {}): OtfSession {
+  return { started_at, ...extra }
+}
+
+describe('filterOtfSessionsInRange', () => {
+  it('keeps only sessions whose start falls inside the inclusive range', () => {
+    const sessions = [
+      mk('2026-04-15T12:00:00Z'), // before
+      mk('2026-06-15T12:00:00Z'), // inside
+      mk('2026-08-15T12:00:00Z'), // after
+    ]
+    // Wide local bounds (weeks of margin) so the assertion is timezone-robust.
+    const range = { start: new Date(2026, 4, 1), end: new Date(2026, 6, 1) }
+    expect(filterOtfSessionsInRange(sessions, range).map(s => s.started_at)).toEqual([
+      '2026-06-15T12:00:00Z',
+    ])
+  })
+})
+
+describe('aggregateOtfZoneMinutes', () => {
+  it('sums each zone across sessions in canonical order; missing blocks contribute zero', () => {
+    const sessions = [
+      mk('a', { zones_min: { gray: 1, blue: 2, green: 3, orange: 4, red: 5 } }),
+      mk('b', { zones_min: { gray: 1, blue: 1, green: 1, orange: 1, red: 1 } }),
+      mk('c'), // no zone block
+    ]
+    expect(aggregateOtfZoneMinutes(sessions).map(b => [b.key, b.minutes])).toEqual([
+      ['gray', 2],
+      ['blue', 3],
+      ['green', 4],
+      ['orange', 5],
+      ['red', 6],
+    ])
+  })
+})
+
+describe('otfHighlights', () => {
+  it('computes totals, average, and bests, treating absent metrics as zero', () => {
+    const sessions = [
+      mk('a', { splat: 10, calories: 500 }),
+      mk('b', { splat: 20, calories: 800 }),
+      mk('c'),
+    ]
+    expect(otfHighlights(sessions)).toEqual({
+      classes: 3,
+      totalSplat: 30,
+      totalCalories: 1300,
+      avgSplat: 10,
+      bestSplat: 20,
+      bestCalories: 800,
+    })
+  })
+
+  it('avgSplat is 0 with no sessions', () => {
+    expect(otfHighlights([]).avgSplat).toBe(0)
+  })
+})
+
+describe('otfMetricTrend', () => {
+  it('emits one dated point per session that has the metric, dropping the rest', () => {
+    const points = otfMetricTrend(
+      [mk('2026-06-01T12:00:00Z', { splat: 10 }), mk('2026-06-02T12:00:00Z')],
+      'splat'
+    )
+    expect(points).toHaveLength(1)
+    expect(points[0].value).toBe(10)
+    expect(points[0].date).toBeInstanceOf(Date)
+  })
+})
+
+describe('earliestOtfDate / formatOtfDate', () => {
+  it('earliestOtfDate returns the minimum start, or null when empty', () => {
+    expect(earliestOtfDate([])).toBeNull()
+    const earliest = earliestOtfDate([mk('2026-06-15T12:00:00Z'), mk('2026-04-01T12:00:00Z')])
+    expect(earliest?.getTime()).toBe(new Date('2026-04-01T12:00:00Z').getTime())
+  })
+
+  it('formatOtfDate renders YYYY-MM-DD', () => {
+    // Noon UTC avoids a day flip under negative-offset test runners.
+    expect(formatOtfDate(mk('2026-06-27T12:00:00Z'))).toMatch(/^2026-06-27$/)
+  })
+})

--- a/lib/training-facility/otf.test.ts
+++ b/lib/training-facility/otf.test.ts
@@ -6,7 +6,10 @@ import {
   aggregateOtfZoneMinutes,
   earliestOtfDate,
   filterOtfSessionsInRange,
+  formatMmss,
   formatOtfDate,
+  mmssToSeconds,
+  otfBlockTrend,
   otfHighlights,
   otfMetricTrend,
 } from './otf'
@@ -92,5 +95,49 @@ describe('earliestOtfDate / formatOtfDate', () => {
   it('formatOtfDate renders YYYY-MM-DD', () => {
     // Noon UTC avoids a day flip under negative-offset test runners.
     expect(formatOtfDate(mk('2026-06-27T12:00:00Z'))).toMatch(/^2026-06-27$/)
+  })
+})
+
+describe('mmssToSeconds / formatMmss', () => {
+  it('parses MM:SS to whole seconds', () => {
+    expect(mmssToSeconds('16:44')).toBe(1004)
+    expect(mmssToSeconds('01:56')).toBe(116)
+  })
+
+  it('returns null on empty or malformed input', () => {
+    expect(mmssToSeconds('')).toBeNull()
+    expect(mmssToSeconds(null)).toBeNull()
+    expect(mmssToSeconds('nope')).toBeNull()
+  })
+
+  it('formats seconds back to M:SS (round-trip)', () => {
+    expect(formatMmss(1004)).toBe('16:44')
+    expect(formatMmss(116)).toBe('1:56')
+    expect(formatMmss(0)).toBe('0:00')
+  })
+})
+
+describe('otfBlockTrend', () => {
+  it('reads a numeric field from the treadmill block, dropping sessions without it', () => {
+    const sessions = [
+      mk('2026-06-01T12:00:00Z', { treadmill: { distance_mi: 1.1, time: '16:00' } }),
+      mk('2026-06-02T12:00:00Z', { rower: { distance_m: 2000, time: '13:00' } }), // no treadmill
+      mk('2026-06-03T12:00:00Z', { treadmill: { distance_mi: 1.4, time: '17:00' } }),
+    ]
+    expect(otfBlockTrend(sessions, 'treadmill', t => t.distance_mi).map(p => p.value)).toEqual([
+      1.1, 1.4,
+    ])
+  })
+
+  it('supports MM:SS metrics via mmssToSeconds and drops null picks', () => {
+    const sessions = [
+      mk('2026-06-01T12:00:00Z', {
+        rower: { distance_m: 2000, time: '13:00', split_500m: '01:56' },
+      }),
+      mk('2026-06-02T12:00:00Z', { rower: { distance_m: 1900, time: '12:00' } }), // no split
+    ]
+    const points = otfBlockTrend(sessions, 'rower', r => mmssToSeconds(r.split_500m))
+    expect(points).toHaveLength(1)
+    expect(points[0].value).toBe(116)
   })
 })

--- a/lib/training-facility/otf.ts
+++ b/lib/training-facility/otf.ts
@@ -96,6 +96,54 @@ export function otfMetricTrend(
   return points
 }
 
+/**
+ * Parse an "MM:SS" duration (how OTbeat reports paces / splits / times) into
+ * whole seconds for a numeric axis. Returns `null` on empty or malformed input.
+ */
+export function mmssToSeconds(value: string | null | undefined): number | null {
+  if (!value || !value.includes(':')) return null
+  const [mm, ss] = value.split(':')
+  const minutes = Number(mm)
+  const seconds = Number(ss)
+  if (!Number.isFinite(minutes) || !Number.isFinite(seconds)) return null
+  return minutes * 60 + seconds
+}
+
+/** Format whole seconds back to "M:SS" — for pace / split axis ticks. */
+export function formatMmss(seconds: number): string {
+  const total = Math.max(0, Math.round(seconds))
+  const m = Math.floor(total / 60)
+  const s = total % 60
+  return `${m}:${String(s).padStart(2, '0')}`
+}
+
+/**
+ * Build a `{date, value}` trend from a numeric field inside each session's
+ * `treadmill` or `rower` JSONB block. Sessions whose block is absent, or whose
+ * picked value isn't a finite number, are dropped so the line isn't pinned to
+ * zero on class formats that omit that machine.
+ *
+ * @param block Which performance block to read.
+ * @param pick Extracts the metric from the block, e.g. `t => t.distance_mi` or
+ *   `r => mmssToSeconds(r.split_500m)` for a "MM:SS" split.
+ */
+export function otfBlockTrend<K extends 'treadmill' | 'rower'>(
+  sessions: readonly OtfSession[],
+  block: K,
+  pick: (b: NonNullable<OtfSession[K]>) => number | null | undefined
+): OtfTrendPoint[] {
+  const points: OtfTrendPoint[] = []
+  for (const s of sessions) {
+    const b = s[block] as NonNullable<OtfSession[K]> | undefined
+    if (!b) continue
+    const value = pick(b)
+    if (typeof value !== 'number' || !Number.isFinite(value)) continue
+    const date = otfSessionDate(s)
+    if (Number.isFinite(date.getTime())) points.push({ date, value })
+  }
+  return points
+}
+
 /** Headline stats for the OTF highlights strip, computed over a session set. */
 export interface OtfHighlights {
   /** Number of classes. */

--- a/lib/training-facility/otf.ts
+++ b/lib/training-facility/otf.ts
@@ -1,0 +1,157 @@
+import { isInRange, type DateRange } from '@/components/training-facility/shared/DateFilter'
+import type { OtfSession, OtfZoneMinutes } from '@/types/otf'
+
+/**
+ * Pure derivations for the OrangeTheory Gym view (#256). Mirrors the
+ * per-activity helper modules (`lib/training-facility/running.ts`,
+ * `stair.ts`) — components stay rendering-only and import these for the
+ * date-range filtering, zone aggregation, and headline stats.
+ */
+
+/** OTbeat HR-zone display order + colors (gray → red), as the email reports them. */
+export const OTF_ZONES: ReadonlyArray<{
+  /** Zone key matching {@link OtfZoneMinutes}. */
+  key: keyof OtfZoneMinutes
+  /** Short axis/label text. */
+  shortLabel: string
+  /** Display color (OTbeat's zone palette). */
+  color: string
+}> = [
+  { key: 'gray', shortLabel: 'Gray', color: '#9ca3af' },
+  { key: 'blue', shortLabel: 'Blue', color: '#3b82f6' },
+  { key: 'green', shortLabel: 'Green', color: '#22c55e' },
+  { key: 'orange', shortLabel: 'Orange', color: '#f97316' },
+  { key: 'red', shortLabel: 'Red', color: '#dc2626' },
+]
+
+/** One zone's display config plus its aggregated minutes, for {@link OTF_ZONES}-ordered bar charts. */
+export interface OtfZoneBucket {
+  /** Zone key matching {@link OtfZoneMinutes}. */
+  key: keyof OtfZoneMinutes
+  /** Short axis label. */
+  shortLabel: string
+  /** Total minutes in this zone across the aggregated sessions. */
+  minutes: number
+  /** Display color. */
+  color: string
+}
+
+/** A single `{date, value}` point for the OTF trend lines (splat, calories, HR). */
+export interface OtfTrendPoint {
+  /** Class start date. */
+  date: Date
+  /** Metric value at that class. */
+  value: number
+}
+
+/** Parse a session's ISO `started_at` to a `Date`. */
+export function otfSessionDate(session: OtfSession): Date {
+  return new Date(session.started_at)
+}
+
+/**
+ * Filter sessions to those whose start falls within the inclusive
+ * {@link DateRange}, preserving order (the dataset arrives ascending).
+ */
+export function filterOtfSessionsInRange(
+  sessions: readonly OtfSession[],
+  range: DateRange
+): OtfSession[] {
+  return sessions.filter(s => {
+    const d = otfSessionDate(s)
+    return Number.isFinite(d.getTime()) && isInRange(d, range)
+  })
+}
+
+/**
+ * Sum each HR zone's minutes across the sessions into {@link OtfZoneBucket}s
+ * in canonical {@link OTF_ZONES} order. Sessions without a zone block
+ * contribute zero.
+ */
+export function aggregateOtfZoneMinutes(sessions: readonly OtfSession[]): OtfZoneBucket[] {
+  return OTF_ZONES.map(z => ({
+    key: z.key,
+    shortLabel: z.shortLabel,
+    color: z.color,
+    minutes: sessions.reduce((acc, s) => acc + (s.zones_min?.[z.key] ?? 0), 0),
+  }))
+}
+
+/**
+ * Build a `{date, value}` trend from each session's value for `metric`,
+ * dropping sessions where the metric is absent so the line isn't pinned to
+ * zero on missing data.
+ */
+export function otfMetricTrend(
+  sessions: readonly OtfSession[],
+  metric: 'splat' | 'calories' | 'avg_hr'
+): OtfTrendPoint[] {
+  const points: OtfTrendPoint[] = []
+  for (const s of sessions) {
+    const value = s[metric]
+    if (typeof value !== 'number') continue
+    const date = otfSessionDate(s)
+    if (Number.isFinite(date.getTime())) points.push({ date, value })
+  }
+  return points
+}
+
+/** Headline stats for the OTF highlights strip, computed over a session set. */
+export interface OtfHighlights {
+  /** Number of classes. */
+  classes: number
+  /** Sum of splat points. */
+  totalSplat: number
+  /** Sum of calories. */
+  totalCalories: number
+  /** Mean splat points per class (0 when no classes). */
+  avgSplat: number
+  /** Highest splat points in a single class. */
+  bestSplat: number
+  /** Highest calories in a single class. */
+  bestCalories: number
+}
+
+/** Compute {@link OtfHighlights} over the given sessions. */
+export function otfHighlights(sessions: readonly OtfSession[]): OtfHighlights {
+  let totalSplat = 0
+  let totalCalories = 0
+  let bestSplat = 0
+  let bestCalories = 0
+  for (const s of sessions) {
+    const splat = s.splat ?? 0
+    const calories = s.calories ?? 0
+    totalSplat += splat
+    totalCalories += calories
+    if (splat > bestSplat) bestSplat = splat
+    if (calories > bestCalories) bestCalories = calories
+  }
+  const classes = sessions.length
+  return {
+    classes,
+    totalSplat,
+    totalCalories,
+    avgSplat: classes ? totalSplat / classes : 0,
+    bestSplat,
+    bestCalories,
+  }
+}
+
+/** Format a session's start as `YYYY-MM-DD` (local). */
+export function formatOtfDate(session: OtfSession): string {
+  const d = otfSessionDate(session)
+  if (!Number.isFinite(d.getTime())) return session.started_at
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(
+    d.getDate()
+  ).padStart(2, '0')}`
+}
+
+/** Earliest session start, or `null` when there are no sessions. Drives the `All` date-filter bound. */
+export function earliestOtfDate(sessions: readonly OtfSession[]): Date | null {
+  let earliest = Infinity
+  for (const s of sessions) {
+    const ms = otfSessionDate(s).getTime()
+    if (Number.isFinite(ms) && ms < earliest) earliest = ms
+  }
+  return Number.isFinite(earliest) ? new Date(earliest) : null
+}

--- a/types/otf.ts
+++ b/types/otf.ts
@@ -1,0 +1,112 @@
+/**
+ * OrangeTheory (OTbeat) data types (#256).
+ *
+ * Consumed shape for the OrangeTheory Gym surface. Mirrors the
+ * `otf_sessions` Supabase table (`supabase/migrations/20260628120000_otf_sessions.sql`)
+ * and the parser record produced by `scripts/lib/otbeat-parser.mjs`. Field
+ * names match the email's own data; the Zod row schemas in
+ * `lib/schemas/otf.ts` are the validation source of truth and these
+ * interfaces mirror them for IDE `Cmd/Ctrl+hover` ergonomics.
+ *
+ * KEEP IN SYNC WITH: `lib/schemas/otf.ts` and `scripts/lib/otbeat-parser.mjs`
+ * (the `OtbeatTreadmill` / `OtbeatRower` JSDoc typedefs).
+ */
+
+/** Minutes spent in each OrangeTheory HR zone during a class. */
+export interface OtfZoneMinutes {
+  /** Gray zone (very light) minutes. */
+  gray: number
+  /** Blue zone (light) minutes. */
+  blue: number
+  /** Green zone (base/comfortable) minutes. */
+  green: number
+  /** Orange zone (challenging — counts toward splat) minutes. */
+  orange: number
+  /** Red zone (all-out — counts toward splat) minutes. */
+  red: number
+}
+
+/**
+ * Treadmill performance block for one class. Imperial units as the OTbeat
+ * email reports them; paces/time are "MM:SS" strings. `null`/absent on
+ * tread-only-omitting or belt-malfunction class formats.
+ */
+export interface OtfTreadmill {
+  /** Total treadmill distance, miles. */
+  distance_mi: number
+  /** Total treadmill time, "MM:SS". */
+  time: string
+  /** Average speed, mph. */
+  avg_mph?: number
+  /** Max speed, mph. */
+  max_mph?: number
+  /** Average incline, percent. */
+  avg_incline?: number
+  /** Max incline, percent. */
+  max_incline?: number
+  /** Average pace, "MM:SS" per mile. */
+  avg_pace?: string
+  /** Fastest pace, "MM:SS" per mile. */
+  fastest_pace?: string
+  /** Total elevation gain, feet. */
+  elevation_ft?: number
+}
+
+/**
+ * Rower performance block for one class. Absent on class formats that omit
+ * the rower (e.g. tread-only Endurance days).
+ */
+export interface OtfRower {
+  /** Total rower distance, meters. */
+  distance_m: number
+  /** Total rower time, "MM:SS". */
+  time: string
+  /** Average wattage. */
+  avg_watt?: number
+  /** Max wattage. */
+  max_watt?: number
+  /** Average speed, km/h. */
+  avg_kmh?: number
+  /** Max speed, km/h. */
+  max_kmh?: number
+  /** Average 500m split, "MM:SS". */
+  split_500m?: string
+  /** Best 500m split, "MM:SS". */
+  best_split_500m?: string
+  /** Average stroke rate, strokes/min. */
+  avg_spm?: number
+}
+
+/** One OrangeTheory studio class — one row in the OTF session log. */
+export interface OtfSession {
+  /** ISO timestamp of the class start (the table's primary key). */
+  started_at: string
+  /** Coach who ran the class. */
+  coach?: string
+  /** Studio location, e.g. "Marina Del Rey, CA". */
+  studio?: string
+  /** Calories burned. */
+  calories?: number
+  /** Splat points (minutes in orange + red zones). */
+  splat?: number
+  /** Step count. */
+  steps?: number
+  /** Average heart rate, BPM. */
+  avg_hr?: number
+  /** Peak heart rate, BPM. */
+  peak_hr?: number
+  /** Minutes per HR zone. Omitted when the email had no zone block. */
+  zones_min?: OtfZoneMinutes
+  /** Treadmill performance block. Omitted when the class format had none. */
+  treadmill?: OtfTreadmill
+  /** Rower performance block. Omitted when the class format had none. */
+  rower?: OtfRower
+}
+
+/** Full OrangeTheory dataset consumed by the Gym OTF view. */
+export interface OtfData {
+  /** ISO timestamp of the most recent ingest (latest `updated_at`); drives the "last synced" display. */
+  imported_at: string
+  /** Every OTF session, ascending by `started_at`. */
+  sessions: OtfSession[]
+}


### PR DESCRIPTION
Closes #256.

Renders the OrangeTheory data (`otf_sessions`, fed by the OTbeat ingestion pipeline in #251 / #252) inside the Training Facility → Gym, mirroring the existing cardio detail-view patterns.

## What's here

**Data layer** (a faithful mirror of the `cardio` layer — same read/validate/assemble split):
- `types/otf.ts` — `OtfSession` / `OtfData` (+ treadmill/rower blocks).
- `lib/schemas/otf.ts` — `OtfSessionRowSchema` (`.strict()`, `null`→absent) + `otfRowToSession` (folds the five `zone_*_min` columns into a `zones_min` map).
- `lib/data/otf-shared.ts` (`assembleOtfData`), `lib/data/otf.ts` (`getOtfData`, browser), `lib/data/otf-server.ts` (`getOtfDataServer`), barrel export.

**View**:
- `components/training-facility/gym/OtfDetailView.tsx` — dark-arena shell + `DateFilter`, a highlights strip (classes / splat / calories / bests), and charts: **minutes-in-zone bars** (`OtfZoneBars`, gray→red, cloning the cardio `HrZoneBars` renderer) plus **splat / calorie / avg-HR** trend lines (`RoughLine`). An expandable **session log** shows each class's coach, splat, calories, HR, and — on expand — the full **treadmill + rower** splits.
- `app/training-facility/gym/otf/page.tsx` — flag-gated like the sibling treadmill/track/stair pages.
- `components/training-facility/scenes/GymScene.tsx` — a left-foreground **OrangeTheory signpost** links into the view. This is the lighter v1 entry we chose for #256; a bespoke equipment illustration can replace it later (happy to file a follow-up).
- `lib/training-facility/otf.ts` — pure helpers (range filter, zone aggregation, trends, highlights).

## Verification
- **26 unit tests** across the data layer, schema, helpers, and the view (chart children stubbed). Full `test:coverage` suite green (lib coverage thresholds met). `tsc` clean on all new code; lint clean.
- Verified on the Vercel preview: `/training-facility/gym/otf` serves (200) and the Gym scene renders the signpost with the correct link. (Charts/log populate client-side from the 24 live `otf_sessions`.)

## Review feedback addressed
- **ResizeObserver never attached** (CodeRabbit, Major): the chart wrapper mounts only after data loads, so the mount effect ran with a null ref and the width stuck at the default → switched to a callback ref.
- **Default "All" range** (codex): re-anchored to the real earliest session once data loads (+ keyed the `DateFilter`), instead of pinning to `EARLIEST_FALLBACK`.
- **Zone-bar tick labels** (CodeRabbit): format with the scale's own precision instead of `Math.round` so tiny ranges don't dupe labels.

## Notes for the reviewer
- Append-only / read-only: the OTF data is anon-readable (same RLS as `cardio_*`); no write paths added.
- **Pre-existing, unrelated — tracked in #264:** a full root `tsc --noEmit` surfaces type errors in `scripts/lib/otbeat-supabase.test.ts` (from #252). This PR's checks are green (the build typecheck passes — those `scripts` test files just aren't in its scope). #264 covers fixing them and adding a `tsc` step to CI. Left out here to stay focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
