### PR TITLE
chore(next): commit Next 16's tsconfig auto-patch

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -12,7 +16,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
       {
@@ -20,7 +24,9 @@
       }
     ],
     "paths": {
-      "@/*": ["./*"]
+      "@/*": [
+        "./*"
+      ]
     }
   },
   "include": [
@@ -31,7 +37,10 @@
     ".next-e2e-default/types/**/*.ts",
     ".next-e2e-training-facility/types/**/*.ts",
     "app/banners",
-    "global.d.ts"
+    "global.d.ts",
+    ".next/dev/types/**/*.ts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## Summary

Since the Next 15→16 bump (#247), running `next dev` / `next build` locally auto-rewrites `tsconfig.json` (`jsx: "preserve"` → `"react-jsx"`, adds `.next/dev/types/**/*.ts` to `include`, reformats arrays). This left an uncommitted `M tsconfig.json` after every local build, which could silently ride along across `git checkout` and pollute unrelated branches. This commits Next's auto-patched tsconfig once so a fresh `next dev` no longer produces a diff.

## Design decision

The issue laid out two options:

- **(a) Accept it** — commit the auto-patched tsconfig once.
- **(b) Leave as-is** — `git restore tsconfig.json` after every local build.

Chose **(a)**. Verified the patch is limited to `jsx: react-jsx`, an added `.next/dev/types/**/*.ts` include glob (mirrors the existing `.next/types/**/*.ts` entry, matches the pre-existing gitignore convention of referencing build-artifact globs from tsconfig without tracking `.next/` itself), and cosmetic array reformatting — no other compiler options moved. `jsx: react-jsx` only affects `tsc`/vitest type-checking since Next compiles via SWC regardless of this setting, and the app already uses React 19's automatic JSX runtime (`@vitejs/plugin-react`), so it's consistent with the existing toolchain rather than a behavior change. Rejected (b): it's a recurring paper cut with no upside — every dev session either forgets to restore the file or risks committing the churn by accident.

No `docs/decisions` ADR convention exists in this repo, so none was added.

## Gate results

- `npx tsc --noEmit` — clean
- `npm run test` — 111 files / 1158 tests passing
- `npm run build` — succeeds; verified re-running `next dev`/`next build` after committing the patched tsconfig produces **no further diff**
- `npm run lint` — fails (`next lint` invalid project directory: Next 16 removed the `next lint` subcommand). Pre-existing, unrelated to this change — tracked by #289 with an open fix in #293.

Closes #290

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run test` — 1158 passing
- [x] `npm run build` succeeds
- [x] Re-ran `next dev` after committing — confirmed `tsconfig.json` no longer changes


---
_Generated by [Claude Code](https://claude.ai/code/session_01CEHJ4u3N9hnKs6GYQXtnUg)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project configuration to use the newer React JSX transform.
  * Reorganized build settings for consistency and included additional generated type definitions in the project scope.
  * No user-facing feature changes were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->