### PR TITLE
feat(otf): mark anomalous sessions excluded + auto-detect at ingest (#268)

### DIFF
--- a/components/training-facility/gym/HrZoneComparison.test.tsx
+++ b/components/training-facility/gym/HrZoneComparison.test.tsx
@@ -88,6 +88,30 @@ describe('HrZoneComparison', () => {
     expect(screen.getByRole('heading', { name: /which to follow/i })).toBeInTheDocument()
   })
 
+  it('ignores excluded OTF sessions when deriving the shared max HR (#268)', async () => {
+    getCardioDataMock.mockResolvedValue(CARDIO)
+    getOtfDataMock.mockResolvedValue({
+      imported_at: '2026-06-30T07:53:00+00:00',
+      sessions: [
+        ...OTF.sessions,
+        // Anomaly with a bogus sky-high peak — must not become the shared max.
+        {
+          started_at: '2026-05-30T16:30:00+00:00',
+          peak_hr: 210,
+          avg_hr: 200,
+          excluded: true,
+          excluded_reason: 'auto: equipment malfunction',
+        },
+      ],
+    } satisfies OtfData)
+    render(<HrZoneComparison />)
+
+    await waitFor(() => expect(screen.getByText('Shared max HR')).toBeInTheDocument())
+    // Still 175 (the valid peak), not 210 from the excluded session.
+    expect(screen.getByText('175')).toBeInTheDocument()
+    expect(screen.queryByText('210')).not.toBeInTheDocument()
+  })
+
   it('shows the empty state when neither system logged zone time', async () => {
     getCardioDataMock.mockResolvedValue(null)
     getOtfDataMock.mockResolvedValue({

--- a/components/training-facility/gym/HrZoneComparison.tsx
+++ b/components/training-facility/gym/HrZoneComparison.tsx
@@ -12,6 +12,7 @@ import {
   type SystemZoneComparison,
   type ZoneTimeShare,
 } from '@/lib/training-facility/hr-zone-comparison'
+import { excludeInvalidOtfSessions } from '@/lib/training-facility/otf'
 import type { CardioData } from '@/types/cardio'
 import type { OtfData } from '@/types/otf'
 
@@ -57,7 +58,11 @@ export function HrZoneComparison(): JSX.Element {
     }
   }, [])
 
-  const otfSessions = useMemo(() => otf?.sessions ?? [], [otf])
+  // Drop excluded/anomalous OTF sessions (#268) so a malfunction or a manual
+  // exclusion (bogus peak_hr / zone minutes) can't skew the shared max HR, the
+  // OTF time-in-zone totals, or the avg-peak/avg-HR markers. This view reads
+  // otf.sessions independently of OtfDetailView, so it needs the same filter.
+  const otfSessions = useMemo(() => excludeInvalidOtfSessions(otf?.sessions ?? []), [otf])
   const cardioSessions = useMemo(() => cardio?.sessions ?? [], [cardio])
 
   const comparison = useMemo(

--- a/components/training-facility/gym/OtfDetailView.test.tsx
+++ b/components/training-facility/gym/OtfDetailView.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, within } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { OtfData } from '@/types/otf'
@@ -24,21 +24,40 @@ vi.mock('next/navigation', () => ({
   useSearchParams: () => new URLSearchParams(),
 }))
 
+const VALID_SESSION = {
+  started_at: '2026-06-27T16:30:00+00:00',
+  coach: 'Mara Magistad',
+  studio: 'Marina Del Rey, CA',
+  splat: 15,
+  calories: 776,
+  avg_hr: 133,
+  peak_hr: 164,
+  zones_min: { gray: 1, blue: 11, green: 29, orange: 14, red: 1 },
+  treadmill: { distance_mi: 1.09, time: '16:44' },
+  rower: { distance_m: 2509, time: '13:54' },
+}
+
 const DATA: OtfData = {
+  imported_at: '2026-06-30T07:53:00+00:00',
+  sessions: [VALID_SESSION],
+}
+
+/** One valid class + one auto-excluded belt-malfunction anomaly (#268). */
+const DATA_WITH_EXCLUDED: OtfData = {
   imported_at: '2026-06-30T07:53:00+00:00',
   sessions: [
     {
-      started_at: '2026-06-27T16:30:00+00:00',
-      coach: 'Mara Magistad',
+      started_at: '2026-05-30T16:30:00+00:00',
+      coach: 'Jacob Buckenmeyer',
       studio: 'Marina Del Rey, CA',
-      splat: 15,
-      calories: 776,
-      avg_hr: 133,
-      peak_hr: 164,
-      zones_min: { gray: 1, blue: 11, green: 29, orange: 14, red: 1 },
-      treadmill: { distance_mi: 1.09, time: '16:44' },
-      rower: { distance_m: 2509, time: '13:54' },
+      splat: 0,
+      calories: 4,
+      avg_hr: 94,
+      peak_hr: 95,
+      excluded: true,
+      excluded_reason: 'auto: near-zero output with no treadmill or rower block',
     },
+    VALID_SESSION,
   ],
 }
 
@@ -66,6 +85,23 @@ describe('OtfDetailView', () => {
     expect(screen.getByRole('heading', { name: /classes/i })).toBeInTheDocument()
     // Splat value appears in both the tile and the table; just assert presence.
     expect(screen.getAllByText('15').length).toBeGreaterThan(0)
+  })
+
+  it('lists an excluded session in the log with a badge but keeps it out of the class count (#268)', async () => {
+    getOtfDataMock.mockResolvedValue(DATA_WITH_EXCLUDED)
+    render(<OtfDetailView />)
+    // The anomaly's coach is still rendered — excluded rows stay in the log.
+    await waitFor(() => expect(screen.getByText('Jacob Buckenmeyer')).toBeInTheDocument())
+    // …flagged with an "Excluded" badge carrying the reason as its title.
+    const badge = screen.getByText('Excluded')
+    expect(badge).toHaveAttribute('title', expect.stringContaining('near-zero output'))
+    // …and counted separately: 1 valid class in range, 1 excluded.
+    expect(screen.getByText(/1 in range/)).toBeInTheDocument()
+    expect(screen.getByText(/1 excluded/)).toBeInTheDocument()
+    // Aggregates run over active sessions only: total calories is 776 (the
+    // valid class), not 780 — the anomaly's 4 cal is left out.
+    const calTile = screen.getByText('Total calories').closest('div') as HTMLElement
+    expect(within(calTile).getByText('776')).toBeInTheDocument()
   })
 
   it('shows the empty state when there are no sessions', async () => {

--- a/components/training-facility/gym/OtfDetailView.tsx
+++ b/components/training-facility/gym/OtfDetailView.tsx
@@ -17,6 +17,7 @@ import {
   OTF_ZONES,
   aggregateOtfZoneMinutes,
   earliestOtfDate,
+  excludeInvalidOtfSessions,
   filterOtfSessionsInRange,
   formatMmss,
   formatOtfDate,
@@ -115,43 +116,48 @@ export function OtfDetailView(): JSX.Element {
     () => (data ? filterOtfSessionsInRange(data.sessions, range) : []),
     [data, range]
   )
-  const buckets = useMemo(() => aggregateOtfZoneMinutes(sessions), [sessions])
-  const splatTrend = useMemo(() => otfMetricTrend(sessions, 'splat'), [sessions])
-  const calorieTrend = useMemo(() => otfMetricTrend(sessions, 'calories'), [sessions])
-  const hrTrend = useMemo(() => otfMetricTrend(sessions, 'avg_hr'), [sessions])
+  // Aggregates, trends, sparklines, and highlights run over the *active*
+  // sessions only — invalid/anomalous classes (e.g. an equipment malfunction,
+  // #268) are dropped so they can't skew a total, average, or trend line. The
+  // full `sessions` set still feeds the session log, which shows them muted.
+  const activeSessions = useMemo(() => excludeInvalidOtfSessions(sessions), [sessions])
+  const buckets = useMemo(() => aggregateOtfZoneMinutes(activeSessions), [activeSessions])
+  const splatTrend = useMemo(() => otfMetricTrend(activeSessions, 'splat'), [activeSessions])
+  const calorieTrend = useMemo(() => otfMetricTrend(activeSessions, 'calories'), [activeSessions])
+  const hrTrend = useMemo(() => otfMetricTrend(activeSessions, 'avg_hr'), [activeSessions])
   const treadDistanceTrend = useMemo(
-    () => otfBlockTrend(sessions, 'treadmill', t => t.distance_mi),
-    [sessions]
+    () => otfBlockTrend(activeSessions, 'treadmill', t => t.distance_mi),
+    [activeSessions]
   )
   const treadPaceTrend = useMemo(
-    () => otfBlockTrend(sessions, 'treadmill', t => mmssToSeconds(t.avg_pace)),
-    [sessions]
+    () => otfBlockTrend(activeSessions, 'treadmill', t => mmssToSeconds(t.avg_pace)),
+    [activeSessions]
   )
   const rowerDistanceTrend = useMemo(
-    () => otfBlockTrend(sessions, 'rower', r => r.distance_m),
-    [sessions]
+    () => otfBlockTrend(activeSessions, 'rower', r => r.distance_m),
+    [activeSessions]
   )
   const rowerSplitTrend = useMemo(
-    () => otfBlockTrend(sessions, 'rower', r => mmssToSeconds(r.split_500m)),
-    [sessions]
+    () => otfBlockTrend(activeSessions, 'rower', r => mmssToSeconds(r.split_500m)),
+    [activeSessions]
   )
   const treadInclineTrend = useMemo(
-    () => otfBlockTrend(sessions, 'treadmill', t => t.avg_incline),
-    [sessions]
+    () => otfBlockTrend(activeSessions, 'treadmill', t => t.avg_incline),
+    [activeSessions]
   )
   const rowerWattsTrend = useMemo(
-    () => otfBlockTrend(sessions, 'rower', r => r.avg_watt),
-    [sessions]
+    () => otfBlockTrend(activeSessions, 'rower', r => r.avg_watt),
+    [activeSessions]
   )
   // Machine time-on-machine, parsed from the "MM:SS" block field, feeds the
   // combined overlays alongside distance and pace/watts.
   const treadTimeTrend = useMemo(
-    () => otfBlockTrend(sessions, 'treadmill', t => mmssToSeconds(t.time)),
-    [sessions]
+    () => otfBlockTrend(activeSessions, 'treadmill', t => mmssToSeconds(t.time)),
+    [activeSessions]
   )
   const rowerTimeTrend = useMemo(
-    () => otfBlockTrend(sessions, 'rower', r => mmssToSeconds(r.time)),
-    [sessions]
+    () => otfBlockTrend(activeSessions, 'rower', r => mmssToSeconds(r.time)),
+    [activeSessions]
   )
   const treadRows = useMemo<OtfSparklineRow[]>(
     () => [
@@ -171,7 +177,7 @@ export function OtfDetailView(): JSX.Element {
     ],
     [rowerDistanceTrend, rowerTimeTrend, rowerWattsTrend, rowerSplitTrend]
   )
-  const highlights = useMemo(() => otfHighlights(sessions), [sessions])
+  const highlights = useMemo(() => otfHighlights(activeSessions), [activeSessions])
 
   const hasAnySessions = !!data && data.sessions.length > 0
 
@@ -493,6 +499,11 @@ function SessionLogTable({ sessions, range }: SessionLogTableProps): JSX.Element
   const rows = useMemo(() => sessions.slice().reverse(), [sessions])
   const [expandedKey, setExpandedKey] = useState<string | null>(null)
 
+  // The log lists excluded classes too (muted), so split the count: N valid
+  // classes drive the aggregates; excluded ones are called out separately.
+  const excludedCount = useMemo(() => sessions.filter(s => s.excluded).length, [sessions])
+  const activeCount = sessions.length - excludedCount
+
   return (
     <section className="mt-8 rounded-[1.6rem] border border-white/10 bg-black/25 p-5">
       <header className="mb-3 flex flex-wrap items-baseline justify-between gap-3">
@@ -500,7 +511,10 @@ function SessionLogTable({ sessions, range }: SessionLogTableProps): JSX.Element
           Classes
         </h2>
         <p className="text-xs text-white/55">
-          {sessions.length === 0 ? 'No classes in range' : `${sessions.length} in range`}
+          {sessions.length === 0 ? 'No classes in range' : `${activeCount} in range`}
+          {excludedCount > 0 && (
+            <span className="ml-1 text-[#f9a870]/80">· {excludedCount} excluded</span>
+          )}
           <span className="ml-2 text-white/35">
             ({formatBound(range.start)} → {formatBound(range.end)})
           </span>
@@ -541,7 +555,10 @@ function SessionLogTable({ sessions, range }: SessionLogTableProps): JSX.Element
             <tbody className="text-[#f7ead9]">
               {rows.map((s, i) => {
                 const rowKey = `${s.started_at}-${i}`
-                const expandable = !!s.treadmill || !!s.rower || !!s.zones_min
+                const excluded = !!s.excluded
+                // Excluded rows are always expandable so the exclusion reason
+                // stays reachable even when the class has no machine/zone block.
+                const expandable = !!s.treadmill || !!s.rower || !!s.zones_min || excluded
                 const isExpanded = expandedKey === rowKey
                 const toggle = () => {
                   if (!expandable) return
@@ -550,7 +567,7 @@ function SessionLogTable({ sessions, range }: SessionLogTableProps): JSX.Element
                 return (
                   <Fragment key={rowKey}>
                     <tr
-                      className={`rounded-md bg-white/5 align-middle ${
+                      className={`rounded-md align-middle ${excluded ? 'bg-white/[0.02] opacity-55' : 'bg-white/5'} ${
                         expandable
                           ? 'cursor-pointer transition hover:bg-white/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/60'
                           : ''
@@ -570,9 +587,29 @@ function SessionLogTable({ sessions, range }: SessionLogTableProps): JSX.Element
                           }
                         : {})}
                     >
-                      <td className="rounded-l-md px-3 py-2 font-mono">{formatOtfDate(s)}</td>
+                      <td className="rounded-l-md px-3 py-2 font-mono">
+                        <span className="inline-flex flex-wrap items-center gap-2">
+                          <span
+                            className={excluded ? 'line-through decoration-white/40' : undefined}
+                          >
+                            {formatOtfDate(s)}
+                          </span>
+                          {excluded && (
+                            <span
+                              title={s.excluded_reason ?? undefined}
+                              className="rounded-full border border-[#f9a870]/40 bg-[#f9a870]/10 px-2 py-0.5 text-[0.6rem] font-semibold uppercase tracking-[0.14em] text-[#f9a870]"
+                            >
+                              Excluded
+                            </span>
+                          )}
+                        </span>
+                      </td>
                       <td className="px-3 py-2">{s.coach ?? '—'}</td>
-                      <td className="px-3 py-2 font-mono text-[#f97316]">{numCell(s.splat)}</td>
+                      <td
+                        className={`px-3 py-2 font-mono ${excluded ? 'text-white/50' : 'text-[#f97316]'}`}
+                      >
+                        {numCell(s.splat)}
+                      </td>
                       <td className="px-3 py-2 font-mono">{numCell(s.calories)}</td>
                       <td className="px-3 py-2 font-mono">{numCell(s.avg_hr)}</td>
                       <td className="px-3 py-2 font-mono">{numCell(s.peak_hr)}</td>
@@ -604,29 +641,37 @@ function ExpandedSession({ session }: { session: OtfSession }): JSX.Element {
   // callback (a property access doesn't stay narrowed across the closure).
   const zones = session.zones_min
   return (
-    <div className="grid gap-4 rounded-xl bg-black/30 p-4 text-xs sm:grid-cols-3">
-      <div>
-        <p className="mb-2 font-mono uppercase tracking-[0.18em] text-white/55">Zones</p>
-        {zones ? (
-          <ul className="space-y-1">
-            {OTF_ZONES.map(z => (
-              <li key={z.key} className="flex items-center gap-2">
-                <span
-                  aria-hidden="true"
-                  className="inline-block h-2.5 w-2.5 rounded-sm"
-                  style={{ backgroundColor: z.color }}
-                />
-                <span className="text-white/70">{z.shortLabel}</span>
-                <span className="ml-auto font-mono text-white/90">{zones[z.key]}m</span>
-              </li>
-            ))}
-          </ul>
-        ) : (
-          <p className="text-white/45">No zone data.</p>
-        )}
+    <div className="space-y-3">
+      {session.excluded && (
+        <p className="rounded-lg border border-[#f9a870]/30 bg-[#f9a870]/10 px-3 py-2 text-xs leading-5 text-[#f9c79b]">
+          <span className="font-semibold uppercase tracking-[0.14em]">Excluded from charts</span>
+          {session.excluded_reason ? ` — ${session.excluded_reason}` : ''}
+        </p>
+      )}
+      <div className="grid gap-4 rounded-xl bg-black/30 p-4 text-xs sm:grid-cols-3">
+        <div>
+          <p className="mb-2 font-mono uppercase tracking-[0.18em] text-white/55">Zones</p>
+          {zones ? (
+            <ul className="space-y-1">
+              {OTF_ZONES.map(z => (
+                <li key={z.key} className="flex items-center gap-2">
+                  <span
+                    aria-hidden="true"
+                    className="inline-block h-2.5 w-2.5 rounded-sm"
+                    style={{ backgroundColor: z.color }}
+                  />
+                  <span className="text-white/70">{z.shortLabel}</span>
+                  <span className="ml-auto font-mono text-white/90">{zones[z.key]}m</span>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-white/45">No zone data.</p>
+          )}
+        </div>
+        <StatBlock title="Treadmill" rows={treadmillRows(session.treadmill)} />
+        <StatBlock title="Rower" rows={rowerRows(session.rower)} />
       </div>
-      <StatBlock title="Treadmill" rows={treadmillRows(session.treadmill)} />
-      <StatBlock title="Rower" rows={rowerRows(session.rower)} />
     </div>
   )
 }

--- a/lib/data/otf-shared.ts
+++ b/lib/data/otf-shared.ts
@@ -26,7 +26,7 @@ const SESSIONS_TABLE = 'otf_sessions'
 const SESSIONS_COLUMNS =
   'started_at, coach, studio, calories, splat, steps, avg_hr, peak_hr, ' +
   'zone_gray_min, zone_blue_min, zone_green_min, zone_orange_min, zone_red_min, ' +
-  'treadmill, rower, updated_at'
+  'treadmill, rower, excluded, excluded_reason, updated_at'
 
 /** Array form of {@link OtfSessionRowSchema} for validating the full read. */
 const OtfSessionRowsSchema = z.array(OtfSessionRowSchema)

--- a/lib/data/otf.test.ts
+++ b/lib/data/otf.test.ts
@@ -142,6 +142,23 @@ describe('getOtfData', () => {
     })
   })
 
+  it('passes the excluded flag + reason through to the session (#268)', async () => {
+    stubSessions([
+      {
+        started_at: '2026-05-30T16:30:00+00:00',
+        coach: 'Jacob Buckenmeyer',
+        calories: 4,
+        splat: 0,
+        excluded: true,
+        excluded_reason: 'auto: near-zero output with no treadmill or rower block',
+        updated_at: '2026-05-30T17:00:00+00:00',
+      },
+    ])
+    const data = await getOtfData()
+    expect(data?.sessions[0].excluded).toBe(true)
+    expect(data?.sessions[0].excluded_reason).toMatch(/near-zero output/)
+  })
+
   it('takes imported_at from the latest updated_at', async () => {
     stubSessions([
       {

--- a/lib/schemas/otf.test.ts
+++ b/lib/schemas/otf.test.ts
@@ -51,6 +51,16 @@ describe('OtfSessionRowSchema', () => {
   it('rejects an empty started_at', () => {
     expect(OtfSessionRowSchema.safeParse({ started_at: '' }).success).toBe(false)
   })
+
+  it('accepts the excluded flag + reason (#268)', () => {
+    const parsed = OtfSessionRowSchema.safeParse({
+      started_at: '2026-05-30T16:30:00+00:00',
+      calories: 4,
+      excluded: true,
+      excluded_reason: 'auto: equipment malfunction',
+    })
+    expect(parsed.success).toBe(true)
+  })
 })
 
 describe('otfRowToSession', () => {
@@ -82,5 +92,22 @@ describe('otfRowToSession', () => {
   it('defaults missing zones to 0 when at least one is present', () => {
     const session = otfRowToSession({ started_at: '2026-06-27T16:30:00+00:00', zone_orange_min: 5 })
     expect(session.zones_min).toEqual({ gray: 0, blue: 0, green: 0, orange: 5, red: 0 })
+  })
+
+  it('passes the excluded flag + reason through (#268)', () => {
+    const session = otfRowToSession({
+      started_at: '2026-05-30T16:30:00+00:00',
+      calories: 4,
+      excluded: true,
+      excluded_reason: 'auto: equipment malfunction',
+    })
+    expect(session.excluded).toBe(true)
+    expect(session.excluded_reason).toBe('auto: equipment malfunction')
+  })
+
+  it('omits excluded when the column is absent', () => {
+    const session = otfRowToSession({ started_at: '2026-06-27T16:30:00+00:00' })
+    expect(session).not.toHaveProperty('excluded')
+    expect(session).not.toHaveProperty('excluded_reason')
   })
 })

--- a/lib/schemas/otf.ts
+++ b/lib/schemas/otf.ts
@@ -77,6 +77,8 @@ export const OtfSessionRowSchema = z
     zone_red_min: z.number().nonnegative().optional(),
     treadmill: OtfTreadmillSchema.optional(),
     rower: OtfRowerSchema.optional(),
+    excluded: z.boolean().optional(),
+    excluded_reason: z.string().optional(),
   })
   .strict()
 
@@ -122,5 +124,7 @@ export function otfRowToSession(row: OtfSessionRow): OtfSession {
 
   if (row.treadmill !== undefined) session.treadmill = row.treadmill
   if (row.rower !== undefined) session.rower = row.rower
+  if (row.excluded !== undefined) session.excluded = row.excluded
+  if (row.excluded_reason !== undefined) session.excluded_reason = row.excluded_reason
   return session
 }

--- a/lib/training-facility/otf.test.ts
+++ b/lib/training-facility/otf.test.ts
@@ -5,6 +5,7 @@ import type { OtfSession } from '@/types/otf'
 import {
   aggregateOtfZoneMinutes,
   earliestOtfDate,
+  excludeInvalidOtfSessions,
   filterOtfSessionsInRange,
   formatMmss,
   formatOtfDate,
@@ -33,6 +34,22 @@ describe('filterOtfSessionsInRange', () => {
     expect(filterOtfSessionsInRange(sessions, range).map(s => s.started_at)).toEqual([
       '2026-06-15T12:00:00Z',
     ])
+  })
+})
+
+describe('excludeInvalidOtfSessions', () => {
+  it('drops sessions flagged excluded, keeps the rest in order', () => {
+    const sessions = [
+      mk('a'),
+      mk('b', { excluded: true, excluded_reason: 'auto: malfunction' }),
+      mk('c', { excluded: false }),
+    ]
+    expect(excludeInvalidOtfSessions(sessions).map(s => s.started_at)).toEqual(['a', 'c'])
+  })
+
+  it('is a no-op when nothing is excluded', () => {
+    const sessions = [mk('a'), mk('b')]
+    expect(excludeInvalidOtfSessions(sessions)).toHaveLength(2)
   })
 })
 

--- a/lib/training-facility/otf.ts
+++ b/lib/training-facility/otf.ts
@@ -82,6 +82,18 @@ export function otfSessionDate(session: OtfSession): Date {
 }
 
 /**
+ * Drop sessions flagged `excluded` — invalid/anomalous classes (e.g. an
+ * equipment malfunction, #268) that must stay out of every aggregate, trend,
+ * and highlight while the session log still lists them, muted. Preserves order.
+ *
+ * Apply this to the range-filtered sessions before any aggregation; keep the
+ * unfiltered set for the log so the excluded rows remain visible.
+ */
+export function excludeInvalidOtfSessions(sessions: readonly OtfSession[]): OtfSession[] {
+  return sessions.filter(s => !s.excluded)
+}
+
+/**
  * Filter sessions to those whose start falls within the inclusive
  * {@link DateRange}, preserving order (the dataset arrives ascending).
  */

--- a/scripts/lib/otbeat-anomaly.mjs
+++ b/scripts/lib/otbeat-anomaly.mjs
@@ -1,0 +1,69 @@
+/**
+ * Auto-detection of anomalous OrangeTheory sessions (#268).
+ *
+ * Some "sessions" aren't real workouts — e.g. an equipment malfunction where
+ * the OTbeat belt logs a class with near-zero output and no treadmill or rower
+ * block (the 05/30/2026 Jacob Buckenmeyer class: 4 calories, 0 splat, no
+ * machine data). Those should be kept in the table (never deleted) but flagged
+ * `excluded` so the OTF view leaves them out of every aggregate and chart.
+ *
+ * This module is the single source of truth for the heuristic. It is:
+ * - called from `recordToRow` (`otbeat-supabase.mjs`) so newly-ingested
+ *   anomalies are flagged at first insert, and
+ * - mirrored by the backfill `UPDATE` in
+ *   `supabase/migrations/20260702120000_otf_sessions_excluded.sql` for the rows
+ *   that predate this feature.
+ *
+ * Loaded as ESM from `.mjs` callers — no TypeScript transpile step, same
+ * constraint as the sibling parser / supabase helpers.
+ *
+ * KEEP THE THRESHOLDS IN SYNC WITH the migration's backfill `WHERE` clause.
+ */
+
+/** Reason string stamped on auto-detected anomalies. Mirrored in the migration backfill. */
+export const AUTO_EXCLUDE_REASON =
+  'auto: near-zero output with no treadmill or rower block (likely equipment malfunction)'
+
+/** A session with fewer calories than this (and no machine block) is treated as non-real. */
+const MAX_ANOMALY_CALORIES = 25
+
+/** A session with more splat points than this is never auto-excluded, regardless of the rest. */
+const MAX_ANOMALY_SPLAT = 1
+
+/**
+ * The signals the anomaly heuristic reads off a session, normalized so the same
+ * classifier serves the parsed-record ingest path and any row-shaped caller.
+ * @typedef {Object} OtfAnomalySignals
+ * @property {number|null|undefined} calories Calories burned, or absent.
+ * @property {number|null|undefined} splat Splat points, or absent.
+ * @property {boolean} hasTreadmill Whether a treadmill performance block is present.
+ * @property {boolean} hasRower Whether a rower performance block is present.
+ */
+
+/**
+ * Classify a session as a likely equipment-malfunction anomaly.
+ *
+ * A real OrangeTheory class always logs at least one machine block (treadmill
+ * or rower) and burns hundreds of calories — the lowest legitimate class in the
+ * dataset is 541 cal with both blocks present. So the conjunction of *no*
+ * machine block **and** near-zero calories **and** ~zero splat is a strong,
+ * false-positive-resistant signal that the belt malfunctioned rather than that
+ * a genuine low-intensity class happened.
+ *
+ * Conservative by design: a real class that merely omits the rower (tread-only
+ * formats) still has a treadmill block and hundreds of calories, so it never
+ * trips this. Widen the thresholds only if a genuine anomaly slips through.
+ *
+ * @param {OtfAnomalySignals} signals Normalized session signals.
+ * @returns {{ excluded: boolean, reason: string | null }} `excluded: true` with
+ *   a {@link AUTO_EXCLUDE_REASON} reason when the session looks anomalous;
+ *   `{ excluded: false, reason: null }` otherwise.
+ */
+export function classifyOtfAnomaly({ calories, splat, hasTreadmill, hasRower }) {
+  const noMachineBlock = !hasTreadmill && !hasRower
+  const nearZeroOutput = (calories ?? 0) < MAX_ANOMALY_CALORIES && (splat ?? 0) <= MAX_ANOMALY_SPLAT
+  if (noMachineBlock && nearZeroOutput) {
+    return { excluded: true, reason: AUTO_EXCLUDE_REASON }
+  }
+  return { excluded: false, reason: null }
+}

--- a/scripts/lib/otbeat-anomaly.test.ts
+++ b/scripts/lib/otbeat-anomaly.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Tests for the OTbeat anomaly heuristic (#268).
+ *
+ * The heuristic decides which sessions are auto-flagged `excluded` at ingest.
+ * The stakes are false positives (hiding a real class) and false negatives
+ * (letting a malfunction skew aggregates), so the cases pin the exact
+ * threshold boundaries against the shape of the real dataset — the 05/30
+ * belt-malfunction anomaly (4 cal, 0 splat, no machine block) vs the lowest
+ * legitimate class (541 cal, both blocks present).
+ */
+import { describe, expect, it } from 'vitest'
+
+import { AUTO_EXCLUDE_REASON, classifyOtfAnomaly } from './otbeat-anomaly.mjs'
+
+describe('classifyOtfAnomaly', () => {
+  it('flags the belt-malfunction shape (near-zero output, no machine block)', () => {
+    const result = classifyOtfAnomaly({
+      calories: 4,
+      splat: 0,
+      hasTreadmill: false,
+      hasRower: false,
+    })
+    expect(result).toEqual({ excluded: true, reason: AUTO_EXCLUDE_REASON })
+  })
+
+  it('does not flag a real class (hundreds of calories, both blocks present)', () => {
+    const result = classifyOtfAnomaly({
+      calories: 541,
+      splat: 2,
+      hasTreadmill: true,
+      hasRower: true,
+    })
+    expect(result).toEqual({ excluded: false, reason: null })
+  })
+
+  it('does not flag a real tread-only class (rower omitted but treadmill present)', () => {
+    // A legitimate format can omit the rower; the treadmill block alone is
+    // enough to prove it was a real workout, so near-zero-cal never applies.
+    const result = classifyOtfAnomaly({
+      calories: 692,
+      splat: 15,
+      hasTreadmill: true,
+      hasRower: false,
+    })
+    expect(result.excluded).toBe(false)
+  })
+
+  it('requires BOTH machine blocks to be absent — one present is enough to keep', () => {
+    expect(
+      classifyOtfAnomaly({ calories: 4, splat: 0, hasTreadmill: false, hasRower: true }).excluded
+    ).toBe(false)
+    expect(
+      classifyOtfAnomaly({ calories: 4, splat: 0, hasTreadmill: true, hasRower: false }).excluded
+    ).toBe(false)
+  })
+
+  it('keeps a machine-less class once calories cross the threshold', () => {
+    // No machine block but real calories → not a malfunction, don't hide it.
+    expect(
+      classifyOtfAnomaly({ calories: 25, splat: 0, hasTreadmill: false, hasRower: false }).excluded
+    ).toBe(false)
+    expect(
+      classifyOtfAnomaly({ calories: 24, splat: 0, hasTreadmill: false, hasRower: false }).excluded
+    ).toBe(true)
+  })
+
+  it('keeps a machine-less class once splat crosses the threshold', () => {
+    // >1 splat means real orange/red-zone minutes were logged — a real effort.
+    expect(
+      classifyOtfAnomaly({ calories: 4, splat: 2, hasTreadmill: false, hasRower: false }).excluded
+    ).toBe(false)
+    expect(
+      classifyOtfAnomaly({ calories: 4, splat: 1, hasTreadmill: false, hasRower: false }).excluded
+    ).toBe(true)
+  })
+
+  it('treats absent calories/splat as zero (a header-only anomaly still flags)', () => {
+    const result = classifyOtfAnomaly({
+      calories: null,
+      splat: undefined,
+      hasTreadmill: false,
+      hasRower: false,
+    })
+    expect(result.excluded).toBe(true)
+  })
+})

--- a/scripts/lib/otbeat-supabase.mjs
+++ b/scripts/lib/otbeat-supabase.mjs
@@ -16,6 +16,7 @@
  * Loaded as ESM from `.mjs` callers — no TypeScript transpile step.
  */
 
+import { classifyOtfAnomaly } from './otbeat-anomaly.mjs'
 import { createServiceRoleClient, loadEnv } from './cardio-supabase.mjs'
 
 export { createServiceRoleClient, loadEnv }
@@ -103,12 +104,24 @@ export function toStartedAt(date, time, timeZone) {
  * the treadmill and rower blocks pass straight through as JSONB (`null` when
  * the class format omitted them). `updated_at` is left to the column default.
  *
+ * `excluded` / `excluded_reason` are set from {@link classifyOtfAnomaly} so a
+ * malfunction session (near-zero output, no machine block — #268) is flagged
+ * at first insert. Because {@link upsertOtfSessions} is append-only
+ * (`ignoreDuplicates`), this only ever runs on a row's *first* write, so a
+ * manual override made later in Supabase is never clobbered by a re-pull.
+ *
  * @param {import('./otbeat-parser.mjs').OtbeatRecord} rec Parsed session.
  * @param {string} [timeZone] Studio timezone for `started_at`.
  * @returns {Record<string, unknown>} Row payload for `otf_sessions`.
  */
 export function recordToRow(rec, timeZone = DEFAULT_STUDIO_TZ) {
   const z = rec.zones_min ?? null
+  const anomaly = classifyOtfAnomaly({
+    calories: rec.calories,
+    splat: rec.splat,
+    hasTreadmill: rec.treadmill != null,
+    hasRower: rec.rower != null,
+  })
   return {
     started_at: toStartedAt(rec.date, rec.time, timeZone),
     coach: rec.coach ?? null,
@@ -125,6 +138,8 @@ export function recordToRow(rec, timeZone = DEFAULT_STUDIO_TZ) {
     zone_red_min: z?.red ?? null,
     treadmill: rec.treadmill ?? null,
     rower: rec.rower ?? null,
+    excluded: anomaly.excluded,
+    excluded_reason: anomaly.reason,
   }
 }
 

--- a/scripts/lib/otbeat-supabase.test.ts
+++ b/scripts/lib/otbeat-supabase.test.ts
@@ -108,6 +108,28 @@ describe('recordToRow', () => {
     expect(row.treadmill).toBeNull()
     expect(row.rower).toBeNull()
   })
+
+  it('auto-flags a belt-malfunction session as excluded (#268)', () => {
+    // 05/30 anomaly: near-zero output, no machine block.
+    const row = recordToRow({ ...bareRecord('05/30/2026', '9:30AM'), calories: 4, splat: 0 }, TZ)
+    expect(row.excluded).toBe(true)
+    expect(row.excluded_reason).toMatch(/^auto:/)
+  })
+
+  it('leaves a real class un-excluded', () => {
+    const row = recordToRow(
+      {
+        ...bareRecord('06/27/2026', '9:30AM'),
+        calories: 776,
+        splat: 15,
+        treadmill: { distance_mi: 1.09, time: '11:24' },
+        rower: { distance_m: 2509, time: '7:58' },
+      },
+      TZ
+    )
+    expect(row.excluded).toBe(false)
+    expect(row.excluded_reason).toBeNull()
+  })
 })
 
 /**

--- a/supabase/migrations/20260702120000_otf_sessions_excluded.sql
+++ b/supabase/migrations/20260702120000_otf_sessions_excluded.sql
@@ -1,0 +1,45 @@
+-- Mark anomalous OTbeat sessions invalid/excluded, without deleting them (#268).
+--
+-- Some rows in otf_sessions aren't real workouts — e.g. an equipment
+-- malfunction where the OTbeat belt logs a "class" with near-zero output and
+-- no treadmill or rower block (the 05/30/2026 Jacob Buckenmeyer class: 4
+-- calories, 0 splat, no machine data). Deleting them would lose the audit
+-- trail and re-appear on the next email re-pull; instead we flag them so the
+-- OTF view leaves them out of every aggregate and chart while the session log
+-- still lists them, muted.
+--
+-- `excluded` defaults to false so every existing and future row is valid until
+-- proven otherwise. The ingest path (`recordToRow` → `classifyOtfAnomaly` in
+-- scripts/lib/otbeat-anomaly.mjs) sets the flag at first insert for new
+-- anomalies; the backfill below covers rows that predate the feature. Because
+-- the importer is append-only (upsert with ignoreDuplicates), a manual
+-- override set later in Supabase is never clobbered by a re-pull.
+--
+-- All DDL is idempotent (add column if not exists) so re-applying on a fresh
+-- dev project or after a branch reset is a safe no-op.
+
+alter table public.otf_sessions
+  add column if not exists excluded boolean not null default false;
+
+alter table public.otf_sessions
+  add column if not exists excluded_reason text;
+
+comment on column public.otf_sessions.excluded is
+  'True when the session is invalid/anomalous (e.g. equipment malfunction) and must be left out of aggregates and charts. The row is kept, not deleted; the session log still shows it, muted. Auto-set at ingest by classifyOtfAnomaly (#268) and overridable manually.';
+
+comment on column public.otf_sessions.excluded_reason is
+  'Human-readable reason the session was excluded; prefixed "auto:" when set by the ingest heuristic. Null when the session is valid.';
+
+-- Backfill rows that predate this feature. Keep the WHERE clause in sync with
+-- classifyOtfAnomaly (scripts/lib/otbeat-anomaly.mjs): no machine block AND
+-- near-zero calories AND ~zero splat. `and not excluded` makes the backfill
+-- re-runnable and never stomps a manual override.
+update public.otf_sessions
+set
+  excluded = true,
+  excluded_reason = 'auto: near-zero output with no treadmill or rower block (likely equipment malfunction)'
+where not excluded
+  and treadmill is null
+  and rower is null
+  and coalesce(calories, 0) < 25
+  and coalesce(splat, 0) <= 1;

--- a/types/otf.ts
+++ b/types/otf.ts
@@ -101,6 +101,15 @@ export interface OtfSession {
   treadmill?: OtfTreadmill
   /** Rower performance block. Omitted when the class format had none. */
   rower?: OtfRower
+  /**
+   * True when the session is invalid/anomalous (e.g. an equipment malfunction)
+   * and should be left out of every aggregate and chart — the session log still
+   * lists it, muted. Auto-detected at ingest (#268) or set manually in Supabase.
+   * Absent/false means a valid session.
+   */
+  excluded?: boolean
+  /** Why the session was excluded (prefixed `auto:` when set by the ingest heuristic). Present only when {@link excluded}. */
+  excluded_reason?: string
 }
 
 /** Full OrangeTheory dataset consumed by the Gym OTF view. */


### PR DESCRIPTION
Closes #268.

## What

Marks anomalous OrangeTheory sessions **invalid/excluded** instead of deleting them, and **auto-detects** them at ingest.

The trigger is the 05/30 belt malfunction: a "class" that logged 4 calories, 0 splat, and no treadmill or rower block. Deleting it would lose the audit trail and it would re-appear on the next weekly email re-pull. So instead we flag it — excluded sessions are kept in the table but left out of every aggregate, trend, sparkline, and highlight, while the session log still lists them (muted, with an **Excluded** badge and the reason).

## Auto-detection

A shared heuristic (`scripts/lib/otbeat-anomaly.mjs`) classifies a session as a likely equipment malfunction when it has **no machine block** AND **near-zero calories** (< 25) AND **~zero splat** (≤ 1). Conservative by design — the lowest legitimate class in the dataset is 541 cal with both blocks present, so a real class (even a tread-only one that omits the rower) never trips it.

It runs in two places, kept in sync:
- **`recordToRow`** sets `excluded`/`excluded_reason` at first insert. Because the importer is append-only (`upsert` with `ignoreDuplicates`), this never runs on a re-pull — so a manual override made later in Supabase is never clobbered.
- **The migration** backfills rows that predate the feature.

## Data model

`supabase/migrations/20260702120000_otf_sessions_excluded.sql` adds:
- `excluded boolean not null default false`
- `excluded_reason text`

Applied to the `court-vision` project. The backfill flagged **exactly the one 05/30 anomaly** — 23 active / 1 excluded. Threaded through `OtfSessionRowSchema`, `otfRowToSession`, `SESSIONS_COLUMNS`, and the `OtfSession` type; a new `excludeInvalidOtfSessions` helper drives the view's active-session split.

## Tests

- Heuristic threshold boundaries (calories/splat cutoffs, needs both machine blocks absent, header-only anomaly).
- `recordToRow` flags the malfunction shape, leaves a real class alone.
- Schema + mapper passthrough of `excluded`/`excluded_reason`.
- Data layer passthrough.
- `excludeInvalidOtfSessions` helper.
- View: excluded row rendered muted with an **Excluded** badge (reason in `title`), listed separately in the count, and kept out of the class count + calorie total.

`typecheck` ✅ · full `test:coverage` ✅ (lib lines 94.98%, gate 80%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added session exclusion metadata so flagged workout sessions can be identified with an optional reason.
  * Updated workout views to keep excluded sessions in the log while omitting them from charts, trends, and summary stats.

* **Bug Fixes**
  * Prevented anomalous sessions from affecting shared max heart rate and zone comparisons.
  * Added visual cues for excluded sessions, including a badge, strike-through date, and exclusion details.

* **Tests**
  * Expanded coverage for exclusion handling across data loading, validation, filtering, and UI behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->