### PR TITLE
feat(otbeat): infer coarse OTF class type + class-type filter (#271)

### DIFF
--- a/components/training-facility/gym/OtfDetailView.test.tsx
+++ b/components/training-facility/gym/OtfDetailView.test.tsx
@@ -145,14 +145,19 @@ describe('OtfDetailView', () => {
     // All three classes present before filtering.
     expect(screen.getByText('Row Coach')).toBeInTheDocument()
     expect(screen.getByText('Tread Coach')).toBeInTheDocument()
+    // "All" starts pressed (unfiltered); the type pills do not.
+    expect(screen.getByRole('button', { name: 'All' })).toHaveAttribute('aria-pressed', 'true')
     // Pick the Tread-focused pill (a button — disambiguates from the Type cell).
     fireEvent.click(screen.getByRole('button', { name: 'Tread-focused' }))
     // Only the tread-only class stays in the log…
     expect(screen.getByText('Tread Coach')).toBeInTheDocument()
     expect(screen.queryByText('Mara Magistad')).not.toBeInTheDocument()
     expect(screen.queryByText('Row Coach')).not.toBeInTheDocument()
-    // …and the aggregates follow: 1 class in range.
+    // …the aggregates follow: 1 class in range…
     expect(screen.getByText(/1 in range/)).toBeInTheDocument()
+    // …and the selected state is exposed to assistive tech.
+    expect(screen.getByRole('button', { name: 'Tread-focused', pressed: true })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'All' })).toHaveAttribute('aria-pressed', 'false')
   })
 
   it('marks a manual class-type override in the log (#271)', async () => {

--- a/components/training-facility/gym/OtfDetailView.test.tsx
+++ b/components/training-facility/gym/OtfDetailView.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, within } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { OtfData } from '@/types/otf'
@@ -61,6 +61,28 @@ const DATA_WITH_EXCLUDED: OtfData = {
   ],
 }
 
+/** Three classes of three distinct inferred types, for the class-type filter (#271). */
+const MULTI_TYPE_DATA: OtfData = {
+  imported_at: '2026-06-30T07:53:00+00:00',
+  sessions: [
+    {
+      started_at: '2026-06-20T16:30:00+00:00',
+      coach: 'Row Coach',
+      splat: 8,
+      calories: 668,
+      class_type: 'Row-focused',
+    },
+    {
+      started_at: '2026-06-24T16:30:00+00:00',
+      coach: 'Tread Coach',
+      splat: 13,
+      calories: 697,
+      class_type: 'Tread-focused',
+    },
+    { ...VALID_SESSION, class_type: 'Tread + Row' },
+  ],
+}
+
 beforeEach(() => {
   getOtfDataMock.mockReset()
 })
@@ -102,6 +124,48 @@ describe('OtfDetailView', () => {
     // valid class), not 780 — the anomaly's 4 cal is left out.
     const calTile = screen.getByText('Total calories').closest('div') as HTMLElement
     expect(within(calTile).getByText('776')).toBeInTheDocument()
+  })
+
+  it('shows each session\'s class type in the log Type column (#271)', async () => {
+    getOtfDataMock.mockResolvedValue(MULTI_TYPE_DATA)
+    render(<OtfDetailView />)
+    await waitFor(() => expect(screen.getByText('Mara Magistad')).toBeInTheDocument())
+    const table = screen.getByRole('table')
+    expect(within(table).getByRole('columnheader', { name: 'Type' })).toBeInTheDocument()
+    // Scope to the table so the filter pills (same labels) don't collide.
+    expect(within(table).getByText('Tread + Row')).toBeInTheDocument()
+    expect(within(table).getByText('Tread-focused')).toBeInTheDocument()
+    expect(within(table).getByText('Row-focused')).toBeInTheDocument()
+  })
+
+  it('scopes the whole view to a picked class type, composing with the range (#271)', async () => {
+    getOtfDataMock.mockResolvedValue(MULTI_TYPE_DATA)
+    render(<OtfDetailView />)
+    await waitFor(() => expect(screen.getByText('Mara Magistad')).toBeInTheDocument())
+    // All three classes present before filtering.
+    expect(screen.getByText('Row Coach')).toBeInTheDocument()
+    expect(screen.getByText('Tread Coach')).toBeInTheDocument()
+    // Pick the Tread-focused pill (a button — disambiguates from the Type cell).
+    fireEvent.click(screen.getByRole('button', { name: 'Tread-focused' }))
+    // Only the tread-only class stays in the log…
+    expect(screen.getByText('Tread Coach')).toBeInTheDocument()
+    expect(screen.queryByText('Mara Magistad')).not.toBeInTheDocument()
+    expect(screen.queryByText('Row Coach')).not.toBeInTheDocument()
+    // …and the aggregates follow: 1 class in range.
+    expect(screen.getByText(/1 in range/)).toBeInTheDocument()
+  })
+
+  it('marks a manual class-type override in the log (#271)', async () => {
+    getOtfDataMock.mockResolvedValue({
+      imported_at: '2026-06-30T07:53:00+00:00',
+      sessions: [{ ...VALID_SESSION, class_type: 'Tread + Row', class_type_override: '2G' }],
+    })
+    render(<OtfDetailView />)
+    await waitFor(() => expect(screen.getByText('Mara Magistad')).toBeInTheDocument())
+    // Override wins over the inferred label and is flagged as manual on hover.
+    const chip = screen.getByText('2G')
+    expect(chip).toHaveAttribute('title', 'Manual override')
+    expect(screen.queryByText('Tread + Row')).not.toBeInTheDocument()
   })
 
   it('shows the empty state when there are no sessions', async () => {

--- a/components/training-facility/gym/OtfDetailView.tsx
+++ b/components/training-facility/gym/OtfDetailView.tsx
@@ -458,13 +458,19 @@ function ClassTypeFilter({
       <span className="mr-1 font-mono text-[0.65rem] uppercase tracking-[0.2em] text-white/45">
         Class type
       </span>
-      <button type="button" onClick={() => onChange(null)} className={pill(value === null)}>
+      <button
+        type="button"
+        aria-pressed={value === null}
+        onClick={() => onChange(null)}
+        className={pill(value === null)}
+      >
         All
       </button>
       {options.map(opt => (
         <button
           key={opt}
           type="button"
+          aria-pressed={value === opt}
           onClick={() => onChange(opt)}
           className={pill(value === opt)}
         >

--- a/components/training-facility/gym/OtfDetailView.tsx
+++ b/components/training-facility/gym/OtfDetailView.tsx
@@ -28,6 +28,7 @@ import {
   otfClassTypes,
   otfHighlights,
   otfMetricTrend,
+  resolveOtfClassTypeFilter,
   type OtfTrendPoint,
 } from '@/lib/training-facility/otf'
 import type { OtfData, OtfRower, OtfSession, OtfTreadmill } from '@/types/otf'
@@ -126,8 +127,17 @@ export function OtfDetailView(): JSX.Element {
   // before the class filter so every option stays reachable.
   const availableClassTypes = useMemo(() => otfClassTypes(rangeSessions), [rangeSessions])
 
-  // Reset the class filter when the selected type leaves the window (e.g. the
-  // date range narrowed past it) so we don't get stuck showing nothing.
+  // Reconcile the stored selection against the window synchronously: `effective`
+  // is what actually filters this render (never a stale value), `visible` keeps
+  // the control — and its "All" clear button — reachable while a filter is on.
+  const { effective: effectiveClassType, visible: showClassTypeFilter } = useMemo(
+    () => resolveOtfClassTypeFilter(classType, availableClassTypes),
+    [classType, availableClassTypes]
+  )
+
+  // Tidy the stored state when the selection leaves the window (e.g. the range
+  // narrowed past it) so a later widen doesn't silently resurrect the filter.
+  // `effectiveClassType` already prevents a stale-render flicker meanwhile.
   useEffect(() => {
     if (classType && !availableClassTypes.includes(classType)) setClassType(null)
   }, [classType, availableClassTypes])
@@ -135,8 +145,8 @@ export function OtfDetailView(): JSX.Element {
   // Apply the class-type filter on top of the date range; this scoped set feeds
   // both the log and (after exclusion) every aggregate.
   const sessions = useMemo(
-    () => filterOtfSessionsByClassType(rangeSessions, classType),
-    [rangeSessions, classType]
+    () => filterOtfSessionsByClassType(rangeSessions, effectiveClassType),
+    [rangeSessions, effectiveClassType]
   )
   // Aggregates, trends, sparklines, and highlights run over the *active*
   // sessions only — invalid/anomalous classes (e.g. an equipment malfunction,
@@ -252,10 +262,10 @@ export function OtfDetailView(): JSX.Element {
           />
         </div>
 
-        {availableClassTypes.length > 1 && (
+        {showClassTypeFilter && (
           <ClassTypeFilter
             options={availableClassTypes}
-            value={classType}
+            value={effectiveClassType}
             onChange={setClassType}
           />
         )}

--- a/components/training-facility/gym/OtfDetailView.tsx
+++ b/components/training-facility/gym/OtfDetailView.tsx
@@ -17,12 +17,15 @@ import {
   OTF_ZONES,
   aggregateOtfZoneMinutes,
   earliestOtfDate,
+  effectiveOtfClassType,
   excludeInvalidOtfSessions,
+  filterOtfSessionsByClassType,
   filterOtfSessionsInRange,
   formatMmss,
   formatOtfDate,
   mmssToSeconds,
   otfBlockTrend,
+  otfClassTypes,
   otfHighlights,
   otfMetricTrend,
   type OtfTrendPoint,
@@ -55,6 +58,9 @@ export function OtfDetailView(): JSX.Element {
   const [loadError, setLoadError] = useState<Error | null>(null)
   const [range, setRange] = useState<DateRange>(() => rangeForPreset('ALL', EARLIEST_FALLBACK))
   const [chartWidth, setChartWidth] = useState(DEFAULT_CHART_WIDTH)
+  // Coarse class-type filter (#271); `null` = "All". Scopes both the log and
+  // every aggregate, composing with the date range and the #268 exclusion.
+  const [classType, setClassType] = useState<string | null>(null)
 
   // The chart wrapper mounts only after data arrives (it lives inside the data
   // branch), so observe it via a callback ref. A mount effect would run while
@@ -112,9 +118,25 @@ export function OtfDetailView(): JSX.Element {
     setRange(rangeForPreset('ALL', earliest))
   }, [earliest, data])
 
-  const sessions = useMemo(
+  const rangeSessions = useMemo(
     () => (data ? filterOtfSessionsInRange(data.sessions, range) : []),
     [data, range]
+  )
+  // Class types present in the current window drive the filter chips. Derived
+  // before the class filter so every option stays reachable.
+  const availableClassTypes = useMemo(() => otfClassTypes(rangeSessions), [rangeSessions])
+
+  // Reset the class filter when the selected type leaves the window (e.g. the
+  // date range narrowed past it) so we don't get stuck showing nothing.
+  useEffect(() => {
+    if (classType && !availableClassTypes.includes(classType)) setClassType(null)
+  }, [classType, availableClassTypes])
+
+  // Apply the class-type filter on top of the date range; this scoped set feeds
+  // both the log and (after exclusion) every aggregate.
+  const sessions = useMemo(
+    () => filterOtfSessionsByClassType(rangeSessions, classType),
+    [rangeSessions, classType]
   )
   // Aggregates, trends, sparklines, and highlights run over the *active*
   // sessions only — invalid/anomalous classes (e.g. an equipment malfunction,
@@ -229,6 +251,14 @@ export function OtfDetailView(): JSX.Element {
             onChange={handleRangeChange}
           />
         </div>
+
+        {availableClassTypes.length > 1 && (
+          <ClassTypeFilter
+            options={availableClassTypes}
+            value={classType}
+            onChange={setClassType}
+          />
+        )}
 
         {loadError ? (
           <ErrorPanel error={loadError} />
@@ -393,6 +423,48 @@ export function OtfDetailView(): JSX.Element {
   )
 }
 
+/**
+ * Coarse class-type filter (#271) — an "All" pill plus one per available
+ * inferred/overridden type. Selecting one scopes the whole view (aggregates +
+ * log). Rendered only when 2+ types are present in the window.
+ */
+function ClassTypeFilter({
+  options,
+  value,
+  onChange,
+}: {
+  options: readonly string[]
+  value: string | null
+  onChange: (next: string | null) => void
+}): JSX.Element {
+  const pill = (active: boolean): string =>
+    `rounded-full border px-3.5 py-1.5 text-xs font-semibold uppercase tracking-[0.16em] transition ${
+      active
+        ? 'border-[#f97316]/60 bg-[#f97316]/20 text-[#f9a870]'
+        : 'border-white/15 bg-white/5 text-white/70 hover:bg-white/10'
+    }`
+  return (
+    <div className="mt-4 flex flex-wrap items-center gap-2">
+      <span className="mr-1 font-mono text-[0.65rem] uppercase tracking-[0.2em] text-white/45">
+        Class type
+      </span>
+      <button type="button" onClick={() => onChange(null)} className={pill(value === null)}>
+        All
+      </button>
+      {options.map(opt => (
+        <button
+          key={opt}
+          type="button"
+          onClick={() => onChange(opt)}
+          className={pill(value === opt)}
+        >
+          {opt}
+        </button>
+      ))}
+    </div>
+  )
+}
+
 /** Shared trend-line chart — `RoughLine` over `{date, value}` points with the OTF font/tick style. */
 function OtfTrendChart({
   data,
@@ -536,6 +608,9 @@ function SessionLogTable({ sessions, range }: SessionLogTableProps): JSX.Element
                   Coach
                 </th>
                 <th scope="col" className="px-3 py-2 font-semibold">
+                  Type
+                </th>
+                <th scope="col" className="px-3 py-2 font-semibold">
                   Splat
                 </th>
                 <th scope="col" className="px-3 py-2 font-semibold">
@@ -605,6 +680,9 @@ function SessionLogTable({ sessions, range }: SessionLogTableProps): JSX.Element
                         </span>
                       </td>
                       <td className="px-3 py-2">{s.coach ?? '—'}</td>
+                      <td className="px-3 py-2">
+                        <ClassTypeCell session={s} />
+                      </td>
                       <td
                         className={`px-3 py-2 font-mono ${excluded ? 'text-white/50' : 'text-[#f97316]'}`}
                       >
@@ -619,7 +697,7 @@ function SessionLogTable({ sessions, range }: SessionLogTableProps): JSX.Element
                     </tr>
                     {isExpanded && expandable && (
                       <tr>
-                        <td colSpan={7} className="px-3 pb-3">
+                        <td colSpan={8} className="px-3 pb-3">
                           <ExpandedSession session={s} />
                         </td>
                       </tr>
@@ -730,6 +808,30 @@ function rowerRows(r: OtfRower | undefined): Array<[string, string]> | null {
   if (r.avg_watt !== undefined) rows.push(['Avg watts', `${r.avg_watt}`])
   if (r.avg_spm !== undefined) rows.push(['Avg SPM', `${r.avg_spm}`])
   return rows
+}
+
+/**
+ * The session's effective class type (#271) as a small chip, or an em dash when
+ * none. A trailing dot marks a manual `class_type_override`; the `title`
+ * distinguishes an override from the auto-inferred label on hover.
+ */
+function ClassTypeCell({ session }: { session: OtfSession }): JSX.Element {
+  const type = effectiveOtfClassType(session)
+  if (!type) return <span className="text-white/35">—</span>
+  const isOverride = !!session.class_type_override?.trim()
+  return (
+    <span
+      title={isOverride ? 'Manual override' : 'Inferred from machine signature'}
+      className="inline-flex items-center gap-1 whitespace-nowrap rounded-full border border-white/10 bg-white/5 px-2 py-0.5 text-[0.65rem] font-medium text-white/75"
+    >
+      {type}
+      {isOverride && (
+        <span aria-hidden="true" className="text-[#f9a870]">
+          •
+        </span>
+      )}
+    </span>
+  )
 }
 
 /** Render a numeric cell, rounding to a whole number, or an em dash when absent. */

--- a/lib/data/otf-shared.ts
+++ b/lib/data/otf-shared.ts
@@ -26,7 +26,7 @@ const SESSIONS_TABLE = 'otf_sessions'
 const SESSIONS_COLUMNS =
   'started_at, coach, studio, calories, splat, steps, avg_hr, peak_hr, ' +
   'zone_gray_min, zone_blue_min, zone_green_min, zone_orange_min, zone_red_min, ' +
-  'treadmill, rower, excluded, excluded_reason, updated_at'
+  'treadmill, rower, excluded, excluded_reason, class_type, class_type_override, updated_at'
 
 /** Array form of {@link OtfSessionRowSchema} for validating the full read. */
 const OtfSessionRowsSchema = z.array(OtfSessionRowSchema)

--- a/lib/data/otf.test.ts
+++ b/lib/data/otf.test.ts
@@ -159,6 +159,19 @@ describe('getOtfData', () => {
     expect(data?.sessions[0].excluded_reason).toMatch(/near-zero output/)
   })
 
+  it('passes class_type + class_type_override through to the session (#271)', async () => {
+    stubSessions([
+      {
+        ...FULL_ROW,
+        class_type: 'Tread + Row',
+        class_type_override: '2G',
+      },
+    ])
+    const data = await getOtfData()
+    expect(data?.sessions[0].class_type).toBe('Tread + Row')
+    expect(data?.sessions[0].class_type_override).toBe('2G')
+  })
+
   it('takes imported_at from the latest updated_at', async () => {
     stubSessions([
       {

--- a/lib/schemas/otf.test.ts
+++ b/lib/schemas/otf.test.ts
@@ -61,6 +61,15 @@ describe('OtfSessionRowSchema', () => {
     })
     expect(parsed.success).toBe(true)
   })
+
+  it('accepts class_type + class_type_override (#271)', () => {
+    const parsed = OtfSessionRowSchema.safeParse({
+      started_at: '2026-06-27T16:30:00+00:00',
+      class_type: 'Tread + Row',
+      class_type_override: '2G',
+    })
+    expect(parsed.success).toBe(true)
+  })
 })
 
 describe('otfRowToSession', () => {
@@ -109,5 +118,21 @@ describe('otfRowToSession', () => {
     const session = otfRowToSession({ started_at: '2026-06-27T16:30:00+00:00' })
     expect(session).not.toHaveProperty('excluded')
     expect(session).not.toHaveProperty('excluded_reason')
+  })
+
+  it('passes class_type + class_type_override through (#271)', () => {
+    const session = otfRowToSession({
+      started_at: '2026-06-27T16:30:00+00:00',
+      class_type: 'Tread + Row',
+      class_type_override: '2G',
+    })
+    expect(session.class_type).toBe('Tread + Row')
+    expect(session.class_type_override).toBe('2G')
+  })
+
+  it('omits class_type / class_type_override when absent', () => {
+    const session = otfRowToSession({ started_at: '2026-06-27T16:30:00+00:00' })
+    expect(session).not.toHaveProperty('class_type')
+    expect(session).not.toHaveProperty('class_type_override')
   })
 })

--- a/lib/schemas/otf.ts
+++ b/lib/schemas/otf.ts
@@ -79,6 +79,8 @@ export const OtfSessionRowSchema = z
     rower: OtfRowerSchema.optional(),
     excluded: z.boolean().optional(),
     excluded_reason: z.string().optional(),
+    class_type: z.string().optional(),
+    class_type_override: z.string().optional(),
   })
   .strict()
 
@@ -126,5 +128,7 @@ export function otfRowToSession(row: OtfSessionRow): OtfSession {
   if (row.rower !== undefined) session.rower = row.rower
   if (row.excluded !== undefined) session.excluded = row.excluded
   if (row.excluded_reason !== undefined) session.excluded_reason = row.excluded_reason
+  if (row.class_type !== undefined) session.class_type = row.class_type
+  if (row.class_type_override !== undefined) session.class_type_override = row.class_type_override
   return session
 }

--- a/lib/training-facility/otf.test.ts
+++ b/lib/training-facility/otf.test.ts
@@ -24,6 +24,7 @@ import {
   otfHighlights,
   otfMetricTrend,
   otfTrendEndpoints,
+  resolveOtfClassTypeFilter,
   type OtfTrendPoint,
 } from './otf'
 
@@ -119,6 +120,57 @@ describe('class-type helpers (#271)', () => {
 
     it('returns an empty list when no session has a type', () => {
       expect(otfClassTypes([mk('a'), mk('b')])).toEqual([])
+    })
+  })
+
+  describe('resolveOtfClassTypeFilter', () => {
+    it('keeps a valid selection and shows the control when there is a real choice', () => {
+      expect(resolveOtfClassTypeFilter('Tread + Row', ['Tread + Row', 'Row-focused'])).toEqual({
+        effective: 'Tread + Row',
+        visible: true,
+      })
+    })
+
+    it('stays visible when the window narrows to the single active type (clearable)', () => {
+      // codex #275: without this the control vanishes with no "All" to clear it,
+      // hiding untyped/excluded rows the log should keep showing.
+      expect(resolveOtfClassTypeFilter('Tread + Row', ['Tread + Row'])).toEqual({
+        effective: 'Tread + Row',
+        visible: true,
+      })
+    })
+
+    it('falls back to null the same render the selection leaves the window', () => {
+      // CodeRabbit #275: filtering must not use a stale type for a frame.
+      expect(resolveOtfClassTypeFilter('Row-focused', ['Tread + Row', 'Tread-focused'])).toEqual({
+        effective: null,
+        visible: true,
+      })
+    })
+
+    it('hides the control with a single option and no active filter', () => {
+      expect(resolveOtfClassTypeFilter(null, ['Tread + Row'])).toEqual({
+        effective: null,
+        visible: false,
+      })
+    })
+
+    it('hides the control when a dropped selection leaves only one option', () => {
+      expect(resolveOtfClassTypeFilter('Row-focused', ['Tread + Row'])).toEqual({
+        effective: null,
+        visible: false,
+      })
+      expect(resolveOtfClassTypeFilter('Row-focused', [])).toEqual({
+        effective: null,
+        visible: false,
+      })
+    })
+
+    it('shows the control with 2+ options even when nothing is selected', () => {
+      expect(resolveOtfClassTypeFilter(null, ['Tread + Row', 'Row-focused'])).toEqual({
+        effective: null,
+        visible: true,
+      })
     })
   })
 

--- a/lib/training-facility/otf.test.ts
+++ b/lib/training-facility/otf.test.ts
@@ -3,14 +3,24 @@ import { describe, expect, it } from 'vitest'
 import type { OtfSession } from '@/types/otf'
 
 import {
+  OTF_CLASS_TYPE_BOTH,
+  OTF_CLASS_TYPE_ROW,
+  OTF_CLASS_TYPE_STRENGTH,
+  OTF_CLASS_TYPE_TREAD,
+} from '../../scripts/lib/otbeat-class-type.mjs'
+import {
+  OTF_CLASS_TYPE_ORDER,
   aggregateOtfZoneMinutes,
   earliestOtfDate,
+  effectiveOtfClassType,
   excludeInvalidOtfSessions,
+  filterOtfSessionsByClassType,
   filterOtfSessionsInRange,
   formatMmss,
   formatOtfDate,
   mmssToSeconds,
   otfBlockTrend,
+  otfClassTypes,
   otfHighlights,
   otfMetricTrend,
   otfTrendEndpoints,
@@ -50,6 +60,90 @@ describe('excludeInvalidOtfSessions', () => {
   it('is a no-op when nothing is excluded', () => {
     const sessions = [mk('a'), mk('b')]
     expect(excludeInvalidOtfSessions(sessions)).toHaveLength(2)
+  })
+})
+
+describe('class-type helpers (#271)', () => {
+  it('OTF_CLASS_TYPE_ORDER stays in sync with the ingest label constants', () => {
+    // Drift guard: the display order and the .mjs classifier must name the same
+    // four auto labels (they live in two files — see the KEEP IN SYNC notes).
+    expect([...OTF_CLASS_TYPE_ORDER].sort()).toEqual(
+      [
+        OTF_CLASS_TYPE_BOTH,
+        OTF_CLASS_TYPE_TREAD,
+        OTF_CLASS_TYPE_ROW,
+        OTF_CLASS_TYPE_STRENGTH,
+      ].sort()
+    )
+  })
+
+  describe('effectiveOtfClassType', () => {
+    it('prefers a manual override over the inferred class_type', () => {
+      expect(effectiveOtfClassType(mk('a', { class_type: 'Tread + Row', class_type_override: '2G' }))).toBe(
+        '2G'
+      )
+    })
+
+    it('falls back to class_type when there is no override', () => {
+      expect(effectiveOtfClassType(mk('a', { class_type: 'Tread-focused' }))).toBe('Tread-focused')
+    })
+
+    it('treats a blank override as unset', () => {
+      expect(
+        effectiveOtfClassType(mk('a', { class_type: 'Row-focused', class_type_override: '  ' }))
+      ).toBe('Row-focused')
+    })
+
+    it('is undefined when the session has neither', () => {
+      expect(effectiveOtfClassType(mk('a'))).toBeUndefined()
+    })
+  })
+
+  describe('otfClassTypes', () => {
+    it('lists distinct effective types, known labels first then extras alphabetically', () => {
+      const sessions = [
+        mk('a', { class_type: 'Row-focused' }),
+        mk('b', { class_type: 'Tread + Row' }),
+        mk('c', { class_type: 'Tread + Row' }), // duplicate collapses
+        mk('d', { class_type: 'Tread-focused' }),
+        mk('e', { class_type: 'Tread + Row', class_type_override: 'Strength 50' }), // manual extra
+        mk('f'), // no type → omitted
+      ]
+      expect(otfClassTypes(sessions)).toEqual([
+        'Tread + Row',
+        'Tread-focused',
+        'Row-focused',
+        'Strength 50',
+      ])
+    })
+
+    it('returns an empty list when no session has a type', () => {
+      expect(otfClassTypes([mk('a'), mk('b')])).toEqual([])
+    })
+  })
+
+  describe('filterOtfSessionsByClassType', () => {
+    const sessions = [
+      mk('a', { class_type: 'Tread + Row' }),
+      mk('b', { class_type: 'Row-focused' }),
+      mk('c', { class_type: 'Tread + Row', class_type_override: '2G' }), // effective = '2G'
+    ]
+
+    it('keeps only sessions whose effective type matches', () => {
+      expect(filterOtfSessionsByClassType(sessions, 'Tread + Row').map(s => s.started_at)).toEqual([
+        'a',
+      ])
+    })
+
+    it('matches on the override, not the inferred label', () => {
+      expect(filterOtfSessionsByClassType(sessions, '2G').map(s => s.started_at)).toEqual(['c'])
+    })
+
+    it('returns every session (a fresh array) for the null "All" sentinel', () => {
+      const result = filterOtfSessionsByClassType(sessions, null)
+      expect(result).toHaveLength(3)
+      expect(result).not.toBe(sessions)
+    })
   })
 })
 

--- a/lib/training-facility/otf.ts
+++ b/lib/training-facility/otf.ts
@@ -154,6 +154,42 @@ export function filterOtfSessionsByClassType(
   return sessions.filter(s => effectiveOtfClassType(s) === classType)
 }
 
+/** Resolved state of the class-type filter for one render. */
+export interface OtfClassTypeFilterState {
+  /**
+   * The class type actually applied this render: the user's `selected` value
+   * when it's still among the `available` options, else `null` ("All"). Derived
+   * synchronously so filtering never lags behind a window change by a render.
+   */
+  effective: string | null
+  /**
+   * Whether the filter control should render — either there's a real choice
+   * (2+ options) or a filter is active and needs a reachable "All" to clear it.
+   */
+  visible: boolean
+}
+
+/**
+ * Reconcile the class-type filter's stored `selected` value against the types
+ * currently `available` in the window (#271).
+ *
+ * Two failure modes this closes:
+ * - **Stale render:** when `selected` just left `available`, `effective` falls
+ *   back to `null` immediately, so the log/aggregates don't render empty for a
+ *   frame while a reset effect catches up.
+ * - **Unclearable filter:** when the window narrows to a single type that's the
+ *   active selection, `visible` stays `true` so the "All" button is still there
+ *   to clear it (otherwise untyped/excluded rows would be hidden with no way
+ *   back).
+ */
+export function resolveOtfClassTypeFilter(
+  selected: string | null,
+  available: readonly string[]
+): OtfClassTypeFilterState {
+  const effective = selected && available.includes(selected) ? selected : null
+  return { effective, visible: available.length > 1 || effective !== null }
+}
+
 /**
  * Filter sessions to those whose start falls within the inclusive
  * {@link DateRange}, preserving order (the dataset arrives ascending).

--- a/lib/training-facility/otf.ts
+++ b/lib/training-facility/otf.ts
@@ -94,6 +94,67 @@ export function excludeInvalidOtfSessions(sessions: readonly OtfSession[]): OtfS
 }
 
 /**
+ * Canonical display order for the coarse auto-inferred class-type labels (#271).
+ *
+ * KEEP IN SYNC WITH the label constants in
+ * `scripts/lib/otbeat-class-type.mjs` (guarded by a drift test in
+ * `otf.test.ts`). Manual `class_type_override` values that aren't in this list
+ * (e.g. "2G", "Strength 50") sort after these, alphabetically, in
+ * {@link otfClassTypes}.
+ */
+export const OTF_CLASS_TYPE_ORDER: readonly string[] = [
+  'Tread + Row',
+  'Tread-focused',
+  'Row-focused',
+  'Strength / Floor',
+]
+
+/**
+ * The class type the view should treat a session as: the manual
+ * `class_type_override` when set, otherwise the auto-inferred `class_type`
+ * (#271). Blank/whitespace strings count as unset. `undefined` when the session
+ * has neither (e.g. a near-zero malfunction with no inferred type).
+ */
+export function effectiveOtfClassType(session: OtfSession): string | undefined {
+  const override = session.class_type_override?.trim()
+  if (override) return override
+  const auto = session.class_type?.trim()
+  return auto ? auto : undefined
+}
+
+/**
+ * Distinct effective class types present across the sessions, for the filter
+ * control's options. Known auto labels come first in {@link OTF_CLASS_TYPE_ORDER}
+ * order; any manual-override values not in that list follow, sorted
+ * alphabetically for a stable, session-order-independent result. Sessions with
+ * no effective type are omitted.
+ */
+export function otfClassTypes(sessions: readonly OtfSession[]): string[] {
+  const present = new Set<string>()
+  for (const s of sessions) {
+    const t = effectiveOtfClassType(s)
+    if (t) present.add(t)
+  }
+  const known = OTF_CLASS_TYPE_ORDER.filter(t => present.has(t))
+  const extras = [...present].filter(t => !OTF_CLASS_TYPE_ORDER.includes(t)).sort()
+  return [...known, ...extras]
+}
+
+/**
+ * Filter sessions to those whose {@link effectiveOtfClassType} equals
+ * `classType`, preserving order. A `null` `classType` is the "All" sentinel and
+ * returns every session (a fresh array). Composes with
+ * {@link filterOtfSessionsInRange} and {@link excludeInvalidOtfSessions}.
+ */
+export function filterOtfSessionsByClassType(
+  sessions: readonly OtfSession[],
+  classType: string | null
+): OtfSession[] {
+  if (!classType) return [...sessions]
+  return sessions.filter(s => effectiveOtfClassType(s) === classType)
+}
+
+/**
  * Filter sessions to those whose start falls within the inclusive
  * {@link DateRange}, preserving order (the dataset arrives ascending).
  */

--- a/scripts/lib/otbeat-class-type.mjs
+++ b/scripts/lib/otbeat-class-type.mjs
@@ -1,0 +1,102 @@
+/**
+ * Coarse class-type inference for OrangeTheory sessions (#271).
+ *
+ * The OTbeat "Studio Workout Summary" email carries **no** class-type token —
+ * nowhere does it say "2G", "3G", "Strength 50", "Tread 50", etc. (verified
+ * against the full flattened body). So we can't parse the studio's official
+ * format name. Instead we infer a *coarse, honest* label from which machine
+ * blocks the class logged and how the tread/rower time splits — enough to
+ * filter the OTF stats by rough format without pretending to know OTF's own
+ * template name.
+ *
+ * Two-column design in `otf_sessions` (mirrors the #268 excluded pattern):
+ * - `class_type` — this auto-inferred coarse label, written at ingest.
+ * - `class_type_override` — a nullable manual column set in Supabase to the
+ *   *real* format name ("2G", "Strength 50", …) when known. The effective type
+ *   the view uses is `override ?? class_type` (see `effectiveOtfClassType` in
+ *   `lib/training-facility/otf.ts`).
+ *
+ * Because {@link import('./otbeat-supabase.mjs').upsertOtfSessions} is
+ * append-only (`ignoreDuplicates` → ON CONFLICT DO NOTHING), `class_type` is
+ * only ever written on a row's *first* insert, so a later manual override is
+ * never clobbered by a re-pull — the same property that lets #268's `excluded`
+ * auto-flag and manual edits coexist.
+ *
+ * This module is the single source of truth for the auto labels. It is:
+ * - called from `recordToRow` (`otbeat-supabase.mjs`) so newly-ingested
+ *   sessions get a `class_type` at first insert, and
+ * - mirrored by the backfill `UPDATE` in
+ *   `supabase/migrations/<ts>_otf_sessions_class_type.sql` for rows that
+ *   predate this feature.
+ *
+ * Loaded as ESM from `.mjs` callers — no TypeScript transpile step, same
+ * constraint as the sibling parser / supabase / anomaly helpers.
+ *
+ * KEEP THE LABEL STRINGS IN SYNC WITH: the migration backfill's `CASE`
+ * expression and `OTF_CLASS_TYPE_ORDER` in `lib/training-facility/otf.ts`
+ * (guarded by a drift test in `lib/training-facility/otf.test.ts`).
+ */
+
+/** Both a treadmill and a rower block, with the tread time ≥ the rower time. */
+export const OTF_CLASS_TYPE_BOTH = 'Tread + Row'
+
+/** A treadmill block but no rower block (tread-only formats). */
+export const OTF_CLASS_TYPE_TREAD = 'Tread-focused'
+
+/**
+ * A rower block that dominates — either no treadmill at all, or the rower time
+ * exceeds the tread time (a row-heavy class).
+ */
+export const OTF_CLASS_TYPE_ROW = 'Row-focused'
+
+/** No machine block at all but real output — a strength / floor-only day. */
+export const OTF_CLASS_TYPE_STRENGTH = 'Strength / Floor'
+
+/**
+ * Minimum calories for a machine-less session to read as a real strength/floor
+ * class rather than a near-zero belt malfunction (which stays `null`). Well
+ * above the #268 anomaly ceiling (25 cal) so the two thresholds don't fight: a
+ * malfunction is both `excluded` (calories < 25) and `class_type = null`.
+ */
+const MIN_STRENGTH_CALORIES = 100
+
+/**
+ * The signals the class-type heuristic reads off a session, normalized so the
+ * same classifier serves the parsed-record ingest path and any row-shaped
+ * caller. Durations are in whole seconds (0 / absent → treated as 0).
+ * @typedef {Object} OtfClassTypeSignals
+ * @property {boolean} hasTreadmill Whether a treadmill performance block is present.
+ * @property {boolean} hasRower Whether a rower performance block is present.
+ * @property {number|null|undefined} [treadSec] Total treadmill time, seconds.
+ * @property {number|null|undefined} [rowerSec] Total rower time, seconds.
+ * @property {number|null|undefined} [calories] Calories burned, or absent.
+ */
+
+/**
+ * Infer a coarse class-type label from a session's machine signature.
+ *
+ * Rules (first match wins):
+ * 1. No treadmill **and** no rower → {@link OTF_CLASS_TYPE_STRENGTH} when
+ *    calories ≥ {@link MIN_STRENGTH_CALORIES}, else `null` (the belt-malfunction
+ *    sentinel — already `excluded` by #268, so it never reaches an aggregate).
+ * 2. Treadmill only → {@link OTF_CLASS_TYPE_TREAD}.
+ * 3. Rower only → {@link OTF_CLASS_TYPE_ROW}.
+ * 4. Both → {@link OTF_CLASS_TYPE_ROW} when the rower time exceeds the tread
+ *    time (a row-heavy class), otherwise {@link OTF_CLASS_TYPE_BOTH}.
+ *
+ * Deliberately coarse: it names which machines were worked, not OTF's official
+ * 2G/3G/Strength template — use `class_type_override` for that. Kept
+ * false-positive-resistant so a normal class never lands on `null`.
+ *
+ * @param {OtfClassTypeSignals} signals Normalized session signals.
+ * @returns {string|null} A coarse class-type label, or `null` when the session
+ *   has no machine block and near-zero output.
+ */
+export function classifyOtfClassType({ hasTreadmill, hasRower, treadSec, rowerSec, calories }) {
+  if (!hasTreadmill && !hasRower) {
+    return (calories ?? 0) >= MIN_STRENGTH_CALORIES ? OTF_CLASS_TYPE_STRENGTH : null
+  }
+  if (hasTreadmill && !hasRower) return OTF_CLASS_TYPE_TREAD
+  if (!hasTreadmill && hasRower) return OTF_CLASS_TYPE_ROW
+  return (rowerSec ?? 0) > (treadSec ?? 0) ? OTF_CLASS_TYPE_ROW : OTF_CLASS_TYPE_BOTH
+}

--- a/scripts/lib/otbeat-class-type.test.ts
+++ b/scripts/lib/otbeat-class-type.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Tests for the OTbeat class-type heuristic (#271).
+ *
+ * The classifier infers a coarse class-type label from a session's machine
+ * signature at ingest. The cases pin each branch against the shape of the real
+ * dataset — both-machine classes (the common 'Tread + Row'), tread-only days,
+ * the two row-heavy classes (05/14, 05/16 — rower time exceeds tread time), and
+ * the machine-less strength/malfunction split.
+ */
+import { describe, expect, it } from 'vitest'
+
+import {
+  OTF_CLASS_TYPE_BOTH,
+  OTF_CLASS_TYPE_ROW,
+  OTF_CLASS_TYPE_STRENGTH,
+  OTF_CLASS_TYPE_TREAD,
+  classifyOtfClassType,
+} from './otbeat-class-type.mjs'
+
+describe('classifyOtfClassType', () => {
+  it('labels a both-machine class as Tread + Row when tread time dominates', () => {
+    // 04/12: tread 14:39 (879s) > rower 05:23 (323s).
+    expect(
+      classifyOtfClassType({
+        hasTreadmill: true,
+        hasRower: true,
+        treadSec: 879,
+        rowerSec: 323,
+        calories: 541,
+      })
+    ).toBe(OTF_CLASS_TYPE_BOTH)
+  })
+
+  it('labels a both-machine class as Row-focused when the rower time exceeds the tread time', () => {
+    // 05/16: rower 19:21 (1161s) > tread 16:44 (1004s).
+    expect(
+      classifyOtfClassType({
+        hasTreadmill: true,
+        hasRower: true,
+        treadSec: 1004,
+        rowerSec: 1161,
+        calories: 710,
+      })
+    ).toBe(OTF_CLASS_TYPE_ROW)
+  })
+
+  it('labels a tread-only class (no rower block) as Tread-focused', () => {
+    expect(
+      classifyOtfClassType({
+        hasTreadmill: true,
+        hasRower: false,
+        treadSec: 1573,
+        calories: 692,
+      })
+    ).toBe(OTF_CLASS_TYPE_TREAD)
+  })
+
+  it('labels a rower-only class (no treadmill block) as Row-focused', () => {
+    expect(
+      classifyOtfClassType({
+        hasTreadmill: false,
+        hasRower: true,
+        rowerSec: 900,
+        calories: 500,
+      })
+    ).toBe(OTF_CLASS_TYPE_ROW)
+  })
+
+  it('labels a machine-less class with real output as Strength / Floor', () => {
+    expect(
+      classifyOtfClassType({
+        hasTreadmill: false,
+        hasRower: false,
+        calories: 300,
+      })
+    ).toBe(OTF_CLASS_TYPE_STRENGTH)
+  })
+
+  it('returns null for the near-zero belt-malfunction shape (no machines, minimal calories)', () => {
+    // 05/30: 4 calories, no machine block — already excluded by #268.
+    expect(
+      classifyOtfClassType({
+        hasTreadmill: false,
+        hasRower: false,
+        calories: 4,
+      })
+    ).toBeNull()
+  })
+
+  it('pins the Strength / Floor calorie boundary at 100', () => {
+    expect(
+      classifyOtfClassType({ hasTreadmill: false, hasRower: false, calories: 100 })
+    ).toBe(OTF_CLASS_TYPE_STRENGTH)
+    expect(
+      classifyOtfClassType({ hasTreadmill: false, hasRower: false, calories: 99 })
+    ).toBeNull()
+  })
+
+  it('treats equal tread/rower time as Tread + Row (tie does not flip to Row-focused)', () => {
+    expect(
+      classifyOtfClassType({
+        hasTreadmill: true,
+        hasRower: true,
+        treadSec: 600,
+        rowerSec: 600,
+      })
+    ).toBe(OTF_CLASS_TYPE_BOTH)
+  })
+
+  it('treats absent tread/rower seconds as zero (both machines, no times → Tread + Row)', () => {
+    expect(
+      classifyOtfClassType({ hasTreadmill: true, hasRower: true })
+    ).toBe(OTF_CLASS_TYPE_BOTH)
+  })
+
+  it('treats absent calories as zero for a machine-less class (→ null)', () => {
+    expect(classifyOtfClassType({ hasTreadmill: false, hasRower: false })).toBeNull()
+  })
+})

--- a/scripts/lib/otbeat-supabase.mjs
+++ b/scripts/lib/otbeat-supabase.mjs
@@ -17,6 +17,8 @@
  */
 
 import { classifyOtfAnomaly } from './otbeat-anomaly.mjs'
+import { classifyOtfClassType } from './otbeat-class-type.mjs'
+import { mmssToSec } from './otbeat-parser.mjs'
 import { createServiceRoleClient, loadEnv } from './cardio-supabase.mjs'
 
 export { createServiceRoleClient, loadEnv }
@@ -106,9 +108,12 @@ export function toStartedAt(date, time, timeZone) {
  *
  * `excluded` / `excluded_reason` are set from {@link classifyOtfAnomaly} so a
  * malfunction session (near-zero output, no machine block — #268) is flagged
- * at first insert. Because {@link upsertOtfSessions} is append-only
- * (`ignoreDuplicates`), this only ever runs on a row's *first* write, so a
- * manual override made later in Supabase is never clobbered by a re-pull.
+ * at first insert. `class_type` is the coarse machine-signature label from
+ * {@link classifyOtfClassType} (#271); `class_type_override` is left unset so a
+ * manual Supabase edit owns it. Because {@link upsertOtfSessions} is
+ * append-only (`ignoreDuplicates`), both auto columns only ever run on a row's
+ * *first* write, so a manual override made later in Supabase is never clobbered
+ * by a re-pull.
  *
  * @param {import('./otbeat-parser.mjs').OtbeatRecord} rec Parsed session.
  * @param {string} [timeZone] Studio timezone for `started_at`.
@@ -116,11 +121,20 @@ export function toStartedAt(date, time, timeZone) {
  */
 export function recordToRow(rec, timeZone = DEFAULT_STUDIO_TZ) {
   const z = rec.zones_min ?? null
+  const hasTreadmill = rec.treadmill != null
+  const hasRower = rec.rower != null
   const anomaly = classifyOtfAnomaly({
     calories: rec.calories,
     splat: rec.splat,
-    hasTreadmill: rec.treadmill != null,
-    hasRower: rec.rower != null,
+    hasTreadmill,
+    hasRower,
+  })
+  const classType = classifyOtfClassType({
+    hasTreadmill,
+    hasRower,
+    treadSec: mmssToSec(rec.treadmill?.time),
+    rowerSec: mmssToSec(rec.rower?.time),
+    calories: rec.calories,
   })
   return {
     started_at: toStartedAt(rec.date, rec.time, timeZone),
@@ -140,6 +154,7 @@ export function recordToRow(rec, timeZone = DEFAULT_STUDIO_TZ) {
     rower: rec.rower ?? null,
     excluded: anomaly.excluded,
     excluded_reason: anomaly.reason,
+    class_type: classType,
   }
 }
 

--- a/scripts/lib/otbeat-supabase.test.ts
+++ b/scripts/lib/otbeat-supabase.test.ts
@@ -130,6 +130,42 @@ describe('recordToRow', () => {
     expect(row.excluded).toBe(false)
     expect(row.excluded_reason).toBeNull()
   })
+
+  it('infers class_type from the machine signature and never writes class_type_override (#271)', () => {
+    // Both blocks, tread 11:24 (684s) > rower 7:58 (478s) → 'Tread + Row'.
+    const row = recordToRow(
+      {
+        ...bareRecord('06/27/2026', '9:30AM'),
+        calories: 776,
+        splat: 15,
+        treadmill: { distance_mi: 1.09, time: '11:24' },
+        rower: { distance_m: 2509, time: '7:58' },
+      },
+      TZ
+    )
+    expect(row.class_type).toBe('Tread + Row')
+    // The override column is manual-only; the append-only importer must never
+    // set it (else a re-pull would clobber a human edit).
+    expect(row.class_type_override).toBeUndefined()
+  })
+
+  it('labels a tread-only class Tread-focused', () => {
+    const row = recordToRow(
+      {
+        ...bareRecord('05/07/2026', '9:30AM'),
+        calories: 692,
+        splat: 15,
+        treadmill: { distance_mi: 2.4, time: '26:13' },
+      },
+      TZ
+    )
+    expect(row.class_type).toBe('Tread-focused')
+  })
+
+  it('leaves class_type null for the belt-malfunction shape', () => {
+    const row = recordToRow({ ...bareRecord('05/30/2026', '9:30AM'), calories: 4, splat: 0 }, TZ)
+    expect(row.class_type).toBeNull()
+  })
 })
 
 /**

--- a/supabase/migrations/20260704120000_otf_sessions_class_type.sql
+++ b/supabase/migrations/20260704120000_otf_sessions_class_type.sql
@@ -1,0 +1,64 @@
+-- Add a coarse, inferred class-type label to OTbeat sessions, plus a manual
+-- override column (#271).
+--
+-- The OTbeat "Studio Workout Summary" email carries no class-type token (no
+-- "2G"/"3G"/"Strength 50"/etc. anywhere in the body), so we can't parse the
+-- studio's official format name. Instead the ingest path infers a coarse label
+-- from which machine blocks the class logged and how the tread/rower time
+-- splits (scripts/lib/otbeat-class-type.mjs → classifyOtfClassType):
+--   * no treadmill AND no rower  -> 'Strength / Floor' (>=100 cal) else NULL
+--   * treadmill only             -> 'Tread-focused'
+--   * rower only                 -> 'Row-focused'
+--   * both, rower time > tread    -> 'Row-focused'
+--   * both, otherwise            -> 'Tread + Row'
+-- The NULL case is the belt-malfunction sentinel — already `excluded` by #268,
+-- so it never reaches an aggregate.
+--
+-- Two columns, mirroring the #268 excluded pattern:
+--   * class_type          — the auto-inferred coarse label, written at ingest.
+--   * class_type_override — nullable, set MANUALLY in Supabase to the real
+--                           format name ('2G', 'Strength 50', …) when known.
+-- The OTF view uses `coalesce(class_type_override, class_type)` as the
+-- effective type (effectiveOtfClassType in lib/training-facility/otf.ts).
+-- Because the importer is append-only (upsert with ignoreDuplicates), both auto
+-- columns are only written on a row's first insert, so a manual override is
+-- never clobbered by a re-pull.
+--
+-- All DDL is idempotent (add column if not exists) so re-applying on a fresh
+-- dev project or after a branch reset is a safe no-op.
+
+alter table public.otf_sessions
+  add column if not exists class_type text;
+
+alter table public.otf_sessions
+  add column if not exists class_type_override text;
+
+comment on column public.otf_sessions.class_type is
+  'Coarse class-type label inferred at ingest from the machine signature (tread/rower blocks + time split) by classifyOtfClassType (#271). One of ''Tread + Row'', ''Tread-focused'', ''Row-focused'', ''Strength / Floor'', or null for a near-zero malfunction. NOT OTF''s official format name — see class_type_override.';
+
+comment on column public.otf_sessions.class_type_override is
+  'Manually-set real OTF format name (e.g. ''2G'', ''Strength 50'') that wins over the inferred class_type. Null unless a human sets it in Supabase; never written by the append-only importer.';
+
+-- Backfill class_type for rows that predate this feature. Keep this CASE in
+-- sync with classifyOtfClassType (scripts/lib/otbeat-class-type.mjs). The
+-- both-present branch compares rower vs treadmill "MM:SS" total time converted
+-- to seconds. `where class_type is null` makes the backfill re-runnable and
+-- never re-stamps a row that already has a value.
+update public.otf_sessions
+set class_type = case
+  when treadmill is null and rower is null then
+    case when coalesce(calories, 0) >= 100 then 'Strength / Floor' else null end
+  when treadmill is not null and rower is null then 'Tread-focused'
+  when treadmill is null and rower is not null then 'Row-focused'
+  else case
+    when (
+      coalesce(nullif(split_part(rower ->> 'time', ':', 1), '')::int, 0) * 60
+        + coalesce(nullif(split_part(rower ->> 'time', ':', 2), '')::int, 0)
+    ) > (
+      coalesce(nullif(split_part(treadmill ->> 'time', ':', 1), '')::int, 0) * 60
+        + coalesce(nullif(split_part(treadmill ->> 'time', ':', 2), '')::int, 0)
+    ) then 'Row-focused'
+    else 'Tread + Row'
+  end
+end
+where class_type is null;

--- a/types/otf.ts
+++ b/types/otf.ts
@@ -110,6 +110,20 @@ export interface OtfSession {
   excluded?: boolean
   /** Why the session was excluded (prefixed `auto:` when set by the ingest heuristic). Present only when {@link excluded}. */
   excluded_reason?: string
+  /**
+   * Coarse class-type label inferred at ingest from the machine signature
+   * (#271): `'Tread + Row'`, `'Tread-focused'`, `'Row-focused'`, or
+   * `'Strength / Floor'`. Absent for a near-zero malfunction. NOT OTF's
+   * official format name — see {@link class_type_override}.
+   */
+  class_type?: string
+  /**
+   * Manually-set real OTF format name (e.g. `'2G'`, `'Strength 50'`) that wins
+   * over {@link class_type}. Set by hand in Supabase; never written by the
+   * append-only importer. The view uses `class_type_override ?? class_type` as
+   * the effective type.
+   */
+  class_type_override?: string
 }
 
 /** Full OrangeTheory dataset consumed by the Gym OTF view. */


### PR DESCRIPTION
Closes #271.

## What
Adds a **coarse, inferred class-type** to every OrangeTheory session plus a **class-type filter** on the OTF stats view.

The OTbeat "Studio Workout Summary" email carries **no class-type token** — nowhere does it say `2G`, `3G`, `Strength 50`, `Tread 50`, etc. (verified against the full flattened email body). So we can't parse the studio's official format name. Instead we:

1. **Infer** a coarse label at ingest from each class's machine signature, and
2. add a **manual override** column for the real format name when it's known.

## Heuristic
`scripts/lib/otbeat-class-type.mjs` (`classifyOtfClassType`) is the single source of truth:

| Signature | Label |
|---|---|
| no treadmill **and** no rower, ≥100 cal | `Strength / Floor` |
| no treadmill **and** no rower, <100 cal | `null` (belt-malfunction sentinel, already `excluded` by #268) |
| treadmill only | `Tread-focused` |
| rower only, **or** rower time > tread time | `Row-focused` |
| both, otherwise | `Tread + Row` |

Calibrated against the live 24-session dataset — distribution: **Tread + Row ×18, Tread-focused ×3, Row-focused ×2, null ×1**. The SQL backfill reproduces the JS classifier exactly (verified: same counts).

## Two-column design (mirrors #268 `excluded`)
- `class_type` — auto-inferred at ingest by `recordToRow`.
- `class_type_override` — nullable, set **manually in Supabase** to the real OTF name (`2G`, `Strength 50`, …); **wins** over `class_type`.

Effective type = `class_type_override ?? class_type` (`effectiveOtfClassType`). Because the importer is append-only (`upsert` + `ignoreDuplicates` → `ON CONFLICT DO NOTHING`), both auto columns are only written on a row's **first** insert, so a manual override is never clobbered by a weekly re-pull — the same property that lets #268's auto-flag and manual edits coexist.

## UI
- A **class-type filter** (pill row, rendered only when 2+ types are present in the window) scopes **every aggregate and the session log**, composing with the date range and the #268 exclusion. Selecting a type that leaves the window auto-resets to "All".
- The session log gains a **Type column**; a manually-overridden value shows a dot + a "Manual override" hover title.

## Migration
`supabase/migrations/20260704120000_otf_sessions_class_type.sql` adds both columns and backfills `class_type` via a `CASE` that mirrors the `.mjs` classifier. **Already applied to the live project** via Supabase MCP.

## Parser note
The parser (`otbeat-parser.mjs`) is **unchanged**. The original #271 "capture class type in the parser" idea is N/A — the source email has no such token — so `class_type` is derived at `recordToRow` instead.

## Tests
- `otbeat-class-type.test.ts` — every classifier branch + threshold boundaries.
- `otbeat-supabase.test.ts` — `recordToRow` sets `class_type`, never writes `class_type_override`.
- `otf.ts` schema + data + helper tests — passthrough, `effectiveOtfClassType`, `otfClassTypes`, `filterOtfSessionsByClassType`, and a **drift guard** asserting `OTF_CLASS_TYPE_ORDER` stays in sync with the `.mjs` label constants.
- `OtfDetailView.test.tsx` — filter renders/scopes the view, Type column, override marker.

Full suite: 1099 passing. Typecheck clean. Coverage gate (`lib/**` ≥80% lines) green — `lib/training-facility/otf.ts` and `lib/schemas/otf.ts` at 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new class-type filter in the session view when multiple class types are available.
  * Added a “Type” column to the session log to show each session’s class type.
  * Sessions with a manual override now display that label and indicate it with a tooltip.

* **Bug Fixes**
  * Improved class-type display and filtering so the view updates consistently based on the selected type.
  * Existing session data now includes class-type information for better browsing and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->