### PR TITLE
docs(skill): harden log-workout for squats + focus rotation

### DIFF
--- a/.claude/skills/log-workout/SKILL.md
+++ b/.claude/skills/log-workout/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: log-workout
-description: Log Lucas's strength sets (pushups, pullups, weighted shrugs, etc.) to the Court Vision Weight Room. Use when the user reports having done sets/reps in natural language — e.g. "3 sets of 10 pushups", "did 25 pushups", "1x5 pullups", "3x10 shrugs at 100lb" (weighted), "shrugs 15 db - 25 reps" (dumbbell, load-first), "another 3x10 pushups", "logged 12 dips yesterday". Parses the sets and any per-set load, writes them to Supabase, and reports today's totals against the daily goals.
+description: Log Lucas's strength sets (pushups, pullups, weighted shrugs, etc.) to the Court Vision Weight Room. Use when the user reports having done sets/reps in natural language — e.g. "3 sets of 10 pushups", "did 25 pushups", "1x5 pullups", "3x20 squats" (bodyweight), "3x10 shrugs at 100lb" (weighted), "shrugs 15 db - 25 reps" (dumbbell, load-first), "another 3x10 pushups", "logged 12 dips yesterday". Parses the sets and any per-set load, writes them to Supabase, and reports today's totals against the daily goals.
 ---
 
 # Log Workout
@@ -16,6 +16,7 @@ The user casually reports completed bodyweight work. Triggers look like:
 - "another 3 sets of 10 pushups" (append to today — see step 4)
 - "did 25 pushups" / "25 pushups" (single set)
 - "1 set of 5 pullups" / "1x5 pullups"
+- "3x20 squats" / "did 50 squats" (bodyweight lower-body — no load)
 - "3x10 shrugs at 100lb" / "25 shrugs @ 95 lbs" (weighted — see step 1b)
 - "shrugs 15 db - 25 reps" / "15 db 25 reps" (dumbbell notation, load-first — see step 1b)
 - "logged 12 dips this morning" / "20 pushups yesterday" (back-dating — see step 3)
@@ -88,6 +89,15 @@ select exercise from public.weight_room_goals order by exercise;
 Use the **exact stored key** for the insert (e.g. parsed `Pull-ups` → stored
 `pullups`). If nothing matches, treat it as a new exercise — see step 6; do not
 invent a near-duplicate key.
+
+**The exercise roster is a moving target — read it live every time; never work
+from a remembered or hardcoded list.** Permanent rings get added over time (e.g.
+`squats`, a bodyweight lower-body goal), and the monthly focus rotates a
+different accessory in each month (`shrugs` in July). Because logging keys purely
+off the `exercise` column in `weight_room_goals`, the skill stays correct across
+new exercises and focus rotations with no change here — *provided* you
+canonicalize against the live table each run rather than assuming only
+pushups/pullups/shrugs exist.
 
 ### 1b. Parse the load (optional)
 


### PR DESCRIPTION
## What

Hardens the `log-workout` skill so it stays correct as the Weight Room exercise roster grows and the monthly focus rotates — no per-exercise edits required.

- Adds a **squats / lower-body example** to the skill description and the trigger list (`"3x20 squats"`, `"did 50 squats"`) so the trigger is obvious and documented.
- Makes step 1's canonicalization rule explicit that **the exercise roster is a moving target** — always re-read `weight_room_goals` live; never work from a remembered/hardcoded list.

## Why

Squats was just added as a permanent lower-body ring, and the monthly focus (`shrugs` in July) rotates monthly. The skill logs sets purely off the `exercise` key, so it already handles both — this just documents that contract and gives the trigger a lower-body example. Pure docs change to `SKILL.md`; no runtime code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded exercise examples to better recognize bodyweight lower-body workouts like “3x20 squats” and “did 50 squats.”
  * Added guidance to keep exercise matching current by using the latest canonical exercise list each time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->