### PR TITLE
chore(env): raise engines floor to node >=24 to match the toolchain

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "vitest": "^4.1.5"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=24"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.2.9",
   "private": true,
   "engines": {
-    "node": ">=22"
+    "node": ">=24"
   },
   "scripts": {
     "dev": "next dev --turbopack",


### PR DESCRIPTION
Follow-up to #295. That PR landed `engines: { node: ">=22" }`, but Codex correctly flagged it as inconsistent with the locked toolchain: `jsdom` and the eslint packages require `^22.13.0 || >=24`, so Node 22.0–22.12 would be an unsupported install despite `package.json` advertising support. The rest of the repo already standardizes on Node 24 — `.nvmrc`, all four CI workflows, and prod.

This raises the floor to `>=24` in both `package.json` and the lockfile's root `engines` mirror (kept in sync so `npm ci` doesn't complain).

## Test plan
- [x] Only the root `engines` changed — dependency `engines` entries untouched
- [ ] CI `typecheck` / `unit` / `e2e` green on Node 24 (unaffected — advisory metadata only)
- [ ] `npm ci` still resolves (package.json ↔ lockfile root `engines` match)

Resolves the Codex review nit from #295.