### PR TITLE
feat(weight-room): surface grease-the-groove campaign windows in the UI

### DIFF
--- a/components/training-facility/weight-room/MonthlyFocusCard.test.tsx
+++ b/components/training-facility/weight-room/MonthlyFocusCard.test.tsx
@@ -82,6 +82,20 @@ describe('MonthlyFocusCard', () => {
     expect(screen.getByText('1d')).toBeInTheDocument()
   })
 
+  it('shows the campaign calendar window', () => {
+    render(
+      <MonthlyFocusCard
+        focus={FOCUS}
+        todayProgress={60}
+        adherence={ADHERENCE}
+        loadStats={BODYWEIGHT_LOAD}
+      />,
+    )
+    expect(screen.getByTestId('monthly-focus-shrugs-window').textContent).toMatch(
+      /Jul 1 .* Jul 31/,
+    )
+  })
+
   it('shows load stats only when the focus has weighted sets', () => {
     const { rerender } = render(
       <MonthlyFocusCard

--- a/components/training-facility/weight-room/MonthlyFocusCard.tsx
+++ b/components/training-facility/weight-room/MonthlyFocusCard.tsx
@@ -1,6 +1,10 @@
 import type { JSX } from 'react'
 
-import type { FocusAdherence, FocusLoadStats } from '@/lib/training-facility/monthly-focus'
+import {
+  formatFocusWindow,
+  type FocusAdherence,
+  type FocusLoadStats,
+} from '@/lib/training-facility/monthly-focus'
 import type { MonthlyFocus } from '@/types/weight-room'
 
 /** Props for {@link MonthlyFocusCard}. */
@@ -27,9 +31,10 @@ function trim1(n: number): string {
 /**
  * "Focus of the Month" card for the Weight Room Log View (#255). Surfaces
  * the active "grease the groove" campaign: today's progress toward the
- * daily target, windowed adherence (day N of the month, days hit, current
- * streak), and — for weighted focuses like shrugs — load stats (top set,
- * average load, tonnage).
+ * daily target, the campaign's calendar window (e.g. `Jul 1 – Jul 31`),
+ * windowed adherence (day N of the month, days hit, current streak), and —
+ * for weighted focuses like shrugs — load stats (top set, average load,
+ * tonnage).
  *
  * Renders nothing about load when the focus is bodyweight
  * (`loadStats.weightedSets === 0`), so a calisthenics focus doesn't show
@@ -81,12 +86,20 @@ export function MonthlyFocusCard({
         ) : null}
       </div>
 
-      {/* Windowed adherence. */}
-      <dl className="grid grid-cols-3 gap-3 text-center">
-        <FocusStat label="Day" value={`${dayOfWindow}/${adherence.daysInWindow}`} />
-        <FocusStat label="Days hit" value={`${adherence.daysHit}`} />
-        <FocusStat label="Streak" value={`${adherence.currentStreak}d`} />
-      </dl>
+      {/* Campaign window + windowed adherence. */}
+      <div className="flex flex-col gap-3">
+        <span
+          data-testid={`monthly-focus-${focus.exercise}-window`}
+          className="text-center font-mono text-[10px] uppercase tracking-[0.18em] tabular-nums text-white/45"
+        >
+          {formatFocusWindow(focus)}
+        </span>
+        <dl className="grid grid-cols-3 gap-3 text-center">
+          <FocusStat label="Day" value={`${dayOfWindow}/${adherence.daysInWindow}`} />
+          <FocusStat label="Days hit" value={`${adherence.daysHit}`} />
+          <FocusStat label="Streak" value={`${adherence.currentStreak}d`} />
+        </dl>
+      </div>
 
       {/* Load stats — only for weighted focuses. */}
       {hasLoad ? (

--- a/components/training-facility/weight-room/UpcomingFocusStrip.test.tsx
+++ b/components/training-facility/weight-room/UpcomingFocusStrip.test.tsx
@@ -33,13 +33,18 @@ describe('UpcomingFocusStrip', () => {
     expect(container).toBeEmptyDOMElement()
   })
 
-  it('lists each upcoming focus with its exercise and month', () => {
+  it('lists each upcoming focus with its exercise and full window', () => {
     render(<UpcomingFocusStrip focuses={[SHRUGS, CALVES]} />)
     expect(screen.getByText('Up Next')).toBeInTheDocument()
     expect(screen.getByTestId('upcoming-focus-shrugs')).toBeInTheDocument()
     expect(screen.getByTestId('upcoming-focus-calf-raises')).toBeInTheDocument()
-    // Month label derived from start_date (locale-formatted; assert the year is present).
-    expect(screen.getByTestId('upcoming-focus-shrugs').textContent).toMatch(/2026/)
+    // Window derived from [start_date, end_date] (locale-formatted, no year).
+    expect(screen.getByTestId('upcoming-focus-shrugs-window').textContent).toMatch(
+      /Jul 1 .* Jul 31/,
+    )
+    expect(screen.getByTestId('upcoming-focus-calf-raises-window').textContent).toMatch(
+      /Aug 1 .* Aug 31/,
+    )
   })
 
   it('tags each chip with its body-region category', () => {

--- a/components/training-facility/weight-room/UpcomingFocusStrip.tsx
+++ b/components/training-facility/weight-room/UpcomingFocusStrip.tsx
@@ -1,5 +1,6 @@
 import type { JSX } from 'react'
 
+import { formatFocusWindow } from '@/lib/training-facility/monthly-focus'
 import type { MonthlyFocus } from '@/types/weight-room'
 
 /** Props for {@link UpcomingFocusStrip}. */
@@ -9,17 +10,6 @@ export interface UpcomingFocusStripProps {
    * `upcomingFocuses`. The strip renders nothing when this is empty.
    */
   focuses: readonly MonthlyFocus[]
-}
-
-/**
- * Format a focus's start date as a short month label (e.g. `Jul 2026`)
- * for the "Up Next" chips. Parses at local noon so the bare
- * `YYYY-MM-DD` doesn't shift a month boundary in negative-offset zones.
- */
-function focusMonthLabel(focus: MonthlyFocus): string {
-  const d = new Date(focus.start_date + 'T12:00:00')
-  if (!Number.isFinite(d.getTime())) return focus.start_date
-  return d.toLocaleDateString(undefined, { month: 'short', year: 'numeric' })
 }
 
 /**
@@ -55,8 +45,11 @@ export function UpcomingFocusStrip({ focuses }: UpcomingFocusStripProps): JSX.El
           >
             {focus.category}
           </span>
-          <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-white/45">
-            {focusMonthLabel(focus)}
+          <span
+            data-testid={`upcoming-focus-${focus.exercise}-window`}
+            className="font-mono text-[10px] uppercase tracking-[0.14em] tabular-nums text-white/45"
+          >
+            {formatFocusWindow(focus)}
           </span>
         </span>
       ))}

--- a/lib/training-facility/monthly-focus.test.ts
+++ b/lib/training-facility/monthly-focus.test.ts
@@ -6,6 +6,7 @@ import {
   activeFocusesForDay,
   computeFocusAdherence,
   computeFocusLoadStats,
+  formatFocusWindow,
   isFocusActiveOnDay,
   upcomingFocuses,
 } from './monthly-focus'
@@ -79,6 +80,26 @@ describe('isFocusActiveOnDay', () => {
     expect(isFocusActiveOnDay(JULY_SHRUGS, '2026-06-30')).toBe(false)
     expect(isFocusActiveOnDay(JULY_SHRUGS, '2026-08-01')).toBe(false)
     expect(isFocusActiveOnDay(JULY_SHRUGS, '')).toBe(false)
+  })
+})
+
+describe('formatFocusWindow', () => {
+  it('formats a same-month window as a short day range without a year', () => {
+    expect(formatFocusWindow(JULY_SHRUGS)).toBe('Jul 1 – Jul 31')
+  })
+
+  it('spans a month/year boundary', () => {
+    const winter: MonthlyFocus = {
+      ...JULY_SHRUGS,
+      start_date: '2026-12-15',
+      end_date: '2027-01-12',
+    }
+    expect(formatFocusWindow(winter)).toBe('Dec 15 – Jan 12')
+  })
+
+  it('falls back to the raw ISO keys when a date is unparseable', () => {
+    const broken: MonthlyFocus = { ...JULY_SHRUGS, end_date: 'not-a-date' }
+    expect(formatFocusWindow(broken)).toBe('2026-07-01 – not-a-date')
   })
 })
 

--- a/lib/training-facility/monthly-focus.ts
+++ b/lib/training-facility/monthly-focus.ts
@@ -80,6 +80,28 @@ export function upcomingFocuses(
 }
 
 /**
+ * Format a focus's `[start_date, end_date]` window as a short human
+ * range, e.g. `Jul 1 – Jul 31` (or `Dec 15 – Jan 12` across a month/year
+ * boundary). Each bare `YYYY-MM-DD` is parsed at local noon so the range
+ * isn't shifted by the viewer's UTC offset, matching the rest of this
+ * module's date handling. Falls back to the raw ISO keys if either date
+ * is unparseable. No year is shown — the rotation is near-term and the
+ * label stays compact; callers wanting the year can read `start_date`.
+ *
+ * @param focus The focus whose window to label.
+ */
+export function formatFocusWindow(focus: MonthlyFocus): string {
+  const start = new Date(focus.start_date + 'T12:00:00')
+  const end = new Date(focus.end_date + 'T12:00:00')
+  if (!Number.isFinite(start.getTime()) || !Number.isFinite(end.getTime())) {
+    return `${focus.start_date} – ${focus.end_date}`
+  }
+  const short = (d: Date): string =>
+    d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
+  return `${short(start)} – ${short(end)}`
+}
+
+/**
  * Add `n` days to a `YYYY-MM-DD` key, returning a new key. Local-noon
  * base time so DST transitions don't shift the calendar day. Same helper
  * shape as `strength-streaks.addDays`.


### PR DESCRIPTION
## What

The grease-the-groove **monthly focus** model has always stored `start_date` / `end_date` (inclusive window, DB-checked `end_date >= start_date`) — but the literal window was never rendered in the UI. The active card showed only a relative `Day 13/31`, and the "Up Next" strip only a start-month chip (`Jul 2026`). This surfaces the actual calendar window in both places.

## Changes

- **`formatFocusWindow()`** (new, in `lib/training-facility/monthly-focus.ts`) → `"Jul 1 – Jul 31"`. Local-noon parse (TZ-safe, matching the module's existing date handling), spans month/year boundaries (`Dec 15 – Jan 12`), falls back to raw ISO keys if unparseable. No year, to stay compact.
- **`MonthlyFocusCard`** — window caption above the Day / Days-hit / Streak grid.
- **`UpcomingFocusStrip`** — full window instead of month-only (drops the local `focusMonthLabel` helper in favor of the shared one).
- **Tests** — unit tests for `formatFocusWindow` (same-month, cross-boundary, unparseable fallback); both component tests now assert the rendered window via new `-window` testids.

## Verification

- `vitest run` on the three affected files — 31 pass
- `tsc --noEmit` — clean
- `eslint` on changed files — clean

No schema/migration touched — this only renders a field that already existed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)