### PR TITLE
fix(health): source column so full import can't clobber manual weights

### DIFF
--- a/.claude/skills/log-weight/SKILL.md
+++ b/.claude/skills/log-weight/SKILL.md
@@ -31,7 +31,15 @@ just swap the table name (see "Sibling tables" below).
 | --- | --- | --- |
 | `date` | `date` **PK** | one row per calendar day; the primary key |
 | `value` | `numeric` | bodyweight in **pounds**; CHECK `value > 0` |
+| `source` | `text` | `'manual'` (this skill) or `'apple_health'` (archive import / auto-sync); CHECK constrains to those two |
 | `created_at` / `updated_at` | `timestamptz` | bookkeeping |
+
+**Multi-source safety:** this table is written by both the log-weight skill and
+the Apple Health importer (`scripts/import-health.mjs`). The `/api/admin/cardio/trends`
+endpoint tags this skill's writes `source='manual'`, and the full import only
+upserts/prunes `source='apple_health'` rows — so a re-import can never overwrite
+or delete a manual morning weigh-in. Manual always wins for a given day. (You
+don't set `source` yourself; the endpoint does it for `body_mass`.)
 
 Because `date` is the primary key, weight is a **once-per-day measurement**, not
 an append log. Re-reporting a day **overwrites** that day's value (this is the

--- a/app/api/admin/cardio/trends/route.test.ts
+++ b/app/api/admin/cardio/trends/route.test.ts
@@ -163,10 +163,11 @@ describe('POST /api/admin/cardio/trends', () => {
     const res = await POST(req as any)
     expect(res.status).toBe(200)
     expect(fromMock).toHaveBeenCalledWith('cardio_body_mass_trend')
-    // Payload carries the value and an explicit updated_at stamp (the tables
-    // have no update trigger, so a re-log must bump it for imported_at).
+    // Payload carries the value, an explicit updated_at stamp (the tables have
+    // no update trigger, so a re-log must bump it for imported_at), and
+    // source='manual' so the full Apple Health import never overwrites it.
     expect(upsertMock).toHaveBeenCalledWith(
-      expect.objectContaining({ date: '2026-07-01', value: 233.8 })
+      expect.objectContaining({ date: '2026-07-01', value: 233.8, source: 'manual' })
     )
     expect(typeof upsertMock.mock.calls[0][0].updated_at).toBe('string')
     const body = await res.json()
@@ -189,6 +190,8 @@ describe('POST /api/admin/cardio/trends', () => {
     expect(upsertMock).toHaveBeenCalledWith(
       expect.objectContaining({ date: '2026-07-02', value: 45.2 })
     )
+    // The manual-source tag is scoped to body mass — hrv has no source column.
+    expect(upsertMock.mock.calls[0][0]).not.toHaveProperty('source')
   })
 
   it('returns 500 when database upsert fails', async () => {

--- a/app/api/admin/cardio/trends/route.ts
+++ b/app/api/admin/cardio/trends/route.ts
@@ -95,11 +95,20 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   // trigger, so overwriting an existing day would otherwise leave the old
   // timestamp — and `imported_at` (MAX(updated_at)) would never advance on a
   // correction/re-log. Matches the import script.
+  //
+  // Body mass is multi-source: tag these writes `source='manual'` so the full
+  // Apple Health import (which only upserts/prunes `source='apple_health'`)
+  // never overwrites or deletes a manually-logged weigh-in. Only
+  // `cardio_body_mass_trend` has the column, so scope it to that metric.
+  const row: {
+    date: string
+    value: number
+    updated_at: string
+    source?: 'manual'
+  } = { date: input.date, value: input.value, updated_at: new Date().toISOString() }
+  if (input.metric === 'body_mass') row.source = 'manual'
   const supabase = createAdminSupabaseClient()
-  const { error, data } = await supabase
-    .from(table)
-    .upsert({ date: input.date, value: input.value, updated_at: new Date().toISOString() })
-    .select()
+  const { error, data } = await supabase.from(table).upsert(row).select()
 
   if (error) {
     return NextResponse.json(

--- a/app/api/health/auto-sync/route.test.ts
+++ b/app/api/health/auto-sync/route.test.ts
@@ -8,7 +8,13 @@ import { POST } from './route'
  * body_mass path added alongside the manual trends endpoint).
  */
 
+// upsertMock is invoked as (table, row) so a test can assert which table each
+// write targeted; the endpoint's `supabase.from(table).upsert(row)` forwards
+// both. selectEqMock backs the manual-weigh-in lookup
+// (`from('cardio_body_mass_trend').select('date').eq('source','manual')`),
+// which runs once per request that carries body mass.
 const upsertMock = vi.fn()
+const selectEqMock = vi.fn()
 const fromMock = vi.fn()
 
 vi.mock('@/lib/supabase/admin', () => ({
@@ -18,7 +24,11 @@ vi.mock('@/lib/supabase/admin', () => ({
 beforeEach(() => {
   vi.resetAllMocks()
   upsertMock.mockResolvedValue({ error: null })
-  fromMock.mockReturnValue({ upsert: upsertMock })
+  selectEqMock.mockResolvedValue({ data: [], error: null })
+  fromMock.mockImplementation((table: string) => ({
+    upsert: (row: unknown) => upsertMock(table, row),
+    select: () => ({ eq: selectEqMock }),
+  }))
 })
 
 afterEach(() => {
@@ -81,7 +91,7 @@ describe('POST /api/health/auto-sync', () => {
       }) as any
     )
     expect(res.status).toBe(200)
-    const tables = fromMock.mock.calls.map((c) => c[0])
+    const tables = upsertMock.mock.calls.map((c) => c[0])
     expect(tables).toEqual([
       'cardio_hrv_trend',
       'cardio_walking_hr_trend',
@@ -90,11 +100,17 @@ describe('POST /api/health/auto-sync', () => {
       'cardio_active_energy_trend',
       'cardio_body_mass_trend',
     ])
-    expect(upsertMock).toHaveBeenCalledWith(
-      expect.objectContaining({ date: '2026-07-01', value: 233.8 })
-    )
-    // updated_at is stamped so re-syncing an existing day advances imported_at.
-    expect(typeof upsertMock.mock.calls.at(-1)?.[0].updated_at).toBe('string')
+    // body_mass is tagged source='apple_health' (only that table has the
+    // column) and stamps updated_at so re-syncing advances imported_at.
+    const bodyMassRow = upsertMock.mock.calls.find(
+      (c) => c[0] === 'cardio_body_mass_trend'
+    )?.[1] as { date: string; value: number; source: string; updated_at: unknown }
+    expect(bodyMassRow).toMatchObject({
+      date: '2026-07-01',
+      value: 233.8,
+      source: 'apple_health',
+    })
+    expect(typeof bodyMassRow.updated_at).toBe('string')
     expect((await res.json()).results).toEqual({
       hrv: 1,
       walking_hr: 1,
@@ -114,7 +130,22 @@ describe('POST /api/health/auto-sync', () => {
     )
     expect(res.status).toBe(200)
     // Only the steps table was touched — null hrv and absent fields skipped.
-    expect(fromMock.mock.calls.map((c) => c[0])).toEqual(['cardio_step_count_trend'])
+    expect(upsertMock.mock.calls.map((c) => c[0])).toEqual(['cardio_step_count_trend'])
+  })
+
+  it('skips body_mass on days that already have a manual weigh-in', async () => {
+    vi.stubEnv('HEALTH_AUTO_SYNC_API_KEY', 'valid-key')
+    // A manual row exists for 2026-07-01 — the scale reading must not clobber it.
+    selectEqMock.mockResolvedValue({ data: [{ date: '2026-07-01' }], error: null })
+    const res = await POST(
+      makeRequest({
+        data: [{ date: '2026-07-01', steps: 9000, body_mass_lbs: 240 }],
+      }) as any
+    )
+    expect(res.status).toBe(200)
+    // steps still written; body_mass skipped because the day is manual.
+    expect(upsertMock.mock.calls.map((c) => c[0])).toEqual(['cardio_step_count_trend'])
+    expect((await res.json()).results.body_mass).toBe(0)
   })
 
   it('returns 500 when a metric upsert fails', async () => {

--- a/app/api/health/auto-sync/route.ts
+++ b/app/api/health/auto-sync/route.ts
@@ -90,16 +90,49 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   }
   const errors: string[] = []
 
+  // Body mass is multi-source: the log-weight skill writes manual morning
+  // weigh-ins (`source='manual'`), which always win over an Apple Health scale
+  // reading. Fetch the manual dates once (only when this batch actually carries
+  // body mass) so those days can be skipped below and never overwritten.
+  const manualBodyMassDates = new Set<string>()
+  const hasBodyMass = batch.data.some(
+    (entry) => entry.body_mass_lbs !== null && entry.body_mass_lbs !== undefined
+  )
+  if (hasBodyMass) {
+    const { data: manualRows, error: manualErr } = await supabase
+      .from('cardio_body_mass_trend')
+      .select('date')
+      .eq('source', 'manual')
+    if (manualErr) {
+      return NextResponse.json(
+        { error: `Database error reading manual weigh-ins: ${manualErr.message}` },
+        { status: 500 }
+      )
+    }
+    for (const r of (manualRows ?? []) as Array<{ date: string }>) {
+      manualBodyMassDates.add(String(r.date).slice(0, 10))
+    }
+  }
+
   for (const entry of batch.data) {
     for (const { field, metric } of SYNC_FIELDS) {
       const value = entry[field]
       if (value === null || value === undefined) continue
+      // A manual weigh-in owns its day — don't let a scale reading overwrite it.
+      if (metric === 'body_mass' && manualBodyMassDates.has(entry.date)) continue
       // Stamp `updated_at`: the trend tables default it on INSERT but have no
       // update trigger, so re-syncing an existing day must set it here or
       // `imported_at` (MAX(updated_at)) never advances. Matches the import script.
-      const { error } = await supabase
-        .from(CARDIO_METRIC_TABLES[metric])
-        .upsert({ date: entry.date, value, updated_at: new Date().toISOString() })
+      // Tag body mass `source='apple_health'` (only that table has the column)
+      // so the full import can tell scale readings from manual weigh-ins.
+      const row: {
+        date: string
+        value: number
+        updated_at: string
+        source?: 'apple_health'
+      } = { date: entry.date, value, updated_at: new Date().toISOString() }
+      if (metric === 'body_mass') row.source = 'apple_health'
+      const { error } = await supabase.from(CARDIO_METRIC_TABLES[metric]).upsert(row)
       if (error) errors.push(`${metric} upsert for ${entry.date}: ${error.message}`)
       else results[metric]++
     }

--- a/scripts/lib/cardio-supabase.mjs
+++ b/scripts/lib/cardio-supabase.mjs
@@ -187,6 +187,13 @@ function sessionToRow(session, importedAt) {
  * pass a deliberately-truncated payload (e.g. "just the last 30 days")
  * unless you want everything older removed.
  *
+ * Body-mass exception: `cardio_body_mass_trend` is multi-source. Manual
+ * weigh-ins logged by the log-weight skill carry `source='manual'`; this
+ * import writes `source='apple_health'`. To keep manual entries authoritative,
+ * the import drops any payload day that already has a manual row and scopes its
+ * prune to `source='apple_health'` — so a full import never overwrites or
+ * deletes a manually-logged day, even one absent from the Apple Health export.
+ *
  * Idempotent — re-running on the same payload is a series of no-op
  * upserts (which still bump `updated_at` to the new batch timestamp)
  * and zero deletes (every row's `updated_at` matches the batch, so
@@ -212,7 +219,10 @@ function sessionToRow(session, importedAt) {
 const LIFESTYLE_TREND_TABLES = [
   ['hrv_trend', 'cardio_hrv_trend'],
   ['walking_hr_trend', 'cardio_walking_hr_trend'],
-  ['body_mass_trend', 'cardio_body_mass_trend'],
+  // body_mass_trend is handled separately (source-aware) in
+  // {@link upsertCardioData}: it is multi-source (manual weigh-ins from the
+  // log-weight skill + Apple Health scale readings), so its upsert and prune
+  // must be scoped to `source='apple_health'` and never touch manual rows.
   ['step_count_trend', 'cardio_step_count_trend'],
   ['sleep_trend', 'cardio_sleep_trend'],
   ['active_energy_trend', 'cardio_active_energy_trend'],
@@ -255,6 +265,36 @@ export async function upsertCardioData(supabase, data) {
     })),
   }))
 
+  // Body mass is multi-source. The log-weight skill writes daily manual
+  // weigh-ins (`source='manual'`); this import writes Apple Health scale
+  // readings (`source='apple_health'`). Manual always wins, so a full import
+  // must never overwrite or prune a day that already has a manual row. Fetch
+  // the manual dates up front (only when the payload actually carries body
+  // mass) and drop those days from the batch; the prune below is likewise
+  // scoped to `source='apple_health'`.
+  const bodyMassPayload = parsed.body_mass_trend ?? []
+  let manualBodyMassDates = new Set()
+  if (bodyMassPayload.length > 0) {
+    const { data: manualRows, error: manualErr } = await supabase
+      .from('cardio_body_mass_trend')
+      .select('date')
+      .eq('source', 'manual')
+    if (manualErr) {
+      throw new Error(`Failed to read manual body-mass dates: ${manualErr.message}`)
+    }
+    manualBodyMassDates = new Set(
+      (manualRows ?? []).map((r) => String(r.date).slice(0, 10)),
+    )
+  }
+  const bodyMassRows = bodyMassPayload
+    .filter((point) => !manualBodyMassDates.has(point.date))
+    .map((point) => ({
+      date: point.date,
+      value: point.value,
+      source: 'apple_health',
+      updated_at: importedAt,
+    }))
+
   if (sessionRows.length > 0) {
     const { error } = await supabase
       .from('cardio_sessions')
@@ -291,6 +331,14 @@ export async function upsertCardioData(supabase, data) {
       throw new Error(`Failed to upsert ${table}: ${error.message}`)
     }
   }
+  if (bodyMassRows.length > 0) {
+    const { error } = await supabase
+      .from('cardio_body_mass_trend')
+      .upsert(bodyMassRows, { onConflict: 'date' })
+    if (error) {
+      throw new Error(`Failed to upsert cardio_body_mass_trend: ${error.message}`)
+    }
+  }
 
   const sessionsPruned = await pruneStaleRows(
     supabase,
@@ -316,6 +364,15 @@ export async function upsertCardioData(supabase, data) {
     lifestyleCounts[field] = rows.length
     lifestylePruned += await pruneStaleRows(supabase, table, importedAt, rows.length > 0)
   }
+  // Scope the body-mass prune to apple_health so manual weigh-ins survive a
+  // full import that doesn't include them (see bodyMassRows above).
+  const bodyMassPruned = await pruneStaleRows(
+    supabase,
+    'cardio_body_mass_trend',
+    importedAt,
+    bodyMassRows.length > 0,
+    'apple_health',
+  )
 
   return {
     sessions: sessionRows.length,
@@ -323,7 +380,11 @@ export async function upsertCardioData(supabase, data) {
     vo2max: vo2Rows.length,
     hrSamples: hrSamplesInserted,
     ...lifestyleCounts,
-    pruned: sessionsPruned + restingPruned + vo2Pruned + lifestylePruned,
+    // Count of Apple Health body-mass rows written (manual days are excluded
+    // from the batch, so this can be < the payload's body_mass_trend length).
+    body_mass_trend: bodyMassRows.length,
+    pruned:
+      sessionsPruned + restingPruned + vo2Pruned + lifestylePruned + bodyMassPruned,
   }
 }
 
@@ -440,13 +501,19 @@ export async function upsertHrSamples(supabase, sessions) {
  * @param {boolean} hadAnyUpserts True iff at least one row was
  *   upserted into `table` in this batch. When false the prune is
  *   skipped entirely (see Empty-payload guard above).
+ * @param {string|null} source When non-null, restrict the prune to rows
+ *   with this `source` value. Used for multi-source tables like
+ *   `cardio_body_mass_trend`, where a full Apple Health import
+ *   (`source='apple_health'`) must not delete manually-logged weigh-ins
+ *   (`source='manual'`) that simply aren't in the export. `null` (the
+ *   default) prunes regardless of source, preserving the original
+ *   single-source behavior for every other table.
  */
-export async function pruneStaleRows(supabase, table, importedAt, hadAnyUpserts) {
+export async function pruneStaleRows(supabase, table, importedAt, hadAnyUpserts, source = null) {
   if (!hadAnyUpserts) return 0
-  const { error, count } = await supabase
-    .from(table)
-    .delete({ count: 'exact' })
-    .lt('updated_at', importedAt)
+  let query = supabase.from(table).delete({ count: 'exact' }).lt('updated_at', importedAt)
+  if (source !== null) query = query.eq('source', source)
+  const { error, count } = await query
   if (error) {
     throw new Error(`Failed to prune stale rows from ${table}: ${error.message}`)
   }

--- a/scripts/lib/cardio-supabase.test.ts
+++ b/scripts/lib/cardio-supabase.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from 'vitest'
 
 // Vitest happily resolves `.mjs` from a `.ts` test file. Public surface is
 // minimal — only the helpers exported for cross-module use are reachable.
-import { pruneStaleRows, upsertHrSamples } from './cardio-supabase.mjs'
+import { pruneStaleRows, upsertCardioData, upsertHrSamples } from './cardio-supabase.mjs'
 
 /**
  * Tests for the stale-row prune helper that backs the "exact mirror"
@@ -265,5 +265,94 @@ describe('upsertHrSamples', () => {
         },
       ]),
     ).rejects.toThrow(/Failed to insert cardio_session_hr_samples.*unique violation/)
+  })
+})
+
+/**
+ * Build a Supabase double for a body-mass-only `upsertCardioData` batch. It
+ * records every `upsert(rows)` and every prune (`delete().lt()[.eq()]`) so a
+ * test can assert that manual weigh-ins are excluded from the apple_health
+ * upsert and that the prune is scoped to `source='apple_health'`. `manualDates`
+ * is what the manual-lookup (`select('date').eq('source','manual')`) returns.
+ */
+function makeBodyMassFakeSupabase(manualDates: string[]): {
+  supabase: { from: ReturnType<typeof vi.fn> }
+  upserts: Array<{ table: string; rows: Array<Record<string, unknown>> }>
+  prunes: Array<{ table: string; source: string | null }>
+} {
+  const upserts: Array<{ table: string; rows: Array<Record<string, unknown>> }> = []
+  const prunes: Array<{ table: string; source: string | null }> = []
+  const supabase = {
+    from: vi.fn((table: string) => ({
+      upsert: (rows: unknown) => {
+        upserts.push({
+          table,
+          rows: (Array.isArray(rows) ? rows : [rows]) as Array<Record<string, unknown>>,
+        })
+        return Promise.resolve({ error: null })
+      },
+      // manual-weigh-in lookup: from(bodyMass).select('date').eq('source','manual')
+      select: () => ({
+        eq: () => Promise.resolve({ data: manualDates.map((d) => ({ date: d })), error: null }),
+      }),
+      // prune chain: delete({count}).lt('updated_at', ts) then optional .eq('source', src)
+      delete: () => {
+        const chain: Record<string, unknown> = { source: null }
+        chain.lt = () => chain
+        chain.eq = (_col: string, value: string) => {
+          chain.source = value
+          return chain
+        }
+        chain.then = (resolve: (r: unknown) => void) => {
+          prunes.push({ table, source: chain.source as string | null })
+          resolve({ error: null, count: 0 })
+        }
+        return chain
+      },
+    })),
+  }
+  return { supabase, upserts, prunes }
+}
+
+/** Minimal valid CardioData with no sessions/HR/VO2max — body mass only. */
+const EMPTY_CARDIO = {
+  imported_at: '2026-07-04T00:00:00Z',
+  sessions: [],
+  resting_hr_trend: [],
+  vo2max_trend: [],
+}
+
+describe('upsertCardioData body-mass source handling', () => {
+  it('excludes manual days from the apple_health upsert and scopes the prune to apple_health', async () => {
+    const { supabase, upserts, prunes } = makeBodyMassFakeSupabase(['2026-06-30'])
+    const counts = await upsertCardioData(supabase, {
+      ...EMPTY_CARDIO,
+      body_mass_trend: [
+        { date: '2026-06-30', value: 232 }, // manual day — must be skipped
+        { date: '2026-07-03', value: 234.4 }, // apple_health-only — must be written
+      ],
+    })
+    const bmUpsert = upserts.find((u) => u.table === 'cardio_body_mass_trend')
+    // The manual day is dropped from the batch; only the apple_health-only day
+    // is written, tagged source='apple_health'.
+    expect(bmUpsert?.rows.map((r) => r.date)).toEqual(['2026-07-03'])
+    expect(bmUpsert?.rows.every((r) => r.source === 'apple_health')).toBe(true)
+    expect(counts.body_mass_trend).toBe(1)
+    // The prune must carry the source filter — this is what stops a full import
+    // from deleting manually-logged days that aren't in the Apple Health export.
+    expect(prunes.find((p) => p.table === 'cardio_body_mass_trend')?.source).toBe('apple_health')
+  })
+
+  it('writes every body-mass day when none are manual', async () => {
+    const { supabase, upserts } = makeBodyMassFakeSupabase([])
+    await upsertCardioData(supabase, {
+      ...EMPTY_CARDIO,
+      body_mass_trend: [
+        { date: '2026-07-02', value: 233 },
+        { date: '2026-07-03', value: 234 },
+      ],
+    })
+    const bmUpsert = upserts.find((u) => u.table === 'cardio_body_mass_trend')
+    expect(bmUpsert?.rows.map((r) => r.date)).toEqual(['2026-07-02', '2026-07-03'])
   })
 })

--- a/supabase/migrations/20260706160000_cardio_body_mass_source.sql
+++ b/supabase/migrations/20260706160000_cardio_body_mass_source.sql
@@ -1,0 +1,24 @@
+-- Add a `source` column to cardio_body_mass_trend so the manual morning
+-- weigh-in (log-weight skill, via /api/admin/cardio/trends) and the Apple
+-- Health archive import (scripts/import-health.mjs) can coexist in one table
+-- without the import overwriting or pruning manual entries.
+--
+-- Background: the full "Export All Health Data" import treats its payload as
+-- authoritative for every table it touches — it upserts each day and then
+-- prunes any day NOT in the batch (see `pruneStaleRows`). Apple Health body
+-- mass is sparse (only days with a synced scale / manual HealthKit entry), but
+-- the log-weight skill records weight daily, so every full import silently
+-- deleted the skill-only days and overwrote shared days with the scale value.
+-- This column lets the import scope its upsert + prune to
+-- `source = 'apple_health'` and leave manual rows untouched.
+--
+-- Values: 'manual' (log-weight skill) | 'apple_health' (import + auto-sync).
+-- Existing rows default to 'apple_health'; the recovery backfill re-tags the
+-- known skill-logged days as 'manual'. Idempotent (`add column if not exists`).
+
+alter table public.cardio_body_mass_trend
+  add column if not exists source text not null default 'apple_health'
+    check (source in ('manual', 'apple_health'));
+
+comment on column public.cardio_body_mass_trend.source is
+  'Origin of the measurement: ''manual'' (log-weight skill / manual upsert endpoint) or ''apple_health'' (archive import / auto-sync). The full import upserts and prunes only source=''apple_health'' rows, so manual morning weigh-ins are never overwritten or deleted by a re-import.';


### PR DESCRIPTION
## Problem

The full Apple Health archive import (`scripts/import-health.mjs`) treats its payload as authoritative for `cardio_body_mass_trend`: it upserts each day, then **prunes any day not in the batch**. Apple Health body mass is sparse (only days with a synced scale / manual HealthKit entry), but the **log-weight skill records weight daily**.

Result: every full import silently **deleted** skill-only days and **overwrote** shared days with the scale value. A `2026-07-04` import pruned ~19 June days I'd logged manually and changed `06-30` from 233.8 → 232.

## Fix — a `source` column, and manual always wins

`cardio_body_mass_trend` becomes multi-source. Manual morning weigh-ins are authoritative for their day; Apple Health fills in every other day (so the richer historical import is still welcome).

- **migration** — `source text not null default 'apple_health' check (source in ('manual','apple_health'))`
- **import (`upsertCardioData`)** — drops payload days that already have a `manual` row from the apple_health upsert; scopes the prune to `source='apple_health'` so manual rows can never be deleted
- **`/api/admin/cardio/trends`** (log-weight skill) — tags `body_mass` writes `source='manual'`
- **`/api/health/auto-sync`** (iPhone Shortcut) — tags `body_mass` `source='apple_health'` and skips any day that already has a manual weigh-in
- **`pruneStaleRows`** — optional `source` filter; `null` (default) is prune-all, unchanged for every other table

## Tests
- source assertions on both endpoints; hrv confirms the tag is body-mass-scoped
- auto-sync: skips body_mass on a day that already has a manual weigh-in
- import integration test: manual day excluded from the upsert **and** prune scoped to apple_health
- `npx tsc --noEmit` clean; 34 tests pass

## Data recovery (already applied to the live DB, not in this diff)
Reconstructed the pruned weigh-ins from Claude Code transcripts (last-write-wins per day) and re-inserted **19 pruned June days + 2 May days**, restored `06-30` to 233.8, all tagged `source='manual'`. Table now holds 26 manual + 15 apple_health rows; verified 0 missing / 0 mismatched.

## Note
The migration is already applied to the production Supabase project (`ryxbnvhxxkrmsrmocume`). Safe to re-run a full `import-health` after merge — it can no longer touch manual rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)