### PR TITLE
fix(health): call createAdminSupabaseClient in auto-sync route

### DIFF
--- a/app/api/health/auto-sync/route.ts
+++ b/app/api/health/auto-sync/route.ts
@@ -17,7 +17,7 @@ import { NextResponse, type NextRequest } from 'next/server'
 import { ZodError } from 'zod'
 
 import { CardioSyncBatchSchema } from '@/lib/schemas/cardio-sync'
-import { createServiceRoleClient } from '@/lib/supabase/admin'
+import { createAdminSupabaseClient } from '@/lib/supabase/admin'
 
 /**
  * Validate the API key from the Authorization header.
@@ -66,7 +66,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   }
 
   // Upsert each metric into its table
-  const supabase = createServiceRoleClient()
+  const supabase = createAdminSupabaseClient()
   const results = { hrv: 0, walking_hr: 0, steps: 0, sleep: 0, active_energy: 0 }
   const errors: string[] = []
 


### PR DESCRIPTION
## What

`app/api/health/auto-sync/route.ts` (added in #279) imports and calls `createServiceRoleClient`, but `lib/supabase/admin.ts` exports **`createAdminSupabaseClient`** — the name every other admin route already uses. The imported symbol doesn't exist, so the build fails.

## Impact

`main` currently does not compile:

- **Typecheck** workflow — `error TS2305: Module '"@/lib/supabase/admin"' has no exported member 'createServiceRoleClient'.`
- **Vercel** build — same error → `Failed to compile` → preview/production deploy fails.

Every PR branched off `main` inherits these two red checks (e.g. #281, the architecture-docs PR).

## Fix

Rename the import and the call site to `createAdminSupabaseClient`. The signature is identical (no-arg, returns `SupabaseClient`), so runtime behaviour is unchanged — this only makes the existing call resolve to the real export.

🤖 Generated with [Claude Code](https://claude.com/claude-code)