### PR TITLE
chore(lint): burn down ESLint backlog and restore rules to error (#292)

### DIFF
--- a/app/api/admin/cardio/trends/route.test.ts
+++ b/app/api/admin/cardio/trends/route.test.ts
@@ -1,3 +1,4 @@
+import type { NextRequest } from 'next/server'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { POST } from './route'
@@ -40,7 +41,7 @@ describe('POST /api/admin/cardio/trends', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ date: '2026-07-01', metric: 'body_mass', value: 233.8 }),
     })
-    const res = await POST(req as any)
+    const res = await POST(req as NextRequest)
     expect(res.status).toBe(401)
     expect(await res.json()).toEqual({ error: 'Unauthorized.' })
   })
@@ -55,7 +56,7 @@ describe('POST /api/admin/cardio/trends', () => {
       },
       body: JSON.stringify({ date: '2026-07-01', metric: 'body_mass', value: 233.8 }),
     })
-    const res = await POST(req as any)
+    const res = await POST(req as NextRequest)
     expect(res.status).toBe(401)
   })
 
@@ -69,7 +70,7 @@ describe('POST /api/admin/cardio/trends', () => {
       },
       body: 'not valid json {',
     })
-    const res = await POST(req as any)
+    const res = await POST(req as NextRequest)
     expect(res.status).toBe(400)
     expect(await res.json()).toEqual({ error: 'Body must be valid JSON.' })
   })
@@ -84,7 +85,7 @@ describe('POST /api/admin/cardio/trends', () => {
       },
       body: JSON.stringify({ date: '2026-7-1', metric: 'body_mass', value: 233.8 }),
     })
-    const res = await POST(req as any)
+    const res = await POST(req as NextRequest)
     expect(res.status).toBe(400)
     const body = await res.json()
     expect(body.error).toBe('Validation failed.')
@@ -100,7 +101,7 @@ describe('POST /api/admin/cardio/trends', () => {
       },
       body: JSON.stringify({ date: '2026-07-01', metric: 'unknown_metric', value: 233.8 }),
     })
-    const res = await POST(req as any)
+    const res = await POST(req as NextRequest)
     expect(res.status).toBe(400)
     const body = await res.json()
     expect(body.error).toBe('Validation failed.')
@@ -116,7 +117,7 @@ describe('POST /api/admin/cardio/trends', () => {
       },
       body: JSON.stringify({ date: '2026-07-01', metric: 'body_mass', value: -100 }),
     })
-    const res = await POST(req as any)
+    const res = await POST(req as NextRequest)
     expect(res.status).toBe(400)
   })
 
@@ -130,7 +131,7 @@ describe('POST /api/admin/cardio/trends', () => {
       },
       body: JSON.stringify({ date: '2026-07-01', metric: 'body_mass', value: 0 }),
     })
-    const res = await POST(req as any)
+    const res = await POST(req as NextRequest)
     expect(res.status).toBe(400)
     expect((await res.json()).error).toBe('Validation failed.')
   })
@@ -145,7 +146,7 @@ describe('POST /api/admin/cardio/trends', () => {
       },
       body: JSON.stringify({ date: '2026-07-01', metric: 'steps', value: 0 }),
     })
-    const res = await POST(req as any)
+    const res = await POST(req as NextRequest)
     expect(res.status).toBe(200)
     expect(fromMock).toHaveBeenCalledWith('cardio_step_count_trend')
   })
@@ -160,7 +161,7 @@ describe('POST /api/admin/cardio/trends', () => {
       },
       body: JSON.stringify({ date: '2026-07-01', metric: 'body_mass', value: 233.8 }),
     })
-    const res = await POST(req as any)
+    const res = await POST(req as NextRequest)
     expect(res.status).toBe(200)
     expect(fromMock).toHaveBeenCalledWith('cardio_body_mass_trend')
     // Payload carries the value, an explicit updated_at stamp (the tables have
@@ -184,7 +185,7 @@ describe('POST /api/admin/cardio/trends', () => {
       },
       body: JSON.stringify({ date: '2026-07-02', metric: 'hrv', value: 45.2 }),
     })
-    const res = await POST(req as any)
+    const res = await POST(req as NextRequest)
     expect(res.status).toBe(200)
     expect(fromMock).toHaveBeenCalledWith('cardio_hrv_trend')
     expect(upsertMock).toHaveBeenCalledWith(
@@ -208,7 +209,7 @@ describe('POST /api/admin/cardio/trends', () => {
       },
       body: JSON.stringify({ date: '2026-07-01', metric: 'body_mass', value: 233.8 }),
     })
-    const res = await POST(req as any)
+    const res = await POST(req as NextRequest)
     expect(res.status).toBe(500)
     const body = await res.json()
     expect(body.error).toContain('Database error')
@@ -224,7 +225,7 @@ describe('POST /api/admin/cardio/trends', () => {
       },
       body: JSON.stringify({ date: '2026-07-01', metric: 'body_mass', value: 233.8 }),
     })
-    const res = await POST(req as any)
+    const res = await POST(req as NextRequest)
     expect(res.status).toBe(401)
   })
 })

--- a/app/api/health/auto-sync/route.test.ts
+++ b/app/api/health/auto-sync/route.test.ts
@@ -1,3 +1,4 @@
+import type { NextRequest } from 'next/server'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { POST } from './route'
@@ -35,40 +36,44 @@ afterEach(() => {
   vi.unstubAllEnvs()
 })
 
-/** Build a POST request with the given JSON body and (optional) key header. */
-function makeRequest(body: unknown, key: string | null = 'valid-key'): Request {
+/**
+ * Build a POST request with the given JSON body and (optional) key header.
+ * Down-cast to `NextRequest` (which extends `Request`) so it drops straight into
+ * the route handler's signature — the handler only touches `Request` members.
+ */
+function makeRequest(body: unknown, key: string | null = 'valid-key'): NextRequest {
   const headers: Record<string, string> = { 'Content-Type': 'application/json' }
   if (key !== null) headers['X-Health-Sync-Key'] = key
   return new Request('http://localhost:3000/api/health/auto-sync', {
     method: 'POST',
     headers,
     body: typeof body === 'string' ? body : JSON.stringify(body),
-  })
+  }) as NextRequest
 }
 
 describe('POST /api/health/auto-sync', () => {
   it('returns 401 when the API key is missing', async () => {
     vi.stubEnv('HEALTH_AUTO_SYNC_API_KEY', 'valid-key')
-    const res = await POST(makeRequest({ data: [] }, null) as any)
+    const res = await POST(makeRequest({ data: [] }, null))
     expect(res.status).toBe(401)
   })
 
   it('returns 401 when the API key is wrong', async () => {
     vi.stubEnv('HEALTH_AUTO_SYNC_API_KEY', 'correct-key')
-    const res = await POST(makeRequest({ data: [] }, 'wrong-key') as any)
+    const res = await POST(makeRequest({ data: [] }, 'wrong-key'))
     expect(res.status).toBe(401)
   })
 
   it('returns 400 when the body is invalid JSON', async () => {
     vi.stubEnv('HEALTH_AUTO_SYNC_API_KEY', 'valid-key')
-    const res = await POST(makeRequest('not json {') as any)
+    const res = await POST(makeRequest('not json {'))
     expect(res.status).toBe(400)
     expect(await res.json()).toEqual({ error: 'Body must be valid JSON.' })
   })
 
   it('returns 400 when a date is malformed', async () => {
     vi.stubEnv('HEALTH_AUTO_SYNC_API_KEY', 'valid-key')
-    const res = await POST(makeRequest({ data: [{ date: '2026-7-1', steps: 100 }] }) as any)
+    const res = await POST(makeRequest({ data: [{ date: '2026-7-1', steps: 100 }] }))
     expect(res.status).toBe(400)
     expect((await res.json()).error).toBe('Validation failed.')
   })
@@ -88,8 +93,7 @@ describe('POST /api/health/auto-sync', () => {
             body_mass_lbs: 233.8,
           },
         ],
-      }) as any
-    )
+      })    )
     expect(res.status).toBe(200)
     const tables = upsertMock.mock.calls.map((c) => c[0])
     expect(tables).toEqual([
@@ -126,8 +130,7 @@ describe('POST /api/health/auto-sync', () => {
     const res = await POST(
       makeRequest({
         data: [{ date: '2026-07-01', steps: 9000, hrv_ms: null }],
-      }) as any
-    )
+      })    )
     expect(res.status).toBe(200)
     // Only the steps table was touched — null hrv and absent fields skipped.
     expect(upsertMock.mock.calls.map((c) => c[0])).toEqual(['cardio_step_count_trend'])
@@ -140,8 +143,7 @@ describe('POST /api/health/auto-sync', () => {
     const res = await POST(
       makeRequest({
         data: [{ date: '2026-07-01', steps: 9000, body_mass_lbs: 240 }],
-      }) as any
-    )
+      })    )
     expect(res.status).toBe(200)
     // steps still written; body_mass skipped because the day is manual.
     expect(upsertMock.mock.calls.map((c) => c[0])).toEqual(['cardio_step_count_trend'])
@@ -151,7 +153,7 @@ describe('POST /api/health/auto-sync', () => {
   it('returns 500 when a metric upsert fails', async () => {
     vi.stubEnv('HEALTH_AUTO_SYNC_API_KEY', 'valid-key')
     upsertMock.mockResolvedValueOnce({ error: { message: 'statement timeout' } })
-    const res = await POST(makeRequest({ data: [{ date: '2026-07-01', steps: 9000 }] }) as any)
+    const res = await POST(makeRequest({ data: [{ date: '2026-07-01', steps: 9000 }] }))
     expect(res.status).toBe(500)
     expect((await res.json()).details[0]).toContain('statement timeout')
   })

--- a/app/api/panel/run/route.test.ts
+++ b/app/api/panel/run/route.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import type { NextRequest } from 'next/server'
 import type {
   MetaSynthesis,
   PanelResult,
@@ -38,6 +39,7 @@ const { POST, maxDuration } = await import('./route')
 const { PanelDegradedError } = await import('@/lib/panel')
 
 /** One parsed NDJSON frame; loose-typed so tests can reach into any variant. */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- test-only wire frame: NDJSON events are a heterogeneous union and assertions reach into variant-specific fields without narrowing
 type WireEvent = { type: string } & Record<string, any>
 
 /** Build a POST request to the route. Same-origin by default (host set, no origin). */
@@ -127,7 +129,7 @@ describe('POST /api/panel/run', () => {
 
   it('returns 404 when the live-panel flag is off, before any metering', async () => {
     vi.stubEnv('NEXT_PUBLIC_ENABLE_PANEL_LIVE', '')
-    const res = await POST(postRun({ targetId: 'courtfolio' }) as any)
+    const res = await POST(postRun({ targetId: 'courtfolio' }) as NextRequest)
     expect(res.status).toBe(404)
     expect(await res.json()).toEqual({ error: 'Not found.' })
     expect(hashClientIpMock).not.toHaveBeenCalled()
@@ -137,7 +139,7 @@ describe('POST /api/panel/run', () => {
   describe('origin guard', () => {
     it('returns 403 on a cross-origin POST', async () => {
       const res = await POST(
-        postRun({ targetId: 'courtfolio' }, { origin: 'https://evil.example' }) as any
+        postRun({ targetId: 'courtfolio' }, { origin: 'https://evil.example' }) as NextRequest
       )
       expect(res.status).toBe(403)
       expect(await res.json()).toEqual({ error: 'Cross-origin requests are not allowed.' })
@@ -145,14 +147,14 @@ describe('POST /api/panel/run', () => {
     })
 
     it('returns 403 on a malformed Origin header', async () => {
-      const res = await POST(postRun({ targetId: 'courtfolio' }, { origin: 'not a url' }) as any)
+      const res = await POST(postRun({ targetId: 'courtfolio' }, { origin: 'not a url' }) as NextRequest)
       expect(res.status).toBe(403)
       expect(admitLiveRunMock).not.toHaveBeenCalled()
     })
 
     it('proceeds when the Origin matches the host', async () => {
       const res = await POST(
-        postRun({ targetId: 'courtfolio' }, { origin: 'http://localhost:3000' }) as any
+        postRun({ targetId: 'courtfolio' }, { origin: 'http://localhost:3000' }) as NextRequest
       )
       expect(res.status).toBe(200)
       await res.text()
@@ -160,7 +162,7 @@ describe('POST /api/panel/run', () => {
     })
 
     it('proceeds when no Origin header is present', async () => {
-      const res = await POST(postRun({ targetId: 'courtfolio' }) as any)
+      const res = await POST(postRun({ targetId: 'courtfolio' }) as NextRequest)
       expect(res.status).toBe(200)
       await res.text()
       expect(admitLiveRunMock).toHaveBeenCalled()
@@ -169,14 +171,14 @@ describe('POST /api/panel/run', () => {
 
   describe('body validation', () => {
     it('returns 400 when the body is not valid JSON', async () => {
-      const res = await POST(postRun('not valid json {') as any)
+      const res = await POST(postRun('not valid json {') as NextRequest)
       expect(res.status).toBe(400)
       expect(await res.json()).toEqual({ error: 'Body must be valid JSON.' })
       expect(admitLiveRunMock).not.toHaveBeenCalled()
     })
 
     it('returns 400 with issues when targetId is missing', async () => {
-      const res = await POST(postRun({}) as any)
+      const res = await POST(postRun({}) as NextRequest)
       expect(res.status).toBe(400)
       const body = await res.json()
       expect(body.error).toBe('Validation failed.')
@@ -185,7 +187,7 @@ describe('POST /api/panel/run', () => {
     })
 
     it('returns 400 for a targetId not in the registry', async () => {
-      const res = await POST(postRun({ targetId: 'nope' }) as any)
+      const res = await POST(postRun({ targetId: 'nope' }) as NextRequest)
       expect(res.status).toBe(400)
       expect(await res.json()).toEqual({ error: 'Unknown target: nope' })
       expect(admitLiveRunMock).not.toHaveBeenCalled()
@@ -195,7 +197,7 @@ describe('POST /api/panel/run', () => {
   describe('stub seam', () => {
     it('streams the stub replay without metering when PANEL_LIVE_STUB=1 outside production', async () => {
       vi.stubEnv('PANEL_LIVE_STUB', '1')
-      const res = await POST(postRun({ targetId: 'courtfolio' }) as any)
+      const res = await POST(postRun({ targetId: 'courtfolio' }) as NextRequest)
       expect(res.status).toBe(200)
       expect(res.headers.get('content-type')).toBe('application/x-ndjson; charset=utf-8')
 
@@ -224,7 +226,7 @@ describe('POST /api/panel/run', () => {
     it('returns 503 when the IP salt is unavailable (hashClientIp → null)', async () => {
       hashClientIpMock.mockReturnValue(null)
       const res = await POST(
-        postRun({ targetId: 'courtfolio' }, { 'x-forwarded-for': '1.2.3.4, 5.6.7.8' }) as any
+        postRun({ targetId: 'courtfolio' }, { 'x-forwarded-for': '1.2.3.4, 5.6.7.8' }) as NextRequest
       )
       expect(res.status).toBe(503)
       expect(await res.json()).toEqual({ error: 'Live runs are unavailable.' })
@@ -234,7 +236,7 @@ describe('POST /api/panel/run', () => {
     })
 
     it('meters as "unknown" when no x-forwarded-for header exists', async () => {
-      const res = await POST(postRun({ targetId: 'courtfolio' }) as any)
+      const res = await POST(postRun({ targetId: 'courtfolio' }) as NextRequest)
       expect(res.status).toBe(200)
       await res.text()
       expect(hashClientIpMock).toHaveBeenCalledWith('unknown')
@@ -244,7 +246,7 @@ describe('POST /api/panel/run', () => {
     it('returns 503 when the admission store throws', async () => {
       const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
       admitLiveRunMock.mockRejectedValue(new Error('supabase down'))
-      const res = await POST(postRun({ targetId: 'courtfolio' }) as any)
+      const res = await POST(postRun({ targetId: 'courtfolio' }) as NextRequest)
       expect(res.status).toBe(503)
       expect(await res.json()).toEqual({ error: 'Live runs are unavailable.' })
       expect(runPanelMock).not.toHaveBeenCalled()
@@ -256,7 +258,7 @@ describe('POST /api/panel/run', () => {
         kind: 'rejected',
         rejection: { kind: 'ip-limit', retryAfterSeconds: 3600 },
       })
-      const res = await POST(postRun({ targetId: 'courtfolio' }) as any)
+      const res = await POST(postRun({ targetId: 'courtfolio' }) as NextRequest)
       expect(res.status).toBe(429)
       expect(res.headers.get('retry-after')).toBe('3600')
       const body = await res.json()
@@ -273,7 +275,7 @@ describe('POST /api/panel/run', () => {
         kind: 'rejected',
         rejection: { kind: 'in-progress', retryAfterSeconds: 90 },
       })
-      const res = await POST(postRun({ targetId: 'courtfolio' }) as any)
+      const res = await POST(postRun({ targetId: 'courtfolio' }) as NextRequest)
       expect(res.status).toBe(429)
       expect(res.headers.get('retry-after')).toBe('90')
       const body = await res.json()
@@ -292,7 +294,7 @@ describe('POST /api/panel/run', () => {
         kind: 'cached',
         run: { id: 'run-7', result: fixtureResult, createdAt },
       })
-      const res = await POST(postRun({ targetId: 'courtfolio' }) as any)
+      const res = await POST(postRun({ targetId: 'courtfolio' }) as NextRequest)
       expect(res.status).toBe(200)
       expect(res.headers.get('content-type')).toBe('application/x-ndjson; charset=utf-8')
 
@@ -318,7 +320,7 @@ describe('POST /api/panel/run', () => {
         return fixtureResult
       })
 
-      const res = await POST(postRun({ targetId: 'courtfolio' }) as any)
+      const res = await POST(postRun({ targetId: 'courtfolio' }) as NextRequest)
       expect(res.status).toBe(200)
       expect(res.headers.get('content-type')).toBe('application/x-ndjson; charset=utf-8')
 
@@ -373,7 +375,7 @@ describe('POST /api/panel/run', () => {
       }
       runPanelMock.mockResolvedValue(degraded)
 
-      const res = await POST(postRun({ targetId: 'courtfolio' }) as any)
+      const res = await POST(postRun({ targetId: 'courtfolio' }) as NextRequest)
       await res.text()
       expect(markCompletedMock).toHaveBeenCalledWith('run-42', degraded, 1)
     })
@@ -388,7 +390,7 @@ describe('POST /api/panel/run', () => {
       }
       runPanelMock.mockResolvedValue(verifierDegraded)
 
-      const res = await POST(postRun({ targetId: 'courtfolio' }) as any)
+      const res = await POST(postRun({ targetId: 'courtfolio' }) as NextRequest)
       await res.text()
       // 1 benched persona + 1 verifier-failed ruling = degradation count 2.
       expect(markCompletedMock).toHaveBeenCalledWith('run-42', verifierDegraded, 2)
@@ -397,7 +399,7 @@ describe('POST /api/panel/run', () => {
     it('records a client abort as AbortError (exempt from the failure cooldown)', async () => {
       runPanelMock.mockRejectedValue(new DOMException('Client disconnected.', 'AbortError'))
 
-      const res = await POST(postRun({ targetId: 'courtfolio' }) as any)
+      const res = await POST(postRun({ targetId: 'courtfolio' }) as NextRequest)
       const events = await readEvents(res)
 
       const runError = events.find(e => e.type === 'run-error')
@@ -409,7 +411,7 @@ describe('POST /api/panel/run', () => {
     it('ends with run-error stage personas and records the failure when the engine rejects early', async () => {
       runPanelMock.mockRejectedValue(new Error('boom'))
 
-      const res = await POST(postRun({ targetId: 'courtfolio' }) as any)
+      const res = await POST(postRun({ targetId: 'courtfolio' }) as NextRequest)
       expect(res.status).toBe(200)
 
       const events = await readEvents(res)
@@ -434,7 +436,7 @@ describe('POST /api/panel/run', () => {
         throw new Error('boom')
       })
 
-      const res = await POST(postRun({ targetId: 'courtfolio' }) as any)
+      const res = await POST(postRun({ targetId: 'courtfolio' }) as NextRequest)
       const events = await readEvents(res)
 
       // The verify-start frame itself was forwarded before the failure.
@@ -459,7 +461,7 @@ describe('POST /api/panel/run', () => {
         )
       )
 
-      const res = await POST(postRun({ targetId: 'courtfolio' }) as any)
+      const res = await POST(postRun({ targetId: 'courtfolio' }) as NextRequest)
       const events = await readEvents(res)
       expect(events[events.length - 1]).toEqual({
         type: 'run-error',

--- a/app/locker-room/page.tsx
+++ b/app/locker-room/page.tsx
@@ -5,7 +5,6 @@ import { LockerRoomSvg } from '@/components/locker-room/LockerRoomSvg'
 import { DadJerseySVG } from '@/components/locker-room/assets/DadJerseySvg'
 import { LockerZone } from '@/components/locker-room/LockerZone'
 import { LockerPlacardSVG } from '@/components/locker-room/LockerPlacardSvg'
-import { InteractiveLockerItem } from '@/components/locker-room/InteractiveLockerItem'
 import { ZoeSvg } from '@/components/locker-room/assets/Zoe'
 import { BasketballSvg } from '@/components/locker-room/assets/basketballSvg'
 import { Melo2sSvg } from '@/components/locker-room/assets/Melo2s'
@@ -28,7 +27,6 @@ import { SnapGhost } from '@/components/locker-room/assets/SnapGhost'
 import { KindSmartCreativeBooks } from '@/components/locker-room/assets/KindSmartCreativeBooks'
 import { SnapchatShoes } from '@/components/locker-room/assets/SnapShoes'
 import { LockerZoneId } from '@/components/locker-room/types'
-import { isSafari } from '@/utils/isSafari'
 
 /**
  * Renders the Locker Room page of the basketball-themed portfolio.

--- a/components/common/LazyMount.tsx
+++ b/components/common/LazyMount.tsx
@@ -56,6 +56,7 @@ export function LazyMount({
     if (typeof IntersectionObserver === 'undefined') {
       // Old browsers without IO: fall back to immediate mount so the
       // content always renders; the perf optimization is best-effort.
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional one-shot fallback inside the IntersectionObserver setup effect
       setVisible(true)
       return
     }

--- a/components/common/MobileSwipeHint.tsx
+++ b/components/common/MobileSwipeHint.tsx
@@ -15,6 +15,7 @@ export const MobileSwipeHint: React.FC = () => {
     } catch {}
     const mql = window.matchMedia(MQL_QUERY)
     if (!mql.matches) return
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional client-only reveal: gated on localStorage + matchMedia, which must not run during SSR
     setVisible(true)
   }, [])
 

--- a/components/contact/FrontOfficeSvg.tsx
+++ b/components/contact/FrontOfficeSvg.tsx
@@ -2,11 +2,8 @@
 
 import React from 'react'
 
-import { useCallback } from 'react'
-
 type FrontOfficeSvgProps = {
-  onZoneClick?: (zoneId: string) => void
-  className?: string
+  /** Content injected per named zone, rendered as an SVG overlay group after the artwork. */
   zoneContent?: Record<string, React.ReactNode>
 }
 
@@ -14,19 +11,7 @@ type FrontOfficeSvgProps = {
  * Inline SVG of a basketball court with zone interactivity.
  * Allows content injection per zone via `zoneContent`.
  */
-export const FrontOfficeSvg: React.FC<FrontOfficeSvgProps> = ({
-  onZoneClick,
-  className,
-  zoneContent = {},
-}) => {
-  const handleClick = useCallback(
-    (zoneId: string) => {
-      if (onZoneClick) {
-        onZoneClick(zoneId)
-      }
-    },
-    [onZoneClick]
-  )
+export const FrontOfficeSvg: React.FC<FrontOfficeSvgProps> = ({ zoneContent = {} }) => {
   return (
     <svg
       viewBox="0 0 1536 1024"

--- a/components/contact/ZoneContactModern.tsx
+++ b/components/contact/ZoneContactModern.tsx
@@ -80,7 +80,7 @@ export function ZoneContactModern() {
           </div>
         </div>
         <div className="text-center text-[10px] text-gray-500 mt-10 italic">
-          "Plays drawn in code. Championships built in commits."
+          &ldquo;Plays drawn in code. Championships built in commits.&rdquo;
         </div>
       </SpringUp>
     </SafeSvgHtml>

--- a/components/contact/ZoneContactSafari.tsx
+++ b/components/contact/ZoneContactSafari.tsx
@@ -105,7 +105,7 @@ export function ZoneContactSafari() {
           marginTop: '0.75rem',
         }}
       >
-        "Plays drawn in code. Championships built in commits."
+        &ldquo;Plays drawn in code. Championships built in commits.&rdquo;
       </div>
     </SafeSvgHtml>
   )

--- a/components/court/CourtInteractionLayer.tsx
+++ b/components/court/CourtInteractionLayer.tsx
@@ -112,7 +112,7 @@ export function CourtInteractionLayer({
     return () => {
       svg.removeEventListener('pointerup', handlePointerUp)
     }
-  }, [handlePointerUp])
+  }, [handlePointerUp, svgRef])
 
   return null
 }

--- a/components/court/CourtSvg.tsx
+++ b/components/court/CourtSvg.tsx
@@ -53,7 +53,7 @@ export const CourtSvg = forwardRef<SVGSVGElement, CourtSvgProps>(
         ref={ref}
         xmlns="http://www.w3.org/2000/svg"
         preserveAspectRatio="xMidYMid meet"
-        className="w-full h-full touch-pan-x touch-pan-y touch-pinch-zoom"
+        className={`w-full h-full touch-pan-x touch-pan-y touch-pinch-zoom ${className}`.trim()}
       >
         <g strokeWidth="2.00" fill="none" strokeLinecap="butt">
           <g id="zone-0" onClick={() => console.log('Clicked zone 0')}>
@@ -2963,3 +2963,5 @@ export const CourtSvg = forwardRef<SVGSVGElement, CourtSvgProps>(
     )
   }
 )
+
+CourtSvg.displayName = 'CourtSvg'

--- a/components/court/CourtTutorialSprite.tsx
+++ b/components/court/CourtTutorialSprite.tsx
@@ -93,19 +93,21 @@ export function CourtTutorialSprite({
     }
   }, [stepData.x, stepData.y, svgRef, scale, x, y, onPositionChange, svgSize])
 
-  // Flip logic
+  // Flip logic — face the direction the sprite is stepping toward, or an
+  // explicit per-step override. Reacts to tutorial-step position changes, so it
+  // has to live in an effect and set state from the new step.
   useEffect(() => {
+    let nextFacingLeft: boolean | null = null
     if (typeof stepData.facingLeft === 'boolean') {
-      setFacingLeft(stepData.facingLeft)
-    } else {
-      if (stepData.x < prevX.current) {
-        setFacingLeft(true)
-      } else if (stepData.x > prevX.current) {
-        setFacingLeft(false)
-      }
+      nextFacingLeft = stepData.facingLeft
+    } else if (stepData.x < prevX.current) {
+      nextFacingLeft = true
+    } else if (stepData.x > prevX.current) {
+      nextFacingLeft = false
     }
+    if (nextFacingLeft !== null) setFacingLeft(nextFacingLeft)
     prevX.current = stepData.x
-  }, [stepData.x, stepData.y])
+  }, [stepData.x, stepData.y, stepData.facingLeft])
 
   return (
     <m.div
@@ -115,6 +117,7 @@ export function CourtTutorialSprite({
       animate={{ opacity: 1 }}
       transition={{ duration: 0.3 }}
     >
+      {/* eslint-disable-next-line @next/next/no-img-element -- animated tutorial sprite: src swaps per step and flips via scaleX; next/image's optimizer/loader is the wrong tool for a tiny local sprite */}
       <img
         src={stepData.img}
         alt="Sprite"

--- a/components/court/FreeRoamPlayer.tsx
+++ b/components/court/FreeRoamPlayer.tsx
@@ -44,7 +44,9 @@ export function FreeRoamPlayer({
   // Refs for input state (no re-renders needed)
   const keysRef = useRef(new Set<string>())
   const clickTargetRef = useRef<{ x: number; y: number } | null>(null)
-  const lastMoveTimeRef = useRef(performance.now())
+  // Seeded to 0 and set to the real clock when the game loop starts (see
+  // `start()`); `performance.now()` is impure and must not run during render.
+  const lastMoveTimeRef = useRef(0)
   const walkFrameTimeRef = useRef(0)
   const gameLoopRef = useRef(0)
   const shootPoseTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -248,6 +250,9 @@ export function FreeRoamPlayer({
       // Reset the clock so the first frame after a pause produces a small dt
       // instead of "time since the loop last ran".
       prevTime = performance.now()
+      // Seed the idle baseline here (not during render) so the shooting-pose
+      // timer measures from when the loop actually starts.
+      lastMoveTimeRef.current = performance.now()
       gameLoopRef.current = requestAnimationFrame(tick)
     }
 
@@ -331,6 +336,7 @@ export function FreeRoamPlayer({
           marginTop: -PLAYER_SIZE / 2,
         }}
       >
+        {/* eslint-disable-next-line @next/next/no-img-element -- walk-cycle game sprite: currentSprite swaps every animation frame; next/image's optimizer/loader is the wrong tool for a tiny local sprite */}
         <img
           src={currentSprite}
           alt=""

--- a/components/court/MobileAdvanceOverlay.tsx
+++ b/components/court/MobileAdvanceOverlay.tsx
@@ -1,22 +1,11 @@
 'use client'
 
-import { useCallback } from 'react'
-
 type Props = {
   active: boolean
   onAdvance: () => void
 }
 
 export function MobileAdvanceOverlay({ active, onAdvance }: Props) {
-  const handlePointerUp = useCallback(
-    (e: React.PointerEvent<HTMLDivElement>) => {
-      if (e.pointerType === 'touch' && e.isPrimary) {
-        onAdvance()
-      }
-    },
-    [onAdvance]
-  )
-
   if (!active) return null
 
   return (

--- a/components/court/TutorialOverlay.tsx
+++ b/components/court/TutorialOverlay.tsx
@@ -91,7 +91,12 @@ export function TutorialOverlay({ active, stepData, glow, svgRef, onPositionChan
 
     const padding = typeof stepData.paddingFactor === 'number' ? stepData.paddingFactor : 1.1
 
+    // Reading svgRef during render is intentional: glow bounds are measured off
+    // the live SVG, and this memo recomputes exactly when it matters — on step /
+    // active / glow changes, by which point the SVG element is mounted.
+    // eslint-disable-next-line react-hooks/refs -- intentional measurement read; see comment above
     if (stepData.targetId && svgRef.current) {
+      // eslint-disable-next-line react-hooks/refs -- intentional measurement read; see comment above
       return getGlowBoundsFromTarget(stepData.targetId, svgRef.current, padding)
     }
 

--- a/components/draft-room/draft-room.test.tsx
+++ b/components/draft-room/draft-room.test.tsx
@@ -37,7 +37,7 @@ describe('PersonaVerdictCard', () => {
   })
 
   it('omits the standout line when none is present', () => {
-    const { standoutObservation, ...rest } = verdict
+    const { standoutObservation: _standoutObservation, ...rest } = verdict
     render(<PersonaVerdictCard verdict={rest} />)
     expect(screen.queryByText(/Standout/)).not.toBeInTheDocument()
   })

--- a/components/locker-room/InteractiveLockerItem.tsx
+++ b/components/locker-room/InteractiveLockerItem.tsx
@@ -1,5 +1,4 @@
 import { m, useAnimation } from 'framer-motion'
-import { useEffect } from 'react'
 
 /**
  * Wraps any locker item with subtle swing animation on hover (desktop) or tap (mobile).

--- a/components/locker-room/LockerRoomSvg.tsx
+++ b/components/locker-room/LockerRoomSvg.tsx
@@ -31,7 +31,7 @@ export const LockerRoomSvg: React.FC<LockerRoomSvgProps> = ({
       viewBox="0 0 1536 1024"
       xmlns="http://www.w3.org/2000/svg"
       preserveAspectRatio="xMidYMid meet"
-      className="w-full h-full max-w-none touch-pan-x touch-pan-y touch-pinch-zoom"
+      className={`w-full h-full max-w-none touch-pan-x touch-pan-y touch-pinch-zoom ${className ?? ''}`.trim()}
     >
       <g fill="none" strokeLinecap="butt" strokeWidth="2.00">
         <g id="grouped-lockers">

--- a/components/project-binder/ProjectDetail.tsx
+++ b/components/project-binder/ProjectDetail.tsx
@@ -81,6 +81,10 @@ export const ProjectDetail = ({ project, onClose, returnFocusTo }: ProjectDetail
     return () => {
       document.removeEventListener('keydown', onKey)
       document.body.style.overflow = previousOverflow
+      // Read returnFocusTo.current at cleanup (close) time on purpose: focus
+      // returns to wherever the trigger ref points when the panel actually
+      // closes, not to whatever it was when the panel opened.
+      // eslint-disable-next-line react-hooks/exhaustive-deps -- intentional cleanup-time ref read; see comment above
       ;(returnFocusTo?.current ?? fallbackTrigger)?.focus?.()
     }
   }, [onClose, returnFocusTo])

--- a/components/training-facility/combine/CombineEntryForm.tsx
+++ b/components/training-facility/combine/CombineEntryForm.tsx
@@ -253,6 +253,10 @@ function CombineEntryFormImpl({
   // recreate the just-deleted benchmark. We gate the cleanup on
   // `wasEditingRef` so the initial mount (when both `editingEntry`
   // and the ref are falsy) doesn't clobber the today-date effect.
+  // Syncs the form panel (open/error/saved state + react-hook-form reset) to the
+  // incoming editingEntry prop — an intentional prop->state sync, gated on
+  // wasEditingRef so the initial mount doesn't clobber the today-date effect.
+  /* eslint-disable react-hooks/set-state-in-effect -- intentional prop->state sync; see comment above */
   useEffect(() => {
     if (editingEntry) {
       reset(toFormValues(editingEntry))
@@ -268,6 +272,7 @@ function CombineEntryFormImpl({
       wasEditingRef.current = false
     }
   }, [editingEntry, reset])
+  /* eslint-enable react-hooks/set-state-in-effect */
 
   function handleCancelEdit(): void {
     setIsOpen(false)

--- a/components/training-facility/combine/ShuttleTrace.tsx
+++ b/components/training-facility/combine/ShuttleTrace.tsx
@@ -612,6 +612,11 @@ interface UseShuttleElapsedArgs {
 function useShuttleElapsed({ maxSeconds, replayKey, reducedMotion }: UseShuttleElapsedArgs): number {
   const [elapsed, setElapsed] = useState(0)
 
+  // Drives the elapsed-time clock via requestAnimationFrame. The synchronous
+  // setElapsed calls seed the animation (snap-to-finish for reduced motion, or
+  // reset to 0 before the rAF loop); the per-frame updates run in the rAF
+  // callback, not the effect body.
+  /* eslint-disable react-hooks/set-state-in-effect -- intentional animation seed; see comment above */
   useEffect(() => {
     if (reducedMotion || maxSeconds <= 0) {
       setElapsed(maxSeconds)
@@ -637,6 +642,7 @@ function useShuttleElapsed({ maxSeconds, replayKey, reducedMotion }: UseShuttleE
       cancelAnimationFrame(raf)
     }
   }, [maxSeconds, replayKey, reducedMotion])
+  /* eslint-enable react-hooks/set-state-in-effect */
 
   return elapsed
 }

--- a/components/training-facility/combine/SprintRace.tsx
+++ b/components/training-facility/combine/SprintRace.tsx
@@ -213,6 +213,7 @@ export function SprintRace({ entries }: SprintRaceProps): JSX.Element | null {
   // post-effect state — and reduced-motion's snap-to-finish behaviour
   // takes effect immediately instead of after a flash.
   const effectiveEnabled =
+    // eslint-disable-next-line react-hooks/refs -- intentional first-paint read (see comment above): treats "nothing seen yet" as "all visible" so the initial frame matches the post-effect state
     enabled.size === 0 && knownDatesRef.current.size === 0
       ? new Set(runs.map((r) => r.date))
       : enabled
@@ -566,6 +567,11 @@ function useSprintElapsed({ runs, replayKey, reducedMotion }: UseSprintElapsedAr
     [runs],
   )
 
+  // Drives the elapsed-time clock via requestAnimationFrame. The synchronous
+  // setElapsed calls seed the animation (snap-to-finish for reduced motion, or
+  // reset to 0 before the rAF loop); the per-frame updates run in the rAF
+  // callback, not the effect body.
+  /* eslint-disable react-hooks/set-state-in-effect -- intentional animation seed; see comment above */
   useEffect(() => {
     if (reducedMotion || maxSeconds <= 0) {
       setElapsed(maxSeconds)
@@ -591,6 +597,7 @@ function useSprintElapsed({ runs, replayKey, reducedMotion }: UseSprintElapsedAr
       cancelAnimationFrame(raf)
     }
   }, [maxSeconds, runsKey, replayKey, reducedMotion])
+  /* eslint-enable react-hooks/set-state-in-effect */
 
   return elapsed
 }

--- a/components/training-facility/gym/MaxHrControl.tsx
+++ b/components/training-facility/gym/MaxHrControl.tsx
@@ -43,6 +43,7 @@ export function MaxHrControl({ onChange }: MaxHrControlProps): JSX.Element {
   }, [maxHr, onChange])
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional: reflect the async-loaded maxHr into the draft field, but not mid-edit
     if (!editing) setDraft(String(maxHr))
   }, [maxHr, editing])
 

--- a/components/training-facility/gym/OtfDetailView.tsx
+++ b/components/training-facility/gym/OtfDetailView.tsx
@@ -5,7 +5,6 @@ import { Fragment, useCallback, useEffect, useMemo, useRef, useState, type JSX }
 
 import { BackToCourtButton } from '@/components/common/BackToCourtButton'
 import { RoughLine } from '@/components/training-facility/shared/charts/RoughLine'
-import { chartPalette } from '@/components/training-facility/shared/charts/palette'
 import { defaultMargin } from '@/components/training-facility/shared/charts/types'
 import {
   DateFilter,
@@ -140,6 +139,7 @@ export function OtfDetailView(): JSX.Element {
   // narrowed past it) so a later widen doesn't silently resurrect the filter.
   // `effectiveClassType` already prevents a stale-render flicker meanwhile.
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional cleanup: drop a stored class-type filter once it leaves the available window
     if (classType && !availableClassTypes.includes(classType)) setClassType(null)
   }, [classType, availableClassTypes])
 

--- a/components/training-facility/gym/SessionRowExpansion.tsx
+++ b/components/training-facility/gym/SessionRowExpansion.tsx
@@ -166,6 +166,7 @@ export function ExpandedHrZoneRow({
   const [mounted, setMounted] = useState(false)
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional post-hydration mount flag (defers client-only measurement to avoid an SSR mismatch)
     setMounted(true)
   }, [])
 

--- a/components/training-facility/scenes/assets/SceneDoor.tsx
+++ b/components/training-facility/scenes/assets/SceneDoor.tsx
@@ -42,8 +42,6 @@ const FRAME_WIDTH = 200
 const FRAME_HEIGHT = 440
 /** Inset between outer frame and inner door panel. */
 const INSET_X = 16
-/** Vertical inset to the inner door panel. */
-const INSET_TOP = 20
 /** Inset between inner panel and recessed sub-panels. */
 const PANEL_INSET = 36
 

--- a/components/training-facility/scenes/assets/ShuttleCones.tsx
+++ b/components/training-facility/scenes/assets/ShuttleCones.tsx
@@ -2,7 +2,6 @@ import { HANDWRITING_FONT, SCENE_PALETTE } from '../scene-primitives'
 import {
   RoughEllipse,
   RoughLineShape,
-  RoughPath,
   RoughPolygon,
   RoughRect,
 } from './rough-shapes'

--- a/components/training-facility/scenes/assets/combine-fixtures.tsx
+++ b/components/training-facility/scenes/assets/combine-fixtures.tsx
@@ -1,7 +1,6 @@
 import { HANDWRITING_FONT, SCENE_PALETTE } from '../scene-primitives'
 import {
   RoughCircle,
-  RoughEllipse,
   RoughLineShape,
   RoughPath,
   RoughRect,

--- a/components/training-facility/scenes/assets/weight-room-fixtures.tsx
+++ b/components/training-facility/scenes/assets/weight-room-fixtures.tsx
@@ -63,6 +63,7 @@ export function WallActivityRings({
   // and the rings re-render with today's correct totals + streaks.
   const [now, setNow] = useState<Date | null>(null)
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional: the viewer's clock must be read post-mount (see comment above) to keep SSR and first client render identical
     setNow(new Date())
   }, [])
 

--- a/components/training-facility/shared/charts/BodyweightOverlay.tsx
+++ b/components/training-facility/shared/charts/BodyweightOverlay.tsx
@@ -120,6 +120,7 @@ export function BodyweightOverlay({
   // SSR/client rough.js generator divergence this avoids.
   const [hydrated, setHydrated] = useState(false)
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional post-hydration flag: defers the rough.js overlay layer to avoid an SSR/client generator divergence
     setHydrated(true)
   }, [])
 

--- a/components/training-facility/weight-room/QuickLog.tsx
+++ b/components/training-facility/weight-room/QuickLog.tsx
@@ -210,6 +210,7 @@ function QuickLogRow({
   // is open so the user's in-progress edits don't get yanked out from
   // under them mid-type.
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional re-seed on lastReps change (row stays mounted across logs); skipped while the form is open
     if (!customOpen) setCustomValue(String(seedCustom))
   }, [seedCustom, customOpen])
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,11 +10,13 @@ import nextTypeScript from 'eslint-config-next/typescript'
  * rules) and `typescript` (typescript-eslint) — then globally ignores build
  * output, coverage, and tooling directories.
  *
- * Two deliberate deviations from the presets are documented inline below:
+ * One deliberate deviation from the presets is documented inline below:
  *  - `settings.react.version` is pinned to work around an ESLint 10 crash in the
- *    preset's bundled `eslint-plugin-react`.
- *  - a batch of rules is temporarily lowered to `warn` so the migration lands on
- *    a passing baseline; burn-down + restoration is tracked in #292.
+ *    preset's bundled `eslint-plugin-react`. This is an upstream blocker, so the
+ *    pin stays until `eslint-config-next` supports ESLint 10 (#292).
+ *
+ * The migration's temporary `warn` downgrades have been burned down and every
+ * rule is restored to `error` (#292).
  */
 const eslintConfig = [
   ...nextCoreWebVitals,
@@ -23,8 +25,9 @@ const eslintConfig = [
   // caps at `eslint ^9.7`. ESLint 10 removed the deprecated `context.getFilename()`
   // that the plugin's React-version auto-detection calls, so linting crashes with
   // "context.getFilename is not a function". Pinning the version here skips that
-  // auto-detection codepath. Remove once the preset officially supports ESLint 10
-  // (tracked in #292).
+  // auto-detection codepath. Remove once eslint-config-next (and its bundled
+  // eslint-plugin-react) officially support ESLint 10 — an upstream blocker
+  // intentionally left in place; see #292 for context.
   { settings: { react: { version: '19' } } },
   {
     ignores: [
@@ -36,22 +39,41 @@ const eslintConfig = [
     ],
   },
   {
-    // Running `eslint .` across the whole repo for the first time (the removed
-    // `next lint` only scanned a subset and hadn't been run recently) surfaced a
-    // pre-existing backlog plus newer react-hooks rules. These are lowered from
-    // `error` to `warn` so the migration ships on a green baseline without hiding
-    // anything — every violation still prints. Burn the backlog down and restore
-    // each rule to `error` per #292.
+    // Honor the leading-underscore convention for intentionally-unused bindings:
+    // destructuring-omit idioms (`const { key: _omit, ...rest } = obj`), unused
+    // callback params kept for signature shape (`(_req, _ctx) => ...`), and
+    // caught errors that are deliberately swallowed. The Next preset's
+    // `no-unused-vars` doesn't set these patterns, so `_`-prefixed names were
+    // being flagged despite the convention.
     rules: {
-      '@typescript-eslint/no-explicit-any': 'warn',
-      'react/no-unescaped-entities': 'warn',
-      'react/display-name': 'warn',
-      'prefer-const': 'warn',
-      'react-hooks/set-state-in-effect': 'warn',
-      'react-hooks/refs': 'warn',
-      'react-hooks/purity': 'warn',
-      'react-hooks/immutability': 'warn',
-      'react-hooks/preserve-manual-memoization': 'warn',
+      '@typescript-eslint/no-unused-vars': [
+        'warn',
+        {
+          argsIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_',
+          destructuredArrayIgnorePattern: '^_',
+        },
+      ],
+    },
+  },
+  {
+    // These rules were temporarily lowered to `warn` when `eslint .` first ran
+    // across the whole repo (#289) so the Next 16 migration could land on a green
+    // baseline. The backlog has since been burned down (#292), so each is
+    // restored to `error` and enforced. Kept explicit — rather than deleting the
+    // block to inherit preset defaults — so the enforcement intent is documented
+    // and survives future preset-default changes.
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'error',
+      'react/no-unescaped-entities': 'error',
+      'react/display-name': 'error',
+      'prefer-const': 'error',
+      'react-hooks/set-state-in-effect': 'error',
+      'react-hooks/refs': 'error',
+      'react-hooks/purity': 'error',
+      'react-hooks/immutability': 'error',
+      'react-hooks/preserve-manual-memoization': 'error',
     },
   },
 ]

--- a/lib/telemetry/with-telemetry.test.ts
+++ b/lib/telemetry/with-telemetry.test.ts
@@ -97,7 +97,6 @@ describe('withTelemetry', () => {
 
   it('labels non-Error throws with their typeof', async () => {
     const wrapped = withTelemetry('GET /resume', async () => {
-      // eslint-disable-next-line no-throw-literal
       throw 'string failure'
     })
 

--- a/lib/training-facility/hr-zone-comparison.ts
+++ b/lib/training-facility/hr-zone-comparison.ts
@@ -17,7 +17,7 @@
  */
 
 import { DEFAULT_MAX_HR, HR_ZONES, bpmRangeForZone } from '@/constants/hr-zones'
-import type { CardioSession, HrZone } from '@/types/cardio'
+import type { CardioSession } from '@/types/cardio'
 import type { OtfSession } from '@/types/otf'
 
 import { OTF_ZONES, bpmRangeForOtfZone } from './otf'

--- a/svgo.config.mjs
+++ b/svgo.config.mjs
@@ -31,7 +31,7 @@
  */
 
 /** @type {import('svgo').Config} */
-export default {
+const config = {
   // Re-run plugins until the output stabilizes — squeezes out the last
   // few percent on these many-path files at negligible build-time cost.
   multipass: true,
@@ -50,3 +50,5 @@ export default {
     },
   ],
 }
+
+export default config

--- a/utils/hooks/useElementRect.ts
+++ b/utils/hooks/useElementRect.ts
@@ -3,6 +3,11 @@ import { useEffect, useState } from 'react'
 export function useElementRect(targetId?: string) {
   const [rect, setRect] = useState<DOMRect | null>(null)
 
+  // Measures a DOM element by id and keeps the rect in sync with resize /
+  // orientation changes — a genuine "sync with an external system" effect. The
+  // synchronous setRect calls clear/seed the measurement on mount and when the
+  // target changes; there's no render-time source for a DOM rect.
+  /* eslint-disable react-hooks/set-state-in-effect -- intentional DOM-measurement sync; see comment above */
   useEffect(() => {
     if (!targetId) {
       setRect(null)
@@ -29,6 +34,7 @@ export function useElementRect(targetId?: string) {
       window.removeEventListener('orientationchange', update)
     }
   }, [targetId])
+  /* eslint-enable react-hooks/set-state-in-effect */
 
   return rect
 }

--- a/utils/hooks/useElementSize.ts
+++ b/utils/hooks/useElementSize.ts
@@ -8,7 +8,7 @@ export function useElementSize<T extends Element>(ref: RefObject<T | null>) {
     if (!el) return
 
     const observer = new ResizeObserver(entries => {
-      for (let entry of entries) {
+      for (const entry of entries) {
         setSize({
           width: entry.contentRect.width,
           height: entry.contentRect.height,

--- a/utils/hooks/useIsMobile.ts
+++ b/utils/hooks/useIsMobile.ts
@@ -1,34 +1,40 @@
-import { useEffect, useState } from 'react'
+import { useSyncExternalStore } from 'react'
 
 const MOBILE_QUERY = '(max-width: 900px), (pointer: coarse)'
 
-const evaluateIsMobile = () => {
-  if (typeof window === 'undefined' || typeof window.matchMedia === 'undefined') return false
+/**
+ * Subscribe to changes in the mobile media query.
+ *
+ * @param callback - invoked whenever the match state flips
+ * @returns an unsubscribe function; a no-op when `matchMedia` is unavailable (SSR)
+ */
+function subscribe(callback: () => void): () => void {
+  if (typeof window === 'undefined' || typeof window.matchMedia === 'undefined') {
+    return () => {}
+  }
+  const mql = window.matchMedia(MOBILE_QUERY)
+  if (mql.addEventListener) {
+    mql.addEventListener('change', callback)
+    return () => mql.removeEventListener('change', callback)
+  }
+  // Legacy Safari (<14) fallback — `addEventListener` on MediaQueryList is unsupported there.
+  mql.addListener(callback)
+  return () => mql.removeListener(callback)
+}
+
+/** Client snapshot: true when the viewport/device matches the mobile query. */
+function getSnapshot(): boolean {
   return window.matchMedia(MOBILE_QUERY).matches
+}
+
+/** Server snapshot: assume desktop during SSR, since no viewport is available. */
+function getServerSnapshot(): boolean {
+  return false
 }
 
 /**
  * Returns true if the viewport/device is mobile based on media queries (width/pointer), not UA sniffing.
  */
 export function useIsMobile(): boolean {
-  const [isMobile, setIsMobile] = useState<boolean>(() => evaluateIsMobile())
-
-  useEffect(() => {
-    if (typeof window === 'undefined' || typeof window.matchMedia === 'undefined') return
-    const mql = window.matchMedia(MOBILE_QUERY)
-    const handleChange = (event: MediaQueryListEvent) => setIsMobile(event.matches)
-
-    setIsMobile(mql.matches)
-    mql.addEventListener
-      ? mql.addEventListener('change', handleChange)
-      : mql.addListener(handleChange)
-
-    return () => {
-      mql.removeEventListener
-        ? mql.removeEventListener('change', handleChange)
-        : mql.removeListener(handleChange)
-    }
-  }, [])
-
-  return isMobile
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
 }

--- a/utils/hooks/useTourState.ts
+++ b/utils/hooks/useTourState.ts
@@ -18,6 +18,13 @@ export function useTourState({ hasSeen, markAsSeen }: Props) {
     setTourStep(0)
   }, [])
 
+  // Stop tour and mark as seen. Declared before `nextStep` so the latter can
+  // depend on a stable, already-initialized reference.
+  const stopTour = useCallback(() => {
+    setTourActive(false)
+    markAsSeen()
+  }, [markAsSeen])
+
   // Go to next step
   const nextStep = useCallback(() => {
     if (tourStep < tourSteps.length - 1) {
@@ -25,17 +32,15 @@ export function useTourState({ hasSeen, markAsSeen }: Props) {
     } else {
       stopTour()
     }
-  }, [tourStep])
+  }, [tourStep, stopTour])
 
-  // Stop tour and mark as seen
-  const stopTour = useCallback(() => {
-    setTourActive(false)
-    markAsSeen()
-  }, [markAsSeen])
-
-  // Auto-start if user has not seen yet
+  // Auto-start once the persisted "has seen" flag resolves to `false`. This
+  // reacts to an async localStorage read (hasSeen: null -> false), so it can't
+  // be derived during render or seeded as initial state without reintroducing
+  // an SSR/hydration mismatch.
   useEffect(() => {
     if (hasSeen === false) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional: reacts to an async-loaded persisted flag; see comment above
       startTour()
     }
   }, [hasSeen, startTour])

--- a/utils/hooks/useZoneContent.tsx
+++ b/utils/hooks/useZoneContent.tsx
@@ -9,7 +9,6 @@ import { CourtTitleSolo } from '@/components/court/CourtTitleSolo'
 import { CourtZone } from '@/components/court/CourtZone'
 import { ZoneBioCard } from '@/components/court/zones/ZoneBioCard'
 import { ZoneCareerStats } from '@/components/court/zones/ZoneCareerStats'
-import { ZoneProjects } from '@/components/court/zones/ZoneProjects'
 import { ZoneEntryButton } from '@/components/common/ZoneEntryButton'
 import { TrainingFacilityCourtEntry } from '@/components/training-facility/TrainingFacilityCourtEntry'
 import { isTrainingFacilityEnabled } from '@/lib/feature-flags'
@@ -30,7 +29,6 @@ type UseZoneContentProps = {
 
 export function useZoneContent({
   tourActive,
-  tourStep,
   isMobile,
   hasSeen,
   markAsSeen,

--- a/utils/useHasSeenIntro.ts
+++ b/utils/useHasSeenIntro.ts
@@ -4,6 +4,10 @@ export function useHasSeenIntro() {
   const [ready, setReady] = useState(false)
   const [showIntro, setShowIntro] = useState(false)
 
+  // Intentional client-only localStorage read on mount: both state values stay
+  // false during SSR and the first client render, then resolve post-hydration,
+  // so there's no server/client mismatch.
+  /* eslint-disable react-hooks/set-state-in-effect -- intentional post-hydration localStorage read; see comment above */
   useEffect(() => {
     try {
       const hasSeen = localStorage.getItem('hasSeenIntro')
@@ -19,6 +23,7 @@ export function useHasSeenIntro() {
       setReady(true)
     }
   }, [])
+  /* eslint-enable react-hooks/set-state-in-effect */
 
   return { ready, showIntro }
 }

--- a/utils/useHasSeenTour.ts
+++ b/utils/useHasSeenTour.ts
@@ -6,6 +6,7 @@ export function useHasSeenTour() {
 
   useEffect(() => {
     const seen = localStorage.getItem('hasSeenCourtTour')
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional client-only localStorage read; starts null so SSR and first client render agree
     setHasSeen(seen === 'true')
   }, [])
 

--- a/utils/useMaxHr.ts
+++ b/utils/useMaxHr.ts
@@ -90,6 +90,11 @@ export function useMaxHr(): UseMaxHrResult {
   const [ready, setReady] = useState(false)
   const [isUserSet, setIsUserSet] = useState(false)
 
+  // Intentional client-only localStorage read on mount. Per the hook's JSDoc,
+  // SSR/pre-hydration returns the default with ready=false; the real value is
+  // only applied after hydration, so seeding it as initial state would
+  // reintroduce a server/client mismatch.
+  /* eslint-disable react-hooks/set-state-in-effect -- intentional post-hydration localStorage read; see comment above */
   useEffect(() => {
     try {
       const raw = localStorage.getItem(MAX_HR_STORAGE_KEY)
@@ -105,6 +110,7 @@ export function useMaxHr(): UseMaxHrResult {
       setReady(true)
     }
   }, [])
+  /* eslint-enable react-hooks/set-state-in-effect */
 
   const setMaxHr = useCallback((value: number): boolean => {
     const parsed = parseMaxHr(value)


### PR DESCRIPTION
Burns the ESLint backlog from #289 down to **zero** and restores strictness. `eslint .` now reports **0 problems** with every migration-downgraded rule back at `error`.

## Part 1 — backlog burn-down + restore to `error`

The Next 16 migration (#289) shipped `eslint .` on a green baseline by lowering a batch of failing rules to `warn`. This clears every violation and flips those rules back to `error` in `eslint.config.mjs` so the backlog can't silently regrow.

**Approach — real fixes first, documented disables only where an effect legitimately sets state:**
- **Structural fixes** where the code is genuinely cleaner for it:
  - `useIsMobile` rewritten on `useSyncExternalStore` (SSR-safe, no hydration mismatch) — removes two `no-unused-expressions` and one `set-state-in-effect`.
  - `useTourState` — `stopTour` hoisted above `nextStep`, dependency arrays corrected (`immutability` + `preserve-manual-memoization` + `exhaustive-deps`).
  - `FreeRoamPlayer` — `performance.now()` moved out of `useRef` initialization into the effect (`purity`).
  - `CourtTutorialSprite` — flip logic consolidated to a single conditional `setFacingLeft`, `facingLeft` added to deps.
  - Dead code / unused imports / `prefer-const` / unescaped entities cleared outright.
- **Justified `eslint-disable`** (narrowly scoped, rationale inline) only for effects that legitimately set state: SSR-safe `localStorage` reads, subscription/measurement syncs, and animation loops. Block-form where an effect has multiple synchronous `setState`s (the rule reports only the first).
- **Route-handler tests** — `POST(req as any)` → `POST(req as NextRequest)` (valid down-cast since `NextRequest extends Request`), eliminating `no-explicit-any` without loosening types.

**Rules restored to `error`:** `@typescript-eslint/no-explicit-any`, `react/no-unescaped-entities`, `react/display-name`, `prefer-const`, and the five react-hooks rules (`set-state-in-effect`, `refs`, `purity`, `immutability`, `preserve-manual-memoization`).

Preset-default `warn` rules (`no-unused-vars`, `exhaustive-deps`, `no-img-element`, `no-unused-expressions`, `import/no-anonymous-default-export`) had their violations fixed but were **not** escalated — that matches the preset and wasn't in #289's downgrade set.

> Note: this branch rebased onto the newly-merged live-panel work (#300/#302), which added `app/api/panel/run/route.test.ts` while `no-explicit-any` was still `warn`. Those 23 casts are fixed here too, so the restore-to-`error` lands clean across the whole tree.

## Part 2 — ESLint 10 pin (intentionally deferred)

The `settings.react.version` pin stays. It's an **upstream blocker**, not something this repo resolves: `eslint@10` removed `context.getFilename()`, which crashes `eslint-config-next@16`'s bundled `eslint-plugin-react@7.37.5` (peer caps at `eslint ^9.7`). The pin skips the crashing React-version auto-detection. The inline comment now documents this as a standing workaround; a follow-up issue tracks removing it once the ecosystem supports ESLint 10.

## Test plan

CI gates (all green locally against the rebased tree):
- [ ] `npx eslint .` → **0 problems** (rules at `error`)
- [ ] `npx tsc --noEmit` → clean
- [ ] `npm test` → 1290 passing
- [ ] `npx next build` → compiles
- [ ] Playwright e2e → green (route smoke + training-facility/draft-room)

Manual spot-checks for the behavior-sensitive hook refactors (preview):
- [ ] **Court tour** — first visit auto-starts the tutorial; the sprite faces the direction it steps toward; Next/Prev work (`useTourState`, `CourtTutorialSprite`, `useHasSeenTour`).
- [ ] **Mobile detection** — resize across the breakpoint (or load on a phone width); responsive layouts switch, no hydration warning in console (`useIsMobile`).
- [ ] **Free-roam player** — the home-court player animates/moves smoothly (`FreeRoamPlayer`).
- [ ] **Combine sprint race** — first paint shows all past-self runs, reduced-motion snaps to finish (`SprintRace`).
- [ ] **Weight room / gym** — Max HR control, Quick Log, and session-row expansion persist and render (`useMaxHr`, `QuickLog`, `MaxHrControl`, `SessionRowExpansion`).
- [ ] **Contact** — the tunnel quote renders with proper curly quotes.

Closes #292.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile-device detection across browsers, including older Safari support.
  * Improved court interaction handling and tutorial character orientation.
  * Ensured tours stop correctly after the final step.
  * Improved timing for idle game poses when gameplay begins.
  * Preserved custom styling on court and locker-room visuals.

* **Style**
  * Updated quotation marks in contact-area messaging for improved typography.

* **Tests**
  * Strengthened route and component test reliability without changing expected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->