### PR TITLE
ci(panel): gate baked evidence freshness + cover composite in dependabot (#311)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,9 +15,17 @@ updates:
           - minor
           - patch
 
-  # GitHub Actions used by the workflows in .github/workflows.
+  # GitHub Actions used by the workflows in .github/workflows AND by the
+  # composite action in .github/actions. Dependabot's github-actions ecosystem
+  # only scans `.github/workflows` for a bare `directory: /`; action references
+  # inside a composite `action.yml` (e.g. actions/setup-node in
+  # .github/actions/node-setup) are NOT covered without an explicit directory
+  # (dependabot-core#6704). `directories` lists both so the composite's pinned
+  # actions keep getting bumps; the shared `groups` folds them into one PR.
   - package-ecosystem: github-actions
-    directory: /
+    directories:
+      - /
+      - /.github/actions/node-setup
     schedule:
       interval: weekly
     groups:

--- a/.github/workflows/panel-evidence.yml
+++ b/.github/workflows/panel-evidence.yml
@@ -1,0 +1,53 @@
+name: Panel evidence
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+# Read-only on the repo (only `checkout` needs it); this job re-bakes evidence
+# and reports whether the committed JSON is current, never writing back to git.
+permissions:
+  contents: read
+
+# Cancel a stale run when a newer commit is pushed to the same PR ref —
+# successive fixups shouldn't burn parallel runners when only the latest
+# matters. Gated to non-main refs so every commit on `main` keeps a completed
+# CI verdict (back-to-back merges must not cancel an earlier commit's run).
+concurrency:
+  group: panel-evidence-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  panel-evidence:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+        with:
+          # Read-only job — don't leave the GITHUB_TOKEN in .git/config.
+          persist-credentials: false
+
+      - name: Set up Node.js and install dependencies
+        uses: ./.github/actions/node-setup
+
+      - name: Verify baked panel evidence is current
+        # `panel:bake` is a pure file read (no secrets/network), so re-running it
+        # here and diffing is a cheap gate. The baked JSON under
+        # lib/panel/evidence/baked/ is what the Draft Room / live panel serves,
+        # and it mirrors real source files (see scripts/panel-projects.ts). Since
+        # baking is a manual step, source edits can silently stale it — this gate
+        # makes staleness a red check instead of a latent bug that only surfaces
+        # when the panel is enabled. The bake is deterministic (repo-relative
+        # paths, truncated file contents, no timestamps), so a clean tree here
+        # means the committed evidence matches HEAD's source.
+        run: |
+          npm run panel:bake
+          if ! git diff --quiet -- lib/panel/evidence/baked/; then
+            echo "::error::Baked panel evidence is out of date. Run 'npm run panel:bake' and commit the changes under lib/panel/evidence/baked/."
+            git --no-pager diff -- lib/panel/evidence/baked/
+            exit 1
+          fi

--- a/.github/workflows/panel-evidence.yml
+++ b/.github/workflows/panel-evidence.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Verify baked panel evidence is current
         # `panel:bake` is a pure file read (no secrets/network), so re-running it
-        # here and diffing is a cheap gate. The baked JSON under
+        # here and checking for changes is a cheap gate. The baked JSON under
         # lib/panel/evidence/baked/ is what the Draft Room / live panel serves,
         # and it mirrors real source files (see scripts/panel-projects.ts). Since
         # baking is a manual step, source edits can silently stale it — this gate
@@ -44,10 +44,19 @@ jobs:
         # when the panel is enabled. The bake is deterministic (repo-relative
         # paths, truncated file contents, no timestamps), so a clean tree here
         # means the committed evidence matches HEAD's source.
+        #
+        # Use `git status --porcelain`, not `git diff --quiet`: when a new
+        # PANEL_PROJECTS entry is added, baking emits a brand-new
+        # baked/<slug>.json that is *untracked*, and `git diff` ignores untracked
+        # files — so a bare diff check would pass green while the new evidence
+        # went uncommitted. Porcelain reports modified-tracked (` M`) and
+        # untracked (`??`) alike, so both forms of staleness fail the gate.
         run: |
           npm run panel:bake
-          if ! git diff --quiet -- lib/panel/evidence/baked/; then
+          changes="$(git status --porcelain -- lib/panel/evidence/baked/)"
+          if [ -n "$changes" ]; then
             echo "::error::Baked panel evidence is out of date. Run 'npm run panel:bake' and commit the changes under lib/panel/evidence/baked/."
+            echo "$changes"
             git --no-pager diff -- lib/panel/evidence/baked/
             exit 1
           fi


### PR DESCRIPTION
Closes #311.

Two related bits of CI hygiene for the panel-evidence pipeline, done together in one PR rather than split into follow-ups.

## What & why

### 1. `panel-evidence` freshness gate (`.github/workflows/panel-evidence.yml`)
Baking panel evidence is a **manual** step (`npm run panel:bake`). Any edit to a tracked source file (see `scripts/panel-projects.ts` for the watched paths — e.g. `.github/workflows/unit.yml`) silently stales `lib/panel/evidence/baked/courtfolio.json`, which is what the Draft Room / live panel actually serves. Today that only surfaces when the panel is enabled.

The new workflow re-bakes on every PR (and on push to `main`) and diffs the result; if the committed JSON is out of date it fails with an actionable `::error::` telling you to run `npm run panel:bake` and commit. It:
- **Dogfoods the shared composite** `./.github/actions/node-setup` (from #307/#310).
- Carries the same hardening as the other workflows: least-privilege `permissions: contents: read`, `persist-credentials: false`, and **main-safe concurrency** (`cancel-in-progress` gated to non-`main` refs so back-to-back merges don't cancel each other's runs).

**Determinism** — the gate is safe on the Linux runner: the baker emits repo-relative paths and truncated file contents with no timestamps, and the repo has no `.gitattributes` with `core.autocrlf=false`, so blobs are byte-identical cross-platform. Verified locally: a fresh `npm run panel:bake` on current `main` produces **zero diff**.

### 2. Dependabot coverage for the composite action (`.github/dependabot.yml`)
Dependabot's `github-actions` ecosystem only scans `.github/workflows` for a bare `directory: /` — action refs inside a composite `action.yml` (e.g. `actions/setup-node` in `.github/actions/node-setup`) get **no** update PRs (dependabot-core#6704). Switched to `directories: [/, /.github/actions/node-setup]` so the composite's pinned actions keep getting bumps; the shared `groups` still folds them into one weekly PR.

## Test plan
- [ ] CI: the new **Panel evidence** check runs and is green on this PR (proves the gate passes against in-sync evidence).
- [ ] Sanity: locally edit a watched source file (e.g. add a comment to `.github/workflows/unit.yml`), run `npm run panel:bake`, confirm `lib/panel/evidence/baked/courtfolio.json` changes — i.e. the gate *would* catch a real staleness. (Revert after.)
- [ ] Confirm all other checks (typecheck, unit, playwright, eslint, Vercel) stay green — the composite reference resolves for the new workflow the same way it does for the others.
- [ ] Dependabot: config validates (GitHub shows no parse error on `.github/dependabot.yml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)