### PR TITLE
feat(draft-room): printed scouting-report theme + draft-room personas (#302)

### DIFF
--- a/app/api/panel/run/route.ts
+++ b/app/api/panel/run/route.ts
@@ -27,6 +27,7 @@ import { z, ZodError } from 'zod'
 import { isPanelLiveEnabled } from '@/lib/feature-flags'
 import { runPanel, PanelDegradedError } from '@/lib/panel'
 import { errorTypeOf } from '@/lib/panel/events'
+import { PORTFOLIO_PERSONAS } from '@/lib/panel/personas'
 import type { PanelEvent, PanelResult } from '@/lib/panel/types'
 import {
   HEARTBEAT_INTERVAL_MS,
@@ -316,13 +317,17 @@ async function handlePOST(request: NextRequest): Promise<Response> {
   // pattern, production-gated so a leaked env var can never serve fabricated
   // "live" runs on the real site. Streams via the same resultToEvents used by
   // the cache-hit path, so the stub cannot drift from the wire protocol.
+  // Roster maps come from the personas the STORED result was judged by (the
+  // portfolio set, until the #301 editorial swap) — the live config's
+  // draft-room personas (#302) wouldn't match the replayed verdicts' ids.
   if (process.env.NODE_ENV !== 'production' && process.env.PANEL_LIVE_STUB === '1') {
+    const stubRosterConfig = { ...target.config, personas: PORTFOLIO_PERSONAS }
     return streamReplay(
       resultToEvents(withReconstructedRulings(courtfolioPanelResult), {
         cached: false,
         startedAt: new Date().toISOString(),
-        modelByPersonaId: modelByPersonaId(target.config),
-        lensByPersonaId: lensByPersonaId(target.config),
+        modelByPersonaId: modelByPersonaId(stubRosterConfig),
+        lensByPersonaId: lensByPersonaId(stubRosterConfig),
       }),
       0.2
     )

--- a/components/draft-room/DraftRoomBody.tsx
+++ b/components/draft-room/DraftRoomBody.tsx
@@ -1,4 +1,5 @@
 import type { PanelResult } from '@/lib/panel/types'
+import { prospectLabel } from './axes'
 import { PersonaVerdictCard } from './PersonaVerdictCard'
 import { AgreementMap } from './AgreementMap'
 import { SynthesisPanel } from './SynthesisPanel'
@@ -25,12 +26,16 @@ export function DraftRoomBody({ result }: DraftRoomBodyProps) {
     <>
       <section aria-label="Panelist verdicts" className="flex flex-col gap-5">
         <h2 className="font-sans text-2xl font-bold text-white">
-          The panel weighs in — independently
+          The scouting reports are in — filed independently
         </h2>
         <div className="grid grid-cols-1 gap-5 md:grid-cols-3">
           {verdicts.map(v => (
             <div key={v.personaId} className="reveal">
-              <PersonaVerdictCard verdict={v} />
+              <PersonaVerdictCard
+                verdict={v}
+                prospect={prospectLabel(result.thesis.targetId)}
+                evalStamp="stored"
+              />
             </div>
           ))}
         </div>
@@ -41,7 +46,9 @@ export function DraftRoomBody({ result }: DraftRoomBodyProps) {
       </div>
 
       <section aria-label="Agreement and disagreement" className="reveal flex flex-col gap-5">
-        <h2 className="font-sans text-2xl font-bold text-white">Converge vs. split</h2>
+        <h2 className="font-sans text-2xl font-bold text-white">
+          The war room — converge vs. split
+        </h2>
         <AgreementMap
           convergence={synthesis.convergence}
           disagreements={synthesis.disagreements}
@@ -50,7 +57,7 @@ export function DraftRoomBody({ result }: DraftRoomBodyProps) {
       </section>
 
       <section aria-label="Meta-judge synthesis" className="reveal flex flex-col gap-5">
-        <h2 className="font-sans text-2xl font-bold text-white">The meta-judge synthesizes</h2>
+        <h2 className="font-sans text-2xl font-bold text-white">The front office decides</h2>
         <SynthesisPanel synthesis={synthesis} />
       </section>
     </>

--- a/components/draft-room/LiveDraftRoom.test.tsx
+++ b/components/draft-room/LiveDraftRoom.test.tsx
@@ -114,10 +114,10 @@ describe('LiveDraftRoom', () => {
     const start = renderWith(IDLE_STATE)
 
     expect(
-      screen.getByRole('heading', { name: 'The panel weighs in — independently' })
+      screen.getByRole('heading', { name: 'The scouting reports are in — filed independently' })
     ).toBeInTheDocument()
     expect(screen.getByRole('heading', { name: 'Replay Peer' })).toBeInTheDocument()
-    expect(screen.getByRole('heading', { name: 'The meta-judge synthesizes' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'The front office decides' })).toBeInTheDocument()
     // The replay is hand-authored, and idle says so.
     expect(screen.getByText(/Illustrative —/)).toBeInTheDocument()
 
@@ -175,9 +175,9 @@ describe('LiveDraftRoom', () => {
     const progress = screen.getByText(/Fact-checking/)
     expect(progress).toHaveTextContent('3/5 gaps re-checked')
     // No synthesis yet, so the closing sections are absent.
-    expect(screen.queryByRole('heading', { name: 'Converge vs. split' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('heading', { name: 'The war room — converge vs. split' })).not.toBeInTheDocument()
     expect(
-      screen.queryByRole('heading', { name: 'The meta-judge synthesizes' })
+      screen.queryByRole('heading', { name: 'The front office decides' })
     ).not.toBeInTheDocument()
   })
 
@@ -192,8 +192,8 @@ describe('LiveDraftRoom', () => {
       })
     )
 
-    expect(screen.getByRole('heading', { name: 'Converge vs. split' })).toBeInTheDocument()
-    expect(screen.getByRole('heading', { name: 'The meta-judge synthesizes' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'The war room — converge vs. split' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'The front office decides' })).toBeInTheDocument()
     expect(screen.getByText('the live synthesis verdict')).toBeInTheDocument()
     // The synthesis supersedes the verify progress line.
     expect(screen.queryByText(/Fact-checking/)).not.toBeInTheDocument()
@@ -250,7 +250,7 @@ describe('LiveDraftRoom', () => {
 
     expect(screen.getByText(/hit its run budget/)).toBeInTheDocument()
     expect(screen.getByRole('heading', { name: 'Replay Peer' })).toBeInTheDocument()
-    expect(screen.getByRole('heading', { name: 'The meta-judge synthesizes' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'The front office decides' })).toBeInTheDocument()
     // No stream ever started, so nothing live is on screen.
     expect(screen.queryByText('Deliberating…')).not.toBeInTheDocument()
   })

--- a/components/draft-room/LiveDraftRoom.tsx
+++ b/components/draft-room/LiveDraftRoom.tsx
@@ -13,6 +13,7 @@
  * whatever already streamed — nothing is papered over.
  */
 import type { PanelResult } from '@/lib/panel/types'
+import { prospectLabel } from './axes'
 import { DraftRoomHeader } from './DraftRoomHeader'
 import { DraftRoomBody } from './DraftRoomBody'
 import { PersonaVerdictCard } from './PersonaVerdictCard'
@@ -118,11 +119,14 @@ function LiveBody({ state }: { state: LivePanelRunState }) {
   const errorById = Object.fromEntries(state.personaErrors.map(e => [e.personaId, e.errorType]))
   const labelById = Object.fromEntries(runStart.personas.map(p => [p.id, p.label]))
 
+  const prospect = prospectLabel(runStart.targetId)
+  const evalStamp = runStart.cached ? 'cached' : 'live'
+
   return (
     <>
       <section aria-label="Panelist verdicts" className="flex flex-col gap-5">
         <h2 className="font-sans text-2xl font-bold text-white">
-          The panel weighs in — independently
+          The scouting reports come in — filed independently
         </h2>
         <div className="grid grid-cols-1 gap-5 md:grid-cols-3">
           {runStart.personas.map(persona => {
@@ -133,6 +137,10 @@ function LiveBody({ state }: { state: LivePanelRunState }) {
                   key={persona.id}
                   verdict={verdict}
                   gapRulings={state.gapRulings[persona.id]}
+                  prospect={prospect}
+                  model={persona.model || undefined}
+                  evalStamp={evalStamp}
+                  evalDate={runStart.startedAt}
                 />
               )
             }
@@ -154,7 +162,7 @@ function LiveBody({ state }: { state: LivePanelRunState }) {
 
       {state.verify && !state.synthesis && state.status !== 'error' ? (
         <p aria-live="polite" className="font-mono text-xs text-neutral-400">
-          Fact-checking the panel’s claims against the evidence… {state.verify.done}/
+          Fact-checking the scouts’ claims against the film… {state.verify.done}/
           {state.verify.total} gaps re-checked.
         </p>
       ) : null}
@@ -162,7 +170,9 @@ function LiveBody({ state }: { state: LivePanelRunState }) {
       {state.synthesis ? (
         <>
           <section aria-label="Agreement and disagreement" className="flex flex-col gap-5">
-            <h2 className="font-sans text-2xl font-bold text-white">Converge vs. split</h2>
+            <h2 className="font-sans text-2xl font-bold text-white">
+              The war room — converge vs. split
+            </h2>
             <AgreementMap
               convergence={state.synthesis.convergence}
               disagreements={state.synthesis.disagreements}
@@ -171,7 +181,7 @@ function LiveBody({ state }: { state: LivePanelRunState }) {
           </section>
 
           <section aria-label="Meta-judge synthesis" className="flex flex-col gap-5">
-            <h2 className="font-sans text-2xl font-bold text-white">The meta-judge synthesizes</h2>
+            <h2 className="font-sans text-2xl font-bold text-white">The front office decides</h2>
             <SynthesisPanel synthesis={state.synthesis} />
           </section>
         </>

--- a/components/draft-room/PersonaPendingCard.tsx
+++ b/components/draft-room/PersonaPendingCard.tsx
@@ -1,44 +1,53 @@
 import type { RunStartPersona } from '@/lib/draft-room/protocol'
 
+/** The model chip's display text: strip the gateway vendor prefix (`anthropic/claude-haiku-4.5` → `claude-haiku-4.5`). */
+function modelShortName(model: string): string {
+  return model.split('/').pop() ?? model
+}
+
 /** Props for {@link PersonaPendingCard}. */
 interface PersonaPendingCardProps {
   /** The persona this slot is waiting on, from the run-start roster. */
   persona: RunStartPersona
 }
 
-/** The model chip's display text: strip the gateway vendor prefix (`anthropic/claude-haiku-4.5` → `claude-haiku-4.5`). */
-function modelShortName(model: string): string {
-  return model.split('/').pop() ?? model
-}
-
 /**
- * A persona's skeleton card while its model call is in flight (#241). The
- * model chip is the honesty detail: three different vendors visibly
- * deliberating at genuinely different speeds *is* the independence proof.
- * CSS pulse only — consistent with the repo's CSS-first animation idiom.
+ * A scout's report while their model call is in flight (#241): a blank
+ * report form filling in. The model chip is the honesty detail: three
+ * different vendors visibly deliberating at genuinely different speeds *is*
+ * the independence proof. CSS pulse only — consistent with the repo's
+ * CSS-first animation idiom.
  */
 export function PersonaPendingCard({ persona }: PersonaPendingCardProps) {
   return (
     <article
       aria-label={`${persona.label} — deliberating`}
-      className="flex h-full min-h-64 flex-col gap-4 rounded-2xl border border-white/10 bg-neutral-800/60 p-5 shadow-md"
+      className="flex h-full min-h-64 flex-col gap-3 rounded-md border border-neutral-900/20 bg-[#f5f0e4]/85 p-5 text-neutral-900 shadow-[0_12px_32px_rgba(0,0,0,0.45)]"
     >
-      <header className="flex flex-col gap-2">
-        <h3 className="font-sans text-lg font-bold text-white">{persona.label}</h3>
-        <span className="w-fit rounded-full bg-white/5 px-2 py-0.5 font-mono text-[0.625rem] text-neutral-400">
+      <span className="font-mono text-[0.625rem] font-bold uppercase tracking-[0.2em] text-neutral-700">
+        Scouting report
+      </span>
+      <div className="flex flex-col gap-1 font-mono text-xs text-neutral-700">
+        <div className="flex gap-2">
+          <span className="uppercase tracking-[0.12em] text-neutral-500">Scout</span>
+          <h3 className="inline font-mono text-xs font-bold text-neutral-900">{persona.label}</h3>
+        </div>
+      </div>
+      {persona.model ? (
+        <span className="w-fit rounded-sm bg-neutral-900/10 px-1.5 py-0.5 font-mono text-[0.625rem] text-neutral-700">
           {modelShortName(persona.model)}
         </span>
-      </header>
+      ) : null}
 
-      <p className="text-sm text-neutral-400">{persona.lens}</p>
+      <p className="text-sm text-neutral-600">{persona.lens}</p>
 
       <div className="mt-auto flex flex-col gap-2" aria-hidden="true">
-        <div className="h-2 w-full animate-pulse rounded bg-white/10" />
-        <div className="h-2 w-4/5 animate-pulse rounded bg-white/10" />
-        <div className="h-2 w-3/5 animate-pulse rounded bg-white/10" />
+        <div className="h-2 w-full animate-pulse rounded-sm bg-neutral-900/10" />
+        <div className="h-2 w-4/5 animate-pulse rounded-sm bg-neutral-900/10" />
+        <div className="h-2 w-3/5 animate-pulse rounded-sm bg-neutral-900/10" />
       </div>
 
-      <p className="font-mono text-[0.625rem] uppercase tracking-[0.16em] text-orange-300/80">
+      <p className="font-mono text-[0.625rem] font-bold uppercase tracking-[0.2em] text-orange-700">
         Deliberating…
       </p>
     </article>
@@ -54,24 +63,35 @@ interface PersonaBenchedCardProps {
 }
 
 /**
- * A persona's card when its model call failed (#241): the run proceeds with
- * the survivors and this slot says so plainly — a benched panelist is shown,
- * never papered over.
+ * A scout's slot when their model call failed (#241): the run proceeds with
+ * the survivors and this report says so plainly — "DID NOT REPORT" is
+ * stamped, never papered over.
  */
 export function PersonaBenchedCard({ persona, errorType }: PersonaBenchedCardProps) {
   return (
     <article
       aria-label={`${persona.label} — did not report`}
-      className="flex h-full min-h-64 flex-col gap-4 rounded-2xl border border-dashed border-white/10 bg-neutral-900/60 p-5"
+      className="flex h-full min-h-64 flex-col gap-3 rounded-md border border-dashed border-neutral-900/30 bg-[#f5f0e4]/60 p-5"
     >
-      <header className="flex flex-col gap-2">
-        <h3 className="font-sans text-lg font-bold text-neutral-400">{persona.label}</h3>
-        <span className="w-fit rounded-full bg-white/5 px-2 py-0.5 font-mono text-[0.625rem] text-neutral-500">
+      <div className="flex items-start justify-between gap-2">
+        <span className="font-mono text-[0.625rem] font-bold uppercase tracking-[0.2em] text-neutral-600">
+          Scouting report
+        </span>
+        <span className="-rotate-3 rounded border-2 border-red-800/60 px-1.5 py-0.5 font-mono text-[0.5625rem] font-bold uppercase tracking-[0.18em] text-red-800/90">
+          Did not report
+        </span>
+      </div>
+      <div className="flex gap-2 font-mono text-xs text-neutral-700">
+        <span className="uppercase tracking-[0.12em] text-neutral-500">Scout</span>
+        <h3 className="inline font-mono text-xs font-bold text-neutral-800">{persona.label}</h3>
+      </div>
+      {persona.model ? (
+        <span className="w-fit rounded-sm bg-neutral-900/10 px-1.5 py-0.5 font-mono text-[0.625rem] text-neutral-600">
           {modelShortName(persona.model)}
         </span>
-      </header>
+      ) : null}
 
-      <p className="text-sm text-neutral-500">
+      <p className="text-sm text-neutral-600">
         Did not report — the model call failed ({errorType}). The panel continued with the
         remaining voices; the synthesis is told this seat was empty.
       </p>

--- a/components/draft-room/PersonaVerdictCard.tsx
+++ b/components/draft-room/PersonaVerdictCard.tsx
@@ -1,73 +1,166 @@
 import type { PersonaVerdict, VerifyVerdict } from '@/lib/panel/types'
 import { ScoreMeter } from './ScoreMeter'
 
+/** How the eval on a report card was produced — drives the corner stamp. */
+export type EvalStamp = 'live' | 'cached' | 'stored'
+
 /** Props for {@link PersonaVerdictCard}. */
 interface PersonaVerdictCardProps {
   /** One panelist's independent verdict. */
   verdict: PersonaVerdict
   /**
    * Live mode only (#241): the fact-checker's ruling per gap index, landed as
-   * each verifier call settles. Omitted on the replay page — gaps render
-   * without badges, exactly as before.
+   * each verifier call settles. Omitted on the replay page — concerns render
+   * without ruling annotations, exactly as before.
    */
   gapRulings?: Partial<Record<number, VerifyVerdict>>
+  /** Display name of the thing under evaluation (the report's PROSPECT line). */
+  prospect?: string
+  /** Gateway model id shown as the report's instrument chip; hidden when empty. */
+  model?: string
+  /** Corner stamp: how this eval was produced. Omitted → no stamp. */
+  evalStamp?: EvalStamp
+  /** ISO timestamp of when the eval ran, shown on the EVAL line when present. */
+  evalDate?: string
 }
 
-/** Badge copy + classes per verifier ruling. The overruled state is the loud one on purpose. */
+/** Corner-stamp copy + ink per {@link EvalStamp}. */
+const EVAL_STAMPS: Record<EvalStamp, { text: string; className: string }> = {
+  live: { text: 'Live eval', className: 'border-red-800/60 text-red-800/90' },
+  cached: { text: 'Recent eval — replayed', className: 'border-neutral-700/50 text-neutral-700' },
+  stored: { text: 'Stored eval', className: 'border-neutral-700/50 text-neutral-700' },
+}
+
+/** Ruling annotation copy + ink per verifier verdict (report ink on paper). */
 const RULING_BADGES: Record<VerifyVerdict, { text: string; className: string }> = {
-  upheld: { text: '✓ upheld', className: 'bg-green-500/10 text-green-300' },
-  refuted: { text: '✗ overruled', className: 'bg-yellow-400/10 text-yellow-300' },
-  unverifiable: { text: '? unverifiable', className: 'bg-white/5 text-neutral-400' },
+  upheld: { text: '✓ upheld', className: 'bg-green-800/10 text-green-900' },
+  refuted: { text: '✗ overruled', className: 'bg-red-800/10 text-red-800' },
+  unverifiable: { text: '? unverifiable', className: 'bg-neutral-900/5 text-neutral-600' },
+}
+
+/** The model chip's display text: strip the gateway vendor prefix. */
+function modelShortName(model: string): string {
+  return model.split('/').pop() ?? model
+}
+
+/** `YYYY-MM-DD` from an ISO timestamp, for the report's EVAL line. */
+function evalDay(iso: string): string {
+  return iso.slice(0, 10)
+}
+
+/** A dashed ink divider between report sections. */
+function ReportRule() {
+  return <hr className="border-t border-dashed border-neutral-900/20" />
+}
+
+/** A report section's letterpress heading. */
+function ReportHeading({ children }: { children: string }) {
+  return (
+    <span className="font-mono text-[0.625rem] font-bold uppercase tracking-[0.2em] text-neutral-700">
+      {children}
+    </span>
+  )
 }
 
 /**
- * A single panelist's card: scores on each axis, the gaps they found (claim →
- * what the artifact shows, with a citation), and the one uncomfortable truth.
+ * A single scout's report, styled as a printed document filed against the
+ * dark arena: header block (prospect / scout / eval), GRADES, CONCERNS
+ * (claim vs. film), and the BOTTOM LINE.
  *
- * This is the "independent deliberation" surface — each card stands alone, never
- * referencing the others, because the panel judges independently (no debate).
+ * This is the "independent deliberation" surface — each report stands alone,
+ * never referencing the others, because the panel judges independently (no
+ * debate).
  *
- * In live mode the fact-checker's rulings rain onto the finished card as each
- * gap is re-checked: overruled claims get struck through, not deleted — the
- * catch is the feature.
+ * In live mode the fact-checker's rulings are annotated onto the filed report
+ * as each gap is re-checked: overruled claims get struck through, not
+ * removed — the catch is the feature.
  */
-export function PersonaVerdictCard({ verdict, gapRulings }: PersonaVerdictCardProps) {
+export function PersonaVerdictCard({
+  verdict,
+  gapRulings,
+  prospect,
+  model,
+  evalStamp,
+  evalDate,
+}: PersonaVerdictCardProps) {
+  const stamp = evalStamp ? EVAL_STAMPS[evalStamp] : undefined
   return (
-    <article className="flex h-full flex-col gap-4 rounded-2xl border border-white/10 bg-neutral-800 p-5 shadow-md">
-      <header>
-        <h3 className="font-sans text-lg font-bold text-white">{verdict.label}</h3>
+    <article className="flex h-full flex-col gap-4 rounded-md border border-neutral-900/20 bg-[#f5f0e4] p-5 text-neutral-900 shadow-[0_12px_32px_rgba(0,0,0,0.45)]">
+      <header className="flex flex-col gap-2">
+        <div className="flex items-start justify-between gap-2">
+          <ReportHeading>Scouting report</ReportHeading>
+          {stamp ? (
+            <span
+              className={`-rotate-3 rounded border-2 px-1.5 py-0.5 font-mono text-[0.5625rem] font-bold uppercase tracking-[0.18em] ${stamp.className}`}
+            >
+              {stamp.text}
+            </span>
+          ) : null}
+        </div>
+        <dl className="flex flex-col gap-0.5 font-mono text-xs text-neutral-700">
+          {prospect ? (
+            <div className="flex gap-2">
+              <dt className="uppercase tracking-[0.12em] text-neutral-500">Prospect</dt>
+              <dd className="font-bold text-neutral-900">{prospect}</dd>
+            </div>
+          ) : null}
+          <div className="flex gap-2">
+            <dt className="uppercase tracking-[0.12em] text-neutral-500">Scout</dt>
+            <dd>
+              <h3 className="inline font-mono text-xs font-bold text-neutral-900">
+                {verdict.label}
+              </h3>
+            </dd>
+          </div>
+          {evalDate ? (
+            <div className="flex gap-2">
+              <dt className="uppercase tracking-[0.12em] text-neutral-500">Eval</dt>
+              <dd>{evalDay(evalDate)}</dd>
+            </div>
+          ) : null}
+        </dl>
+        {model ? (
+          <span className="w-fit rounded-sm bg-neutral-900/10 px-1.5 py-0.5 font-mono text-[0.625rem] text-neutral-700">
+            {modelShortName(model)}
+          </span>
+        ) : null}
       </header>
 
-      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-        {verdict.scores.map(s => (
-          <ScoreMeter key={s.axisId} axisId={s.axisId} score={s.score} rationale={s.rationale} />
-        ))}
-      </div>
+      <ReportRule />
 
       <div className="flex flex-col gap-3">
-        <span className="font-mono text-[0.625rem] uppercase tracking-[0.16em] text-orange-300/80">
-          Gaps (claim vs. artifact)
-        </span>
+        <ReportHeading>Grades</ReportHeading>
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          {verdict.scores.map(s => (
+            <ScoreMeter key={s.axisId} axisId={s.axisId} score={s.score} rationale={s.rationale} />
+          ))}
+        </div>
+      </div>
+
+      <ReportRule />
+
+      <div className="flex flex-col gap-3">
+        <ReportHeading>Concerns (claim vs. film)</ReportHeading>
         <ul className="flex flex-col gap-3">
           {verdict.gaps.map((gap, i) => {
             const ruling = gapRulings?.[i]
             return (
-              <li key={i} className="border-l-2 border-orange-500/40 pl-3">
+              <li key={i} className="border-l-2 border-orange-700/50 pl-3">
                 <p
-                  className={`text-sm font-medium text-neutral-200${
-                    ruling === 'refuted' ? ' line-through decoration-yellow-400/60' : ''
+                  className={`text-sm font-medium text-neutral-900${
+                    ruling === 'refuted' ? ' line-through decoration-red-800/60' : ''
                   }`}
                 >
                   {gap.claim}
                 </p>
-                <p className="mt-0.5 text-sm text-neutral-400">{gap.artifactShows}</p>
+                <p className="mt-0.5 text-sm text-neutral-600">{gap.artifactShows}</p>
                 <span className="mt-1 flex flex-wrap items-center gap-1.5">
-                  <code className="inline-block rounded bg-orange-500/10 px-1.5 py-0.5 font-mono text-[0.6875rem] text-orange-300">
+                  <code className="inline-block rounded-sm bg-neutral-900/10 px-1.5 py-0.5 font-mono text-[0.6875rem] text-neutral-800">
                     {gap.citation}
                   </code>
                   {ruling ? (
                     <span
-                      className={`rounded-full px-2 py-0.5 font-mono text-[0.625rem] ${RULING_BADGES[ruling].className}`}
+                      className={`rounded-sm px-1.5 py-0.5 font-mono text-[0.625rem] font-bold uppercase tracking-[0.08em] ${RULING_BADGES[ruling].className}`}
                     >
                       {RULING_BADGES[ruling].text}
                     </span>
@@ -79,18 +172,20 @@ export function PersonaVerdictCard({ verdict, gapRulings }: PersonaVerdictCardPr
         </ul>
       </div>
 
-      <div className="mt-auto rounded-lg bg-black/30 p-3">
-        <span className="font-mono text-[0.625rem] uppercase tracking-[0.16em] text-neutral-500">
-          Uncomfortable truth
-        </span>
-        <p className="mt-1 text-sm italic leading-snug text-neutral-300">
+      <ReportRule />
+
+      <div className="mt-auto flex flex-col gap-2">
+        <ReportHeading>Bottom line</ReportHeading>
+        <p className="border-l-2 border-red-800/40 pl-3 text-sm font-medium italic leading-snug text-neutral-800">
           {verdict.uncomfortableTruth}
         </p>
       </div>
 
       {verdict.standoutObservation ? (
-        <p className="text-xs leading-snug text-neutral-500">
-          <span className="text-orange-300">Standout — </span>
+        <p className="text-xs leading-snug text-neutral-600">
+          <span className="font-mono font-bold uppercase tracking-[0.08em] text-orange-700">
+            Standout —{' '}
+          </span>
           {verdict.standoutObservation}
         </p>
       ) : null}

--- a/components/draft-room/ScoreMeter.tsx
+++ b/components/draft-room/ScoreMeter.tsx
@@ -11,27 +11,33 @@ interface ScoreMeterProps {
 }
 
 /**
- * A labeled 0–10 score bar in the brand's spotlight orange. Presentational only.
- * The fill width encodes the score; the numeric value is shown for exactness and
- * is the accessible source of truth (the bar is `aria-hidden`).
+ * A labeled 0–10 grade bar, styled as a line item in the GRADES block of a
+ * printed scouting report (ink on paper — this renders inside the paper-toned
+ * {@link PersonaVerdictCard}). Presentational only. The fill width encodes
+ * the score; the numeric value is shown for exactness and is the accessible
+ * source of truth (the bar is `aria-hidden`).
  */
 export function ScoreMeter({ axisId, score, rationale }: ScoreMeterProps) {
   const pct = Math.max(0, Math.min(10, score)) * 10
   return (
     <div>
       <div className="flex items-baseline justify-between gap-2">
-        <span className="font-mono text-[0.625rem] uppercase tracking-[0.16em] text-orange-300/80">
+        <span className="font-mono text-[0.625rem] uppercase tracking-[0.16em] text-neutral-600">
           {axisLabel(axisId)}
         </span>
-        <span className="font-sans text-sm font-bold tabular-nums text-orange-400">{score}/10</span>
+        <span className="font-mono text-sm font-bold tabular-nums text-neutral-900">
+          {score}/10
+        </span>
       </div>
       <div
-        className="mt-1 h-1.5 w-full overflow-hidden rounded-full bg-white/10"
+        className="mt-1 h-1.5 w-full overflow-hidden rounded-sm bg-neutral-900/10"
         aria-hidden="true"
       >
-        <div className="h-full rounded-full bg-orange-500" style={{ width: `${pct}%` }} />
+        <div className="h-full bg-orange-600" style={{ width: `${pct}%` }} />
       </div>
-      {rationale ? <p className="mt-1 text-xs leading-snug text-neutral-400">{rationale}</p> : null}
+      {rationale ? (
+        <p className="mt-1 text-xs leading-snug text-neutral-600">{rationale}</p>
+      ) : null}
     </div>
   )
 }

--- a/components/draft-room/SynthesisPanel.tsx
+++ b/components/draft-room/SynthesisPanel.tsx
@@ -48,9 +48,11 @@ export function SynthesisPanel({ synthesis }: SynthesisPanelProps) {
 
       {synthesis.caughtErrors.length > 0 ? (
         <section className="rounded-2xl border border-yellow-400/30 bg-neutral-800 p-5">
-          <h3 className="font-sans text-lg font-bold text-yellow-300">⚠️ Overruled panel claims</h3>
+          <h3 className="font-sans text-lg font-bold text-yellow-300">
+            ⚠️ Overruled scouting claims
+          </h3>
           <p className="mt-1 text-xs text-neutral-400">
-            The fact-checker re-checked every grounded claim against the code and threw these out —
+            The fact-checker re-checked every grounded claim against the film and threw these out —
             confident-sounding, but wrong.
           </p>
           <ul className="mt-3 flex flex-col gap-3">
@@ -65,10 +67,10 @@ export function SynthesisPanel({ synthesis }: SynthesisPanelProps) {
       ) : null}
 
       <section className="rounded-2xl border border-orange-500/40 bg-gradient-to-b from-neutral-800 to-neutral-900 p-6">
-        <span className="font-mono text-[0.625rem] uppercase tracking-[0.16em] text-orange-300">
-          The verdict
+        <span className="inline-block -rotate-1 rounded border-2 border-orange-500/60 px-2 py-0.5 font-mono text-[0.625rem] font-bold uppercase tracking-[0.2em] text-orange-300">
+          Front office verdict
         </span>
-        <p className="mt-2 text-base leading-relaxed text-neutral-100">{synthesis.verdict}</p>
+        <p className="mt-3 text-base leading-relaxed text-neutral-100">{synthesis.verdict}</p>
       </section>
     </div>
   )

--- a/components/draft-room/axes.ts
+++ b/components/draft-room/axes.ts
@@ -14,3 +14,11 @@ export const AXIS_LABEL: Record<string, string> = {
 export function axisLabel(axisId: string): string {
   return AXIS_LABEL[axisId] ?? axisId
 }
+
+/**
+ * Display name for a target id on the report's PROSPECT line (`courtfolio` →
+ * `Courtfolio`). Presentation only — ids stay slugs everywhere else.
+ */
+export function prospectLabel(targetId: string): string {
+  return targetId.charAt(0).toUpperCase() + targetId.slice(1)
+}

--- a/components/draft-room/draft-room.test.tsx
+++ b/components/draft-room/draft-room.test.tsx
@@ -99,7 +99,7 @@ describe('SynthesisPanel', () => {
     render(<SynthesisPanel synthesis={synthesis} />)
     expect(screen.getByText('buries its best signal')).toBeInTheDocument()
     expect(screen.getByText('lead with the sprint race')).toBeInTheDocument()
-    const caught = screen.getByText(/Overruled panel claims/).closest('section')
+    const caught = screen.getByText(/Overruled scouting claims/).closest('section')
     expect(caught).not.toBeNull()
     expect(within(caught as HTMLElement).getByText(/the morph does not exist/)).toBeInTheDocument()
     expect(screen.getByText(/the front door hides/)).toBeInTheDocument()
@@ -107,6 +107,6 @@ describe('SynthesisPanel', () => {
 
   it('hides the overruled-claims section when nothing was refuted', () => {
     render(<SynthesisPanel synthesis={{ ...synthesis, caughtErrors: [] }} />)
-    expect(screen.queryByText(/Overruled panel claims/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/Overruled scouting claims/)).not.toBeInTheDocument()
   })
 })

--- a/e2e/draft-room-enabled.spec.ts
+++ b/e2e/draft-room-enabled.spec.ts
@@ -32,8 +32,8 @@ test.describe('draft room showcase', () => {
   })
 
   test('shows the verifier’s overruled claims and the final verdict', async ({ page }) => {
-    await expect(page.getByRole('heading', { name: /overruled panel claims/i })).toBeVisible()
-    await expect(page.getByText('The verdict')).toBeVisible()
+    await expect(page.getByRole('heading', { name: /overruled scouting claims/i })).toBeVisible()
+    await expect(page.getByText(/front office verdict/i)).toBeVisible()
   })
 
   test('explains why the panel does not debate', async ({ page }) => {

--- a/e2e/draft-room-live.spec.ts
+++ b/e2e/draft-room-live.spec.ts
@@ -52,9 +52,9 @@ test.describe('draft room live mode (stubbed stream)', () => {
     // The synthesis arrives last: map, overruled claims, verdict.
     await expect(page.getByRole('heading', { name: /where they split/i })).toBeVisible(streamed)
     await expect(
-      page.getByRole('heading', { name: /overruled panel claims/i })
+      page.getByRole('heading', { name: /overruled scouting claims/i })
     ).toBeVisible(streamed)
-    await expect(page.getByText('The verdict')).toBeVisible(streamed)
+    await expect(page.getByText(/front office verdict/i)).toBeVisible(streamed)
 
     // Terminal state: the button unlocks for another run.
     await expect(page.getByRole('button', { name: /run it live/i })).toBeEnabled(streamed)

--- a/lib/draft-room/live-target.test.ts
+++ b/lib/draft-room/live-target.test.ts
@@ -3,7 +3,7 @@
 import { describe, expect, it } from 'vitest'
 
 import { courtfolioPanelResult } from '@/app/draft-room/panelResult'
-import { portfolioConfig } from '@/lib/panel/config'
+import { DRAFT_ROOM_PERSONAS } from '@/lib/panel/personas'
 
 import { PANEL_STAGE_LIMITS } from './limits'
 import {
@@ -44,13 +44,9 @@ describe('livePanelConfig', () => {
     expect(livePanelConfig.limits).toBe(PANEL_STAGE_LIMITS)
   })
 
-  it('runs the portfolio persona set (live runs stay comparable with the shipped replay)', () => {
-    expect(livePanelConfig.personas).toBe(portfolioConfig.personas)
-    expect(livePanelConfig.personas.map(p => p.id)).toEqual([
-      'hiring-manager',
-      'staff-mentor',
-      'skeptical-peer',
-    ])
+  it('runs the draft-room persona set — the front office judges live runs (#302)', () => {
+    expect(livePanelConfig.personas).toBe(DRAFT_ROOM_PERSONAS)
+    expect(livePanelConfig.personas.map(p => p.id)).toEqual(['gm', 'scout', 'coach'])
   })
 })
 

--- a/lib/draft-room/live-target.ts
+++ b/lib/draft-room/live-target.ts
@@ -14,6 +14,7 @@
 import { z } from 'zod'
 
 import { portfolioConfig } from '@/lib/panel/config'
+import { DRAFT_ROOM_PERSONAS } from '@/lib/panel/personas'
 import type { EvidenceContext, PanelConfig, Thesis } from '@/lib/panel/types'
 import bakedCourtfolio from '@/lib/panel/evidence/baked/courtfolio.json'
 
@@ -52,12 +53,15 @@ export const COURTFOLIO_THESIS: Thesis = {
 
 /**
  * The run config for live panels: the validated portfolio set plus the #241
- * per-stage output-token ceilings. Swapping to the draft-room persona skin
- * (GM / scout / coach) is a one-field change here, deferred so live runs stay
- * comparable with the shipped replay.
+ * per-stage output-token ceilings — and the draft-room persona skin (#302):
+ * live runs are judged by the GM / Film-Room Scout / Head Coach, the theme's
+ * front office. The stored replay stays portfolio-voiced until a real run
+ * replaces it (the #301 editorial step), so the two persona sets coexist
+ * until then.
  */
 export const livePanelConfig: PanelConfig = {
   ...portfolioConfig,
+  personas: DRAFT_ROOM_PERSONAS,
   limits: PANEL_STAGE_LIMITS,
 }
 


### PR DESCRIPTION
## Summary

The Draft Room's content *is* a scouting report — now the page reads like one. Each persona card becomes a **paper-toned printed report** filed against the dark arena backdrop (mock approved in-session), and live runs are judged by the **GM / Film-Room Scout / Head Coach** front office (#241's deferred scope line).

## The report card

- Header block: `PROSPECT: Courtfolio` / `SCOUT: <persona>` / `EVAL: <date>` + a rotated corner stamp for provenance — `LIVE EVAL` (red ink), `RECENT EVAL — REPLAYED`, `STORED EVAL`
- `GRADES` — axis scores as ink-on-paper fill bars
- `CONCERNS (CLAIM VS. FILM)` — the gaps, with the fact-checker's rulings annotated per-gap as they land live (`✓ UPHELD` / `✗ OVERRULED` struck through, kept visible / `? UNVERIFIABLE`)
- `BOTTOM LINE` + `STANDOUT`
- Streaming states keep the frame: pending = blank form filling in (model chip = the vendor visibly deliberating), benched = `DID NOT REPORT` stamp

War room / front office stay dark-arena (the paper reports carry the visual hierarchy): *"The war room — converge vs. split"*, *"Overruled scouting claims"*, and a rotated `FRONT OFFICE VERDICT` stamp.

## Personas

`livePanelConfig` switches to `DRAFT_ROOM_PERSONAS`. The stored replay stays portfolio-voiced until a real run replaces it (#301 editorial step); the stub derives its roster maps from the personas the stored result was actually judged by, so replayed model chips stay truthful.

## Honesty constraints held

Stamps and grades render only real model output — no derived draft grades the panel didn't produce. Ink tones on paper hold ≥4.5:1 contrast. No new deps; CSS-only stamps and pulses.

## Test plan

- [x] Unit: 1290 pass (updated assertions for renamed sections + persona swap)
- [x] e2e: 37/37 (draft-room specs updated for the renamed headings)
- [x] `tsc --noEmit` clean, lint 0 errors
- [x] Visual verification: replay, mid-stream (LIVE EVAL stamps + skeletons), settled cards with rulings, and front-office verdict all captured against the stubbed stream

Closes #302. Refs #241, #300, #301.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added scouting report details, including prospect, scout, evaluation status, date, and model information.
  * Introduced updated verdict, pending, and benched report layouts with evaluation stamps.
  * Live draft rooms now use the draft-room scouting panel configuration.

* **Style**
  * Refreshed headings, labels, badges, score meters, and synthesis panels with a printed scouting-report visual style.
  * Clarified language for scouting claims and front office conclusions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->