### PR TITLE
feat(weight-room): tendon-load ramp-rate panel (#316)

### DIFF
--- a/app/training-facility/weight-room/history/page.tsx
+++ b/app/training-facility/weight-room/history/page.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link'
 import { notFound } from 'next/navigation'
 
 import { BackToCourtButton } from '@/components/common/BackToCourtButton'
+import { LoadManagementPanel } from '@/components/training-facility/weight-room/LoadManagementPanel'
 import { StrengthHeatmap } from '@/components/training-facility/weight-room/StrengthHeatmap'
 import { StrengthStats } from '@/components/training-facility/weight-room/StrengthStats'
 import { StrengthVsBodyweightChart } from '@/components/training-facility/weight-room/StrengthVsBodyweightChart'
@@ -12,6 +13,7 @@ import { WeightRoomSubNav } from '@/components/training-facility/weight-room/Wei
 import { getCardioDataServer } from '@/lib/data/cardio-server'
 import { getWeightRoomDataServer } from '@/lib/data/weight-room-server'
 import { isTrainingFacilityEnabled } from '@/lib/feature-flags'
+import { buildMovementLoads } from '@/lib/training-facility/load-management'
 import { computeStrengthStats } from '@/lib/training-facility/weight-room-history'
 import type { ExerciseGoal } from '@/types/weight-room'
 
@@ -48,6 +50,7 @@ export default async function WeightRoomHistoryPage(): Promise<JSX.Element> {
   const goals: readonly ExerciseGoal[] = data?.goals ?? []
   const sets = data?.sets ?? []
   const stats = computeStrengthStats(sets, goals)
+  const loads = buildMovementLoads(sets, goals)
   const bodyMass = cardio?.body_mass_trend ?? []
 
   // The relative-strength overlay is featured for pull-ups specifically —
@@ -108,6 +111,24 @@ export default async function WeightRoomHistoryPage(): Promise<JSX.Element> {
           </section>
         ) : (
           <>
+            <section className="mt-10">
+              <h2 className="font-mono text-[11px] uppercase tracking-[0.32em] text-amber-300/80">
+                Load Management
+              </h2>
+              <p className="mt-2 max-w-xl text-sm leading-7 text-[#e8d5be]">
+                Ramp rate per movement, bucketed in Pacific time. The injury driver for tendon is how
+                fast weekly volume climbs, not its absolute size &mdash; a{' '}
+                <abbr title="week-over-week">WoW</abbr> jump past +10% or an{' '}
+                <abbr title="acute:chronic workload ratio — acute 7-day volume over the 28-day weekly baseline">
+                  ACWR
+                </abbr>{' '}
+                over 1.3 flags for a closer look.
+              </p>
+              <div className="mt-4">
+                <LoadManagementPanel loads={loads} />
+              </div>
+            </section>
+
             <section
               aria-label="Per-exercise heatmaps"
               data-testid="weight-room-heatmaps"

--- a/components/training-facility/weight-room/LoadManagementPanel.test.tsx
+++ b/components/training-facility/weight-room/LoadManagementPanel.test.tsx
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest'
+import { render } from '@testing-library/react'
+
+import type { MovementLoad } from '@/lib/training-facility/load-management'
+
+import { LoadManagementPanel } from './LoadManagementPanel'
+
+/** 28 dummy sparkline points — the panel only reads `volume` for the trend. */
+const SPARKLINE: MovementLoad['sparkline'] = Array.from({ length: 28 }, (_, i) => ({
+  dayKey: `2026-06-${String((i % 28) + 1).padStart(2, '0')}`,
+  volume: i * 10,
+}))
+
+const PUSHUPS_LOAD: MovementLoad = {
+  movement: 'pushups',
+  color: '#EA580C',
+  metric: 'reps',
+  unitLabel: 'reps',
+  acute7d: 1240,
+  prior7d: 1088,
+  chronic28d: 4200,
+  chronicWeekly: 1050,
+  wowPct: 0.14,
+  acwr: 1.18,
+  flag: 'yellow',
+  wowFlag: 'yellow',
+  acwrFlag: 'green',
+  sparkline: SPARKLINE,
+}
+
+describe('LoadManagementPanel', () => {
+  it('renders the empty-state copy when loads is empty', () => {
+    const { getByTestId } = render(<LoadManagementPanel loads={[]} />)
+    expect(getByTestId('load-management-empty')).toBeInTheDocument()
+  })
+
+  it('renders one card per movement, tagged with its flag', () => {
+    const { getByTestId } = render(
+      <LoadManagementPanel
+        loads={[PUSHUPS_LOAD, { ...PUSHUPS_LOAD, movement: 'squats', flag: 'red' }]}
+      />,
+    )
+    expect(getByTestId('load-card-pushups')).toHaveAttribute('data-flag', 'yellow')
+    expect(getByTestId('load-card-squats')).toHaveAttribute('data-flag', 'red')
+  })
+
+  it('shows 7d volume, WoW %, and ACWR for a bodyweight movement', () => {
+    const { getByTestId } = render(<LoadManagementPanel loads={[PUSHUPS_LOAD]} />)
+    const card = getByTestId('load-card-pushups')
+    expect(card.textContent).toContain('1,240')
+    expect(card.textContent).toContain('7d rep volume')
+    expect(card.textContent).toContain('+14%')
+    expect(card.textContent).toContain('1.18')
+  })
+
+  it('labels loaded movements with load-volume and pounds', () => {
+    const { getByTestId } = render(
+      <LoadManagementPanel
+        loads={[{ ...PUSHUPS_LOAD, movement: 'shrugs', metric: 'load', unitLabel: 'lb' }]}
+      />,
+    )
+    const card = getByTestId('load-card-shrugs')
+    expect(card.textContent).toContain('7d load volume')
+    expect(card.textContent).toContain('lb')
+  })
+
+  it('renders an em-dash when WoW or ACWR is null', () => {
+    const { getByTestId } = render(
+      <LoadManagementPanel loads={[{ ...PUSHUPS_LOAD, wowPct: null, acwr: null }]} />,
+    )
+    expect(getByTestId('load-card-pushups').textContent).toContain('—')
+  })
+
+  it('surfaces the flag label for screen readers', () => {
+    const { getByTestId } = render(<LoadManagementPanel loads={[PUSHUPS_LOAD]} />)
+    const card = getByTestId('load-card-pushups')
+    expect(card).toHaveAttribute('aria-label', 'pushups: Caution')
+    expect(card.textContent).toContain('Caution')
+  })
+
+  it('uses the movement color on the heading', () => {
+    const { getByText } = render(<LoadManagementPanel loads={[PUSHUPS_LOAD]} />)
+    const heading = getByText('pushups')
+    const styleAttr = heading.getAttribute('style') ?? ''
+    expect(styleAttr).toMatch(/#EA580C|rgb\(\s*234,\s*88,\s*12\s*\)/i)
+  })
+})

--- a/components/training-facility/weight-room/LoadManagementPanel.tsx
+++ b/components/training-facility/weight-room/LoadManagementPanel.tsx
@@ -1,0 +1,171 @@
+import type { JSX } from 'react'
+
+import { RoughSparkline } from '@/components/training-facility/shared/charts/RoughSparkline'
+import { RAMP_FLAGS } from '@/constants/ramp-rate'
+import type { MovementLoad } from '@/lib/training-facility/load-management'
+
+/** Sparkline box size, in px. Fixed so every card's trend reads at the same scale. */
+const SPARK_WIDTH = 220
+const SPARK_HEIGHT = 44
+
+/** Props for {@link LoadManagementPanel}. */
+export interface LoadManagementPanelProps {
+  /**
+   * One pre-computed entry per actively-ramped movement — see
+   * {@link import('@/lib/training-facility/load-management').buildMovementLoads}.
+   * Empty array renders the empty-state message.
+   */
+  loads: readonly MovementLoad[]
+}
+
+/**
+ * Load Management panel for the Weight Room History View (#316). One card
+ * per movement surfacing the tendon-load ramp signals: trailing-7-day
+ * volume, week-over-week change, ACWR, a 28-day trailing sparkline, and a
+ * color-coded flag (worst of the WoW and ACWR signals). Read-only.
+ *
+ * Purely presentational — all bucketing and threshold logic lives in
+ * `buildMovementLoads` / `constants/ramp-rate`, so this component only
+ * formats and lays out. Cream cards on the dark Weight Room surface,
+ * matching {@link import('./StrengthStats').StrengthStats}.
+ */
+export function LoadManagementPanel({ loads }: LoadManagementPanelProps): JSX.Element {
+  if (loads.length === 0) {
+    return (
+      <p
+        data-testid="load-management-empty"
+        className="rounded-[1.2rem] border border-white/10 bg-white/5 p-6 text-center text-sm text-[#e8d5be]/70"
+      >
+        No movements logged in the last 28 days — start logging sets to track ramp rate.
+      </p>
+    )
+  }
+
+  return (
+    <section aria-label="Load management" className="grid gap-4 md:grid-cols-2">
+      {loads.map(load => (
+        <MovementLoadCard key={load.movement} load={load} />
+      ))}
+    </section>
+  )
+}
+
+interface MovementLoadCardProps {
+  load: MovementLoad
+}
+
+function MovementLoadCard({ load }: MovementLoadCardProps): JSX.Element {
+  const flagMeta = RAMP_FLAGS[load.flag]
+  const volumeLabel = load.metric === 'load' ? '7d load volume' : '7d rep volume'
+
+  return (
+    <article
+      data-testid={`load-card-${load.movement}`}
+      data-flag={load.flag}
+      aria-label={`${load.movement}: ${flagMeta.label}`}
+      className="rounded-[1.2rem] border border-white/10 bg-[#f5f1e6] p-5 text-[#0a0a0a] shadow-[0_12px_32px_rgba(0,0,0,0.28)]"
+    >
+      <header className="flex items-baseline justify-between gap-3">
+        <h3
+          className="font-mono text-sm font-bold uppercase tracking-[0.2em]"
+          style={{ color: load.color }}
+        >
+          {load.movement}
+        </h3>
+        <span className="flex items-center gap-1.5">
+          <span
+            aria-hidden="true"
+            className="h-2.5 w-2.5 rounded-full"
+            style={{ backgroundColor: flagMeta.color }}
+          />
+          <span className="font-mono text-[10px] font-bold uppercase tracking-[0.22em] text-[#0a0a0a]/70">
+            {flagMeta.label}
+          </span>
+        </span>
+      </header>
+
+      <div className="mt-5 grid grid-cols-2 gap-4">
+        <div className="col-span-2">
+          <p className="flex items-baseline gap-1.5">
+            <span className="font-mono text-3xl font-semibold tabular-nums">
+              {formatVolume(load.acute7d)}
+            </span>
+            <span className="font-mono text-[10px] uppercase tracking-[0.2em] text-[#0a0a0a]/60">
+              {load.unitLabel}
+            </span>
+          </p>
+          <p className="mt-1 font-mono text-[10px] font-bold uppercase tracking-[0.22em] text-[#0a0a0a]/65">
+            {volumeLabel}
+          </p>
+        </div>
+
+        <MetricCell label="WoW" value={formatWow(load.wowPct)} flag={load.wowFlag} />
+        <MetricCell label="ACWR" value={formatAcwr(load.acwr)} flag={load.acwrFlag} />
+      </div>
+
+      <div className="mt-5 border-t border-white/10 pt-4">
+        <p className="mb-2 font-mono text-[10px] uppercase tracking-[0.22em] text-[#0a0a0a]/55">
+          Trailing 28 days
+        </p>
+        <div className="overflow-x-auto">
+          <RoughSparkline
+            points={load.sparkline.map((p, i) => ({ x: i, y: p.volume }))}
+            width={SPARK_WIDTH}
+            height={SPARK_HEIGHT}
+            stroke={load.color}
+            ariaLabel={`${load.movement} 28-day ${load.metric === 'load' ? 'load' : 'rep'} volume trend`}
+          />
+        </div>
+      </div>
+    </article>
+  )
+}
+
+interface MetricCellProps {
+  label: string
+  value: string
+  flag: MovementLoad['flag']
+}
+
+/**
+ * One numeric ramp signal (WoW or ACWR). Tints the value with the flag
+ * color so an elevated signal reads at a glance without relying on the
+ * card's overall dot alone.
+ */
+function MetricCell({ label, value, flag }: MetricCellProps): JSX.Element {
+  const flagMeta = RAMP_FLAGS[flag]
+  return (
+    <div>
+      <p
+        className="font-mono text-3xl font-semibold tabular-nums"
+        style={{ color: flag === 'green' ? undefined : flagMeta.color }}
+      >
+        {value}
+      </p>
+      <p className="mt-1 font-mono text-[10px] font-bold uppercase tracking-[0.22em] text-[#0a0a0a]/65">
+        {label}
+      </p>
+    </div>
+  )
+}
+
+/** Format an absolute volume with thousands separators, no decimals. */
+function formatVolume(volume: number): string {
+  return Math.round(volume).toLocaleString('en-US')
+}
+
+/**
+ * Format a week-over-week change as a signed whole-percent, or `—` when
+ * there's no prior week to compare against.
+ */
+function formatWow(wowPct: number | null): string {
+  if (wowPct == null || !Number.isFinite(wowPct)) return '—'
+  const pct = Math.round(wowPct * 100)
+  return `${pct > 0 ? '+' : ''}${pct}%`
+}
+
+/** Format an ACWR to two decimals, or `—` when there's no chronic baseline. */
+function formatAcwr(acwr: number | null): string {
+  if (acwr == null || !Number.isFinite(acwr)) return '—'
+  return acwr.toFixed(2)
+}

--- a/constants/ramp-rate.test.ts
+++ b/constants/ramp-rate.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest'
+
+import {
+  classifyAcwr,
+  classifyWowPct,
+  combineFlags,
+  RAMP_FLAGS,
+  RAMP_RATE_THRESHOLDS,
+  type RampRateThresholds,
+} from './ramp-rate'
+
+describe('classifyAcwr', () => {
+  it('returns green when there is no baseline (null / non-finite)', () => {
+    expect(classifyAcwr(null)).toBe('green')
+    expect(classifyAcwr(Number.NaN)).toBe('green')
+    expect(classifyAcwr(Number.POSITIVE_INFINITY)).toBe('green')
+  })
+
+  it('flags detraining below 0.8', () => {
+    expect(classifyAcwr(0.5)).toBe('yellow')
+    expect(classifyAcwr(0.79)).toBe('yellow')
+  })
+
+  it('is green across the sweet spot [0.8, 1.3]', () => {
+    expect(classifyAcwr(0.8)).toBe('green')
+    expect(classifyAcwr(1.0)).toBe('green')
+    expect(classifyAcwr(1.3)).toBe('green')
+  })
+
+  it('flags elevated in (1.3, 1.5]', () => {
+    expect(classifyAcwr(1.31)).toBe('yellow')
+    expect(classifyAcwr(1.5)).toBe('yellow')
+  })
+
+  it('flags red above 1.5', () => {
+    expect(classifyAcwr(1.51)).toBe('red')
+    expect(classifyAcwr(2)).toBe('red')
+  })
+
+  it('honors overridden thresholds', () => {
+    const strict: RampRateThresholds = {
+      ...RAMP_RATE_THRESHOLDS,
+      acwrGreenMax: 1.1,
+      acwrElevatedMax: 1.2,
+    }
+    // 1.4 is elevated (yellow) by default but red under the tighter ceiling.
+    expect(classifyAcwr(1.4)).toBe('yellow')
+    expect(classifyAcwr(1.4, strict)).toBe('red')
+  })
+})
+
+describe('classifyWowPct', () => {
+  it('returns green when there is no prior week (null / non-finite)', () => {
+    expect(classifyWowPct(null)).toBe('green')
+    expect(classifyWowPct(Number.NaN)).toBe('green')
+  })
+
+  it('is green at or below the +10% ceiling', () => {
+    expect(classifyWowPct(0)).toBe('green')
+    expect(classifyWowPct(0.1)).toBe('green')
+  })
+
+  it('is green for flat-or-down weeks', () => {
+    expect(classifyWowPct(-0.25)).toBe('green')
+  })
+
+  it('flags yellow above +10%', () => {
+    expect(classifyWowPct(0.1001)).toBe('yellow')
+    expect(classifyWowPct(0.5)).toBe('yellow')
+  })
+
+  it('honors an overridden ceiling', () => {
+    const loose: RampRateThresholds = { ...RAMP_RATE_THRESHOLDS, wowYellowPct: 0.25 }
+    expect(classifyWowPct(0.2, loose)).toBe('green')
+    expect(classifyWowPct(0.2)).toBe('yellow')
+  })
+})
+
+describe('combineFlags', () => {
+  it('returns green with no flags', () => {
+    expect(combineFlags()).toBe('green')
+  })
+
+  it('returns the worst of the given flags', () => {
+    expect(combineFlags('green', 'green')).toBe('green')
+    expect(combineFlags('green', 'yellow')).toBe('yellow')
+    expect(combineFlags('yellow', 'red')).toBe('red')
+    expect(combineFlags('red', 'green')).toBe('red')
+  })
+})
+
+describe('RAMP_FLAGS', () => {
+  it('has metadata for every flag', () => {
+    for (const flag of ['green', 'yellow', 'red'] as const) {
+      expect(RAMP_FLAGS[flag].flag).toBe(flag)
+      expect(RAMP_FLAGS[flag].color).toMatch(/^#[0-9a-f]{6}$/i)
+      expect(RAMP_FLAGS[flag].label.length).toBeGreaterThan(0)
+    }
+  })
+})

--- a/constants/ramp-rate.ts
+++ b/constants/ramp-rate.ts
@@ -1,0 +1,150 @@
+/**
+ * Tendon-load ramp-rate thresholds for the Weight Room Load Management
+ * panel (#316). Mirrors the tunable-config pattern of
+ * {@link import('@/constants/hr-zones').HR_ZONES} and the `TSB_ZONES`
+ * threshold object: the ceilings live here, not inline in the math, so
+ * they can be dialed as tendons adapt without touching the aggregation
+ * or the UI.
+ *
+ * **Why rate-of-change, not absolute volume:** the injury driver for
+ * tendon is how fast weekly volume climbs relative to the tissue's
+ * recent baseline. Two signals capture that:
+ * - **WoW %** — week-over-week change in the trailing-7-day volume. A
+ *   jump past {@link RampRateThresholds.wowYellowPct} outpaces the
+ *   ~10%/week rule of thumb for safe progression.
+ * - **ACWR** (acute:chronic workload ratio) — acute (7-day) volume over
+ *   the chronic weekly baseline (28-day ÷ 4). The "sweet spot" band sits
+ *   between {@link RampRateThresholds.acwrDetrainMax} and
+ *   {@link RampRateThresholds.acwrGreenMax}; below is detraining, above
+ *   is progressively elevated risk.
+ */
+
+/** Traffic-light severity for a single movement's ramp signals. */
+export type RampFlag = 'green' | 'yellow' | 'red'
+
+/**
+ * Tunable ramp-rate ceilings. Fractions are unitless (`0.1` = 10%); ACWR
+ * bounds are ratios. All comparisons treat the named bound as the top of
+ * its band (see {@link classifyAcwr} / {@link classifyWowPct}).
+ */
+export interface RampRateThresholds {
+  /**
+   * Week-over-week volume increase above which the movement flags yellow.
+   * `0.1` = +10%, the soft tendon-safe weekly ceiling. Only *increases*
+   * trip this; volume drops are caught by the ACWR detraining band.
+   */
+  wowYellowPct: number
+  /**
+   * ACWR below this reads as detraining (yellow) — losing the chronic
+   * base that protects the tendon. `0.8` per the classic acute:chronic
+   * model.
+   */
+  acwrDetrainMax: number
+  /**
+   * Top of the ACWR "sweet spot". At or below this (and at/above
+   * {@link RampRateThresholds.acwrDetrainMax}) is green. `1.3`.
+   */
+  acwrGreenMax: number
+  /**
+   * Top of the elevated-but-not-critical ACWR band. Above
+   * {@link RampRateThresholds.acwrGreenMax} through this value is yellow;
+   * above it is red. `1.5`.
+   */
+  acwrElevatedMax: number
+}
+
+/**
+ * Default ramp-rate ceilings (#316). Personal-tool starting points, not
+ * clinical constants — bump `wowYellowPct` as a movement's tendons
+ * demonstrably tolerate faster ramps, tighten it after a flare.
+ */
+export const RAMP_RATE_THRESHOLDS: RampRateThresholds = {
+  wowYellowPct: 0.1,
+  acwrDetrainMax: 0.8,
+  acwrGreenMax: 1.3,
+  acwrElevatedMax: 1.5,
+}
+
+/** Display metadata for one {@link RampFlag} — the flag's color and human label. */
+export interface RampFlagMeta {
+  /** The flag this metadata describes. */
+  flag: RampFlag
+  /** Short human label for tooltips / accessible names, e.g. "Elevated risk". */
+  label: string
+  /**
+   * Hex color for the flag dot. Green→red matching the HR-zone palette so
+   * the two facilities read as one system. Hex (not Tailwind) so SVG can
+   * consume it directly.
+   */
+  color: string
+}
+
+/** Flag color + label, keyed by {@link RampFlag}. Consumed by the panel UI. */
+export const RAMP_FLAGS: Record<RampFlag, RampFlagMeta> = {
+  green: { flag: 'green', label: 'On track', color: '#22c55e' },
+  yellow: { flag: 'yellow', label: 'Caution', color: '#eab308' },
+  red: { flag: 'red', label: 'Elevated risk', color: '#dc2626' },
+}
+
+/**
+ * Numeric severity rank per flag (higher = worse). Used to pick the
+ * worst flag across a movement's signals ({@link combineFlags}) and to
+ * sort at-risk movements to the top of the panel.
+ */
+export const FLAG_SEVERITY: Record<RampFlag, number> = {
+  green: 0,
+  yellow: 1,
+  red: 2,
+}
+
+/**
+ * Classify an acute:chronic workload ratio into a traffic-light flag.
+ *
+ * `null` (no chronic baseline yet — too little history to judge) returns
+ * `green`: there is nothing to flag, and the card renders the value as
+ * "—" rather than a false alarm.
+ *
+ * @param acwr acute(7d) ÷ chronic-weekly(28d ÷ 4), or `null` when the
+ *   chronic baseline is zero.
+ * @param thresholds override the default {@link RAMP_RATE_THRESHOLDS}.
+ */
+export function classifyAcwr(
+  acwr: number | null,
+  thresholds: RampRateThresholds = RAMP_RATE_THRESHOLDS,
+): RampFlag {
+  if (acwr == null || !Number.isFinite(acwr)) return 'green'
+  if (acwr < thresholds.acwrDetrainMax) return 'yellow'
+  if (acwr <= thresholds.acwrGreenMax) return 'green'
+  if (acwr <= thresholds.acwrElevatedMax) return 'yellow'
+  return 'red'
+}
+
+/**
+ * Classify a week-over-week volume change into a traffic-light flag.
+ * Only increases past {@link RampRateThresholds.wowYellowPct} flag
+ * yellow; flat-or-down weeks are green (a deliberate deload is not a
+ * tendon risk). `null` (no prior week to compare) returns `green`.
+ *
+ * @param wowPct fractional change of trailing-7 volume vs the prior 7
+ *   days (`0.14` = +14%), or `null` when the prior week had zero volume.
+ * @param thresholds override the default {@link RAMP_RATE_THRESHOLDS}.
+ */
+export function classifyWowPct(
+  wowPct: number | null,
+  thresholds: RampRateThresholds = RAMP_RATE_THRESHOLDS,
+): RampFlag {
+  if (wowPct == null || !Number.isFinite(wowPct)) return 'green'
+  return wowPct > thresholds.wowYellowPct ? 'yellow' : 'green'
+}
+
+/**
+ * Reduce several per-signal flags to the single worst one (red beats
+ * yellow beats green) — the color the movement's card shows overall.
+ * With no arguments, returns `green`.
+ */
+export function combineFlags(...flags: RampFlag[]): RampFlag {
+  return flags.reduce<RampFlag>(
+    (worst, f) => (FLAG_SEVERITY[f] > FLAG_SEVERITY[worst] ? f : worst),
+    'green',
+  )
+}

--- a/lib/training-facility/load-management.test.ts
+++ b/lib/training-facility/load-management.test.ts
@@ -49,6 +49,7 @@ describe('buildMovementLoads', () => {
 
   it('computes acute/prior/chronic volume, WoW %, and ACWR for a bodyweight movement', () => {
     const sets = [
+      set('2026-05-01', 'pushups', 50), // history anchor — predates the chronic window
       set('2026-07-05', 'pushups', 100), // prior week
       set('2026-07-10', 'pushups', 60), // acute
       set('2026-07-14', 'pushups', 60), // acute
@@ -60,10 +61,10 @@ describe('buildMovementLoads', () => {
     expect(load.unitLabel).toBe('reps')
     expect(load.acute7d).toBe(120)
     expect(load.prior7d).toBe(100)
-    expect(load.chronic28d).toBe(270)
+    expect(load.chronic28d).toBe(270) // in-window only; the May anchor is excluded
     expect(load.chronicWeekly).toBeCloseTo(67.5)
-    expect(load.wowPct).toBeCloseTo(0.2)
-    expect(load.acwr).toBeCloseTo(120 / 67.5)
+    expect(load.wowPct).toBe(0.2)
+    expect(load.acwr).toBe(1.78) // 120 / 67.5 = 1.777…, rounded to display precision
     expect(load.wowFlag).toBe('yellow') // +20% > +10%
     expect(load.acwrFlag).toBe('red') // ~1.78 > 1.5
     expect(load.flag).toBe('red') // worst of the two
@@ -71,6 +72,7 @@ describe('buildMovementLoads', () => {
 
   it('drives loaded movements off load-volume (Σ reps × weight)', () => {
     const sets = [
+      set('2026-05-15', 'shrugs', 30, 100), // history anchor
       set('2026-06-23', 'shrugs', 30, 100),
       set('2026-06-30', 'shrugs', 30, 100),
       set('2026-07-07', 'shrugs', 30, 100),
@@ -81,9 +83,9 @@ describe('buildMovementLoads', () => {
     expect(load.metric).toBe('load')
     expect(load.unitLabel).toBe('lb')
     expect(load.acute7d).toBe(3000) // 30 × 100
-    expect(load.chronic28d).toBe(12000) // four weeks
-    expect(load.acwr).toBeCloseTo(1) // 3000 / (12000 / 4)
-    expect(load.wowPct).toBeCloseTo(0)
+    expect(load.chronic28d).toBe(12000) // four in-window weeks
+    expect(load.acwr).toBe(1) // 3000 / (12000 / 4)
+    expect(load.wowPct).toBe(0)
     expect(load.flag).toBe('green')
   })
 
@@ -100,12 +102,68 @@ describe('buildMovementLoads', () => {
     expect(load.acute7d).toBe(40) // rep count, not load-volume
   })
 
+  it('scores a movement on its current regime, not its history', () => {
+    // Weighted for months, then switched to bodyweight three weeks ago.
+    // The historical weighted sets fall outside the window; only the recent
+    // bodyweight ones count, so it must read as a rep-based movement rather
+    // than collapse to zero tonnage and drop off the panel.
+    const sets = [
+      set('2026-04-01', 'curls', 30, 100),
+      set('2026-04-15', 'curls', 30, 100),
+      set('2026-05-01', 'curls', 30, 100),
+      set('2026-07-01', 'curls', 20),
+      set('2026-07-08', 'curls', 20),
+      set('2026-07-14', 'curls', 20),
+    ]
+    const load = byName(buildMovementLoads(sets, [], NOW)).curls
+
+    expect(load.metric).toBe('reps') // in-window sets are all bodyweight
+    expect(load.acute7d).toBe(20) // rep volume, not the historical tonnage
+  })
+
+  it('withholds ACWR until the movement has a full chronic window of history', () => {
+    // Two weeks of steady training — a real chronic baseline needs four, so
+    // dividing by 4 here would raise a false ACWR alarm. Show no ratio.
+    const sets = [
+      set('2026-07-05', 'newmove', 100), // prior week
+      set('2026-07-14', 'newmove', 100), // acute
+    ]
+    const load = byName(buildMovementLoads(sets, [], NOW)).newmove
+
+    expect(load.chronic28d).toBe(200) // still rendered
+    expect(load.acwr).toBeNull()
+    expect(load.acwrFlag).toBe('green') // no false alarm on thin history
+    expect(load.wowPct).toBe(0)
+    expect(load.flag).toBe('green')
+  })
+
+  it('rounds WoW to whole percent so the shown number and the flag agree', () => {
+    const sets = [
+      // +10.4% actual → rounds to +10% and stays green (at the ceiling).
+      set('2026-07-05', 'edge', 1000),
+      set('2026-07-14', 'edge', 1104),
+      // +10.6% actual → rounds to +11% and flags yellow.
+      set('2026-07-05', 'over', 1000),
+      set('2026-07-14', 'over', 1106),
+    ]
+    const map = byName(buildMovementLoads(sets, [], NOW))
+
+    expect(map.edge.wowPct).toBe(0.1)
+    expect(map.edge.wowFlag).toBe('green')
+    expect(map.over.wowPct).toBe(0.11)
+    expect(map.over.wowFlag).toBe('yellow')
+  })
+
   it('reports WoW as null when there is no prior week to compare', () => {
-    const load = byName(buildMovementLoads([set('2026-07-14', 'squats', 100)], [], NOW)).squats
+    const sets = [
+      set('2026-05-01', 'squats', 50), // history anchor so ACWR is defined
+      set('2026-07-14', 'squats', 100), // acute only, nothing the week before
+    ]
+    const load = byName(buildMovementLoads(sets, [], NOW)).squats
 
     expect(load.wowPct).toBeNull()
     expect(load.wowFlag).toBe('green') // nothing to flag
-    expect(load.acwr).toBeCloseTo(4) // 100 / (100 / 4)
+    expect(load.acwr).toBe(4) // 100 / (100 / 4)
     expect(load.acwrFlag).toBe('red')
   })
 
@@ -116,12 +174,15 @@ describe('buildMovementLoads', () => {
 
   it('sorts worst-flag-first, then alphabetically', () => {
     const sets = [
-      // pushups → red
+      // pushups → red (spike over an established base)
+      set('2026-05-01', 'pushups', 50),
       set('2026-07-05', 'pushups', 100),
       set('2026-07-14', 'pushups', 200),
-      // squats → red (spike from nothing)
+      // squats → red (spike over an established base)
+      set('2026-05-01', 'squats', 50),
       set('2026-07-14', 'squats', 100),
       // shrugs → green (steady four weeks)
+      set('2026-05-15', 'shrugs', 30, 100),
       set('2026-06-23', 'shrugs', 30, 100),
       set('2026-06-30', 'shrugs', 30, 100),
       set('2026-07-07', 'shrugs', 30, 100),

--- a/lib/training-facility/load-management.test.ts
+++ b/lib/training-facility/load-management.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect } from 'vitest'
+
+import type { StrengthSet } from '@/types/weight-room'
+
+import { buildMovementLoads, pacificDayKey } from './load-management'
+
+/**
+ * Minimal {@link StrengthSet} stamped at noon Pacific on `dayKey` (noon so
+ * the set lands safely mid-day regardless of PST/PDT). Pass `weight` for a
+ * loaded set; omit it for bodyweight.
+ */
+function set(dayKey: string, exercise: string, reps: number, weight?: number): StrengthSet {
+  return {
+    id: `${dayKey}-${exercise}-${reps}-${weight ?? 'bw'}`,
+    logged_at: `${dayKey}T12:00:00-07:00`,
+    exercise,
+    reps,
+    ...(weight != null ? { weight_lbs: weight } : {}),
+  }
+}
+
+/** Fixed "today" anchor — noon PDT on Wed 2026-07-15. */
+const NOW = new Date('2026-07-15T12:00:00-07:00')
+
+/** Index the result by movement name for terse per-movement assertions. */
+function byName(loads: ReturnType<typeof buildMovementLoads>) {
+  return Object.fromEntries(loads.map(l => [l.movement, l]))
+}
+
+describe('pacificDayKey', () => {
+  it('buckets to the Pacific calendar day, not the UTC one', () => {
+    // 05:00 UTC = 22:00 PDT the previous day.
+    expect(pacificDayKey(new Date('2026-07-12T05:00:00Z'))).toBe('2026-07-11')
+    // 07:00 UTC = 00:00 PDT — the day flips.
+    expect(pacificDayKey(new Date('2026-07-12T07:00:00Z'))).toBe('2026-07-12')
+  })
+
+  it('tracks the DST offset (PST is UTC-8 in winter)', () => {
+    // 07:00 UTC in January = 23:00 PST the previous day.
+    expect(pacificDayKey(new Date('2026-01-12T07:00:00Z'))).toBe('2026-01-11')
+    expect(pacificDayKey(new Date('2026-01-12T08:00:00Z'))).toBe('2026-01-12')
+  })
+})
+
+describe('buildMovementLoads', () => {
+  it('returns nothing for no sets', () => {
+    expect(buildMovementLoads([], [], NOW)).toEqual([])
+  })
+
+  it('computes acute/prior/chronic volume, WoW %, and ACWR for a bodyweight movement', () => {
+    const sets = [
+      set('2026-07-05', 'pushups', 100), // prior week
+      set('2026-07-10', 'pushups', 60), // acute
+      set('2026-07-14', 'pushups', 60), // acute
+      set('2026-06-20', 'pushups', 50), // chronic-only (before prior week)
+    ]
+    const load = byName(buildMovementLoads(sets, [], NOW)).pushups
+
+    expect(load.metric).toBe('reps')
+    expect(load.unitLabel).toBe('reps')
+    expect(load.acute7d).toBe(120)
+    expect(load.prior7d).toBe(100)
+    expect(load.chronic28d).toBe(270)
+    expect(load.chronicWeekly).toBeCloseTo(67.5)
+    expect(load.wowPct).toBeCloseTo(0.2)
+    expect(load.acwr).toBeCloseTo(120 / 67.5)
+    expect(load.wowFlag).toBe('yellow') // +20% > +10%
+    expect(load.acwrFlag).toBe('red') // ~1.78 > 1.5
+    expect(load.flag).toBe('red') // worst of the two
+  })
+
+  it('drives loaded movements off load-volume (Σ reps × weight)', () => {
+    const sets = [
+      set('2026-06-23', 'shrugs', 30, 100),
+      set('2026-06-30', 'shrugs', 30, 100),
+      set('2026-07-07', 'shrugs', 30, 100),
+      set('2026-07-14', 'shrugs', 30, 100),
+    ]
+    const load = byName(buildMovementLoads(sets, [], NOW)).shrugs
+
+    expect(load.metric).toBe('load')
+    expect(load.unitLabel).toBe('lb')
+    expect(load.acute7d).toBe(3000) // 30 × 100
+    expect(load.chronic28d).toBe(12000) // four weeks
+    expect(load.acwr).toBeCloseTo(1) // 3000 / (12000 / 4)
+    expect(load.wowPct).toBeCloseTo(0)
+    expect(load.flag).toBe('green')
+  })
+
+  it('keeps a mostly-bodyweight movement rep-based despite an occasional weighted set', () => {
+    const sets = [
+      set('2026-07-11', 'pullups', 10, 25), // 1 of 4 weighted → still bodyweight
+      set('2026-07-12', 'pullups', 10),
+      set('2026-07-13', 'pullups', 10),
+      set('2026-07-14', 'pullups', 10),
+    ]
+    const load = byName(buildMovementLoads(sets, [], NOW)).pullups
+
+    expect(load.metric).toBe('reps')
+    expect(load.acute7d).toBe(40) // rep count, not load-volume
+  })
+
+  it('reports WoW as null when there is no prior week to compare', () => {
+    const load = byName(buildMovementLoads([set('2026-07-14', 'squats', 100)], [], NOW)).squats
+
+    expect(load.wowPct).toBeNull()
+    expect(load.wowFlag).toBe('green') // nothing to flag
+    expect(load.acwr).toBeCloseTo(4) // 100 / (100 / 4)
+    expect(load.acwrFlag).toBe('red')
+  })
+
+  it('drops movements dormant across the trailing 28 days', () => {
+    const loads = buildMovementLoads([set('2026-06-01', 'dips', 50)], [], NOW)
+    expect(loads).toEqual([])
+  })
+
+  it('sorts worst-flag-first, then alphabetically', () => {
+    const sets = [
+      // pushups → red
+      set('2026-07-05', 'pushups', 100),
+      set('2026-07-14', 'pushups', 200),
+      // squats → red (spike from nothing)
+      set('2026-07-14', 'squats', 100),
+      // shrugs → green (steady four weeks)
+      set('2026-06-23', 'shrugs', 30, 100),
+      set('2026-06-30', 'shrugs', 30, 100),
+      set('2026-07-07', 'shrugs', 30, 100),
+      set('2026-07-14', 'shrugs', 30, 100),
+    ]
+    const order = buildMovementLoads(sets, [], NOW).map(l => l.movement)
+    expect(order).toEqual(['pushups', 'squats', 'shrugs'])
+  })
+
+  it('emits a 28-day sparkline whose volume sums to the chronic total', () => {
+    const sets = [
+      set('2026-07-05', 'pushups', 100),
+      set('2026-07-10', 'pushups', 60),
+      set('2026-07-14', 'pushups', 60),
+      set('2026-06-20', 'pushups', 50),
+    ]
+    const load = byName(buildMovementLoads(sets, [], NOW)).pushups
+
+    expect(load.sparkline).toHaveLength(28)
+    expect(load.sparkline[27].dayKey).toBe('2026-07-15') // ends today
+    expect(load.sparkline[0].dayKey).toBe('2026-06-18') // 28-day window start
+    const sum = load.sparkline.reduce((acc, p) => acc + p.volume, 0)
+    expect(sum).toBe(load.chronic28d)
+  })
+
+  it('uses the matching goal color, falling back to a default', () => {
+    const goals = [{ exercise: 'pushups', daily_target: 100, color: '#123456' }]
+    const loads = buildMovementLoads(
+      [set('2026-07-14', 'pushups', 100), set('2026-07-14', 'squats', 100)],
+      goals,
+      NOW,
+    )
+    const map = byName(loads)
+    expect(map.pushups.color).toBe('#123456')
+    expect(map.squats.color).toBe('#EA580C') // default
+  })
+
+  it('ignores sets with an unparseable timestamp', () => {
+    const sets = [
+      set('2026-07-14', 'pushups', 60),
+      { id: 'bad', logged_at: 'not-a-date', exercise: 'pushups', reps: 999 },
+    ]
+    const load = byName(buildMovementLoads(sets, [], NOW)).pushups
+    expect(load.acute7d).toBe(60) // the garbage row contributes nothing
+  })
+})

--- a/lib/training-facility/load-management.ts
+++ b/lib/training-facility/load-management.ts
@@ -27,17 +27,20 @@ export const PACIFIC_TZ = 'America/Los_Angeles'
 
 /** Trailing days in the acute window. */
 const ACUTE_DAYS = 7
-/** Trailing days in the chronic window; ÷4 gives the chronic weekly baseline. */
-const CHRONIC_DAYS = 28
-/** Trailing days rendered in each movement's sparkline. */
-const SPARKLINE_DAYS = 28
 /**
- * Fraction of a movement's sets that must carry external load before it's
- * treated as a loaded movement (driven by load-volume) rather than a
- * bodyweight one (driven by rep volume). At `0.5`, an all-weighted
+ * Trailing days in the chronic window; ÷4 gives the chronic weekly
+ * baseline. Also the length of each movement's sparkline, so the sparkline
+ * and the chronic total are always the same 28 days of data.
+ */
+const CHRONIC_DAYS = 28
+/**
+ * Fraction of a movement's *in-window* sets that must carry external load
+ * before it's treated as a loaded movement (driven by load-volume) rather
+ * than a bodyweight one (driven by rep volume). At `0.5`, an all-weighted
  * movement like shrugs uses tonnage while a mostly-bodyweight movement
  * like pull-ups stays rep-based even if it has the occasional weighted
- * set.
+ * set. Decided over the chronic window (not all history) so a movement
+ * that recently switched loading regime is scored on its current scale.
  */
 const LOADED_SET_FRACTION = 0.5
 
@@ -88,18 +91,6 @@ function shiftDayKey(key: string, delta: number): string {
   return `${yy}-${mm}-${dd}`
 }
 
-/**
- * Sum `days` of daily volume ending at (and including) `endKey`, reading
- * missing days as zero.
- */
-function sumWindow(volByDay: ReadonlyMap<string, number>, endKey: string, days: number): number {
-  let total = 0
-  for (let i = 0; i < days; i++) {
-    total += volByDay.get(shiftDayKey(endKey, -i)) ?? 0
-  }
-  return total
-}
-
 /** One point in a movement's trailing daily-volume sparkline. */
 export interface DailyVolumePoint {
   /** `YYYY-MM-DD` Pacific calendar day. */
@@ -133,14 +124,18 @@ export interface MovementLoad {
   chronicWeekly: number
   /**
    * Week-over-week fractional change of the trailing-7 volume
-   * (`(acute − prior) ÷ prior`). `null` when `prior7d` is `0` (a
-   * brand-new ramp with no week to compare against).
+   * (`(acute − prior) ÷ prior`), rounded to whole percent so the card's
+   * displayed number and its flag color are computed from the same value
+   * and can never disagree at the threshold. `null` when `prior7d` is `0`
+   * (a brand-new ramp with no week to compare against).
    */
   wowPct: number | null
   /**
-   * Acute:chronic workload ratio (`acute7d ÷ chronicWeekly`). Always
-   * finite for a rendered movement, since movements with no chronic
-   * volume are filtered out.
+   * Acute:chronic workload ratio (`acute7d ÷ chronicWeekly`), rounded to
+   * two decimals to match the displayed value. `null` until the movement's
+   * history spans the full chronic window — ACWR's baseline is a 4-week
+   * average, and dividing a partial window by 4 would raise a false alarm,
+   * so a young movement shows no ratio rather than a misleading one.
    */
   acwr: number | null
   /** Overall flag — the worst of {@link wowFlag} and {@link acwrFlag}. */
@@ -149,7 +144,7 @@ export interface MovementLoad {
   wowFlag: RampFlag
   /** Flag from the ACWR signal alone. */
   acwrFlag: RampFlag
-  /** Trailing {@link SPARKLINE_DAYS}-day daily volume, oldest → newest. */
+  /** Trailing {@link CHRONIC_DAYS}-day daily volume, oldest → newest. */
   sparkline: DailyVolumePoint[]
 }
 
@@ -180,6 +175,16 @@ export function buildMovementLoads(
   const todayKey = pacificDayKey(now)
   const colorByExercise = new Map(goals.map(g => [g.exercise, g.color]))
 
+  // Precompute the trailing chronic-window day keys once — they're shared
+  // by every movement. Index 0 is today; index CHRONIC_DAYS-1 is the
+  // window's oldest day. This replaces per-set/per-window `shiftDayKey`
+  // calls (which built dozens of throwaway Dates per movement) with a
+  // single O(1) offset lookup keyed on the Pacific day.
+  const trailingKeys: string[] = []
+  for (let i = 0; i < CHRONIC_DAYS; i++) trailingKeys.push(shiftDayKey(todayKey, -i))
+  const offsetByKey = new Map(trailingKeys.map((key, i) => [key, i]))
+  const chronicStartKey = trailingKeys[CHRONIC_DAYS - 1]
+
   const byExercise = new Map<string, StrengthSet[]>()
   for (const s of sets) {
     const arr = byExercise.get(s.exercise)
@@ -189,42 +194,69 @@ export function buildMovementLoads(
 
   const loads: MovementLoad[] = []
   for (const [movement, exSets] of byExercise) {
-    // Primary metric: load-volume when the movement is predominantly
-    // weighted, else reps. Decided over all sets so an occasional
-    // weighted rep on a bodyweight movement doesn't flip its whole scale.
-    const weightedCount = exSets.filter(
-      s => typeof s.weight_lbs === 'number' && s.weight_lbs > 0,
-    ).length
-    const loaded = exSets.length > 0 && weightedCount / exSets.length >= LOADED_SET_FRACTION
+    // Bucket every set into the trailing window as BOTH rep volume and
+    // load volume; pick which one drives the ramp math afterward from the
+    // sets that actually fall inside the window. Tracking both means a
+    // movement that switched loading regime (weighted → bodyweight) is
+    // scored on its current scale instead of vanishing to zero tonnage.
+    const repByOffset: number[] = new Array(CHRONIC_DAYS).fill(0)
+    const loadByOffset: number[] = new Array(CHRONIC_DAYS).fill(0)
+    let inWindowSets = 0
+    let inWindowWeighted = 0
+    let earliestKey: string | null = null
 
-    const volByDay = new Map<string, number>()
     for (const s of exSets) {
       const d = new Date(s.logged_at)
       if (!Number.isFinite(d.getTime())) continue
       const key = pacificDayKey(d)
-      const vol = loaded ? s.reps * (s.weight_lbs ?? 0) : s.reps
-      volByDay.set(key, (volByDay.get(key) ?? 0) + vol)
+      if (earliestKey === null || key < earliestKey) earliestKey = key
+      const offset = offsetByKey.get(key)
+      if (offset === undefined) continue // outside the trailing chronic window
+      const weight = typeof s.weight_lbs === 'number' && s.weight_lbs > 0 ? s.weight_lbs : 0
+      repByOffset[offset] += s.reps
+      loadByOffset[offset] += s.reps * weight
+      inWindowSets += 1
+      if (weight > 0) inWindowWeighted += 1
     }
 
-    const chronic28d = sumWindow(volByDay, todayKey, CHRONIC_DAYS)
     // Dormant movement — nothing in the trailing chronic window. Skip so
     // the panel only shows what's actively being ramped.
+    if (inWindowSets === 0) continue
+
+    const loaded = inWindowWeighted / inWindowSets >= LOADED_SET_FRACTION
+    const volByOffset = loaded ? loadByOffset : repByOffset
+
+    let chronic28d = 0
+    for (let i = 0; i < CHRONIC_DAYS; i++) chronic28d += volByOffset[i]
+    // A loaded movement whose only in-window sets carry no external load
+    // has zero tonnage — nothing to ramp. Skip it.
     if (chronic28d <= 0) continue
 
-    const acute7d = sumWindow(volByDay, todayKey, ACUTE_DAYS)
-    const prior7d = sumWindow(volByDay, shiftDayKey(todayKey, -ACUTE_DAYS), ACUTE_DAYS)
-    const chronicWeekly = chronic28d / (CHRONIC_DAYS / ACUTE_DAYS)
+    let acute7d = 0
+    for (let i = 0; i < ACUTE_DAYS; i++) acute7d += volByOffset[i]
+    let prior7d = 0
+    for (let i = ACUTE_DAYS; i < 2 * ACUTE_DAYS; i++) prior7d += volByOffset[i]
 
-    const wowPct = prior7d === 0 ? null : (acute7d - prior7d) / prior7d
-    const acwr = chronicWeekly === 0 ? null : acute7d / chronicWeekly
+    const wowExact = prior7d === 0 ? null : (acute7d - prior7d) / prior7d
+    // Round to the precision the card renders so the displayed number and
+    // the flag color are derived from one value — no "+10% tinted yellow".
+    const wowPct = wowExact === null ? null : Math.round(wowExact * 100) / 100
+
+    // ACWR is trustworthy only once the chronic window is a full 4 weeks of
+    // the movement's life; before that its ÷4 baseline is understated and
+    // would false-alarm. Show no ratio until the earliest set predates the
+    // window (ISO day keys compare lexically).
+    const chronicWeekly = chronic28d / (CHRONIC_DAYS / ACUTE_DAYS)
+    const hasChronicBase = earliestKey !== null && earliestKey <= chronicStartKey
+    const acwrExact = hasChronicBase ? acute7d / chronicWeekly : null
+    const acwr = acwrExact === null ? null : Math.round(acwrExact * 100) / 100
 
     const wowFlag = classifyWowPct(wowPct)
     const acwrFlag = classifyAcwr(acwr)
 
     const sparkline: DailyVolumePoint[] = []
-    for (let i = SPARKLINE_DAYS - 1; i >= 0; i--) {
-      const key = shiftDayKey(todayKey, -i)
-      sparkline.push({ dayKey: key, volume: volByDay.get(key) ?? 0 })
+    for (let i = CHRONIC_DAYS - 1; i >= 0; i--) {
+      sparkline.push({ dayKey: trailingKeys[i], volume: volByOffset[i] })
     }
 
     loads.push({

--- a/lib/training-facility/load-management.ts
+++ b/lib/training-facility/load-management.ts
@@ -1,0 +1,252 @@
+import {
+  classifyAcwr,
+  classifyWowPct,
+  combineFlags,
+  FLAG_SEVERITY,
+  type RampFlag,
+} from '@/constants/ramp-rate'
+import type { ExerciseGoal, StrengthSet } from '@/types/weight-room'
+
+/**
+ * Ramp-rate aggregation for the Weight Room Load Management panel (#316).
+ *
+ * Turns raw {@link StrengthSet} rows into a per-movement view of how fast
+ * volume is climbing relative to the tendon's recent baseline. All
+ * calendar bucketing is anchored to **Pacific time** ({@link PACIFIC_TZ}),
+ * not the server's local zone — on Vercel the server runs in UTC, so
+ * bucketing in local time would silently shift every day boundary. The
+ * thresholds that turn these numbers into flags live in
+ * {@link import('@/constants/ramp-rate').RAMP_RATE_THRESHOLDS}.
+ *
+ * Windows are **calendar-day** windows (not "last N sets"), so a rest day
+ * contributes a real zero and correctly drags the acute load down.
+ */
+
+/** IANA zone every day/week bucket is anchored to. Never bucket on raw UTC. */
+export const PACIFIC_TZ = 'America/Los_Angeles'
+
+/** Trailing days in the acute window. */
+const ACUTE_DAYS = 7
+/** Trailing days in the chronic window; ÷4 gives the chronic weekly baseline. */
+const CHRONIC_DAYS = 28
+/** Trailing days rendered in each movement's sparkline. */
+const SPARKLINE_DAYS = 28
+/**
+ * Fraction of a movement's sets that must carry external load before it's
+ * treated as a loaded movement (driven by load-volume) rather than a
+ * bodyweight one (driven by rep volume). At `0.5`, an all-weighted
+ * movement like shrugs uses tonnage while a mostly-bodyweight movement
+ * like pull-ups stays rep-based even if it has the occasional weighted
+ * set.
+ */
+const LOADED_SET_FRACTION = 0.5
+
+/** Movement color when no matching {@link ExerciseGoal} supplies one. Rim-orange. */
+const DEFAULT_MOVEMENT_COLOR = '#EA580C'
+
+/** Reused Pacific date formatter — constructing one per call is expensive. */
+const PACIFIC_DATE_FORMAT = new Intl.DateTimeFormat('en-CA', {
+  timeZone: PACIFIC_TZ,
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+})
+
+/**
+ * The `YYYY-MM-DD` **Pacific** calendar day a timestamp falls on. A set
+ * logged at `2026-07-12T05:00:00Z` (10pm PT on the 11th) buckets to
+ * `2026-07-11`. Assembled from `formatToParts` rather than string-parsing
+ * the formatter output so a locale/ICU quirk can't reorder the fields.
+ *
+ * @param d any `Date`; callers pass `new Date(set.logged_at)`.
+ */
+export function pacificDayKey(d: Date): string {
+  const parts = PACIFIC_DATE_FORMAT.formatToParts(d)
+  let year = ''
+  let month = ''
+  let day = ''
+  for (const part of parts) {
+    if (part.type === 'year') year = part.value
+    else if (part.type === 'month') month = part.value
+    else if (part.type === 'day') day = part.value
+  }
+  return `${year}-${month}-${day}`
+}
+
+/**
+ * Shift a `YYYY-MM-DD` calendar key by `delta` days. Arithmetic runs in
+ * UTC on the bare calendar numbers (no zone, no DST), so the returned key
+ * is always a clean calendar date — never off-by-an-hour onto the wrong
+ * day the way raw millisecond math can be across a DST transition.
+ */
+function shiftDayKey(key: string, delta: number): string {
+  const [y, m, d] = key.split('-').map(Number)
+  const dt = new Date(Date.UTC(y, m - 1, d + delta))
+  const yy = dt.getUTCFullYear()
+  const mm = String(dt.getUTCMonth() + 1).padStart(2, '0')
+  const dd = String(dt.getUTCDate()).padStart(2, '0')
+  return `${yy}-${mm}-${dd}`
+}
+
+/**
+ * Sum `days` of daily volume ending at (and including) `endKey`, reading
+ * missing days as zero.
+ */
+function sumWindow(volByDay: ReadonlyMap<string, number>, endKey: string, days: number): number {
+  let total = 0
+  for (let i = 0; i < days; i++) {
+    total += volByDay.get(shiftDayKey(endKey, -i)) ?? 0
+  }
+  return total
+}
+
+/** One point in a movement's trailing daily-volume sparkline. */
+export interface DailyVolumePoint {
+  /** `YYYY-MM-DD` Pacific calendar day. */
+  dayKey: string
+  /** Total primary-metric volume logged that day. `0` on rest days. */
+  volume: number
+}
+
+/**
+ * A single movement's ramp-rate readout — one card on the Load Management
+ * panel. Volume is measured in the movement's *primary metric*: rep count
+ * for bodyweight movements, load-volume (`Σ reps × weight_lbs`) for
+ * predominantly weighted ones (see {@link MovementLoad.metric}).
+ */
+export interface MovementLoad {
+  /** Exercise name, verbatim from the set rows (e.g. `pullups`). */
+  movement: string
+  /** Hex display color from the matching {@link ExerciseGoal}, or a default. */
+  color: string
+  /** Which volume the ramp math is computed on. */
+  metric: 'reps' | 'load'
+  /** Unit suffix for display — `reps` or `lb`. */
+  unitLabel: string
+  /** Trailing-7-day (acute) volume. */
+  acute7d: number
+  /** The 7 days before the acute window — the WoW comparison base. */
+  prior7d: number
+  /** Trailing-28-day (chronic) volume. */
+  chronic28d: number
+  /** Chronic weekly baseline — `chronic28d ÷ 4`. The ACWR denominator. */
+  chronicWeekly: number
+  /**
+   * Week-over-week fractional change of the trailing-7 volume
+   * (`(acute − prior) ÷ prior`). `null` when `prior7d` is `0` (a
+   * brand-new ramp with no week to compare against).
+   */
+  wowPct: number | null
+  /**
+   * Acute:chronic workload ratio (`acute7d ÷ chronicWeekly`). Always
+   * finite for a rendered movement, since movements with no chronic
+   * volume are filtered out.
+   */
+  acwr: number | null
+  /** Overall flag — the worst of {@link wowFlag} and {@link acwrFlag}. */
+  flag: RampFlag
+  /** Flag from the WoW signal alone. */
+  wowFlag: RampFlag
+  /** Flag from the ACWR signal alone. */
+  acwrFlag: RampFlag
+  /** Trailing {@link SPARKLINE_DAYS}-day daily volume, oldest → newest. */
+  sparkline: DailyVolumePoint[]
+}
+
+/**
+ * Build one {@link MovementLoad} per actively-ramped movement from raw
+ * set rows. A movement is included only when it has volume in the
+ * trailing 28-day chronic window — dormant movements (last trained months
+ * ago) are dropped so the panel stays focused on what's currently loading
+ * tissue. Movements are returned worst-flag-first, then alphabetically,
+ * so anything elevated sorts to the top.
+ *
+ * The movement list is derived from the *data*, not a hardcoded set of
+ * exercises, so new movements appear automatically. `goals` only supplies
+ * display color; a movement with sets but no configured goal still shows.
+ *
+ * @param sets every logged set from
+ *   {@link import('@/types/weight-room').WeightRoomData.sets}.
+ * @param goals configured exercise goals, used purely for per-movement
+ *   color lookup.
+ * @param now override for the "today" anchor of every window. Defaults to
+ *   `new Date()`; tests pass a fixed instant for determinism.
+ */
+export function buildMovementLoads(
+  sets: readonly StrengthSet[],
+  goals: readonly ExerciseGoal[] = [],
+  now: Date = new Date(),
+): MovementLoad[] {
+  const todayKey = pacificDayKey(now)
+  const colorByExercise = new Map(goals.map(g => [g.exercise, g.color]))
+
+  const byExercise = new Map<string, StrengthSet[]>()
+  for (const s of sets) {
+    const arr = byExercise.get(s.exercise)
+    if (arr) arr.push(s)
+    else byExercise.set(s.exercise, [s])
+  }
+
+  const loads: MovementLoad[] = []
+  for (const [movement, exSets] of byExercise) {
+    // Primary metric: load-volume when the movement is predominantly
+    // weighted, else reps. Decided over all sets so an occasional
+    // weighted rep on a bodyweight movement doesn't flip its whole scale.
+    const weightedCount = exSets.filter(
+      s => typeof s.weight_lbs === 'number' && s.weight_lbs > 0,
+    ).length
+    const loaded = exSets.length > 0 && weightedCount / exSets.length >= LOADED_SET_FRACTION
+
+    const volByDay = new Map<string, number>()
+    for (const s of exSets) {
+      const d = new Date(s.logged_at)
+      if (!Number.isFinite(d.getTime())) continue
+      const key = pacificDayKey(d)
+      const vol = loaded ? s.reps * (s.weight_lbs ?? 0) : s.reps
+      volByDay.set(key, (volByDay.get(key) ?? 0) + vol)
+    }
+
+    const chronic28d = sumWindow(volByDay, todayKey, CHRONIC_DAYS)
+    // Dormant movement — nothing in the trailing chronic window. Skip so
+    // the panel only shows what's actively being ramped.
+    if (chronic28d <= 0) continue
+
+    const acute7d = sumWindow(volByDay, todayKey, ACUTE_DAYS)
+    const prior7d = sumWindow(volByDay, shiftDayKey(todayKey, -ACUTE_DAYS), ACUTE_DAYS)
+    const chronicWeekly = chronic28d / (CHRONIC_DAYS / ACUTE_DAYS)
+
+    const wowPct = prior7d === 0 ? null : (acute7d - prior7d) / prior7d
+    const acwr = chronicWeekly === 0 ? null : acute7d / chronicWeekly
+
+    const wowFlag = classifyWowPct(wowPct)
+    const acwrFlag = classifyAcwr(acwr)
+
+    const sparkline: DailyVolumePoint[] = []
+    for (let i = SPARKLINE_DAYS - 1; i >= 0; i--) {
+      const key = shiftDayKey(todayKey, -i)
+      sparkline.push({ dayKey: key, volume: volByDay.get(key) ?? 0 })
+    }
+
+    loads.push({
+      movement,
+      color: colorByExercise.get(movement) ?? DEFAULT_MOVEMENT_COLOR,
+      metric: loaded ? 'load' : 'reps',
+      unitLabel: loaded ? 'lb' : 'reps',
+      acute7d,
+      prior7d,
+      chronic28d,
+      chronicWeekly,
+      wowPct,
+      acwr,
+      flag: combineFlags(wowFlag, acwrFlag),
+      wowFlag,
+      acwrFlag,
+      sparkline,
+    })
+  }
+
+  loads.sort(
+    (a, b) => FLAG_SEVERITY[b.flag] - FLAG_SEVERITY[a.flag] || a.movement.localeCompare(b.movement),
+  )
+  return loads
+}


### PR DESCRIPTION
## What

Adds a **Load Management** panel to the Weight Room History page (`/training-facility/weight-room/history`) — a read-only, per-movement view of tendon-load ramp rate. The injury driver for tendon is *rate of change* of volume, not absolute volume, and that's silent to RHR/HRV; this surfaces it.

Per movement:
- **Trailing 7-day (acute) volume**, week-over-week % change, and **ACWR** (acute ÷ chronic-weekly, where chronic = trailing 28d ÷ 4).
- A **28-day trailing sparkline** (one series per chart — no multi-series).
- A **color-coded flag** (green / yellow / red), the worst of the WoW and ACWR signals.

Design decisions (from the issue + upfront alignment):
- **Pacific bucketing.** All day windows are anchored to `America/Los_Angeles` via a `pacificDayKey` helper. The rest of the app buckets in the *server's* local zone, which is UTC on Vercel — exactly what the issue says never to do — so this panel deliberately diverges. Calendar-day windows (not "last N sets") mean rest days contribute a real zero and correctly drag the acute load down.
- **Tunable thresholds.** WoW +10% and the ACWR bands (0.8 / 1.3 / 1.5) live in `constants/ramp-rate.ts`, mirroring the HR-zone / `TSB_ZONES` config pattern — not hardcoded in the math.
- **Extensible.** Movements are derived from the data, not a hardcoded list; a new exercise appears automatically. Loaded movements (predominantly weighted, e.g. shrugs) ramp on load-volume `Σ(reps × weight_lbs)`; bodyweight movements ramp on reps.
- **Scope.** Phase 1 only. Phase 2 (tendon probe log — new table + write route + per-zone trend) is split to #317.

## Files

- `constants/ramp-rate.ts` — tunable thresholds + `classifyAcwr` / `classifyWowPct` / `combineFlags`.
- `lib/training-facility/load-management.ts` — PT-anchored bucketing, window math, `buildMovementLoads`.
- `components/training-facility/weight-room/LoadManagementPanel.tsx` — presentational cards + sparkline.
- `app/training-facility/weight-room/history/page.tsx` — renders the panel as the first analytics section.
- Co-located tests for all three new modules.

## Test plan

- [ ] Visit `/training-facility/weight-room/history` (Training Facility flag on). A **Load Management** section renders above the heatmaps.
- [ ] Each active movement shows one card: 7d volume (with unit), WoW %, ACWR, a 28-day sparkline, and a colored flag dot + label.
- [ ] A movement with WoW > +10% **or** ACWR > 1.3 is visibly flagged (yellow), > 1.5 red; a steady movement is green.
- [ ] Loaded movements (e.g. weighted shrugs) show `lb` / "7d load volume"; bodyweight movements show `reps` / "7d rep volume".
- [ ] A movement with no prior week shows `—` for WoW; the card still renders.
- [ ] Movements not trained in the last 28 days don't appear; with no recent movements the empty-state copy shows.
- [ ] Cards are legible at mobile width (390px) and desktop.

### Verification run locally
- `npx tsc --noEmit` — clean
- `npm run test:coverage` — 1323 tests pass; per-path coverage gate (lib/constants/shared ≥ 80% lines) green
- `npx eslint` on changed files — clean
- `npx next build` — compiles; `/training-facility/weight-room/history` prerenders

Closes #316.
