### PR TITLE
feat(gym): reconcile Apple Watch vs OrangeTheory HR zones (#261)

### DIFF
--- a/app/training-facility/gym/zones/page.tsx
+++ b/app/training-facility/gym/zones/page.tsx
@@ -1,0 +1,20 @@
+import { notFound } from 'next/navigation'
+
+import { HrZoneComparison } from '@/components/training-facility/gym/HrZoneComparison'
+import { isTrainingFacilityEnabled } from '@/lib/feature-flags'
+
+/**
+ * HR-zone reconciliation view (#261) — Apple Watch vs OrangeTheory zones on one
+ * shared, data-derived max HR. Reached from a link in the OrangeTheory detail
+ * view; gated behind the Training Facility feature flag for staged rollout,
+ * matching the sibling gym detail pages.
+ *
+ * No `<Suspense>` boundary (like the OTF page) because `HrZoneComparison`
+ * doesn't read `useSearchParams()` — it owns its own loading panel and fetches
+ * both datasets client-side from a mount effect.
+ */
+export default function TrainingFacilityGymZonesPage() {
+  if (!isTrainingFacilityEnabled()) notFound()
+
+  return <HrZoneComparison />
+}

--- a/components/training-facility/gym/HrZoneComparison.test.tsx
+++ b/components/training-facility/gym/HrZoneComparison.test.tsx
@@ -100,12 +100,22 @@ describe('HrZoneComparison', () => {
     expect(screen.getByText('170')).toBeInTheDocument()
   })
 
-  it('shows the error panel when both datasets are unavailable', async () => {
+  it('renders the empty state (not an error) when both tables are empty', async () => {
+    // Both readers resolve null on an empty table — the sibling views' empty
+    // contract. That is not a failure; it should not surface the error panel.
     getCardioDataMock.mockResolvedValue(null)
     getOtfDataMock.mockResolvedValue(null)
     render(<HrZoneComparison />)
-    await waitFor(() =>
-      expect(screen.getByRole('alert')).toHaveTextContent(/no cardio or orangetheory data/i),
-    )
+    await waitFor(() => expect(screen.getByText(/no time-in-zone yet/i)).toBeInTheDocument())
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+
+  it('shows the error panel when a data read genuinely fails', async () => {
+    // A real query/schema failure rejects (rather than resolving null); it must
+    // surface, not be masked into a partial "the other source is just empty".
+    getCardioDataMock.mockRejectedValue(new Error('boom'))
+    getOtfDataMock.mockResolvedValue(OTF)
+    render(<HrZoneComparison />)
+    await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent(/boom/))
   })
 })

--- a/components/training-facility/gym/HrZoneComparison.test.tsx
+++ b/components/training-facility/gym/HrZoneComparison.test.tsx
@@ -1,0 +1,111 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { CardioData } from '@/types/cardio'
+import type { OtfData } from '@/types/otf'
+
+import { HrZoneComparison } from './HrZoneComparison'
+
+/**
+ * Render tests for the HR-zone reconciliation view (#261). Both data readers
+ * are mocked; the tests focus on branch decisions (loading → data, empty,
+ * error) and that both systems' derived boundaries surface. Sibling pattern:
+ * `OtfDetailView.test.tsx`.
+ */
+
+const getCardioDataMock = vi.fn()
+const getOtfDataMock = vi.fn()
+
+vi.mock('@/lib/data', () => ({
+  getCardioData: () => getCardioDataMock(),
+  getOtfData: () => getOtfDataMock(),
+}))
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/training-facility/gym/zones',
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), prefetch: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+}))
+
+const CARDIO: CardioData = {
+  imported_at: '2026-06-30T07:53:00+00:00',
+  sessions: [
+    {
+      date: '2026-06-27',
+      activity: 'stair',
+      duration_seconds: 600,
+      max_hr: 158,
+      hr_seconds_in_zone: { 1: 0, 2: 300, 3: 300, 4: 0, 5: 0 },
+    },
+  ],
+  resting_hr_trend: [],
+  vo2max_trend: [],
+}
+
+const OTF: OtfData = {
+  imported_at: '2026-06-30T07:53:00+00:00',
+  sessions: [
+    {
+      started_at: '2026-06-27T16:30:00+00:00',
+      peak_hr: 175,
+      avg_hr: 125,
+      zones_min: { gray: 1, blue: 11, green: 29, orange: 14, red: 1 },
+    },
+  ],
+}
+
+beforeEach(() => {
+  getCardioDataMock.mockReset()
+  getOtfDataMock.mockReset()
+})
+
+describe('HrZoneComparison', () => {
+  it('renders the header and a link back to the OrangeTheory view', () => {
+    getCardioDataMock.mockResolvedValue(CARDIO)
+    getOtfDataMock.mockResolvedValue(OTF)
+    render(<HrZoneComparison />)
+    expect(screen.getByRole('heading', { level: 1, name: /apple watch vs orangetheory/i })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /orangetheory/i })).toHaveAttribute(
+      'href',
+      '/training-facility/gym/otf',
+    )
+  })
+
+  it('derives the shared max HR from the observed peak and renders both systems', async () => {
+    getCardioDataMock.mockResolvedValue(CARDIO)
+    getOtfDataMock.mockResolvedValue(OTF)
+    render(<HrZoneComparison />)
+
+    await waitFor(() => expect(screen.getByText('Shared max HR')).toBeInTheDocument())
+
+    // Observed peak 175 wins over the cardio max of 158.
+    expect(screen.getByText('175')).toBeInTheDocument()
+    // Both system cards render.
+    expect(screen.getByRole('heading', { name: 'Apple Watch' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'OrangeTheory' })).toBeInTheDocument()
+    // A derived Apple boundary (Z1 at 175 = 88–105) is shown.
+    expect(screen.getAllByText('88–105').length).toBeGreaterThan(0)
+    // The recommendation note is always present with data.
+    expect(screen.getByRole('heading', { name: /which to follow/i })).toBeInTheDocument()
+  })
+
+  it('shows the empty state when neither system logged zone time', async () => {
+    getCardioDataMock.mockResolvedValue(null)
+    getOtfDataMock.mockResolvedValue({
+      imported_at: '',
+      sessions: [{ started_at: '2026-06-27T16:30:00+00:00', peak_hr: 170 }],
+    } satisfies OtfData)
+    render(<HrZoneComparison />)
+    await waitFor(() => expect(screen.getByText(/no time-in-zone yet/i)).toBeInTheDocument())
+    // Max HR callout still resolves the observed peak even with no zone time.
+    expect(screen.getByText('170')).toBeInTheDocument()
+  })
+
+  it('shows the error panel when both datasets are unavailable', async () => {
+    getCardioDataMock.mockResolvedValue(null)
+    getOtfDataMock.mockResolvedValue(null)
+    render(<HrZoneComparison />)
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent(/no cardio or orangetheory data/i),
+    )
+  })
+})

--- a/components/training-facility/gym/HrZoneComparison.tsx
+++ b/components/training-facility/gym/HrZoneComparison.tsx
@@ -1,0 +1,422 @@
+'use client'
+
+import Link from 'next/link'
+import { useEffect, useMemo, useState, type JSX } from 'react'
+
+import { BackToCourtButton } from '@/components/common/BackToCourtButton'
+import { getCardioData, getOtfData } from '@/lib/data'
+import {
+  averageOf,
+  bandForBpm,
+  buildHrZoneComparison,
+  type SystemZoneComparison,
+  type ZoneTimeShare,
+} from '@/lib/training-facility/hr-zone-comparison'
+import type { CardioData } from '@/types/cardio'
+import type { OtfData } from '@/types/otf'
+
+/**
+ * Apple-vs-OrangeTheory HR-zone reconciliation view (#261). Loads both the
+ * Apple cardio dataset and the OTbeat session data, derives one shared maxHR
+ * from observed peaks, and renders each system's personal bpm boundaries and
+ * time-in-zone side by side — explicitly as two different band systems, not a
+ * one-to-one mapping. Ends with a short recommendation on which to treat as the
+ * canonical cross-session model.
+ *
+ * Self-contained (own dark-arena shell + loading/error panels), matching the
+ * sibling `OtfDetailView`; reached from a link in that view's header.
+ */
+export function HrZoneComparison(): JSX.Element {
+  const [cardio, setCardio] = useState<CardioData | null>(null)
+  const [otf, setOtf] = useState<OtfData | null>(null)
+  const [ready, setReady] = useState(false)
+  const [loadError, setLoadError] = useState<Error | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    Promise.all([getCardioData().catch(() => null), getOtfData().catch(() => null)])
+      .then(([cardioData, otfData]) => {
+        if (cancelled) return
+        // A total failure of both reads surfaces as the error panel; a single
+        // source being empty is fine — the comparison still renders the other.
+        if (cardioData === null && otfData === null) {
+          setLoadError(new Error('No cardio or OrangeTheory data available yet.'))
+        }
+        setCardio(cardioData)
+        setOtf(otfData)
+        setReady(true)
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return
+        setLoadError(err instanceof Error ? err : new Error(String(err)))
+        setReady(true)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const otfSessions = useMemo(() => otf?.sessions ?? [], [otf])
+  const cardioSessions = useMemo(() => cardio?.sessions ?? [], [cardio])
+
+  const comparison = useMemo(
+    () => buildHrZoneComparison(cardioSessions, otfSessions),
+    [cardioSessions, otfSessions],
+  )
+
+  // Personal markers: average OTF peak / average HR placed against the bands.
+  const avgPeak = useMemo(() => averageOf(otfSessions, 'peak_hr'), [otfSessions])
+  const avgHr = useMemo(() => averageOf(otfSessions, 'avg_hr'), [otfSessions])
+
+  const hasData = comparison.apple.total > 0 || comparison.otf.total > 0
+
+  return (
+    <div className="relative min-h-svh overflow-hidden bg-[#120d0a] text-[#f7ead9]">
+      <div
+        aria-hidden="true"
+        className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(249,115,22,0.12),transparent_30%),linear-gradient(180deg,#241811_0%,#120d0a_52%,#0b0806_100%)]"
+      />
+
+      <div className="relative z-10 mx-auto flex min-h-svh w-full max-w-5xl flex-col px-6 py-8 sm:px-8 lg:px-12">
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <BackToCourtButton />
+          <Link
+            href="/training-facility/gym/otf"
+            className="rounded-full border border-white/15 bg-white/5 px-4 py-2 text-xs font-semibold uppercase tracking-[0.28em] text-white/80 transition hover:bg-white/10"
+          >
+            ← OrangeTheory
+          </Link>
+        </div>
+
+        <header className="mt-12">
+          <div className="text-xs font-semibold uppercase tracking-[0.38em] text-[#f97316]">
+            Heart-rate zones
+          </div>
+          <h1 className="mt-3 text-4xl font-black uppercase tracking-[0.08em] text-[#fff7ec] sm:text-5xl">
+            Apple Watch vs OrangeTheory
+          </h1>
+          <p className="mt-4 max-w-2xl text-sm leading-7 text-[#e8d5be] sm:text-base">
+            Two different 5-zone systems feed this dashboard — different band cut-points and
+            different max-HR assumptions. Here they are on one shared, data-derived max HR, so
+            &ldquo;what are my zones&rdquo; and &ldquo;what does my time actually look like&rdquo;
+            are answerable at a glance. They&rsquo;re shown side by side, not mapped onto each
+            other.
+          </p>
+        </header>
+
+        {loadError ? (
+          <ErrorPanel error={loadError} />
+        ) : !ready ? (
+          <LoadingPanel />
+        ) : (
+          <>
+            <MaxHrCallout
+              maxHr={comparison.maxHr}
+              source={comparison.maxHrSource}
+              observedPeak={comparison.observedPeak}
+              avgPeak={avgPeak}
+              avgHr={avgHr}
+            />
+
+            {!hasData ? (
+              <EmptyState />
+            ) : (
+              <div className="mt-8 grid gap-6 lg:grid-cols-2">
+                <SystemCard
+                  system={comparison.apple}
+                  helper="Even 10%-of-maxHR bands. We store raw HR samples and bucket them ourselves — this is the all-day model."
+                  avgHr={avgHr}
+                  avgPeak={avgPeak}
+                />
+                <SystemCard
+                  system={comparison.otf}
+                  helper="OTbeat's own uneven bands, arriving pre-bucketed as minutes. Orange + red minutes are splat points — the studio-effort model."
+                  avgHr={avgHr}
+                  avgPeak={avgPeak}
+                />
+              </div>
+            )}
+
+            <RecommendationNote source={comparison.maxHrSource} observedPeak={comparison.observedPeak} />
+          </>
+        )}
+      </div>
+    </div>
+  )
+}
+
+/** Format a band's logged time — Apple stores seconds, OTF stores minutes — as a compact `Nm`. */
+function formatBandTime(value: number, unit: SystemZoneComparison['unit']): string {
+  const minutes = unit === 'seconds' ? value / 60 : value
+  if (minutes <= 0) return '—'
+  if (minutes < 1) return '<1m'
+  return `${Math.round(minutes)}m`
+}
+
+/** The shared-maxHR callout: the value, where it came from, and the personal-average context. */
+function MaxHrCallout({
+  maxHr,
+  source,
+  observedPeak,
+  avgPeak,
+  avgHr,
+}: {
+  maxHr: number
+  source: 'observed' | 'default'
+  observedPeak: number | null
+  avgPeak: number | null
+  avgHr: number | null
+}): JSX.Element {
+  return (
+    <section className="mt-8 rounded-[1.6rem] border border-white/10 bg-black/25 p-5">
+      <div className="flex flex-wrap items-baseline gap-x-6 gap-y-2">
+        <div>
+          <p className="font-mono text-[0.65rem] uppercase tracking-[0.24em] text-white/55">
+            Shared max HR
+          </p>
+          <p className="mt-1 text-3xl font-black text-[#f97316]">
+            {maxHr}
+            <span className="ml-1 text-sm font-semibold text-white/50">bpm</span>
+          </p>
+        </div>
+        <p className="max-w-md text-xs leading-6 text-white/65">
+          {source === 'observed' ? (
+            <>
+              Derived from your highest observed peak
+              {observedPeak !== null ? ` (${observedPeak} bpm)` : ''} across OrangeTheory classes
+              and Apple cardio — a <em>floor</em>, since you may not have truly maxed out. It
+              updates automatically as higher peaks land.
+            </>
+          ) : (
+            <>
+              No peak on file yet — falling back to the formula default ({maxHr} bpm). Both zone
+              tables below will re-scale to your real peak once cardio or OrangeTheory data arrives.
+            </>
+          )}
+        </p>
+      </div>
+      {(avgPeak !== null || avgHr !== null) && (
+        <p className="mt-3 border-t border-white/10 pt-3 text-xs leading-6 text-white/55">
+          {avgPeak !== null ? `Avg OTF peak ${Math.round(avgPeak)} bpm. ` : ''}
+          {avgHr !== null ? `Avg HR ${Math.round(avgHr)} bpm.` : ''}
+        </p>
+      )}
+    </section>
+  )
+}
+
+/** One system's card — personal bpm boundaries + time-in-zone strip + per-band rows. */
+function SystemCard({
+  system,
+  helper,
+  avgHr,
+  avgPeak,
+}: {
+  system: SystemZoneComparison
+  helper: string
+  avgHr: number | null
+  avgPeak: number | null
+}): JSX.Element {
+  const avgHrBand = avgHr !== null ? bandForBpm(system.bands, avgHr) : null
+  const avgPeakBand = avgPeak !== null ? bandForBpm(system.bands, avgPeak) : null
+
+  return (
+    <section className="rounded-[1.6rem] border border-white/10 bg-[#f5f1e6] p-5 text-[#0a0a0a] shadow-[0_18px_46px_rgba(0,0,0,0.34)]">
+      <header className="mb-1 flex flex-wrap items-baseline justify-between gap-2">
+        <h2 className="font-mono text-xs font-bold uppercase tracking-[0.24em] text-[#0a0a0a]">
+          {system.label}
+        </h2>
+        <span className="font-mono text-[0.65rem] uppercase tracking-[0.18em] text-[#404040]">
+          {formatBandTime(system.total, system.unit)} logged
+        </span>
+      </header>
+      <p className="mb-4 text-xs leading-5 text-[#404040]">{helper}</p>
+
+      <ZoneShareStrip system={system} />
+
+      <table className="mt-4 w-full text-left text-sm">
+        <thead>
+          <tr className="font-mono text-[0.6rem] uppercase tracking-[0.16em] text-[#737373]">
+            <th scope="col" className="pb-1 font-semibold">
+              Zone
+            </th>
+            <th scope="col" className="pb-1 font-semibold">
+              BPM
+            </th>
+            <th scope="col" className="pb-1 text-right font-semibold">
+              Time
+            </th>
+            <th scope="col" className="pb-1 text-right font-semibold">
+              Share
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {system.bands.map(band => (
+            <tr key={band.key} className="align-middle">
+              <td className="py-1">
+                <span className="inline-flex items-center gap-2">
+                  <span
+                    aria-hidden="true"
+                    className="inline-block h-2.5 w-2.5 rounded-sm"
+                    style={{ backgroundColor: band.color }}
+                  />
+                  <span className="font-semibold text-[#0a0a0a]">{band.shortLabel}</span>
+                  <span className="text-[#737373]">{band.label}</span>
+                </span>
+              </td>
+              <td className="py-1 font-mono text-[#404040]">
+                {band.minBpm}–{band.maxBpm}
+              </td>
+              <td className="py-1 text-right font-mono text-[#404040]">
+                {formatBandTime(band.value, system.unit)}
+              </td>
+              <td className="py-1 text-right font-mono text-[#0a0a0a]">
+                {system.total > 0 ? `${Math.round(band.share * 100)}%` : '—'}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      {(avgHrBand || avgPeakBand) && (
+        <p className="mt-3 border-t border-black/10 pt-3 text-xs leading-6 text-[#404040]">
+          {avgHrBand ? (
+            <>
+              Avg HR lands in <ZoneChip band={avgHrBand} />.{' '}
+            </>
+          ) : null}
+          {avgPeakBand ? (
+            <>
+              Avg peak lands in <ZoneChip band={avgPeakBand} />.
+            </>
+          ) : null}
+        </p>
+      )}
+    </section>
+  )
+}
+
+/** Inline colored zone name — a small swatch + label used in the avg-HR/peak sentence. */
+function ZoneChip({ band }: { band: ZoneTimeShare }): JSX.Element {
+  return (
+    <span className="inline-flex items-center gap-1 font-semibold text-[#0a0a0a]">
+      <span
+        aria-hidden="true"
+        className="inline-block h-2 w-2 rounded-sm"
+        style={{ backgroundColor: band.color }}
+      />
+      {band.shortLabel}
+    </span>
+  )
+}
+
+/**
+ * Proportional time-in-zone strip — the {@link ZoneTimeShare} bands as adjacent
+ * colored segments sized by `share`. Mirrors `SessionZoneStrip`'s look (rounded,
+ * bordered, native-title tooltip) but takes the richer band shape so it works
+ * for both the 5 Apple zones and the 5 OTF zones. Renders an em-dash when the
+ * system logged no time.
+ */
+function ZoneShareStrip({ system }: { system: SystemZoneComparison }): JSX.Element {
+  if (system.total <= 0) {
+    return (
+      <span aria-label="No zone data" className="font-mono text-[#737373]">
+        —
+      </span>
+    )
+  }
+  const tooltip = system.bands
+    .map(b => `${b.shortLabel}: ${formatBandTime(b.value, system.unit)}`)
+    .join(', ')
+  return (
+    <span
+      role="img"
+      aria-label={`${system.label} time in zone — ${tooltip}`}
+      title={tooltip}
+      className="flex h-3 w-full overflow-hidden rounded-sm border border-black/15"
+    >
+      {system.bands.map(band => {
+        if (band.share <= 0) return null
+        return (
+          <span
+            key={band.key}
+            data-testid={`share-segment-${system.system}-${band.key}`}
+            aria-hidden="true"
+            className="h-full"
+            style={{ width: `${band.share * 100}%`, backgroundColor: band.color }}
+          />
+        )
+      })}
+    </span>
+  )
+}
+
+/** Short recommendation on which model to treat as canonical, and why. */
+function RecommendationNote({
+  source,
+  observedPeak,
+}: {
+  source: 'observed' | 'default'
+  observedPeak: number | null
+}): JSX.Element {
+  return (
+    <section className="mt-8 rounded-[1.6rem] border border-[#f97316]/25 bg-[#f97316]/5 p-5">
+      <h2 className="font-mono text-xs font-bold uppercase tracking-[0.24em] text-[#f97316]">
+        Which to follow
+      </h2>
+      <div className="mt-3 space-y-3 text-sm leading-7 text-[#e8d5be]">
+        <p>
+          For cross-session consistency, follow the <strong>Apple even-band model</strong> on the
+          shared observed max HR
+          {source === 'observed' && observedPeak !== null ? ` (${observedPeak} bpm)` : ''} as the
+          canonical model. It&rsquo;s built from raw samples we control, so the same bpm means the
+          same zone in every session — and it&rsquo;s the all-day model, not tied to one studio
+          format.
+        </p>
+        <p>
+          Keep OrangeTheory&rsquo;s bands as <strong>studio-effort context</strong>, not a second
+          truth: its minutes arrive pre-bucketed off OTF&rsquo;s own age-based max HR, so they
+          can&rsquo;t be re-bucketed to match. Read splat (orange + red) as &ldquo;how hard was that
+          class,&rdquo; and read the Apple zones for everything cross-session.
+        </p>
+      </div>
+    </section>
+  )
+}
+
+function LoadingPanel(): JSX.Element {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="mt-10 rounded-[1.6rem] border border-white/10 bg-black/25 p-8 text-center text-sm text-white/65"
+    >
+      Loading heart-rate data…
+    </div>
+  )
+}
+
+function EmptyState(): JSX.Element {
+  return (
+    <div className="mt-8 rounded-[1.6rem] border border-white/10 bg-black/25 p-8 text-center text-sm leading-6 text-white/65">
+      <p className="font-semibold uppercase tracking-[0.18em] text-white/80">No time-in-zone yet</p>
+      <p className="mt-2 text-white/55">
+        The zone tables above show your boundaries; per-zone time fills in as cardio and
+        OrangeTheory sessions land.
+      </p>
+    </div>
+  )
+}
+
+function ErrorPanel({ error }: { error: Error }): JSX.Element {
+  return (
+    <div
+      role="alert"
+      className="mt-10 rounded-[1.6rem] border border-red-400/30 bg-red-950/40 p-6 text-sm leading-6 text-red-100"
+    >
+      <p className="font-semibold uppercase tracking-[0.18em]">Could not load heart-rate data</p>
+      <p className="mt-2 text-red-100/80">{error.message}</p>
+    </div>
+  )
+}

--- a/components/training-facility/gym/HrZoneComparison.tsx
+++ b/components/training-facility/gym/HrZoneComparison.tsx
@@ -34,14 +34,15 @@ export function HrZoneComparison(): JSX.Element {
 
   useEffect(() => {
     let cancelled = false
-    Promise.all([getCardioData().catch(() => null), getOtfData().catch(() => null)])
+    // Both readers resolve `null` on an *empty table* (the sibling views' empty
+    // contract) and reject only on a real query/schema failure. Let a genuine
+    // rejection from either source propagate to the error panel rather than
+    // swallowing it to `null` — a masked failure would render a partial
+    // comparison that looks like "the other source is just empty". Two empty
+    // tables are not an error; they fall through to the empty state.
+    Promise.all([getCardioData(), getOtfData()])
       .then(([cardioData, otfData]) => {
         if (cancelled) return
-        // A total failure of both reads surfaces as the error panel; a single
-        // source being empty is fine — the comparison still renders the other.
-        if (cardioData === null && otfData === null) {
-          setLoadError(new Error('No cardio or OrangeTheory data available yet.'))
-        }
         setCardio(cardioData)
         setOtf(otfData)
         setReady(true)

--- a/components/training-facility/gym/OtfDetailView.tsx
+++ b/components/training-facility/gym/OtfDetailView.tsx
@@ -156,12 +156,20 @@ export function OtfDetailView(): JSX.Element {
       <div className="relative z-10 mx-auto flex min-h-svh w-full max-w-5xl flex-col px-6 py-8 sm:px-8 lg:px-12">
         <div className="flex flex-wrap items-center justify-between gap-4">
           <BackToCourtButton />
-          <Link
-            href="/training-facility/gym"
-            className="rounded-full border border-white/15 bg-white/5 px-4 py-2 text-xs font-semibold uppercase tracking-[0.28em] text-white/80 transition hover:bg-white/10"
-          >
-            ← The Gym
-          </Link>
+          <div className="flex flex-wrap items-center gap-3">
+            <Link
+              href="/training-facility/gym/zones"
+              className="rounded-full border border-[#f97316]/40 bg-[#f97316]/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.28em] text-[#f9a870] transition hover:bg-[#f97316]/20"
+            >
+              Zones vs Apple →
+            </Link>
+            <Link
+              href="/training-facility/gym"
+              className="rounded-full border border-white/15 bg-white/5 px-4 py-2 text-xs font-semibold uppercase tracking-[0.28em] text-white/80 transition hover:bg-white/10"
+            >
+              ← The Gym
+            </Link>
+          </div>
         </div>
 
         <header className="mt-12">

--- a/lib/training-facility/hr-zone-comparison.test.ts
+++ b/lib/training-facility/hr-zone-comparison.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from 'vitest'
+
+import { DEFAULT_MAX_HR } from '@/constants/hr-zones'
+import type { CardioSession } from '@/types/cardio'
+import type { OtfSession } from '@/types/otf'
+
+import {
+  averageOf,
+  bandForBpm,
+  buildHrZoneComparison,
+  observedMaxHr,
+} from './hr-zone-comparison'
+
+/** OTF session factory. */
+function otf(started_at: string, extra: Partial<OtfSession> = {}): OtfSession {
+  return { started_at, ...extra }
+}
+
+/** Cardio session factory — stair activity is arbitrary; only HR fields matter here. */
+function cardio(date: string, extra: Partial<CardioSession> = {}): CardioSession {
+  return { date, activity: 'stair', duration_seconds: 0, ...extra }
+}
+
+describe('observedMaxHr', () => {
+  it('falls back to the default when no input carries a peak', () => {
+    expect(observedMaxHr({})).toEqual({
+      maxHr: DEFAULT_MAX_HR,
+      source: 'default',
+      observedPeak: null,
+    })
+  })
+
+  it('takes the highest peak across OTF peak_hr and Apple max_hr', () => {
+    const result = observedMaxHr({
+      otfSessions: [otf('a', { peak_hr: 175 }), otf('b', { peak_hr: 168 })],
+      cardioSessions: [cardio('2026-06-01', { max_hr: 150 })],
+    })
+    expect(result).toEqual({ maxHr: 175, source: 'observed', observedPeak: 175 })
+  })
+
+  it('considers raw HR samples that exceed a session max_hr', () => {
+    const result = observedMaxHr({
+      cardioSessions: [
+        cardio('2026-06-01', {
+          max_hr: 170,
+          hr_samples: [
+            { ts: '2026-06-01T00:00:00Z', bpm: 165 },
+            { ts: '2026-06-01T00:01:00Z', bpm: 181 },
+          ],
+        }),
+      ],
+    })
+    expect(result.maxHr).toBe(181)
+    expect(result.source).toBe('observed')
+  })
+
+  it('ignores non-finite and non-positive candidates', () => {
+    const result = observedMaxHr({
+      otfSessions: [otf('a', { peak_hr: 0 }), otf('b', { peak_hr: Number.NaN })],
+      cardioSessions: [cardio('2026-06-01', { max_hr: -5 })],
+    })
+    expect(result.source).toBe('default')
+    expect(result.observedPeak).toBeNull()
+  })
+})
+
+describe('buildHrZoneComparison', () => {
+  it('projects both systems onto the observed peak and matches the issue #261 tables', () => {
+    const otfSessions = [otf('a', { peak_hr: 175 })]
+    const cmp = buildHrZoneComparison([], otfSessions)
+
+    expect(cmp.maxHr).toBe(175)
+    expect(cmp.maxHrSource).toBe('observed')
+    expect(cmp.observedPeak).toBe(175)
+
+    // Apple even bands at 175 — issue #261's table is hand-rounded (70% of 175
+    // = 122.5 → 123); the shared bpmRangeForZone helper hits the IEEE-754
+    // representation of 122.5 (122.4999…) and rounds to 122. Matching the real
+    // helper output rather than the illustrative table.
+    expect(cmp.apple.bands.map(b => [b.shortLabel, b.minBpm, b.maxBpm])).toEqual([
+      ['Z1', 88, 105],
+      ['Z2', 105, 122],
+      ['Z3', 122, 140],
+      ['Z4', 140, 158],
+      ['Z5', 158, 175],
+    ])
+
+    // OTF uneven bands at 175 (issue table; blue's 122 same float note as above).
+    expect(cmp.otf.bands.map(b => [b.shortLabel, b.minBpm, b.maxBpm])).toEqual([
+      ['Gray', 88, 105],
+      ['Blue', 107, 122],
+      ['Green', 124, 145],
+      ['Orange', 147, 159],
+      ['Red', 161, 175],
+    ])
+  })
+
+  it('honors an explicit maxHrOverride over the derived peak', () => {
+    const cmp = buildHrZoneComparison([], [otf('a', { peak_hr: 175 })], {
+      maxHrOverride: 190,
+    })
+    expect(cmp.maxHr).toBe(190)
+  })
+
+  it('folds Apple seconds and OTF minutes into per-system shares that sum to 1', () => {
+    const cardioSessions = [
+      cardio('2026-06-01', {
+        max_hr: 160,
+        hr_seconds_in_zone: { 1: 0, 2: 300, 3: 300, 4: 0, 5: 0 },
+      }),
+    ]
+    const otfSessions = [otf('a', { peak_hr: 170, zones_min: { gray: 5, blue: 10, green: 20, orange: 4, red: 1 } })]
+
+    const cmp = buildHrZoneComparison(cardioSessions, otfSessions)
+
+    expect(cmp.apple.total).toBe(600)
+    expect(cmp.apple.unit).toBe('seconds')
+    const appleShare = cmp.apple.bands.map(b => b.share)
+    expect(appleShare[1]).toBeCloseTo(0.5)
+    expect(appleShare[2]).toBeCloseTo(0.5)
+    expect(appleShare.reduce((a, b) => a + b, 0)).toBeCloseTo(1)
+
+    expect(cmp.otf.total).toBe(40)
+    expect(cmp.otf.unit).toBe('minutes')
+    expect(cmp.otf.bands.map(b => b.share).reduce((a, b) => a + b, 0)).toBeCloseTo(1)
+  })
+
+  it('gives every band a zero share when a system logged no time', () => {
+    const cmp = buildHrZoneComparison([], [], { maxHrOverride: 175 })
+    expect(cmp.apple.total).toBe(0)
+    expect(cmp.apple.bands.every(b => b.share === 0)).toBe(true)
+    expect(cmp.otf.bands.every(b => b.share === 0)).toBe(true)
+  })
+})
+
+describe('averageOf', () => {
+  it('averages only sessions carrying the field', () => {
+    const sessions = [otf('a', { peak_hr: 160 }), otf('b', { peak_hr: 164 }), otf('c')]
+    expect(averageOf(sessions, 'peak_hr')).toBe(162)
+  })
+
+  it('returns null when no session carries the field', () => {
+    expect(averageOf([otf('a'), otf('b')], 'avg_hr')).toBeNull()
+  })
+})
+
+describe('bandForBpm', () => {
+  const cmp = buildHrZoneComparison([], [], { maxHrOverride: 175 })
+
+  it('lands an avg OTF peak of 162 in the red zone under both systems', () => {
+    expect(bandForBpm(cmp.otf.bands, 162)?.shortLabel).toBe('Red')
+    expect(bandForBpm(cmp.apple.bands, 162)?.shortLabel).toBe('Z5')
+  })
+
+  it('lands an avg HR of 125 in Z3 (Apple) and green (OTF)', () => {
+    expect(bandForBpm(cmp.apple.bands, 125)?.shortLabel).toBe('Z3')
+    expect(bandForBpm(cmp.otf.bands, 125)?.shortLabel).toBe('Green')
+  })
+
+  it('returns null below the lowest band floor', () => {
+    expect(bandForBpm(cmp.apple.bands, 80)).toBeNull()
+    expect(bandForBpm(cmp.otf.bands, 80)).toBeNull()
+  })
+})

--- a/lib/training-facility/hr-zone-comparison.ts
+++ b/lib/training-facility/hr-zone-comparison.ts
@@ -1,0 +1,267 @@
+/**
+ * Reconcile the two HR-zone systems feeding the Gym data (#261): Apple Watch /
+ * cardio (`constants/hr-zones.ts`, even 10% bands, raw samples we bucket
+ * ourselves) versus OrangeTheory (`lib/training-facility/otf.ts`, uneven bands,
+ * pre-bucketed minutes from the OTbeat emails).
+ *
+ * The two don't line up — different band cut-points *and* different maxHR
+ * baselines — so this module (1) derives one shared maxHR from real data (the
+ * highest peak observed, a floor rather than a formula), and (2) projects both
+ * systems onto it as bpm boundaries plus time-in-zone shares, side by side.
+ *
+ * It is pure and isomorphic — the view (`HrZoneComparison.tsx`) stays
+ * rendering-only and imports these for the maxHR derivation and comparison
+ * assembly. Deliberately does NOT re-bucket OTF minutes into Apple zones: the
+ * OTbeat emails carry no raw samples, so an accurate remap is impossible (issue
+ * #261, out of scope). The two systems are presented as parallel, not mapped.
+ */
+
+import { DEFAULT_MAX_HR, HR_ZONES, bpmRangeForZone } from '@/constants/hr-zones'
+import type { CardioSession, HrZone } from '@/types/cardio'
+import type { OtfSession } from '@/types/otf'
+
+import { OTF_ZONES, bpmRangeForOtfZone } from './otf'
+import { aggregateOtfZoneMinutes } from './otf'
+import { aggregateHrZoneSeconds } from './cardio-shared'
+
+/** Where the resolved max HR came from. */
+export type MaxHrSource = 'observed' | 'default'
+
+/** The derived max-HR baseline both zone systems are projected onto. */
+export interface ObservedMaxHr {
+  /**
+   * Max HR in BPM used for both systems' band boundaries. The highest peak
+   * seen in the data when available (`source: 'observed'`), else
+   * {@link DEFAULT_MAX_HR} (`source: 'default'`).
+   */
+  maxHr: number
+  /** Whether {@link maxHr} came from observed data or the Fox-formula default. */
+  source: MaxHrSource
+  /**
+   * Highest peak actually observed across the inputs, or `null` when no input
+   * carried a usable peak. A *floor* on true max HR — the user may not have
+   * truly maxed out — surfaced in the UI as "observed, auto-updating".
+   */
+  observedPeak: number | null
+}
+
+/** Inputs to {@link observedMaxHr} — either source may be empty/omitted. */
+export interface ObservedMaxHrInputs {
+  /** OrangeTheory sessions; each session's `peak_hr` is considered. */
+  otfSessions?: readonly OtfSession[]
+  /**
+   * Apple cardio sessions; each session's `max_hr` and any `hr_samples` bpm
+   * are considered (samples can exceed the stored `max_hr` on some exports).
+   */
+  cardioSessions?: readonly CardioSession[]
+}
+
+/**
+ * Derive a shared max-HR baseline from real data: the highest peak seen across
+ * OTF `peak_hr` and Apple `max_hr` / HR samples. Falls back to
+ * {@link DEFAULT_MAX_HR} when nothing usable is present.
+ *
+ * The observed peak is treated as a floor (not a formula estimate), matching
+ * the reconciliation goal of #261 — one baseline both models share, grounded in
+ * data rather than `220 − age`. Non-finite and non-positive candidates are
+ * ignored so a sensor glitch (`0`, `NaN`) can't poison the result.
+ */
+export function observedMaxHr(inputs: ObservedMaxHrInputs): ObservedMaxHr {
+  let peak = 0
+  const consider = (value: unknown): void => {
+    if (typeof value === 'number' && Number.isFinite(value) && value > peak) {
+      peak = value
+    }
+  }
+
+  for (const s of inputs.otfSessions ?? []) consider(s.peak_hr)
+  for (const s of inputs.cardioSessions ?? []) {
+    consider(s.max_hr)
+    for (const sample of s.hr_samples ?? []) consider(sample.bpm)
+  }
+
+  if (peak > 0) {
+    return { maxHr: peak, source: 'observed', observedPeak: peak }
+  }
+  return { maxHr: DEFAULT_MAX_HR, source: 'default', observedPeak: null }
+}
+
+/** One zone's band boundaries plus its share of logged time, for one system. */
+export interface ZoneTimeShare {
+  /** Stable key — Apple `'Z1'`–`'Z5'` or OTF `'gray'`–`'red'`. */
+  key: string
+  /** Long label, e.g. "Aerobic Base" (Apple) or "Base" (OTF green). */
+  label: string
+  /** Short label, e.g. "Z2" (Apple) or "Green" (OTF). */
+  shortLabel: string
+  /** Display color from the source system's palette. */
+  color: string
+  /** Lower bpm bound at the shared maxHR, inclusive, rounded. */
+  minBpm: number
+  /** Upper bpm bound at the shared maxHR, rounded. */
+  maxBpm: number
+  /**
+   * Time logged in this band across the input sessions, in the parent
+   * {@link SystemZoneComparison.unit} — seconds (Apple) or minutes (OTF).
+   */
+  value: number
+  /** Fraction 0–1 of the system's total time-in-zone this band holds; 0 when the system logged no time. */
+  share: number
+}
+
+/** One HR-zone system (Apple or OTF) resolved to a shared maxHR, with time-in-zone. */
+export interface SystemZoneComparison {
+  /** Which system this describes. */
+  system: 'apple' | 'otf'
+  /** Human-facing system name — "Apple Watch" / "OrangeTheory". */
+  label: string
+  /** Unit of every band's `value` — Apple stores seconds, OTF stores minutes. */
+  unit: 'seconds' | 'minutes'
+  /** Per-band boundaries + time share, in the system's canonical order (low → high). */
+  bands: ZoneTimeShare[]
+  /** Sum of `value` across bands, same unit as `unit`. 0 when no data. */
+  total: number
+}
+
+/** Both HR-zone systems projected onto one derived maxHR, ready to render side by side. */
+export interface HrZoneComparison {
+  /** The shared maxHR both systems' bpm boundaries were computed at. */
+  maxHr: number
+  /** Whether {@link maxHr} is data-observed or the formula default. */
+  maxHrSource: MaxHrSource
+  /** Highest peak observed across the inputs, or `null` when none. */
+  observedPeak: number | null
+  /** Apple even-band system (Z1–Z5), time-in-zone in seconds. */
+  apple: SystemZoneComparison
+  /** OrangeTheory uneven-band system (gray–red), time-in-zone in minutes. */
+  otf: SystemZoneComparison
+}
+
+/** Options for {@link buildHrZoneComparison}. */
+export interface BuildHrZoneComparisonOptions {
+  /**
+   * Explicit max HR to project both systems onto. When omitted, the value is
+   * derived from the data via {@link observedMaxHr} — the default behavior for
+   * #261's "observed peak, auto-updating" baseline. Pass a value to preview a
+   * tested or hypothetical max.
+   */
+  maxHrOverride?: number
+}
+
+/**
+ * Assemble the full {@link HrZoneComparison} from Apple cardio + OTF sessions.
+ *
+ * Resolves the shared maxHR (observed peak by default; `maxHrOverride` wins
+ * when given), then projects each system's bands to bpm at that maxHR and folds
+ * in time-in-zone: Apple seconds via {@link aggregateHrZoneSeconds}, OTF minutes
+ * via {@link aggregateOtfZoneMinutes}. Each band's `share` is its fraction of
+ * its *own* system's total — the two systems are never summed together, since
+ * their bands and units differ.
+ *
+ * @param cardioSessions Apple cardio sessions (already range-filtered by the caller).
+ * @param otfSessions OrangeTheory sessions (already range-filtered by the caller).
+ */
+export function buildHrZoneComparison(
+  cardioSessions: readonly CardioSession[],
+  otfSessions: readonly OtfSession[],
+  options: BuildHrZoneComparisonOptions = {},
+): HrZoneComparison {
+  const derived = observedMaxHr({ cardioSessions, otfSessions })
+  const override = options.maxHrOverride
+  const useOverride = typeof override === 'number' && Number.isFinite(override) && override > 0
+  const maxHr = useOverride ? override : derived.maxHr
+
+  const appleSeconds = aggregateHrZoneSeconds(cardioSessions)
+  const appleTotal = appleSeconds.reduce((acc, b) => acc + b.seconds, 0)
+  const appleBands: ZoneTimeShare[] = HR_ZONES.map((zone, i) => {
+    const [minBpm, maxBpm] = bpmRangeForZone(zone, maxHr)
+    const seconds = appleSeconds[i]?.seconds ?? 0
+    return {
+      key: zone.id,
+      label: zone.label,
+      shortLabel: zone.shortLabel,
+      color: zone.color,
+      minBpm,
+      maxBpm,
+      value: seconds,
+      share: appleTotal > 0 ? seconds / appleTotal : 0,
+    }
+  })
+
+  const otfMinutes = aggregateOtfZoneMinutes(otfSessions)
+  const otfTotal = otfMinutes.reduce((acc, b) => acc + b.minutes, 0)
+  const otfBands: ZoneTimeShare[] = OTF_ZONES.map((zone, i) => {
+    const [minBpm, maxBpm] = bpmRangeForOtfZone(zone, maxHr)
+    const minutes = otfMinutes[i]?.minutes ?? 0
+    return {
+      key: zone.key,
+      label: zone.label,
+      shortLabel: zone.shortLabel,
+      color: zone.color,
+      minBpm,
+      maxBpm,
+      value: minutes,
+      share: otfTotal > 0 ? minutes / otfTotal : 0,
+    }
+  })
+
+  return {
+    maxHr,
+    maxHrSource: useOverride ? 'observed' : derived.source,
+    observedPeak: derived.observedPeak,
+    apple: {
+      system: 'apple',
+      label: 'Apple Watch',
+      unit: 'seconds',
+      bands: appleBands,
+      total: appleTotal,
+    },
+    otf: {
+      system: 'otf',
+      label: 'OrangeTheory',
+      unit: 'minutes',
+      bands: otfBands,
+      total: otfTotal,
+    },
+  }
+}
+
+/**
+ * Average of a numeric session field across sessions that carry it, or `null`
+ * when none do. Used by the comparison view to place "my avg OTF peak / avg HR"
+ * against the derived bands — e.g. showing that an avg peak of 162 lands in red
+ * under both systems.
+ */
+export function averageOf(
+  sessions: readonly OtfSession[],
+  field: 'peak_hr' | 'avg_hr',
+): number | null {
+  let sum = 0
+  let count = 0
+  for (const s of sessions) {
+    const value = s[field]
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      sum += value
+      count += 1
+    }
+  }
+  return count > 0 ? sum / count : null
+}
+
+/**
+ * Which band of a system contains `bpm`, or `null` when it falls below the
+ * lowest band's floor. Bounds are inclusive on both ends (the published bands
+ * already leave 1-bpm gaps for OTF); a bpm in a gap resolves to the nearest
+ * lower band it satisfies. Used to annotate a marker (e.g. avg HR) with the
+ * zone it lands in.
+ */
+export function bandForBpm(
+  bands: readonly ZoneTimeShare[],
+  bpm: number,
+): ZoneTimeShare | null {
+  let match: ZoneTimeShare | null = null
+  for (const band of bands) {
+    if (bpm >= band.minBpm) match = band
+  }
+  return match
+}

--- a/lib/training-facility/otf.ts
+++ b/lib/training-facility/otf.ts
@@ -8,21 +8,53 @@ import type { OtfSession, OtfZoneMinutes } from '@/types/otf'
  * date-range filtering, zone aggregation, and headline stats.
  */
 
-/** OTbeat HR-zone display order + colors (gray → red), as the email reports them. */
-export const OTF_ZONES: ReadonlyArray<{
+/** One OTbeat HR zone: display config plus its %-of-maxHR band boundaries. */
+export interface OtfZoneConfig {
   /** Zone key matching {@link OtfZoneMinutes}. */
   key: keyof OtfZoneMinutes
-  /** Short axis/label text. */
+  /** Short axis/label text (OTbeat names its zones by color). */
   shortLabel: string
+  /** Long display name — OTbeat's effort description for the zone. */
+  label: string
   /** Display color (OTbeat's zone palette). */
   color: string
-}> = [
-  { key: 'gray', shortLabel: 'Gray', color: '#9ca3af' },
-  { key: 'blue', shortLabel: 'Blue', color: '#3b82f6' },
-  { key: 'green', shortLabel: 'Green', color: '#22c55e' },
-  { key: 'orange', shortLabel: 'Orange', color: '#f97316' },
-  { key: 'red', shortLabel: 'Red', color: '#dc2626' },
+  /**
+   * Lower band bound as a fraction of max HR, inclusive. As OTbeat publishes
+   * them (#261) — uneven bands, unlike the Apple model's even 10% steps.
+   */
+  minPct: number
+  /**
+   * Upper band bound as a fraction of max HR, inclusive. OTbeat publishes
+   * integer percentages with 1%-point gaps between zones (e.g. gray ends at
+   * 60%, blue starts at 61%), so this is not exactly the next zone's `minPct`.
+   */
+  maxPct: number
+}
+
+/**
+ * OTbeat HR-zone display order + colors (gray → red) and %-of-maxHR bands, as
+ * the OrangeTheory app reports them. Bands are uneven (green is a wide
+ * 71–83%, orange a narrow 84–91%) and are off OTF's *own* maxHR estimate —
+ * see {@link bpmRangeForOtfZone} to resolve them to bpm for a chosen maxHR.
+ */
+export const OTF_ZONES: readonly OtfZoneConfig[] = [
+  { key: 'gray', shortLabel: 'Gray', label: 'Very light', color: '#9ca3af', minPct: 0.5, maxPct: 0.6 },
+  { key: 'blue', shortLabel: 'Blue', label: 'Light', color: '#3b82f6', minPct: 0.61, maxPct: 0.7 },
+  { key: 'green', shortLabel: 'Green', label: 'Base', color: '#22c55e', minPct: 0.71, maxPct: 0.83 },
+  { key: 'orange', shortLabel: 'Orange', label: 'Challenging', color: '#f97316', minPct: 0.84, maxPct: 0.91 },
+  { key: 'red', shortLabel: 'Red', label: 'All out', color: '#dc2626', minPct: 0.92, maxPct: 1.0 },
 ]
+
+/**
+ * Resolve an OTF zone's literal BPM range for a given max HR — the OTbeat
+ * counterpart to `bpmRangeForZone` (Apple) in `constants/hr-zones.ts`. Used
+ * by the zone-comparison view to label each band with concrete BPM values.
+ *
+ * @returns `[minBpm, maxBpm]` rounded to whole BPM.
+ */
+export function bpmRangeForOtfZone(zone: OtfZoneConfig, maxHr: number): [number, number] {
+  return [Math.round(zone.minPct * maxHr), Math.round(zone.maxPct * maxHr)]
+}
 
 /** One zone's display config plus its aggregated minutes, for {@link OTF_ZONES}-ordered bar charts. */
 export interface OtfZoneBucket {


### PR DESCRIPTION
Closes #261.

Reconciles the two 5-zone HR systems feeding the Gym — Apple Watch (even 10%
bands, raw samples we bucket) and OrangeTheory (uneven bands, pre-bucketed
minutes) — by projecting both onto **one shared, data-derived max HR** and
showing them **side by side, not mapped onto each other**.

Per the design decisions on the issue: max HR = **observed peak from data**
(auto-updating, a floor), and **both systems kept for comparison** — no
canonical model is force-picked (the recommendation note argues for one, but
both stay rendered).

## Two slices

**1. Pure logic** (`lib/training-facility/hr-zone-comparison.ts` + `otf.ts`)
- Extend `OTF_ZONES` with %-of-maxHR band boundaries (as OTbeat publishes them —
  uneven, with 1%-point gaps) and add `bpmRangeForOtfZone`, the OTF counterpart
  to the existing `bpmRangeForZone`.
- `observedMaxHr` — highest peak across OTF `peak_hr` and Apple `max_hr` / HR
  samples; falls back to `DEFAULT_MAX_HR` when no peak is on file.
- `buildHrZoneComparison` — projects both systems' bands to bpm at the shared
  maxHR and folds in time-in-zone (Apple seconds, OTF minutes) as per-system
  shares. The two systems are never summed together.
- `averageOf` / `bandForBpm` — place avg HR / avg peak against the derived bands.

**2. View** (`HrZoneComparison.tsx` + `zones/page.tsx`)
- New `/training-facility/gym/zones` surface: shared-maxHR callout, one card per
  system (personal bpm boundaries + proportional time-in-zone strip + per-band
  time/share + where avg HR/peak land), and a short "which to follow" note.
- Reached from a new **"Zones vs Apple →"** link in the OrangeTheory view header.

## Deliberately out of scope (per #261)
Re-bucketing OTF minutes into Apple zones — the OTbeat emails carry no raw
samples, so an accurate remap is impossible. The systems are parallel, not mapped.

## Notes
- The illustrative bpm tables in the issue are hand-rounded (70% of 175 = 122.5
  → 123); the shared `bpmRangeForZone` helper hits the IEEE-754 value (122.4999…
  → 122). Tests assert the real helper output, not the illustrative table — I
  reused the existing helper rather than changing its rounding (it's shared with
  the cardio dashboard).

## Testing
- `tsc --noEmit` clean across the worktree.
- `hr-zone-comparison.test.ts` (13) — observed-maxHR derivation, both-system
  projection matching #261's tables, share math, avg-HR/peak band placement.
- `HrZoneComparison.test.tsx` (4) — loading→data, empty, error branches +
  observed-peak wins over cardio max.
- `otf.test.ts` still green after the `OTF_ZONES` extension.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new heart-rate zone comparison page for Training Facility gym users.
  * Introduced a side-by-side view comparing Apple Watch and Orangetheory zone data, with shared max-HR context and zone breakdowns.
  * Added a navigation link to open the comparison from the gym detail view.

* **Bug Fixes**
  * Improved handling for missing data by showing empty or error states when one or both sources are unavailable.

* **Tests**
  * Added coverage for the comparison view and supporting heart-rate zone calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->