### PR TITLE
chore(ci): OTbeat ingest weekly → daily, ordered before life's republisher

### DIFF
--- a/.github/workflows/otbeat-ingest.yml
+++ b/.github/workflows/otbeat-ingest.yml
@@ -2,10 +2,14 @@ name: OTbeat ingest
 
 on:
   schedule:
-    # Mondays 14:00 UTC (~7am Pacific). The import's 8-day lookback window is
-    # wider than this weekly cadence, so a missed/failed run self-heals on the
-    # next one without gaps or duplicates (append-only, dedupe by started_at).
-    - cron: '0 14 * * 1'
+    # Daily 07:00 UTC (~midnight Pacific): the evening's classes have already
+    # emailed their OTbeat summaries, and life's gym-visits republisher runs at
+    # 08:00 UTC -- one hour later -- so a class reaches the telemetry warehouse
+    # (and the fitness dashboard's pace stat) the same night, instead of up to
+    # a week later on the old Monday-weekly cadence (life#221). The import's
+    # 8-day lookback dwarfs the daily cadence, so missed/failed runs self-heal
+    # without gaps or duplicates (append-only, dedupe by started_at).
+    - cron: '0 7 * * *'
   # Manual trigger for the first run and ad-hoc catch-ups.
   workflow_dispatch: {}
 


### PR DESCRIPTION
life's new fitness dashboard (life#221/life#223) reads visits daily and shows a live cost-per-visit pace stat — but this ingest ran Mondays only, so a Tuesday class was invisible for up to 7 days (and this week's classes currently read as 'idle July' over there).

**Change**: `0 14 * * 1` → `0 7 * * *` — daily at 07:00 UTC (~midnight PT):
- Evening classes have already emailed their OTbeat summary by then
- life's `gym-visits` republisher fires at 08:00 UTC, **one hour after** — so class → warehouse → dashboard the same night (bumping to daily at the old 14:00 would have kept a pointless extra day of lag behind the 08:00 republisher)
- The 8-day lookback + `started_at` dedupe were built for exactly this: failed runs self-heal, re-runs can't duplicate

Cost: ~6 extra short runs/week of Actions minutes + Gmail API reads — noise.

Note: the last **scheduled** run failed (Jun 29) and was rescued manually — worth a glance at that failure's log before relying on the daily cadence; either way, courtfolio's Actions failures are now watched by the daily Lifeline digest.

## Test plan
- [ ] After merge: next 07:00 UTC run green, `otf_sessions` gains any classes from this week
- [ ] Following 08:00 UTC gym-visits run republishes them; life's fitness dashboard July visits update

🤖 Generated with [Claude Code](https://claude.com/claude-code)