### PR TITLE
feat(otf): add regression trend line to per-metric charts (#267)

### DIFF
--- a/components/training-facility/gym/OtfDetailView.tsx
+++ b/components/training-facility/gym/OtfDetailView.tsx
@@ -27,6 +27,7 @@ import {
   otfBlockTrend,
   otfClassTypes,
   otfHighlights,
+  otfLinearRegression,
   otfMetricTrend,
   resolveOtfClassTypeFilter,
   type OtfTrendPoint,
@@ -498,6 +499,10 @@ function OtfTrendChart({
   /** Optional y-axis tick formatter (e.g. `formatMmss` for pace/split). Defaults to whole numbers. */
   yTickFormat?: (value: number) => string
 }): JSX.Element {
+  // Least-squares trend line drawn as a dashed overlay — the "am I improving?"
+  // read. `null` (fewer than two classes, or all on one day) hides it.
+  const regression = otfLinearRegression(data)
+  const overlay = regression?.points.map(p => ({ x: p.date, y: p.value }))
   return (
     <RoughLine<OtfTrendPoint>
       data={data}
@@ -509,6 +514,7 @@ function OtfTrendChart({
       fontFamily={FONT_FAMILY}
       yLabel={yLabel}
       yTickFormat={yTickFormat ?? (v => `${Math.round(v)}`)}
+      overlay={overlay}
       ariaLabel={ariaLabel}
       emptyMessage={emptyMessage}
     />

--- a/components/training-facility/shared/charts/RoughLine.tsx
+++ b/components/training-facility/shared/charts/RoughLine.tsx
@@ -15,6 +15,19 @@ export interface RoughLineProps<T> extends ChartCommonProps {
   /** Render a small rough dot at each data point. */
   showDots?: boolean
   dotRadius?: number
+  /**
+   * Optional secondary line drawn over the data line (but under the dots) as a
+   * crisp dashed path — e.g. a regression or rolling-average trend. Its x-type
+   * must match the data's (`number` or `Date`); its points are folded into the
+   * axis extents so it never clips. Fewer than two points renders nothing.
+   */
+  overlay?: { x: number | Date; y: number }[]
+  /** Overlay line color. Defaults to a muted ink so the data line stays dominant. */
+  overlayStroke?: string
+  /** Overlay stroke width. Defaults to 1.5. */
+  overlayStrokeWidth?: number
+  /** Overlay `stroke-dasharray`. Defaults to `'6 4'` — reads as "computed". */
+  overlayDash?: string
   xLabel?: string
   yLabel?: string
   xTickCount?: number
@@ -38,6 +51,10 @@ export function RoughLine<T>({
   strokeWidth = 2,
   showDots = true,
   dotRadius = 4,
+  overlay,
+  overlayStroke = chartPalette.inkSoft,
+  overlayStrokeWidth = 1.5,
+  overlayDash = '6 4',
   roughness = 1.4,
   seed = 1,
   fontFamily = 'inherit',
@@ -73,6 +90,8 @@ export function RoughLine<T>({
 
   const xValues = data.map(x)
   const yValues = data.map(y)
+  const overlayXValues = overlay?.map((d) => d.x) ?? []
+  const overlayYValues = overlay?.map((d) => d.y) ?? []
   const usingTime = isDateValue(xValues[0])
 
   // Each branch keeps its scale fully typed, so the rest of the function
@@ -82,7 +101,8 @@ export function RoughLine<T>({
   let xTicks: AxisTick[]
   if (usingTime) {
     const dateValues = xValues as Date[]
-    const [tMin, tMax] = extent(dateValues.map((d) => d.getTime()))
+    const overlayTimes = (overlayXValues as Date[]).map((d) => d.getTime())
+    const [tMin, tMax] = extent([...dateValues.map((d) => d.getTime()), ...overlayTimes])
     const timeScale: ScaleTime<number, number> = scaleTime()
       .domain([new Date(tMin), new Date(tMax)])
       .range([0, innerW])
@@ -94,7 +114,7 @@ export function RoughLine<T>({
       offset: timeScale(tick),
     }))
   } else {
-    const [xMin, xMax] = extent(xValues as number[])
+    const [xMin, xMax] = extent([...(xValues as number[]), ...(overlayXValues as number[])])
     const linearScale: ScaleLinear<number, number> = scaleLinear()
       .domain([xMin, xMax])
       .range([0, innerW])
@@ -105,7 +125,7 @@ export function RoughLine<T>({
     }))
   }
 
-  const [yMin, yMax] = extent(yValues)
+  const [yMin, yMax] = extent([...yValues, ...overlayYValues])
   const yPad = (yMax - yMin) * 0.1 || 1
   const yScale = scaleLinear()
     .domain([yMin - yPad, yMax + yPad])
@@ -113,6 +133,8 @@ export function RoughLine<T>({
     .range([innerH, 0])
 
   const points: [number, number][] = data.map((d) => [scaleX(x(d)), yScale(y(d))])
+  const overlayPoints: [number, number][] =
+    overlay?.map((d) => [scaleX(d.x), yScale(d.y)]) ?? []
 
   const gen = getGenerator()
   const linePath = gen.linearPath(points, { stroke, strokeWidth, roughness, seed })
@@ -168,6 +190,20 @@ export function RoughLine<T>({
             strokeLinejoin="round"
           />
         ))}
+        {overlayPoints.length >= 2 && (
+          <path
+            data-testid="rough-line-overlay"
+            d={overlayPoints
+              .map(([px, py], i) => `${i === 0 ? 'M' : 'L'}${px},${py}`)
+              .join(' ')}
+            stroke={overlayStroke}
+            strokeWidth={overlayStrokeWidth}
+            strokeDasharray={overlayDash}
+            fill="none"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        )}
         {showDots &&
           points.map(([px, py], i) => {
             const dot = gen.circle(px, py, dotRadius * 2, {

--- a/components/training-facility/shared/charts/primitives.test.tsx
+++ b/components/training-facility/shared/charts/primitives.test.tsx
@@ -79,6 +79,77 @@ describe('RoughLine', () => {
     // role=img plus aria-labelledby resolves the accessible name from the heading.
     expect(screen.getByRole('img', { name: 'Chart heading' })).toBeInTheDocument()
   })
+
+  it('draws a dashed overlay path when a two-point overlay is supplied (#267)', () => {
+    const { container } = render(
+      <RoughLine
+        data={[
+          { x: 0, y: 1 },
+          { x: 1, y: 2 },
+          { x: 2, y: 3 },
+        ]}
+        x={(d) => d.x}
+        y={(d) => d.y}
+        width={400}
+        height={200}
+        overlay={[
+          { x: 0, y: 1 },
+          { x: 2, y: 3 },
+        ]}
+        ariaLabel="trend with overlay"
+      />,
+    )
+    const overlayPath = container.querySelector('[data-testid="rough-line-overlay"]')
+    expect(overlayPath).not.toBeNull()
+    // Crisp polyline (M…L…), dashed, not a rough.js multi-stroke sketch.
+    expect(overlayPath?.getAttribute('d')).toMatch(/^M[\d.-]+,[\d.-]+ L/)
+    expect(overlayPath?.getAttribute('stroke-dasharray')).toBe('6 4')
+  })
+
+  it('draws a time-axis overlay (the OTF regression path) without clipping (#267)', () => {
+    // Mirrors OtfTrendChart: Date x + a two-point regression overlay whose
+    // endpoints exceed the data's y-range, so the extent-folding must widen
+    // the y-domain to keep the dashed line on-canvas.
+    const { container } = render(
+      <RoughLine
+        data={[
+          { x: new Date(2026, 5, 1), y: 10 },
+          { x: new Date(2026, 5, 3), y: 14 },
+          { x: new Date(2026, 5, 5), y: 12 },
+        ]}
+        x={(d) => d.x}
+        y={(d) => d.y}
+        width={400}
+        height={200}
+        overlay={[
+          { x: new Date(2026, 5, 1), y: 9 },
+          { x: new Date(2026, 5, 5), y: 15 },
+        ]}
+        ariaLabel="date trend with regression"
+      />,
+    )
+    const overlayPath = container.querySelector('[data-testid="rough-line-overlay"]')
+    expect(overlayPath).not.toBeNull()
+    expect(overlayPath?.getAttribute('stroke-dasharray')).toBe('6 4')
+  })
+
+  it('renders no overlay path when the overlay has fewer than two points', () => {
+    const { container } = render(
+      <RoughLine
+        data={[
+          { x: 0, y: 1 },
+          { x: 1, y: 2 },
+        ]}
+        x={(d) => d.x}
+        y={(d) => d.y}
+        width={400}
+        height={200}
+        overlay={[{ x: 0, y: 1 }]}
+        ariaLabel="trend with degenerate overlay"
+      />,
+    )
+    expect(container.querySelector('[data-testid="rough-line-overlay"]')).toBeNull()
+  })
 })
 
 describe('RoughBar', () => {

--- a/lib/training-facility/otf.test.ts
+++ b/lib/training-facility/otf.test.ts
@@ -22,7 +22,9 @@ import {
   otfBlockTrend,
   otfClassTypes,
   otfHighlights,
+  otfLinearRegression,
   otfMetricTrend,
+  otfRollingAverage,
   otfTrendEndpoints,
   resolveOtfClassTypeFilter,
   type OtfTrendPoint,
@@ -326,5 +328,90 @@ describe('otfTrendEndpoints', () => {
 
   it('returns null for an empty trend', () => {
     expect(otfTrendEndpoints([])).toBeNull()
+  })
+})
+
+describe('otfLinearRegression (#267)', () => {
+  // One point per day starting 2026-06-01, so `slopePerDay` is directly the
+  // per-step delta in the fitted values.
+  const pt = (day: number, value: number): OtfTrendPoint => ({
+    date: new Date(2026, 5, day),
+    value,
+  })
+
+  it('fits a rising line with positive per-day slope', () => {
+    const line = otfLinearRegression([pt(1, 10), pt(2, 20), pt(3, 30)])
+    expect(line).not.toBeNull()
+    expect(line!.slopePerDay).toBeCloseTo(10, 6)
+  })
+
+  it('fits a falling line with negative per-day slope', () => {
+    const line = otfLinearRegression([pt(1, 30), pt(2, 20), pt(3, 10)])
+    expect(line!.slopePerDay).toBeCloseTo(-10, 6)
+  })
+
+  it('spans the trend x-domain: endpoints sit at the min and max dates', () => {
+    const line = otfLinearRegression([pt(1, 10), pt(2, 20), pt(3, 30)])!
+    expect(line.points).toHaveLength(2)
+    expect(line.points[0].date.getTime()).toBe(new Date(2026, 5, 1).getTime())
+    expect(line.points[1].date.getTime()).toBe(new Date(2026, 5, 3).getTime())
+    // On a perfectly linear trend the fitted endpoints equal the data.
+    expect(line.points[0].value).toBeCloseTo(10, 6)
+    expect(line.points[1].value).toBeCloseTo(30, 6)
+  })
+
+  it('fits the least-squares line through noisy data', () => {
+    // y ≈ 5x + noise; the closed-form least-squares slope for
+    // (1,4)(2,11)(3,14)(4,21) is 108/20 = 5.4 per day.
+    const line = otfLinearRegression([pt(1, 4), pt(2, 11), pt(3, 14), pt(4, 21)])!
+    expect(line.slopePerDay).toBeCloseTo(5.4, 4)
+  })
+
+  it('returns null for fewer than two points', () => {
+    expect(otfLinearRegression([])).toBeNull()
+    expect(otfLinearRegression([pt(1, 10)])).toBeNull()
+  })
+
+  it('returns null when every point shares one date (zero x-variance)', () => {
+    const sameDay = { date: new Date(2026, 5, 1), value: 0 }
+    expect(
+      otfLinearRegression([
+        { ...sameDay, value: 10 },
+        { ...sameDay, value: 20 },
+      ])
+    ).toBeNull()
+  })
+})
+
+describe('otfRollingAverage (#267)', () => {
+  const pt = (day: number, value: number): OtfTrendPoint => ({
+    date: new Date(2026, 5, day),
+    value,
+  })
+
+  it('averages up to `window` trailing points, keeping original dates', () => {
+    const avg = otfRollingAverage([pt(1, 10), pt(2, 20), pt(3, 30), pt(4, 40)], 2)
+    expect(avg.map(p => p.value)).toEqual([10, 15, 25, 35])
+    expect(avg.map(p => p.date.getTime())).toEqual([
+      new Date(2026, 5, 1).getTime(),
+      new Date(2026, 5, 2).getTime(),
+      new Date(2026, 5, 3).getTime(),
+      new Date(2026, 5, 4).getTime(),
+    ])
+  })
+
+  it('uses min-periods 1 so output length matches input', () => {
+    const avg = otfRollingAverage([pt(1, 10), pt(2, 20), pt(3, 30)], 3)
+    expect(avg.map(p => p.value)).toEqual([10, 15, 20])
+  })
+
+  it('a window of 1 (or below) returns the original values', () => {
+    const trend = [pt(1, 10), pt(2, 20)]
+    expect(otfRollingAverage(trend, 1).map(p => p.value)).toEqual([10, 20])
+    expect(otfRollingAverage(trend, 0).map(p => p.value)).toEqual([10, 20])
+  })
+
+  it('returns an empty array for an empty trend', () => {
+    expect(otfRollingAverage([], 3)).toEqual([])
   })
 })

--- a/lib/training-facility/otf.ts
+++ b/lib/training-facility/otf.ts
@@ -306,6 +306,92 @@ export function otfTrendEndpoints(trend: readonly OtfTrendPoint[]): OtfTrendEndp
   return { first: trend[0].value, last: trend[trend.length - 1].value }
 }
 
+/**
+ * A least-squares trend line fitted over a `{date, value}` trend, expressed as
+ * the two endpoints to draw plus the daily slope for a direction read-out.
+ */
+export interface OtfTrendLine {
+  /**
+   * Two points on the fitted line — at the earliest and latest dates in the
+   * trend — so a chart can draw the regression as a single straight segment
+   * spanning the same x-domain as the data.
+   */
+  points: OtfTrendPoint[]
+  /**
+   * Change in the fitted value per calendar day. Positive means the metric is
+   * rising over time; the caller decides whether up is good (watts, distance)
+   * or bad (pace, split).
+   */
+  slopePerDay: number
+}
+
+/** Milliseconds in a day — converts the ms-based regression slope to per-day. */
+const MS_PER_DAY = 86_400_000
+
+/**
+ * Fit a least-squares regression line to a `{date, value}` trend, using each
+ * point's epoch-milliseconds as x. Returns the line's endpoints (at the min and
+ * max date, so it spans the data's x-domain) and its per-day slope.
+ *
+ * Returns `null` when the line is undefined: fewer than two points, or every
+ * point sharing the same date (zero x-variance — a vertical line has no slope).
+ */
+export function otfLinearRegression(trend: readonly OtfTrendPoint[]): OtfTrendLine | null {
+  if (trend.length < 2) return null
+  const n = trend.length
+  let sumX = 0
+  let sumY = 0
+  let sumXY = 0
+  let sumXX = 0
+  let minX = Infinity
+  let maxX = -Infinity
+  for (const p of trend) {
+    const x = p.date.getTime()
+    const y = p.value
+    sumX += x
+    sumY += y
+    sumXY += x * y
+    sumXX += x * x
+    if (x < minX) minX = x
+    if (x > maxX) maxX = x
+  }
+  const denom = n * sumXX - sumX * sumX
+  if (denom === 0) return null
+  const slopePerMs = (n * sumXY - sumX * sumY) / denom
+  const intercept = (sumY - slopePerMs * sumX) / n
+  return {
+    points: [
+      { date: new Date(minX), value: slopePerMs * minX + intercept },
+      { date: new Date(maxX), value: slopePerMs * maxX + intercept },
+    ],
+    slopePerDay: slopePerMs * MS_PER_DAY,
+  }
+}
+
+/**
+ * Trailing moving average of a `{date, value}` trend. Each output point keeps
+ * its original date and replaces the value with the mean of up to `window`
+ * values ending at that point (min-periods 1, so the output is the same length
+ * as the input and the leading points average whatever is available so far).
+ *
+ * @param window Number of trailing points to average; values below 1 are
+ *   treated as 1, yielding the original trend.
+ */
+export function otfRollingAverage(
+  trend: readonly OtfTrendPoint[],
+  window: number
+): OtfTrendPoint[] {
+  const size = Math.max(1, Math.floor(window))
+  const out: OtfTrendPoint[] = []
+  for (let i = 0; i < trend.length; i++) {
+    const start = Math.max(0, i - size + 1)
+    let sum = 0
+    for (let j = start; j <= i; j++) sum += trend[j].value
+    out.push({ date: trend[i].date, value: sum / (i - start + 1) })
+  }
+  return out
+}
+
 /** Headline stats for the OTF highlights strip, computed over a session set. */
 export interface OtfHighlights {
   /** Number of classes. */


### PR DESCRIPTION
## What

Adds a **least-squares regression trend line** as a dashed overlay on every OTF per-metric chart, so the view answers "am I trending up or down?" — not just "what happened each class." Closes #267.

## Changes

- **`lib/training-facility/otf.ts`**
  - `otfLinearRegression(trend)` — least-squares fit over each point's epoch-ms `x`. Returns the line's endpoints at the min/max date (so it spans the data's x-domain) plus `slopePerDay`. Returns `null` for fewer than 2 points or zero x-variance (all classes on one day → no defined slope).
  - `otfRollingAverage(trend, window)` — trailing moving average, min-periods 1 (output length matches input).
- **`RoughLine`** — new optional `overlay` prop (+ `overlayStroke` / `overlayStrokeWidth` / `overlayDash`). Rendered as a **crisp dashed `<path>`** over the sketchy rough.js data line but under the dots. Overlay points are folded into the x/y axis extents so the line never clips. A muted ink dash on the cream card reads as "computed" and stays subordinate to the orange data line.
- **`OtfDetailView` → `OtfTrendChart`** — computes the regression and passes its endpoints as `overlay`. Applies to all nine trend charts (splat, calories, avg HR, tread distance/pace/incline, rower distance/split/watts).

## Scope notes

- `otfRollingAverage` ships as a **tested helper but is intentionally not wired** into the small per-metric charts — a third line would clutter them. It's ready for a future combined/expanded view.
- A **slope-direction annotation** ("↓ good for pace/split, ↑ good for watts/distance") is deferred as a follow-up to keep this PR tight — the issue's "down is good" hint lives in the metric semantics, not yet surfaced as a label.

## Testing

- `otfLinearRegression`: rising/falling slope sign, endpoint span, least-squares fit through noisy data, null for `<2` points and zero x-variance.
- `otfRollingAverage`: trailing window, min-periods 1, `window ≤ 1` passthrough, empty input.
- `RoughLine`: dashed overlay renders (numeric **and** time axis, the production path), and no overlay path when `< 2` points.
- Full suite green: **1118 unit tests pass**, `tsc --noEmit` clean, `RoughLine.tsx` at 100% line coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
