### PR TITLE
ci(lint): add ESLint gate to enforce restored error rules (#305)

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -1,0 +1,38 @@
+name: Lint
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  eslint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+        with:
+          # Read-only job — don't leave the GITHUB_TOKEN in .git/config.
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        # `eslint .` over the whole repo. #304 restored nine migration-era rules
+        # to `error` in eslint.config.mjs, but they were enforced only on
+        # developers' machines — this gate is what makes "restore to `error`"
+        # actually stick, so a future PR can't silently regrow the backlog.
+        # Runs the `lint` script (plain `eslint .`): it fails on `error`-level
+        # rules while tolerating the deliberate `no-unused-vars` `warn` that
+        # honors the leading-underscore convention.
+        run: npm run lint

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -6,6 +6,12 @@ on:
     branches:
       - main
 
+# Read-only on the repo (only `checkout` needs it); this job lints and reports
+# a status, never writing back to git. Least-privilege token, matching
+# otbeat-ingest.yml.
+permissions:
+  contents: read
+
 jobs:
   eslint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Adds a **Lint** CI workflow that runs `npm run lint` (`eslint .`) on pull requests and pushes to `main`, mirroring `typecheck.yml`.

This is part **(a)** of #305. #304 restored nine migration-era rules to `error` in `eslint.config.mjs`, but CI only ran typecheck / unit / playwright — so those `error` rules were enforced only on developers' machines. A future PR could reintroduce violations undetected and silently regrow the burned-down backlog. This gate is what makes "restore to `error`" actually stick.

The job runs the existing `lint` script (plain `eslint .`), which fails on `error`-level rules while tolerating the deliberate `@typescript-eslint/no-unused-vars` `warn` that honors the leading-underscore convention. `--max-warnings=0` was intentionally **not** added, to respect that `warn`.

### Scope note

Part **(b)** of #305 — dropping the `settings.react.version` pin in `eslint.config.mjs` — stays blocked on `eslint-config-next` supporting ESLint 10 (removing it now crashes linting: `context.getFilename is not a function`). This PR uses `Refs #305`, not `Closes`, so the issue stays open to track that upstream-watch item.

## Test plan

- [ ] CI shows a new **Lint** check on this PR alongside Typecheck / Unit / Playwright.
- [ ] The Lint check passes (baseline `main` is clean — verified locally with `npm run lint`, exit 0).
- [ ] Confirm the workflow triggers on `pull_request` and on `push` to `main` (see `.github/workflows/eslint.yml`).
- [ ] Sanity: intentionally introducing an `error`-level violation (e.g. a bare `any`) on a scratch branch would fail this check — the whole point of the gate.

Refs #305.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated lint checks for pull requests and updates to the main branch.
  * Configured consistent Node.js setup, dependency installation, caching, and lint execution in CI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->