### PR TITLE
feat(otf): monthly mileage tracker with milestone badges (#321)

### DIFF
--- a/app/api/admin/otf/mileage-awards/[id]/route.test.ts
+++ b/app/api/admin/otf/mileage-awards/[id]/route.test.ts
@@ -1,0 +1,156 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextResponse } from 'next/server'
+
+import { DELETE, PATCH } from './route'
+
+/**
+ * Tests for `PATCH`/`DELETE /api/admin/otf/mileage-awards/[id]` (#321). Auth
+ * gate + Supabase service-role client mocked; both verbs end their chain in
+ * `.select().maybeSingle()`, so a missing row resolves `{ data: null }` → 404.
+ */
+
+const requireAdminMock = vi.fn()
+vi.mock('@/lib/auth/require-admin', () => ({
+  requireAdmin: () => requireAdminMock(),
+}))
+
+const maybeSingleMock = vi.fn()
+const supabaseChain = {
+  from: vi.fn(() => supabaseChain),
+  update: vi.fn(() => supabaseChain),
+  delete: vi.fn(() => supabaseChain),
+  eq: vi.fn(() => supabaseChain),
+  select: vi.fn(() => supabaseChain),
+  maybeSingle: vi.fn(() => maybeSingleMock()),
+}
+vi.mock('@/lib/supabase/admin', () => ({
+  createAdminSupabaseClient: () => supabaseChain,
+}))
+
+const VALID_ID = '44444444-4444-4444-8444-444444444444'
+
+beforeEach(() => {
+  requireAdminMock.mockReset()
+  maybeSingleMock.mockReset()
+  supabaseChain.from.mockClear()
+  supabaseChain.update.mockClear()
+  supabaseChain.delete.mockClear()
+  supabaseChain.eq.mockClear()
+  supabaseChain.select.mockClear()
+  supabaseChain.maybeSingle.mockClear()
+  supabaseChain.from.mockReturnValue(supabaseChain)
+  supabaseChain.update.mockReturnValue(supabaseChain)
+  supabaseChain.delete.mockReturnValue(supabaseChain)
+  supabaseChain.eq.mockReturnValue(supabaseChain)
+  supabaseChain.select.mockReturnValue(supabaseChain)
+  supabaseChain.maybeSingle.mockImplementation(() => maybeSingleMock())
+})
+
+function ctx(id: string): { params: Promise<{ id: string }> } {
+  return { params: Promise.resolve({ id }) }
+}
+
+function patchRequest(body: unknown): Request {
+  return new Request(`http://localhost/api/admin/otf/mileage-awards/${VALID_ID}`, {
+    method: 'PATCH',
+    headers: { 'content-type': 'application/json' },
+    body: typeof body === 'string' ? body : JSON.stringify(body),
+  })
+}
+
+describe('PATCH /api/admin/otf/mileage-awards/[id]', () => {
+  it('returns 401 when not signed in', async () => {
+    requireAdminMock.mockResolvedValueOnce({
+      ok: false,
+      response: NextResponse.json({ error: 'Sign in required.' }, { status: 401 }),
+    })
+    const res = await PATCH(patchRequest({ miles: 20 }) as never, ctx(VALID_ID))
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 400 for a non-UUID id', async () => {
+    requireAdminMock.mockResolvedValue({ ok: true, email: 'a@b.com' })
+    const res = await PATCH(patchRequest({ miles: 20 }) as never, ctx('not-a-uuid'))
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 for an empty patch', async () => {
+    requireAdminMock.mockResolvedValue({ ok: true, email: 'a@b.com' })
+    const res = await PATCH(patchRequest({}) as never, ctx(VALID_ID))
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 404 when no tier matches the id', async () => {
+    requireAdminMock.mockResolvedValue({ ok: true, email: 'a@b.com' })
+    maybeSingleMock.mockResolvedValueOnce({ data: null, error: null })
+    const res = await PATCH(patchRequest({ miles: 20 }) as never, ctx(VALID_ID))
+    expect(res.status).toBe(404)
+  })
+
+  it('returns 409 when the new label collides', async () => {
+    requireAdminMock.mockResolvedValue({ ok: true, email: 'a@b.com' })
+    maybeSingleMock.mockResolvedValueOnce({ data: null, error: { code: '23505', message: 'dup' } })
+    const res = await PATCH(patchRequest({ label: 'Marathon' }) as never, ctx(VALID_ID))
+    expect(res.status).toBe(409)
+  })
+
+  it('returns 200 and updates only the supplied fields', async () => {
+    requireAdminMock.mockResolvedValue({ ok: true, email: 'a@b.com' })
+    maybeSingleMock.mockResolvedValueOnce({
+      data: { id: VALID_ID, label: 'Marathon', miles: 26.2, color: '#F97316' },
+      error: null,
+    })
+    const res = await PATCH(patchRequest({ miles: 26.2 }) as never, ctx(VALID_ID))
+    expect(res.status).toBe(200)
+    // Only `miles` was sent, so the update payload carries miles but no label.
+    expect(supabaseChain.update).toHaveBeenCalledWith(expect.objectContaining({ miles: 26.2 }))
+    expect(supabaseChain.update).not.toHaveBeenCalledWith(
+      expect.objectContaining({ label: expect.anything() }),
+    )
+    expect(supabaseChain.eq).toHaveBeenCalledWith('id', VALID_ID)
+  })
+})
+
+describe('DELETE /api/admin/otf/mileage-awards/[id]', () => {
+  it('returns 401 when not signed in', async () => {
+    requireAdminMock.mockResolvedValueOnce({
+      ok: false,
+      response: NextResponse.json({ error: 'Sign in required.' }, { status: 401 }),
+    })
+    const res = await DELETE({} as never, ctx(VALID_ID))
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 400 for a non-UUID id', async () => {
+    requireAdminMock.mockResolvedValue({ ok: true, email: 'a@b.com' })
+    const res = await DELETE({} as never, ctx('not-a-uuid'))
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 404 when no tier matches the id', async () => {
+    requireAdminMock.mockResolvedValue({ ok: true, email: 'a@b.com' })
+    maybeSingleMock.mockResolvedValueOnce({ data: null, error: null })
+    const res = await DELETE({} as never, ctx(VALID_ID))
+    expect(res.status).toBe(404)
+  })
+
+  it('returns 500 on an unexpected Supabase error', async () => {
+    requireAdminMock.mockResolvedValue({ ok: true, email: 'a@b.com' })
+    maybeSingleMock.mockResolvedValueOnce({ data: null, error: { message: 'boom' } })
+    const res = await DELETE({} as never, ctx(VALID_ID))
+    expect(res.status).toBe(500)
+  })
+
+  it('returns 200 with the deleted row on success', async () => {
+    requireAdminMock.mockResolvedValue({ ok: true, email: 'a@b.com' })
+    maybeSingleMock.mockResolvedValueOnce({
+      data: { id: VALID_ID, label: 'Ultra', miles: 31.1, color: '#EA580C' },
+      error: null,
+    })
+    const res = await DELETE({} as never, ctx(VALID_ID))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toEqual({ id: VALID_ID, label: 'Ultra', miles: 31.1, color: '#EA580C' })
+    expect(supabaseChain.eq).toHaveBeenCalledWith('id', VALID_ID)
+  })
+})

--- a/app/api/admin/otf/mileage-awards/[id]/route.ts
+++ b/app/api/admin/otf/mileage-awards/[id]/route.ts
@@ -1,0 +1,162 @@
+/**
+ * Admin-only item endpoint for OTF mileage milestone tiers (#321) — edit
+ * (PATCH) and remove (DELETE). Sibling of the collection POST: same admin
+ * gate, same service-role client, same `otf_mileage_awards` table whose RLS
+ * permits SELECT only.
+ */
+
+import { NextResponse, type NextRequest } from 'next/server'
+import { ZodError } from 'zod'
+
+import { requireAdmin } from '@/lib/auth/require-admin'
+import { OtfMileageAwardUpdateSchema } from '@/lib/schemas/otf'
+import { createAdminSupabaseClient } from '@/lib/supabase/admin'
+import { withTelemetry } from '@/lib/telemetry/with-telemetry'
+
+/** Next.js route context; `params.id` is the award row's UUID from the URL. */
+interface Context {
+  params: Promise<{ id: string }>
+}
+
+/**
+ * Loose UUID guard — keeps the 400 (malformed id, a client bug) vs 404
+ * (valid-but-missing id) distinction clean before hitting Postgres.
+ */
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+/** Postgres unique-violation SQLSTATE — raised when a renamed `label` collides. */
+const UNIQUE_VIOLATION = '23505'
+
+/**
+ * Edit one mileage tier by `id`. Body must conform to
+ * {@link OtfMileageAwardUpdateSchema} — every field optional, but at least one
+ * of `label` / `miles` / `color` required. Only the supplied fields change.
+ *
+ * Status codes:
+ * - 200 — updated (response echoes the row)
+ * - 400 — `id` not a UUID, empty patch, or payload failed validation / bad JSON
+ * - 401 — not signed in
+ * - 403 — not on the allowlist
+ * - 404 — no tier exists for `id`
+ * - 409 — the new `label` collides with another tier
+ * - 500 — unexpected Supabase error
+ *
+ * @param request Incoming JSON request whose body matches
+ *   {@link OtfMileageAwardUpdateSchema}.
+ * @param ctx Next.js route context; `ctx.params.id` is the tier's UUID.
+ * @throws when Supabase env vars are missing (misconfigured deploy). Domain
+ *   failures are returned as JSON responses, not thrown.
+ */
+async function handlePATCH(request: NextRequest, ctx: Context): Promise<NextResponse> {
+  const auth = await requireAdmin()
+  if (!auth.ok) return auth.response
+
+  const { id } = await ctx.params
+  if (!UUID_REGEX.test(id)) {
+    return NextResponse.json({ error: 'id must be a UUID.' }, { status: 400 })
+  }
+
+  let payload: unknown
+  try {
+    payload = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Body must be valid JSON.' }, { status: 400 })
+  }
+
+  let patch
+  try {
+    patch = OtfMileageAwardUpdateSchema.parse(payload)
+  } catch (err) {
+    if (err instanceof ZodError) {
+      return NextResponse.json(
+        { error: 'Validation failed.', issues: err.flatten() },
+        { status: 400 },
+      )
+    }
+    throw err
+  }
+
+  // Only the supplied fields are written; `color` maps undefined → null so a
+  // caller can clear the accent by sending `null`-equivalent (omitting it keeps
+  // the current value, sending it as an empty string is rejected by the schema).
+  const update: Record<string, unknown> = { updated_at: new Date().toISOString() }
+  if (patch.label !== undefined) update.label = patch.label
+  if (patch.miles !== undefined) update.miles = patch.miles
+  if (patch.color !== undefined) update.color = patch.color
+
+  const supabase = createAdminSupabaseClient()
+  const { data, error } = await supabase
+    .from('otf_mileage_awards')
+    .update(update)
+    .eq('id', id)
+    .select('id, label, miles, color')
+    .maybeSingle()
+
+  if (error) {
+    if (error.code === UNIQUE_VIOLATION) {
+      return NextResponse.json(
+        { error: `A milestone labeled '${patch.label}' already exists.` },
+        { status: 409 },
+      )
+    }
+    return NextResponse.json(
+      { error: `Failed to update mileage award: ${error.message}` },
+      { status: 500 },
+    )
+  }
+  if (!data) {
+    return NextResponse.json({ error: `No mileage award for id '${id}'.` }, { status: 404 })
+  }
+  return NextResponse.json(data, { status: 200 })
+}
+
+/**
+ * Delete one mileage tier by `id`.
+ *
+ * Status codes:
+ * - 200 — deleted (response body echoes the removed row)
+ * - 400 — `id` is not a valid UUID
+ * - 401 — not signed in
+ * - 403 — not on the allowlist
+ * - 404 — no tier exists for `id`
+ * - 500 — unexpected Supabase error
+ *
+ * @param _request Unused — DELETE has no body. Required by the handler signature.
+ * @param ctx Next.js route context; `ctx.params.id` is the tier's UUID.
+ * @throws when Supabase env vars are missing (misconfigured deploy). Domain
+ *   failures are returned as JSON responses, not thrown.
+ */
+async function handleDELETE(_request: NextRequest, ctx: Context): Promise<NextResponse> {
+  const auth = await requireAdmin()
+  if (!auth.ok) return auth.response
+
+  const { id } = await ctx.params
+  if (!UUID_REGEX.test(id)) {
+    return NextResponse.json({ error: 'id must be a UUID.' }, { status: 400 })
+  }
+
+  const supabase = createAdminSupabaseClient()
+  const { data, error } = await supabase
+    .from('otf_mileage_awards')
+    .delete()
+    .eq('id', id)
+    .select('id, label, miles, color')
+    .maybeSingle()
+
+  if (error) {
+    return NextResponse.json(
+      { error: `Failed to delete mileage award: ${error.message}` },
+      { status: 500 },
+    )
+  }
+  if (!data) {
+    return NextResponse.json({ error: `No mileage award for id '${id}'.` }, { status: 404 })
+  }
+  return NextResponse.json(data, { status: 200 })
+}
+
+/** `handlePATCH` wrapped with one-event-per-request telemetry (#220). */
+export const PATCH = withTelemetry('PATCH /api/admin/otf/mileage-awards/[id]', handlePATCH)
+
+/** `handleDELETE` wrapped with one-event-per-request telemetry (#220). */
+export const DELETE = withTelemetry('DELETE /api/admin/otf/mileage-awards/[id]', handleDELETE)

--- a/app/api/admin/otf/mileage-awards/[id]/route.ts
+++ b/app/api/admin/otf/mileage-awards/[id]/route.ts
@@ -76,9 +76,9 @@ async function handlePATCH(request: NextRequest, ctx: Context): Promise<NextResp
     throw err
   }
 
-  // Only the supplied fields are written; `color` maps undefined → null so a
-  // caller can clear the accent by sending `null`-equivalent (omitting it keeps
-  // the current value, sending it as an empty string is rejected by the schema).
+  // Patch semantics: only fields present in the validated body are written, so
+  // omitting a field leaves the column untouched. The schema rejects an empty
+  // string for `color`, so a tier's accent can be changed but not cleared here.
   const update: Record<string, unknown> = { updated_at: new Date().toISOString() }
   if (patch.label !== undefined) update.label = patch.label
   if (patch.miles !== undefined) update.miles = patch.miles

--- a/app/api/admin/otf/mileage-awards/route.test.ts
+++ b/app/api/admin/otf/mileage-awards/route.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextResponse } from 'next/server'
+
+import { POST } from './route'
+
+/**
+ * Tests for `POST /api/admin/otf/mileage-awards` (#321). The auth gate and the
+ * Supabase service-role client are mocked; the route's single write ends in
+ * `.insert().select().single()`, so the mock resolves that terminal call.
+ */
+
+const requireAdminMock = vi.fn()
+vi.mock('@/lib/auth/require-admin', () => ({
+  requireAdmin: () => requireAdminMock(),
+}))
+
+const singleMock = vi.fn()
+const supabaseChain = {
+  from: vi.fn(() => supabaseChain),
+  insert: vi.fn(() => supabaseChain),
+  select: vi.fn(() => supabaseChain),
+  single: vi.fn(() => singleMock()),
+}
+vi.mock('@/lib/supabase/admin', () => ({
+  createAdminSupabaseClient: () => supabaseChain,
+}))
+
+const validAward = { label: 'Ultra', miles: 31.1, color: '#EA580C' }
+
+beforeEach(() => {
+  requireAdminMock.mockReset()
+  singleMock.mockReset()
+  supabaseChain.from.mockClear()
+  supabaseChain.insert.mockClear()
+  supabaseChain.select.mockClear()
+  supabaseChain.single.mockClear()
+  supabaseChain.from.mockReturnValue(supabaseChain)
+  supabaseChain.insert.mockReturnValue(supabaseChain)
+  supabaseChain.select.mockReturnValue(supabaseChain)
+  supabaseChain.single.mockImplementation(() => singleMock())
+  // Happy-path default; individual tests override.
+  singleMock.mockResolvedValue({ data: { id: 'a1', ...validAward }, error: null })
+})
+
+function makeRequest(body: unknown): Request {
+  return new Request('http://localhost/api/admin/otf/mileage-awards', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: typeof body === 'string' ? body : JSON.stringify(body),
+  })
+}
+
+describe('POST /api/admin/otf/mileage-awards', () => {
+  it('returns 401 when not signed in', async () => {
+    requireAdminMock.mockResolvedValueOnce({
+      ok: false,
+      response: NextResponse.json({ error: 'Sign in required.' }, { status: 401 }),
+    })
+    const res = await POST(makeRequest(validAward) as never)
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 400 when the body is not valid JSON', async () => {
+    requireAdminMock.mockResolvedValue({ ok: true, email: 'a@b.com' })
+    const res = await POST(makeRequest('{ not json') as never)
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 when label is missing', async () => {
+    requireAdminMock.mockResolvedValue({ ok: true, email: 'a@b.com' })
+    const res = await POST(makeRequest({ miles: 13.1 }) as never)
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 when miles is not positive', async () => {
+    requireAdminMock.mockResolvedValue({ ok: true, email: 'a@b.com' })
+    const res = await POST(makeRequest({ label: 'Zero', miles: 0 }) as never)
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 409 when the label already exists', async () => {
+    requireAdminMock.mockResolvedValue({ ok: true, email: 'a@b.com' })
+    singleMock.mockResolvedValueOnce({ data: null, error: { code: '23505', message: 'dup' } })
+    const res = await POST(makeRequest(validAward) as never)
+    expect(res.status).toBe(409)
+  })
+
+  it('returns 500 on an unexpected Supabase error', async () => {
+    requireAdminMock.mockResolvedValue({ ok: true, email: 'a@b.com' })
+    singleMock.mockResolvedValueOnce({ data: null, error: { code: 'XX001', message: 'boom' } })
+    const res = await POST(makeRequest(validAward) as never)
+    expect(res.status).toBe(500)
+  })
+
+  it('returns 201 and inserts the tier on success', async () => {
+    requireAdminMock.mockResolvedValue({ ok: true, email: 'a@b.com' })
+    const res = await POST(makeRequest(validAward) as never)
+    expect(res.status).toBe(201)
+    expect(supabaseChain.insert).toHaveBeenCalledWith(
+      expect.objectContaining({ label: 'Ultra', miles: 31.1, color: '#EA580C' }),
+    )
+  })
+
+  it('writes color: null when the color is omitted', async () => {
+    requireAdminMock.mockResolvedValue({ ok: true, email: 'a@b.com' })
+    await POST(makeRequest({ label: 'Marathon', miles: 26.2 }) as never)
+    expect(supabaseChain.insert).toHaveBeenCalledWith(expect.objectContaining({ color: null }))
+  })
+})

--- a/app/api/admin/otf/mileage-awards/route.ts
+++ b/app/api/admin/otf/mileage-awards/route.ts
@@ -1,0 +1,96 @@
+/**
+ * Admin-only collection endpoint for OTF mileage milestone tiers (#321).
+ *
+ * The monthly-mileage section lights up a badge as the month's OTF miles cross
+ * each tier's threshold (half marathon, marathon, ultra…). The ladder lives in
+ * `otf_mileage_awards`, whose RLS permits SELECT only, so the admin editor
+ * funnels creates through this gate on the service-role client — mirroring the
+ * Weight Room monthly-focus routes.
+ *
+ * Pair with `[id]/route.ts` for PATCH (edit) and DELETE.
+ */
+
+import { NextResponse, type NextRequest } from 'next/server'
+import { ZodError } from 'zod'
+
+import { requireAdmin } from '@/lib/auth/require-admin'
+import { OtfMileageAwardCreateSchema } from '@/lib/schemas/otf'
+import { createAdminSupabaseClient } from '@/lib/supabase/admin'
+import { withTelemetry } from '@/lib/telemetry/with-telemetry'
+
+/** Postgres unique-violation SQLSTATE — raised when `label` collides. */
+const UNIQUE_VIOLATION = '23505'
+
+/**
+ * Create a mileage milestone tier. Body must conform to
+ * {@link OtfMileageAwardCreateSchema} — `label` (unique, trimmed) and `miles`
+ * (positive) required; `color` optional.
+ *
+ * Status codes:
+ * - 201 — created (response echoes the inserted row)
+ * - 400 — payload failed Zod validation or wasn't valid JSON
+ * - 401 — not signed in
+ * - 403 — signed in but email not on the allowlist
+ * - 409 — a tier with the same `label` already exists
+ * - 500 — unexpected Supabase error
+ *
+ * @param request Incoming JSON request whose body matches
+ *   {@link OtfMileageAwardCreateSchema}.
+ * @throws when Supabase env vars are missing (misconfigured deploy).
+ *   Domain failures are returned as JSON responses, not thrown.
+ */
+async function handlePOST(request: NextRequest): Promise<NextResponse> {
+  const auth = await requireAdmin()
+  if (!auth.ok) return auth.response
+
+  let payload: unknown
+  try {
+    payload = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Body must be valid JSON.' }, { status: 400 })
+  }
+
+  let award
+  try {
+    award = OtfMileageAwardCreateSchema.parse(payload)
+  } catch (err) {
+    if (err instanceof ZodError) {
+      return NextResponse.json(
+        { error: 'Validation failed.', issues: err.flatten() },
+        { status: 400 },
+      )
+    }
+    throw err
+  }
+
+  const supabase = createAdminSupabaseClient()
+  const now = new Date().toISOString()
+  const { data, error } = await supabase
+    .from('otf_mileage_awards')
+    .insert({
+      label: award.label,
+      miles: award.miles,
+      color: award.color ?? null,
+      updated_at: now,
+    })
+    .select('id, label, miles, color')
+    .single()
+
+  if (error) {
+    if (error.code === UNIQUE_VIOLATION) {
+      return NextResponse.json(
+        { error: `A milestone labeled '${award.label}' already exists.` },
+        { status: 409 },
+      )
+    }
+    return NextResponse.json(
+      { error: `Failed to create mileage award: ${error.message}` },
+      { status: 500 },
+    )
+  }
+
+  return NextResponse.json(data, { status: 201 })
+}
+
+/** `handlePOST` wrapped with one-event-per-request telemetry (#220). */
+export const POST = withTelemetry('POST /api/admin/otf/mileage-awards', handlePOST)

--- a/app/training-facility/gym/otf/settings/page.tsx
+++ b/app/training-facility/gym/otf/settings/page.tsx
@@ -1,0 +1,72 @@
+import type { JSX } from 'react'
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+
+import { BackToCourtButton } from '@/components/common/BackToCourtButton'
+import { OtfMileageAwardsSettings } from '@/components/training-facility/gym/OtfMileageAwardsSettings'
+import { requireAdminPage } from '@/lib/auth/require-admin-page'
+import { getOtfMileageAwardsServer } from '@/lib/data/otf-server'
+import { isTrainingFacilityEnabled } from '@/lib/feature-flags'
+
+/**
+ * OrangeTheory mileage-milestone settings page (#321). Admin-only — non-admins
+ * get a 404 via `notFound()` so the route doesn't hint at its existence to
+ * unauthenticated viewers.
+ *
+ * Server Component because the admin check has to run server-side
+ * (`ADMIN_EMAILS` is intentionally not a `NEXT_PUBLIC_*` var, so the allowlist
+ * never reaches the browser bundle). The editor UI is a client island that
+ * posts to the admin API routes — see {@link OtfMileageAwardsSettings}.
+ *
+ * The milestone ladder is read server-side and passed to the island so the
+ * form hydrates with current values; the island refreshes via
+ * `router.refresh()` after each mutation to pick up the new state.
+ */
+export default async function OtfMileageSettingsPage(): Promise<JSX.Element> {
+  if (!isTrainingFacilityEnabled()) notFound()
+  await requireAdminPage()
+
+  // Catch transient read errors so a flaky Supabase response surfaces as an
+  // empty editor instead of 500ing the page. The island handles `awards: []`
+  // gracefully (renders the add form without an existing-tier list).
+  const awards = await getOtfMileageAwardsServer().catch(() => [])
+
+  return (
+    <div className="relative min-h-svh overflow-hidden bg-[#120d0a] text-[#f7ead9]">
+      <div
+        aria-hidden="true"
+        className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(249,115,22,0.12),transparent_30%),linear-gradient(180deg,#241811_0%,#120d0a_55%,#0b0806_100%)]"
+      />
+
+      <div className="relative z-10 mx-auto flex min-h-svh w-full max-w-3xl flex-col px-4 py-6 sm:px-6 sm:py-8 lg:px-10">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <BackToCourtButton />
+          <Link
+            href="/training-facility/gym/otf"
+            className="rounded-full border border-white/15 bg-white/5 px-4 py-2 text-xs font-semibold uppercase tracking-[0.28em] text-white/80 transition hover:bg-white/10"
+          >
+            ← OrangeTheory
+          </Link>
+        </div>
+
+        <header className="mt-12">
+          <p className="font-mono text-[11px] uppercase tracking-[0.32em] text-[#f97316]">
+            OrangeTheory · Settings
+          </p>
+          <h1 className="mt-2 text-3xl font-black uppercase tracking-[0.06em] text-[#fff7ec] sm:text-5xl">
+            Mileage milestones
+          </h1>
+          <p className="mt-3 max-w-xl text-sm leading-7 text-[#e8d5be] sm:text-base">
+            Distance thresholds that light up a badge as each month&apos;s OTF
+            miles (treadmill + rower) add up. Edit a tier&apos;s distance and the
+            badges re-light instantly — nothing is stored per month.
+          </p>
+        </header>
+
+        <section className="mt-10">
+          <OtfMileageAwardsSettings initialAwards={awards} />
+        </section>
+      </div>
+    </div>
+  )
+}

--- a/components/training-facility/gym/OtfDetailView.test.tsx
+++ b/components/training-facility/gym/OtfDetailView.test.tsx
@@ -14,7 +14,17 @@ import { OtfDetailView } from './OtfDetailView'
 
 const getOtfDataMock = vi.fn()
 
-vi.mock('@/lib/data', () => ({ getOtfData: () => getOtfDataMock() }))
+vi.mock('@/lib/data', () => ({
+  getOtfData: () => getOtfDataMock(),
+  // The mileage section (#321) fetches its ladder here; an empty ladder keeps
+  // these branch tests focused on the session-driven states.
+  getOtfMileageAwards: () => Promise.resolve([]),
+}))
+// The mileage section reads admin state to decide whether to show the
+// Milestones link; stub it non-admin so no network call escapes the test.
+vi.mock('@/lib/auth/use-admin-session', () => ({
+  useAdminSession: () => ({ isAdmin: false, isLoading: false, email: null }),
+}))
 vi.mock('./OtfZoneBars', () => ({ OtfZoneBars: () => null }))
 vi.mock('./OtfSparklineSummary', () => ({ OtfSparklineSummary: () => null }))
 vi.mock('@/components/training-facility/shared/charts/RoughLine', () => ({ RoughLine: () => null }))

--- a/components/training-facility/gym/OtfDetailView.tsx
+++ b/components/training-facility/gym/OtfDetailView.tsx
@@ -11,7 +11,8 @@ import {
   rangeForPreset,
   type DateRange,
 } from '@/components/training-facility/shared/DateFilter'
-import { getOtfData } from '@/lib/data'
+import { useAdminSession } from '@/lib/auth/use-admin-session'
+import { getOtfData, getOtfMileageAwards } from '@/lib/data'
 import {
   OTF_ZONES,
   aggregateOtfZoneMinutes,
@@ -31,8 +32,9 @@ import {
   resolveOtfClassTypeFilter,
   type OtfTrendPoint,
 } from '@/lib/training-facility/otf'
-import type { OtfData, OtfRower, OtfSession, OtfTreadmill } from '@/types/otf'
+import type { OtfData, OtfMileageAward, OtfRower, OtfSession, OtfTreadmill } from '@/types/otf'
 
+import { OtfMileageSection } from './OtfMileageSection'
 import { OtfSparklineSummary, type OtfSparklineRow } from './OtfSparklineSummary'
 import { OtfZoneBars } from './OtfZoneBars'
 
@@ -56,6 +58,11 @@ const EMPTY_OTF: OtfData = { imported_at: '', sessions: [] }
  */
 export function OtfDetailView(): JSX.Element {
   const [data, setData] = useState<OtfData | null>(null)
+  // Milestone ladder for the monthly-mileage section (#321). Independent of the
+  // session read: a failure here downgrades to an empty ladder (no badges)
+  // rather than blanking the page, so it never blocks the charts.
+  const [mileageAwards, setMileageAwards] = useState<OtfMileageAward[]>([])
+  const { isAdmin } = useAdminSession()
   const [loadError, setLoadError] = useState<Error | null>(null)
   const [range, setRange] = useState<DateRange>(() => rangeForPreset('ALL', EARLIEST_FALLBACK))
   const [chartWidth, setChartWidth] = useState(DEFAULT_CHART_WIDTH)
@@ -100,6 +107,17 @@ export function OtfDetailView(): JSX.Element {
       .catch((err: unknown) => {
         if (cancelled) return
         setLoadError(err instanceof Error ? err : new Error(String(err)))
+      })
+    // Load the milestone ladder in parallel; its failure is non-fatal (the
+    // mileage section just shows no badges), so it has its own catch and never
+    // trips `loadError`.
+    getOtfMileageAwards()
+      .then(awards => {
+        if (cancelled) return
+        setMileageAwards(awards)
+      })
+      .catch(() => {
+        /* leave the ladder empty — the section renders miles with no badges */
       })
     return () => {
       cancelled = true
@@ -253,6 +271,14 @@ export function OtfDetailView(): JSX.Element {
             Scoped to the date range.
           </p>
         </header>
+
+        {data ? (
+          <OtfMileageSection
+            sessions={data.sessions}
+            awards={mileageAwards}
+            isAdmin={isAdmin}
+          />
+        ) : null}
 
         <div className="mt-8">
           <DateFilter

--- a/components/training-facility/gym/OtfMileageAwardsSettings.tsx
+++ b/components/training-facility/gym/OtfMileageAwardsSettings.tsx
@@ -1,0 +1,284 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import { useState, useTransition, type FormEvent, type JSX } from 'react'
+
+import type { OtfMileageAward } from '@/types/otf'
+
+/** Props for {@link OtfMileageAwardsSettings}. */
+export interface OtfMileageAwardsSettingsProps {
+  /**
+   * The milestone ladder as read by the server component on first paint. The
+   * editor hydrates from this list; mutations refresh via `router.refresh()`
+   * so the next render comes from a fresh server fetch (no client cache to
+   * invalidate).
+   */
+  initialAwards: readonly OtfMileageAward[]
+}
+
+/** Accent applied to a new tier's color picker before the admin changes it — OTF orange. */
+const DEFAULT_NEW_COLOR = '#F97316'
+
+/**
+ * Admin-only editor for the OTF monthly-mileage milestone ladder (#321).
+ * Renders each existing tier as an editable row (label + miles + color) and a
+ * small form to add a new tier. Each mutation hits the admin API routes under
+ * `/api/admin/otf/mileage-awards`; on success the parent page's server data
+ * refreshes via `router.refresh()` so the ladder re-reads without a manual
+ * reload. Mirrors the Weight Room `StrengthSettings` editor.
+ */
+export function OtfMileageAwardsSettings({
+  initialAwards,
+}: OtfMileageAwardsSettingsProps): JSX.Element {
+  const router = useRouter()
+  const [error, setError] = useState<string | null>(null)
+  const [isPending, startTransition] = useTransition()
+
+  function refresh(): void {
+    startTransition(() => {
+      router.refresh()
+    })
+  }
+
+  async function createAward(body: {
+    label: string
+    miles: number
+    color: string
+  }): Promise<boolean> {
+    setError(null)
+    const res = await fetch('/api/admin/otf/mileage-awards', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+    if (!res.ok) {
+      const payload = (await res.json().catch(() => ({}))) as { error?: string }
+      setError(payload.error ?? `Save failed (${res.status})`)
+      return false
+    }
+    refresh()
+    return true
+  }
+
+  async function updateAward(
+    id: string,
+    body: { label: string; miles: number; color: string },
+  ): Promise<void> {
+    setError(null)
+    const res = await fetch(`/api/admin/otf/mileage-awards/${encodeURIComponent(id)}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+    if (!res.ok) {
+      const payload = (await res.json().catch(() => ({}))) as { error?: string }
+      setError(payload.error ?? `Save failed (${res.status})`)
+      return
+    }
+    refresh()
+  }
+
+  async function deleteAward(award: OtfMileageAward): Promise<void> {
+    setError(null)
+    const ok = window.confirm(`Delete the "${award.label}" milestone?`)
+    if (!ok) return
+    const res = await fetch(`/api/admin/otf/mileage-awards/${encodeURIComponent(award.id)}`, {
+      method: 'DELETE',
+    })
+    if (!res.ok) {
+      const payload = (await res.json().catch(() => ({}))) as { error?: string }
+      setError(payload.error ?? `Delete failed (${res.status})`)
+      return
+    }
+    refresh()
+  }
+
+  return (
+    <div className="space-y-8">
+      {error ? (
+        <p
+          role="alert"
+          className="rounded border border-rose-400/30 bg-rose-950/40 px-3 py-2 font-mono text-[12px] text-rose-200"
+        >
+          {error}
+        </p>
+      ) : null}
+
+      <section aria-label="Existing milestones">
+        <h2 className="font-mono text-[11px] uppercase tracking-[0.32em] text-amber-300/80">
+          Milestones
+        </h2>
+        {initialAwards.length === 0 ? (
+          <p className="mt-3 text-sm text-[#e8d5be]/70">
+            No milestones yet — add one below to start lighting up badges.
+          </p>
+        ) : (
+          <ul className="mt-3 space-y-3">
+            {initialAwards.map((award) => (
+              <AwardRow
+                key={award.id}
+                award={award}
+                disabled={isPending}
+                onSave={updateAward}
+                onDelete={deleteAward}
+              />
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <section aria-label="Add a milestone">
+        <h2 className="font-mono text-[11px] uppercase tracking-[0.32em] text-amber-300/80">
+          Add milestone
+        </h2>
+        <AddAwardForm disabled={isPending} onAdd={createAward} />
+      </section>
+    </div>
+  )
+}
+
+/** Props for one editable milestone row. */
+interface AwardRowProps {
+  award: OtfMileageAward
+  disabled: boolean
+  onSave: (id: string, body: { label: string; miles: number; color: string }) => Promise<void>
+  onDelete: (award: OtfMileageAward) => Promise<void>
+}
+
+/** One existing milestone tier as an inline-editable label / miles / color form. */
+function AwardRow({ award, disabled, onSave, onDelete }: AwardRowProps): JSX.Element {
+  const [label, setLabel] = useState<string>(award.label)
+  const [miles, setMiles] = useState<number>(award.miles)
+  const [color, setColor] = useState<string>(award.color ?? DEFAULT_NEW_COLOR)
+  const dirty = label !== award.label || miles !== award.miles || color !== (award.color ?? DEFAULT_NEW_COLOR)
+
+  async function handleSubmit(e: FormEvent<HTMLFormElement>): Promise<void> {
+    e.preventDefault()
+    const trimmed = label.trim()
+    if (!dirty || trimmed.length === 0 || !(miles > 0)) return
+    await onSave(award.id, { label: trimmed, miles, color })
+  }
+
+  return (
+    <li className="rounded-[1.1rem] border border-white/10 bg-white/5 p-4">
+      <form onSubmit={handleSubmit} className="flex flex-wrap items-center gap-3 sm:gap-4">
+        <label className="flex items-center gap-2 text-xs text-white/70">
+          <span className="font-mono uppercase tracking-[0.18em]">name</span>
+          <input
+            type="text"
+            value={label}
+            onChange={(e) => setLabel(e.target.value)}
+            className="w-40 rounded border border-white/15 bg-black/40 px-2 py-1 font-mono text-sm text-white focus:border-amber-300/60 focus:outline-none"
+          />
+        </label>
+        <label className="flex items-center gap-2 text-xs text-white/70">
+          <span className="font-mono uppercase tracking-[0.18em]">miles</span>
+          <input
+            type="number"
+            min={0.1}
+            step={0.1}
+            value={miles}
+            onChange={(e) => setMiles(Number(e.target.value))}
+            className="w-20 rounded border border-white/15 bg-black/40 px-2 py-1 text-right font-mono text-sm text-white focus:border-amber-300/60 focus:outline-none"
+          />
+        </label>
+        <label className="flex items-center gap-2 text-xs text-white/70">
+          <span className="font-mono uppercase tracking-[0.18em]">color</span>
+          <input
+            type="color"
+            value={color}
+            onChange={(e) => setColor(e.target.value)}
+            className="h-8 w-12 cursor-pointer rounded border border-white/15 bg-black/40"
+          />
+        </label>
+        <div className="ml-auto flex gap-2">
+          <button
+            type="submit"
+            disabled={disabled || !dirty}
+            className="rounded-full border border-amber-200/30 bg-amber-200/10 px-4 py-1.5 font-mono text-[11px] uppercase tracking-[0.22em] text-amber-100 transition hover:bg-amber-200/20 disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            Save
+          </button>
+          <button
+            type="button"
+            disabled={disabled}
+            onClick={() => onDelete(award)}
+            className="rounded-full border border-rose-300/25 bg-rose-300/5 px-4 py-1.5 font-mono text-[11px] uppercase tracking-[0.22em] text-rose-200 transition hover:bg-rose-300/15 disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            Delete
+          </button>
+        </div>
+      </form>
+    </li>
+  )
+}
+
+/** Props for the add-milestone form. */
+interface AddAwardFormProps {
+  disabled: boolean
+  onAdd: (body: { label: string; miles: number; color: string }) => Promise<boolean>
+}
+
+/** Small form to append a new milestone tier; clears itself on a successful add. */
+function AddAwardForm({ disabled, onAdd }: AddAwardFormProps): JSX.Element {
+  const [label, setLabel] = useState<string>('')
+  const [miles, setMiles] = useState<number>(13.1)
+  const [color, setColor] = useState<string>(DEFAULT_NEW_COLOR)
+
+  async function handleSubmit(e: FormEvent<HTMLFormElement>): Promise<void> {
+    e.preventDefault()
+    const trimmed = label.trim()
+    if (trimmed.length === 0 || !(miles > 0)) return
+    const ok = await onAdd({ label: trimmed, miles, color })
+    if (!ok) return
+    setLabel('')
+    setMiles(13.1)
+    setColor(DEFAULT_NEW_COLOR)
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="mt-3 grid gap-3 rounded-[1.1rem] border border-white/10 bg-white/5 p-4 sm:grid-cols-[1fr_auto_auto_auto] sm:items-end"
+    >
+      <label className="flex flex-col gap-1 text-xs text-white/70">
+        <span className="font-mono uppercase tracking-[0.18em]">name</span>
+        <input
+          type="text"
+          required
+          value={label}
+          onChange={(e) => setLabel(e.target.value)}
+          placeholder="Marathon"
+          className="rounded border border-white/15 bg-black/40 px-2 py-1.5 font-mono text-sm text-white focus:border-amber-300/60 focus:outline-none"
+        />
+      </label>
+      <label className="flex flex-col gap-1 text-xs text-white/70">
+        <span className="font-mono uppercase tracking-[0.18em]">miles</span>
+        <input
+          type="number"
+          min={0.1}
+          step={0.1}
+          value={miles}
+          onChange={(e) => setMiles(Number(e.target.value))}
+          className="w-24 rounded border border-white/15 bg-black/40 px-2 py-1.5 text-right font-mono text-sm text-white focus:border-amber-300/60 focus:outline-none"
+        />
+      </label>
+      <label className="flex flex-col gap-1 text-xs text-white/70">
+        <span className="font-mono uppercase tracking-[0.18em]">color</span>
+        <input
+          type="color"
+          value={color}
+          onChange={(e) => setColor(e.target.value)}
+          className="h-9 w-16 cursor-pointer rounded border border-white/15 bg-black/40"
+        />
+      </label>
+      <button
+        type="submit"
+        disabled={disabled || label.trim().length === 0}
+        className="rounded-full border border-amber-200/30 bg-amber-200/10 px-5 py-2 font-mono text-[11px] uppercase tracking-[0.22em] text-amber-100 transition hover:bg-amber-200/20 disabled:cursor-not-allowed disabled:opacity-40"
+      >
+        Add
+      </button>
+    </form>
+  )
+}

--- a/components/training-facility/gym/OtfMileageSection.test.tsx
+++ b/components/training-facility/gym/OtfMileageSection.test.tsx
@@ -1,0 +1,97 @@
+import { render, screen, within } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import type { OtfMileageAward, OtfSession } from '@/types/otf'
+
+import { OtfMileageSection } from './OtfMileageSection'
+
+/**
+ * Aggregation and award math live in `otf-mileage.test.ts`; these tests assert
+ * the DOM this component owns — the headline current-month card, earned-badge
+ * chips, progress-to-next copy, the scrollable history, and the admin-only
+ * Milestones link.
+ */
+
+/** A session covering `treadMiles` on the tread, dated midday-UTC for tz stability. */
+function ride(started_at: string, treadMiles: number): OtfSession {
+  return { started_at, treadmill: { distance_mi: treadMiles, time: '20:00' } }
+}
+
+const AWARDS: OtfMileageAward[] = [
+  { id: 'a', label: 'Half Marathon', miles: 13.1, color: '#FBBF24' },
+  { id: 'b', label: 'Marathon', miles: 26.2, color: '#F97316' },
+  { id: 'c', label: '50K Ultra', miles: 31.1, color: '#EA580C' },
+]
+
+/** July 13, 2026 (local) — the fixed "now" for every case. */
+const NOW = new Date(2026, 6, 13)
+
+describe('OtfMileageSection', () => {
+  it('headlines the current month with its miles and an earned badge', () => {
+    render(
+      <OtfMileageSection
+        sessions={[ride('2026-07-02T12:00:00Z', 10), ride('2026-07-09T12:00:00Z', 5)]}
+        awards={AWARDS}
+        now={NOW}
+      />,
+    )
+    expect(screen.getByText('July 2026')).toBeInTheDocument()
+    expect(screen.getByText('15.0')).toBeInTheDocument()
+    expect(screen.getByText('2 classes')).toBeInTheDocument()
+    // 15 mi clears the half but not the marathon.
+    expect(screen.getByText('Half Marathon')).toBeInTheDocument()
+    expect(screen.getByText('11.2 mi to Marathon')).toBeInTheDocument()
+  })
+
+  it('shows a zero current month and points at the first tier when nothing is logged yet', () => {
+    render(<OtfMileageSection sessions={[]} awards={AWARDS} now={NOW} />)
+    expect(screen.getByText('0.0')).toBeInTheDocument()
+    expect(screen.getByText('No milestone yet this month.')).toBeInTheDocument()
+    expect(screen.getByText('13.1 mi to Half Marathon')).toBeInTheDocument()
+    expect(screen.getByText('No earlier months logged yet.')).toBeInTheDocument()
+  })
+
+  it('celebrates once every milestone is cleared', () => {
+    render(<OtfMileageSection sessions={[ride('2026-07-01T12:00:00Z', 40)]} awards={AWARDS} now={NOW} />)
+    expect(screen.getByText('Every milestone cleared 🎉')).toBeInTheDocument()
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument()
+  })
+
+  it('lists prior months newest first and keeps them out of the headline', () => {
+    render(
+      <OtfMileageSection
+        sessions={[
+          ride('2026-07-05T12:00:00Z', 4),
+          ride('2026-06-10T12:00:00Z', 14),
+          ride('2026-05-10T12:00:00Z', 2),
+        ]}
+        awards={AWARDS}
+        now={NOW}
+      />,
+    )
+    const history = screen.getByText('Earlier months').closest('div') as HTMLElement
+    const rows = within(history).getAllByRole('listitem')
+    expect(rows).toHaveLength(2)
+    expect(rows[0]).toHaveTextContent('June 2026')
+    expect(rows[0]).toHaveTextContent('14.0 mi')
+    expect(rows[1]).toHaveTextContent('May 2026')
+  })
+
+  it('renders the admin Milestones link only for admins', () => {
+    const { rerender } = render(
+      <OtfMileageSection sessions={[]} awards={AWARDS} now={NOW} isAdmin={false} />,
+    )
+    expect(screen.queryByRole('link', { name: 'Milestones' })).not.toBeInTheDocument()
+
+    rerender(<OtfMileageSection sessions={[]} awards={AWARDS} now={NOW} isAdmin />)
+    const link = screen.getByRole('link', { name: 'Milestones' })
+    expect(link).toHaveAttribute('href', '/training-facility/gym/otf/settings')
+  })
+
+  it('still renders miles with no badges when the ladder is empty', () => {
+    render(<OtfMileageSection sessions={[ride('2026-07-03T12:00:00Z', 3)]} awards={[]} now={NOW} />)
+    expect(screen.getByText('3.0')).toBeInTheDocument()
+    expect(screen.getByText('No milestone yet this month.')).toBeInTheDocument()
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument()
+  })
+})

--- a/components/training-facility/gym/OtfMileageSection.tsx
+++ b/components/training-facility/gym/OtfMileageSection.tsx
@@ -1,0 +1,212 @@
+import Link from 'next/link'
+import { useMemo, type CSSProperties, type JSX } from 'react'
+
+import {
+  buildOtfMileageView,
+  type AwardedMonth,
+} from '@/lib/training-facility/otf-mileage'
+import type { OtfMileageAward, OtfSession } from '@/types/otf'
+
+/** Fallback accent for a milestone tier with no configured `color`. */
+const DEFAULT_AWARD_COLOR = '#F97316'
+
+/** Props for {@link OtfMileageSection}. */
+export interface OtfMileageSectionProps {
+  /**
+   * All OTF sessions, unfiltered. This section is intentionally independent of
+   * the page's date/class filters — it always reports the current calendar
+   * month plus the full month history — so it takes the raw session list, not
+   * the filtered one.
+   */
+  sessions: readonly OtfSession[]
+  /** The milestone ladder from `otf_mileage_awards`; may be empty (no badges). */
+  awards: readonly OtfMileageAward[]
+  /** When true, render the admin-only link to the milestone settings editor. */
+  isAdmin?: boolean
+  /**
+   * Reference "current" time, injected for deterministic tests. Defaults to the
+   * render-time clock in the browser.
+   */
+  now?: Date
+}
+
+/** Miles formatted to one decimal — the display precision for every total. */
+function formatMiles(miles: number): string {
+  return miles.toFixed(1)
+}
+
+/**
+ * Monthly OTF mileage tracker (#321) — "marathon month" without the paid app.
+ *
+ * Sums each calendar month's treadmill + rower miles and lights up milestone
+ * badges (half marathon, marathon, ultra…) as the month's total crosses each
+ * configurable threshold. The current month is the headline (miles-to-date and
+ * progress toward the next badge); prior months scroll below. Excluded/anomalous
+ * sessions (#268) are dropped by {@link buildOtfMileageView}. Filter-independent
+ * by design — see {@link OtfMileageSectionProps.sessions}.
+ */
+export function OtfMileageSection({
+  sessions,
+  awards,
+  isAdmin = false,
+  now,
+}: OtfMileageSectionProps): JSX.Element {
+  // `now` defaults to the render clock; folded into the memo so tests that pass
+  // an explicit `now` stay deterministic while the live view tracks the date.
+  const view = useMemo(
+    () => buildOtfMileageView(sessions, awards, now ?? new Date()),
+    [sessions, awards, now],
+  )
+  const { current, history } = view
+
+  return (
+    <section
+      data-testid="otf-mileage-section"
+      aria-label="Monthly OTF mileage"
+      className="mt-8 rounded-[1.4rem] border border-[#f97316]/20 bg-white/[0.03] p-5 sm:p-6"
+    >
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <p className="font-mono text-[11px] uppercase tracking-[0.32em] text-[#f97316]">
+            Marathon month
+          </p>
+          <h2 className="mt-1 text-lg font-black uppercase tracking-[0.06em] text-[#fff7ec] sm:text-xl">
+            Monthly mileage
+          </h2>
+        </div>
+        {isAdmin ? (
+          <Link
+            href="/training-facility/gym/otf/settings"
+            className="rounded-full border border-[#f97316]/40 bg-[#f97316]/10 px-3 py-1.5 font-mono text-[10px] font-semibold uppercase tracking-[0.24em] text-[#f9a870] transition hover:bg-[#f97316]/20"
+          >
+            Milestones
+          </Link>
+        ) : null}
+      </div>
+
+      <CurrentMonthCard month={current} />
+
+      <div className="mt-5">
+        <h3 className="font-mono text-[10px] uppercase tracking-[0.28em] text-white/50">
+          Earlier months
+        </h3>
+        {history.length === 0 ? (
+          <p className="mt-2 text-sm text-[#e8d5be]/60">No earlier months logged yet.</p>
+        ) : (
+          <ul className="mt-2 max-h-64 space-y-2 overflow-y-auto pr-1">
+            {history.map((month) => (
+              <HistoryRow key={month.monthKey} month={month} />
+            ))}
+          </ul>
+        )}
+      </div>
+    </section>
+  )
+}
+
+/** The current calendar month: miles-to-date, earned badges, and progress to next. */
+function CurrentMonthCard({ month }: { month: AwardedMonth }): JSX.Element {
+  const { label, miles, classes, earned, next, remainingToNext } = month
+  const pct =
+    next && next.miles > 0 ? Math.min(100, Math.round((miles / next.miles) * 100)) : 100
+
+  return (
+    <div className="mt-4 rounded-[1.1rem] border border-white/10 bg-black/30 p-4 sm:p-5">
+      <div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1">
+        <p className="font-mono text-[11px] uppercase tracking-[0.28em] text-white/60">
+          {label}
+        </p>
+        <p className="text-sm text-white/50">
+          {classes} {classes === 1 ? 'class' : 'classes'}
+        </p>
+      </div>
+
+      <p className="mt-2 flex items-baseline gap-2">
+        <span className="text-4xl font-black tabular-nums text-[#fff7ec] sm:text-5xl">
+          {formatMiles(miles)}
+        </span>
+        <span className="font-mono text-sm uppercase tracking-[0.2em] text-[#f9a870]">miles</span>
+      </p>
+
+      {earned.length > 0 ? (
+        <div className="mt-3 flex flex-wrap gap-2" aria-label="Milestones earned this month">
+          {earned.map((award) => (
+            <AwardBadge key={award.id} award={award} />
+          ))}
+        </div>
+      ) : (
+        <p className="mt-3 text-sm text-[#e8d5be]/60">No milestone yet this month.</p>
+      )}
+
+      {next ? (
+        <div className="mt-4">
+          <div
+            className="h-2 w-full overflow-hidden rounded-full bg-white/10"
+            role="progressbar"
+            aria-valuenow={pct}
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-label={`Progress to ${next.label}`}
+          >
+            <div
+              className="h-full rounded-full"
+              style={{ width: `${pct}%`, backgroundColor: next.color ?? DEFAULT_AWARD_COLOR }}
+            />
+          </div>
+          <p className="mt-2 font-mono text-[11px] uppercase tracking-[0.2em] text-white/60">
+            {formatMiles(remainingToNext ?? 0)} mi to {next.label}
+          </p>
+        </div>
+      ) : earned.length > 0 ? (
+        <p className="mt-4 font-mono text-[11px] uppercase tracking-[0.2em] text-[#f9a870]">
+          Every milestone cleared 🎉
+        </p>
+      ) : null}
+    </div>
+  )
+}
+
+/** One prior month as a compact row: label, miles, and its earned-badge chips. */
+function HistoryRow({ month }: { month: AwardedMonth }): JSX.Element {
+  return (
+    <li className="flex flex-wrap items-center gap-x-3 gap-y-1 rounded-[0.9rem] border border-white/5 bg-white/[0.02] px-3 py-2">
+      <span className="font-mono text-[11px] uppercase tracking-[0.2em] text-white/70">
+        {month.label}
+      </span>
+      <span className="tabular-nums text-sm font-semibold text-[#fff7ec]">
+        {formatMiles(month.miles)} mi
+      </span>
+      {month.earned.length > 0 ? (
+        <span className="ml-auto flex flex-wrap gap-1.5">
+          {month.earned.map((award) => (
+            <AwardBadge key={award.id} award={award} compact />
+          ))}
+        </span>
+      ) : null}
+    </li>
+  )
+}
+
+/** A milestone badge chip tinted with the tier's configured accent color. */
+function AwardBadge({
+  award,
+  compact = false,
+}: {
+  award: OtfMileageAward
+  compact?: boolean
+}): JSX.Element {
+  const color = award.color ?? DEFAULT_AWARD_COLOR
+  const style: CSSProperties = { borderColor: color, color }
+  return (
+    <span
+      style={style}
+      className={
+        compact
+          ? 'rounded-full border px-2 py-0.5 font-mono text-[9px] uppercase tracking-[0.16em]'
+          : 'rounded-full border px-3 py-1 font-mono text-[10px] uppercase tracking-[0.18em]'
+      }
+    >
+      {award.label}
+    </span>
+  )
+}

--- a/lib/data/index.ts
+++ b/lib/data/index.ts
@@ -18,7 +18,7 @@
  */
 
 export { getCardioData } from './cardio';
-export { getOtfData } from './otf';
+export { getOtfData, getOtfMileageAwards } from './otf';
 export {
   getMovementBenchmarks,
   logBenchmark,

--- a/lib/data/otf-server.ts
+++ b/lib/data/otf-server.ts
@@ -1,9 +1,9 @@
 import 'server-only'
 
 import { createServerSupabaseClient } from '@/lib/supabase/server'
-import type { OtfData } from '@/types/otf'
+import type { OtfData, OtfMileageAward } from '@/types/otf'
 
-import { assembleOtfData } from './otf-shared'
+import { assembleOtfData, assembleOtfMileageAwards } from './otf-shared'
 
 /**
  * Server-side OrangeTheory dataset reader (SSR / Server Components). Wraps
@@ -16,4 +16,17 @@ import { assembleOtfData } from './otf-shared'
 export async function getOtfDataServer(): Promise<OtfData | null> {
   const supabase = await createServerSupabaseClient()
   return assembleOtfData(supabase)
+}
+
+/**
+ * Server-side reader for the monthly-mileage milestone ladder (#321), for the
+ * admin settings page's initial hydration. Wraps {@link assembleOtfMileageAwards}
+ * with the request-scoped server client.
+ *
+ * @throws See {@link assembleOtfMileageAwards}. The settings page
+ *   `.catch(() => [])` so a read blip renders an empty editor rather than 500ing.
+ */
+export async function getOtfMileageAwardsServer(): Promise<OtfMileageAward[]> {
+  const supabase = await createServerSupabaseClient()
+  return assembleOtfMileageAwards(supabase)
 }

--- a/lib/data/otf-shared.ts
+++ b/lib/data/otf-shared.ts
@@ -1,8 +1,13 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
 import { z } from 'zod'
 
-import { OtfSessionRowSchema, otfRowToSession } from '@/lib/schemas/otf'
-import type { OtfData } from '@/types/otf'
+import {
+  OtfMileageAwardRowSchema,
+  OtfSessionRowSchema,
+  otfMileageAwardRowToAward,
+  otfRowToSession,
+} from '@/lib/schemas/otf'
+import type { OtfData, OtfMileageAward } from '@/types/otf'
 
 /**
  * Pure OTF-read helper shared between the browser entry (`lib/data/otf.ts`)
@@ -30,6 +35,52 @@ const SESSIONS_COLUMNS =
 
 /** Array form of {@link OtfSessionRowSchema} for validating the full read. */
 const OtfSessionRowsSchema = z.array(OtfSessionRowSchema)
+
+/** Supabase table backing the monthly-mileage milestone ladder (#321). */
+const MILEAGE_AWARDS_TABLE = 'otf_mileage_awards'
+
+/** Whitelisted columns for `otf_mileage_awards`, in sync with {@link OtfMileageAwardRowSchema}. */
+const MILEAGE_AWARDS_COLUMNS = 'id, label, miles, color'
+
+/** Array form of {@link OtfMileageAwardRowSchema} for validating the awards read. */
+const OtfMileageAwardRowsSchema = z.array(OtfMileageAwardRowSchema)
+
+/**
+ * Fetch the monthly-mileage milestone ladder (#321) using the supplied client.
+ * Shared between `getOtfMileageAwards` (browser) and `getOtfMileageAwardsServer`
+ * (server) so the read shape and validation can't drift.
+ *
+ * Unlike {@link assembleOtfData}, returns an **empty array** (not `null`) when
+ * the table is empty — the mileage card always renders its current-month total,
+ * just with no badges to unlock, so an empty ladder is a valid steady state
+ * rather than a "no data yet" branch. Ordered by `miles` ascending so callers
+ * get the tiers low → high without re-sorting.
+ *
+ * @param supabase Browser or server SSR client (both anon role; the table's RLS
+ *   allows anon SELECT).
+ * @throws when the Supabase query fails or row-shape validation fails. The OTF
+ *   view downgrades this to an empty ladder so a read blip can't blank the page.
+ */
+export async function assembleOtfMileageAwards(
+  supabase: SupabaseClient,
+): Promise<OtfMileageAward[]> {
+  const res = await supabase
+    .from(MILEAGE_AWARDS_TABLE)
+    .select(MILEAGE_AWARDS_COLUMNS)
+    .order('miles', { ascending: true })
+
+  if (res.error) {
+    throw new Error(`Failed to load OTF mileage awards: ${res.error.message}`)
+  }
+
+  const raw = (res.data ?? []) as unknown as Array<Record<string, unknown>>
+  const parsed = OtfMileageAwardRowsSchema.safeParse(raw.map(stripNulls))
+  if (!parsed.success) {
+    throw new Error(`otf_mileage_awards failed schema validation: ${parsed.error.message}`)
+  }
+
+  return parsed.data.map(otfMileageAwardRowToAward)
+}
 
 /**
  * Fetch the full OrangeTheory dataset from Supabase using the supplied

--- a/lib/data/otf.ts
+++ b/lib/data/otf.ts
@@ -1,7 +1,7 @@
 import { getBrowserSupabaseClient } from '@/lib/supabase/browser'
-import type { OtfData } from '@/types/otf'
+import type { OtfData, OtfMileageAward } from '@/types/otf'
 
-import { assembleOtfData } from './otf-shared'
+import { assembleOtfData, assembleOtfMileageAwards } from './otf-shared'
 
 /**
  * Browser-side OrangeTheory dataset reader. Wraps the shared
@@ -14,4 +14,16 @@ import { assembleOtfData } from './otf-shared'
  */
 export async function getOtfData(): Promise<OtfData | null> {
   return assembleOtfData(getBrowserSupabaseClient())
+}
+
+/**
+ * Browser-side reader for the monthly-mileage milestone ladder (#321). Wraps
+ * {@link assembleOtfMileageAwards} with the cached browser client; the OTF
+ * mileage section fetches it alongside {@link getOtfData} from a client effect.
+ *
+ * @throws See {@link assembleOtfMileageAwards}. The view downgrades this to an
+ *   empty ladder so a read blip can't blank the page.
+ */
+export async function getOtfMileageAwards(): Promise<OtfMileageAward[]> {
+  return assembleOtfMileageAwards(getBrowserSupabaseClient())
 }

--- a/lib/schemas/otf.ts
+++ b/lib/schemas/otf.ts
@@ -16,7 +16,7 @@
 
 import { z } from 'zod'
 
-import type { OtfSession } from '@/types/otf'
+import type { OtfMileageAward, OtfSession } from '@/types/otf'
 
 /**
  * Treadmill JSONB block. Non-strict (extra keys stripped, not rejected) so
@@ -132,3 +132,58 @@ export function otfRowToSession(row: OtfSessionRow): OtfSession {
   if (row.class_type_override !== undefined) session.class_type_override = row.class_type_override
   return session
 }
+
+/**
+ * Zod schema for one row of `public.otf_mileage_awards` (#321) on read.
+ * `.strict()` so a column added to the table without updating this schema /
+ * the data-layer whitelist fails loudly instead of leaking to the view.
+ * `color` is `.optional()` (not `.nullable()`): the data layer maps Postgres
+ * `NULL` → absent before validation, matching {@link OtfSessionRowSchema}.
+ */
+export const OtfMileageAwardRowSchema = z
+  .object({
+    id: z.string().uuid(),
+    label: z.string().min(1),
+    miles: z.number().positive(),
+    color: z.string().optional(),
+  })
+  .strict()
+
+/** Validated `otf_mileage_awards` row inferred from {@link OtfMileageAwardRowSchema}. */
+export type OtfMileageAwardRow = z.infer<typeof OtfMileageAwardRowSchema>
+
+/** Translate a validated `otf_mileage_awards` row into the consumed {@link OtfMileageAward} shape. */
+export function otfMileageAwardRowToAward(row: OtfMileageAwardRow): OtfMileageAward {
+  const award: OtfMileageAward = { id: row.id, label: row.label, miles: row.miles }
+  if (row.color !== undefined) award.color = row.color
+  return award
+}
+
+/**
+ * Request-body schema for creating a mileage award tier via the admin route
+ * (`POST /api/admin/otf/mileage-awards`). `label` is trimmed and length-capped;
+ * `miles` must be positive; `color` is optional (UI applies a default accent
+ * when absent). Extra keys are stripped.
+ */
+export const OtfMileageAwardCreateSchema = z.object({
+  label: z.string().trim().min(1, 'label is required').max(60, 'label is too long'),
+  miles: z.number().positive('miles must be positive'),
+  color: z.string().trim().min(1).optional(),
+})
+
+/** Validated create payload inferred from {@link OtfMileageAwardCreateSchema}. */
+export type OtfMileageAwardCreate = z.infer<typeof OtfMileageAwardCreateSchema>
+
+/**
+ * Request-body schema for editing a tier via the admin item route
+ * (`PATCH /api/admin/otf/mileage-awards/[id]`). Every field is optional so a
+ * caller can change just the label or just the threshold, but the body must
+ * carry at least one field — an empty patch is a client bug, not a no-op.
+ */
+export const OtfMileageAwardUpdateSchema = OtfMileageAwardCreateSchema.partial().refine(
+  (patch) => Object.keys(patch).length > 0,
+  { message: 'At least one field (label, miles, or color) is required.' },
+)
+
+/** Validated update payload inferred from {@link OtfMileageAwardUpdateSchema}. */
+export type OtfMileageAwardUpdate = z.infer<typeof OtfMileageAwardUpdateSchema>

--- a/lib/training-facility/otf-mileage.test.ts
+++ b/lib/training-facility/otf-mileage.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from 'vitest'
+
+import type { OtfMileageAward, OtfSession } from '@/types/otf'
+
+import {
+  METERS_PER_MILE,
+  buildOtfMileageView,
+  monthKeyOf,
+  monthLabelOf,
+  monthlyOtfMileage,
+  resolveAwards,
+  sessionMiles,
+} from './otf-mileage'
+
+/**
+ * Session factory. `started_at` defaults to a midday-UTC timestamp so the
+ * local calendar month is stable across every realistic timezone (noon UTC
+ * lands on the same date from UTC-11 to UTC+11).
+ */
+function mk(started_at: string, extra: Partial<OtfSession> = {}): OtfSession {
+  return { started_at, ...extra }
+}
+
+/** A session that covers `treadMiles` on the tread and `rowerMeters` on the rower. */
+function ride(started_at: string, treadMiles: number, rowerMeters: number): OtfSession {
+  return mk(started_at, {
+    treadmill: { distance_mi: treadMiles, time: '20:00' },
+    rower: { distance_m: rowerMeters, time: '10:00' },
+  })
+}
+
+/** A representative milestone ladder, intentionally passed out of order. */
+const AWARDS: OtfMileageAward[] = [
+  { id: 'b', label: 'Marathon', miles: 26.2 },
+  { id: 'a', label: 'Half Marathon', miles: 13.1 },
+  { id: 'c', label: '50K Ultra', miles: 31.1 },
+]
+
+describe('sessionMiles', () => {
+  it('is 0 for a session with neither machine', () => {
+    expect(sessionMiles(mk('2026-07-15T12:00:00Z'))).toBe(0)
+  })
+
+  it('uses treadmill miles directly', () => {
+    const session = mk('2026-07-15T12:00:00Z', {
+      treadmill: { distance_mi: 2.5, time: '25:00' },
+    })
+    expect(sessionMiles(session)).toBeCloseTo(2.5, 10)
+  })
+
+  it('converts rower meters to miles', () => {
+    const session = mk('2026-07-15T12:00:00Z', {
+      rower: { distance_m: 2 * METERS_PER_MILE, time: '12:00' },
+    })
+    expect(sessionMiles(session)).toBeCloseTo(2, 10)
+  })
+
+  it('sums treadmill miles and converted rower miles', () => {
+    expect(sessionMiles(ride('2026-07-15T12:00:00Z', 1.5, METERS_PER_MILE))).toBeCloseTo(2.5, 10)
+  })
+})
+
+describe('monthKeyOf / monthLabelOf', () => {
+  it('zero-pads the month in the key', () => {
+    expect(monthKeyOf(new Date(2026, 0, 5))).toBe('2026-01')
+    expect(monthKeyOf(new Date(2026, 11, 31))).toBe('2026-12')
+  })
+
+  it('renders a human month label', () => {
+    expect(monthLabelOf(2026, 6)).toBe('July 2026')
+    expect(monthLabelOf(2026, 0)).toBe('January 2026')
+  })
+})
+
+describe('monthlyOtfMileage', () => {
+  it('returns an empty array for no sessions', () => {
+    expect(monthlyOtfMileage([])).toEqual([])
+  })
+
+  it('buckets by calendar month, newest first, summing tread + row', () => {
+    const sessions = [
+      ride('2026-06-10T12:00:00Z', 1, METERS_PER_MILE), // June: 2 mi
+      ride('2026-07-05T12:00:00Z', 3, 0), // July: 3 mi
+      ride('2026-07-20T12:00:00Z', 0, 2 * METERS_PER_MILE), // July: 2 mi
+    ]
+    const months = monthlyOtfMileage(sessions)
+
+    expect(months.map(m => m.monthKey)).toEqual(['2026-07', '2026-06'])
+    expect(months[0].label).toBe('July 2026')
+    expect(months[0].miles).toBeCloseTo(5, 10)
+    expect(months[0].classes).toBe(2)
+    expect(months[1].miles).toBeCloseTo(2, 10)
+    expect(months[1].classes).toBe(1)
+  })
+
+  it('drops excluded sessions from the totals and counts', () => {
+    const sessions = [
+      ride('2026-07-05T12:00:00Z', 3, 0),
+      { ...ride('2026-07-06T12:00:00Z', 99, 0), excluded: true },
+    ]
+    const [july] = monthlyOtfMileage(sessions)
+    expect(july.miles).toBeCloseTo(3, 10)
+    expect(july.classes).toBe(1)
+  })
+})
+
+describe('resolveAwards', () => {
+  it('earns nothing and points at the first tier when the ladder is untouched', () => {
+    const progress = resolveAwards(5, AWARDS)
+    expect(progress.earned).toEqual([])
+    expect(progress.next?.label).toBe('Half Marathon')
+    expect(progress.remainingToNext).toBeCloseTo(13.1 - 5, 10)
+  })
+
+  it('earns a tier at exactly its threshold', () => {
+    const progress = resolveAwards(13.1, AWARDS)
+    expect(progress.earned.map(a => a.label)).toEqual(['Half Marathon'])
+    expect(progress.next?.label).toBe('Marathon')
+  })
+
+  it('earns every tier at or below the total, sorted low to high', () => {
+    const progress = resolveAwards(28, AWARDS)
+    expect(progress.earned.map(a => a.label)).toEqual(['Half Marathon', 'Marathon'])
+    expect(progress.next?.label).toBe('50K Ultra')
+    expect(progress.remainingToNext).toBeCloseTo(31.1 - 28, 10)
+  })
+
+  it('has no next tier once every milestone is earned', () => {
+    const progress = resolveAwards(40, AWARDS)
+    expect(progress.earned).toHaveLength(3)
+    expect(progress.next).toBeNull()
+    expect(progress.remainingToNext).toBeNull()
+  })
+
+  it('handles an empty ladder', () => {
+    const progress = resolveAwards(20, [])
+    expect(progress.earned).toEqual([])
+    expect(progress.next).toBeNull()
+    expect(progress.remainingToNext).toBeNull()
+  })
+})
+
+describe('buildOtfMileageView', () => {
+  const now = new Date(2026, 6, 13) // July 13, 2026 (local)
+
+  it('synthesizes a zero current month when nothing is logged yet', () => {
+    const view = buildOtfMileageView([ride('2026-05-10T12:00:00Z', 4, 0)], AWARDS, now)
+    expect(view.current.monthKey).toBe('2026-07')
+    expect(view.current.label).toBe('July 2026')
+    expect(view.current.miles).toBe(0)
+    expect(view.current.classes).toBe(0)
+    expect(view.current.earned).toEqual([])
+    expect(view.current.next?.label).toBe('Half Marathon')
+    expect(view.history.map(m => m.monthKey)).toEqual(['2026-05'])
+  })
+
+  it('reports the real current-month total and keeps it out of history', () => {
+    const view = buildOtfMileageView(
+      [
+        ride('2026-07-02T12:00:00Z', 10, 0),
+        ride('2026-07-09T12:00:00Z', 5, 0),
+        ride('2026-06-15T12:00:00Z', 3, 0),
+      ],
+      AWARDS,
+      now,
+    )
+    expect(view.current.monthKey).toBe('2026-07')
+    expect(view.current.miles).toBeCloseTo(15, 10)
+    expect(view.current.classes).toBe(2)
+    expect(view.current.earned.map(a => a.label)).toEqual(['Half Marathon'])
+    expect(view.current.next?.label).toBe('Marathon')
+    expect(view.history.map(m => m.monthKey)).toEqual(['2026-06'])
+    expect(view.history[0].miles).toBeCloseTo(3, 10)
+  })
+
+  it('orders history newest first and resolves awards per month', () => {
+    const view = buildOtfMileageView(
+      [
+        ride('2026-04-10T12:00:00Z', 30, 0),
+        ride('2026-05-10T12:00:00Z', 13.1, 0),
+        ride('2026-06-10T12:00:00Z', 1, 0),
+      ],
+      AWARDS,
+      now,
+    )
+    expect(view.history.map(m => m.monthKey)).toEqual(['2026-06', '2026-05', '2026-04'])
+    expect(view.history[1].earned.map(a => a.label)).toEqual(['Half Marathon'])
+    expect(view.history[2].earned.map(a => a.label)).toEqual(['Half Marathon', 'Marathon'])
+  })
+})

--- a/lib/training-facility/otf-mileage.ts
+++ b/lib/training-facility/otf-mileage.ts
@@ -1,0 +1,229 @@
+/**
+ * Pure monthly-mileage helpers for the OrangeTheory view (#321).
+ *
+ * "Marathon month" tracking: total the miles you cover at OTF each calendar
+ * month (treadmill distance + rower distance) and light up milestone badges
+ * (half marathon, marathon, ultra…) as the month's total crosses each
+ * threshold. A paid app tracks this; we do it for free off the session data
+ * we already ingest.
+ *
+ * This module is pure and isomorphic — it imports no Supabase client and no
+ * React — so it unit-tests cleanly and runs on either side of the SSR/CSR
+ * boundary. The milestone ladder ({@link OtfMileageAward}) is data-driven,
+ * loaded from `otf_mileage_awards` and editable in the admin settings page;
+ * nothing here hardcodes a threshold.
+ *
+ * Distance provenance mirrors the rest of the OTF layer: treadmill distance
+ * is already miles (`treadmill.distance_mi`), rower distance is meters
+ * (`rower.distance_m`) and is converted here. Excluded/anomalous sessions
+ * (#268) are dropped before any total, exactly as the charts and highlights
+ * drop them.
+ */
+
+import type { OtfMileageAward, OtfSession } from '@/types/otf'
+
+import { excludeInvalidOtfSessions, otfSessionDate } from './otf'
+
+/** Meters per statute mile — the rower reports `distance_m`, milestones are in miles. */
+export const METERS_PER_MILE = 1609.344
+
+/** Month names for {@link monthLabelOf}, indexed 0 (January) – 11 (December). */
+const MONTH_NAMES = [
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December',
+] as const
+
+/**
+ * Miles covered in a single session: treadmill miles plus rower meters
+ * converted to miles. A session missing either machine contributes 0 for that
+ * machine, so a tread-only or row-only class still totals correctly. Does not
+ * consider `excluded` — callers filter first (see {@link monthlyOtfMileage}).
+ */
+export function sessionMiles(session: OtfSession): number {
+  const treadMiles = session.treadmill?.distance_mi ?? 0
+  const rowerMiles = (session.rower?.distance_m ?? 0) / METERS_PER_MILE
+  return treadMiles + rowerMiles
+}
+
+/**
+ * Local-timezone `YYYY-MM` bucket key for a date. Uses the viewer's local
+ * calendar month (via {@link otfSessionDate}'s `Date`), matching how the OTF
+ * day-bucketing helpers treat session dates, so a late-night class counts in
+ * the month the user experienced it, not the UTC month.
+ */
+export function monthKeyOf(date: Date): string {
+  const year = date.getFullYear()
+  const month = date.getMonth() + 1
+  return `${year}-${String(month).padStart(2, '0')}`
+}
+
+/** Human month label like `"July 2026"` from a 0-based month index and full year. */
+export function monthLabelOf(year: number, monthIndex: number): string {
+  return `${MONTH_NAMES[monthIndex]} ${year}`
+}
+
+/**
+ * One calendar month's OTF mileage total.
+ *
+ * @property monthKey   Local-tz `YYYY-MM` sort/identity key.
+ * @property year       Local-tz calendar year.
+ * @property monthIndex 0-based month (0 = January).
+ * @property label      Display label, e.g. `"July 2026"`.
+ * @property miles      Summed treadmill + rower miles for the month (excluded sessions dropped).
+ * @property classes    Number of counted (non-excluded) sessions in the month.
+ */
+export interface MonthlyMileage {
+  monthKey: string
+  year: number
+  monthIndex: number
+  label: string
+  miles: number
+  classes: number
+}
+
+/**
+ * Total OTF miles per calendar month, newest month first.
+ *
+ * Excluded/anomalous sessions (#268) are dropped before totaling. Months with
+ * no counted sessions do not appear — the total is built from the data, so an
+ * inactive month is simply absent (the view synthesizes a zero row for the
+ * *current* month via {@link buildOtfMileageView}). Bucketing is by local-tz
+ * calendar month (see {@link monthKeyOf}).
+ */
+export function monthlyOtfMileage(sessions: readonly OtfSession[]): MonthlyMileage[] {
+  const byMonth = new Map<string, MonthlyMileage>()
+
+  for (const session of excludeInvalidOtfSessions(sessions)) {
+    const date = otfSessionDate(session)
+    const monthKey = monthKeyOf(date)
+    const existing = byMonth.get(monthKey)
+    if (existing) {
+      existing.miles += sessionMiles(session)
+      existing.classes += 1
+    } else {
+      byMonth.set(monthKey, {
+        monthKey,
+        year: date.getFullYear(),
+        monthIndex: date.getMonth(),
+        label: monthLabelOf(date.getFullYear(), date.getMonth()),
+        miles: sessionMiles(session),
+        classes: 1,
+      })
+    }
+  }
+
+  return [...byMonth.values()].sort((a, b) => (a.monthKey < b.monthKey ? 1 : -1))
+}
+
+/**
+ * A month's mileage total resolved against the milestone ladder.
+ *
+ * @property earned         Tiers whose threshold the month's miles have reached, low → high.
+ * @property next           Lowest not-yet-earned tier, or `null` when every tier is earned (or the ladder is empty).
+ * @property remainingToNext Miles still needed to reach {@link next}, or `null` when there is no next tier.
+ */
+export interface AwardProgress {
+  earned: OtfMileageAward[]
+  next: OtfMileageAward | null
+  remainingToNext: number | null
+}
+
+/**
+ * Resolve a mileage total against the milestone ladder: which tiers are
+ * earned, the next one to chase, and how far off it is. Stateless — a pure
+ * function of the total and the ladder, recomputed each render (#321), so
+ * nothing is persisted per month and editing a tier's threshold re-lights the
+ * badges immediately.
+ *
+ * A tier counts as earned at `miles >= threshold` (hitting the marathon line
+ * exactly earns it). The ladder is sorted ascending defensively so callers may
+ * pass it in any order.
+ */
+export function resolveAwards(
+  miles: number,
+  awards: readonly OtfMileageAward[],
+): AwardProgress {
+  const ladder = [...awards].sort((a, b) => a.miles - b.miles)
+  const earned = ladder.filter((award) => miles >= award.miles)
+  const next = ladder.find((award) => award.miles > miles) ?? null
+  return {
+    earned,
+    next,
+    remainingToNext: next ? next.miles - miles : null,
+  }
+}
+
+/** A month's mileage total with its milestone ladder already resolved. */
+export interface AwardedMonth extends MonthlyMileage, AwardProgress {}
+
+/**
+ * The mileage section's full display model (#321): the current calendar month
+ * as a headline plus the scrollable history of prior months.
+ *
+ * @property current The current calendar month, always present — synthesized as
+ *   a zero-mile month when no class has been logged yet this month, so the
+ *   headline card and its "miles to your first badge" progress always render.
+ * @property history Prior months with logged mileage, newest first. Excludes the
+ *   current month (it's the headline). A month dated in the future relative to
+ *   `now` (clock skew / bad data) sorts to the top of history rather than the
+ *   headline.
+ */
+export interface OtfMileageView {
+  current: AwardedMonth
+  history: AwardedMonth[]
+}
+
+/** Attach resolved award progress to a {@link MonthlyMileage} row. */
+function awardMonth(month: MonthlyMileage, awards: readonly OtfMileageAward[]): AwardedMonth {
+  return { ...month, ...resolveAwards(month.miles, awards) }
+}
+
+/**
+ * Build the mileage section's display model from raw sessions, the milestone
+ * ladder, and the current time.
+ *
+ * `now` is injected (not read from the clock here) to keep this pure and
+ * testable; the client component passes `new Date()`. The current calendar
+ * month is always returned as {@link OtfMileageView.current} — with its real
+ * total when classes exist, or a zero row otherwise — and every other month
+ * with logged mileage falls into {@link OtfMileageView.history}, newest first.
+ *
+ * @param sessions Raw OTF sessions (excluded ones are dropped internally).
+ * @param awards   The milestone ladder; may be empty (no badges, no next tier).
+ * @param now      The reference "current" time, in the viewer's local timezone.
+ */
+export function buildOtfMileageView(
+  sessions: readonly OtfSession[],
+  awards: readonly OtfMileageAward[],
+  now: Date,
+): OtfMileageView {
+  const months = monthlyOtfMileage(sessions)
+  const currentKey = monthKeyOf(now)
+
+  const currentMonth =
+    months.find((month) => month.monthKey === currentKey) ??
+    ({
+      monthKey: currentKey,
+      year: now.getFullYear(),
+      monthIndex: now.getMonth(),
+      label: monthLabelOf(now.getFullYear(), now.getMonth()),
+      miles: 0,
+      classes: 0,
+    } satisfies MonthlyMileage)
+
+  const history = months
+    .filter((month) => month.monthKey !== currentKey)
+    .map((month) => awardMonth(month, awards))
+
+  return { current: awardMonth(currentMonth, awards), history }
+}

--- a/supabase/migrations/20260713120000_otf_mileage_awards.sql
+++ b/supabase/migrations/20260713120000_otf_mileage_awards.sql
@@ -1,0 +1,69 @@
+-- OrangeTheory monthly-mileage milestone awards (#321).
+--
+-- Backs the "Marathon Month" mileage view on the OTF surface
+-- (`components/training-facility/gym/OtfDetailView.tsx`): a per-calendar-month
+-- total of treadmill + rower miles that unlocks milestone badges (half
+-- marathon, marathon, ultra, …) as the month's total crosses each threshold.
+--
+-- WHY A DEDICATED TABLE (not a code constant): the ladder is owner-editable at
+-- runtime — add/rename/retune a tier without a deploy — so the tiers live in
+-- Supabase and are managed through an admin-gated API route
+-- (`app/api/admin/otf/mileage-awards/*`), mirroring the Weight Room goals /
+-- monthly-focus model. The public OTF card reads them (anon SELECT); the awards
+-- earned per month are recomputed from the session data on every render
+-- (stateless — nothing is persisted per-month).
+--
+-- RLS mirrors `otf_sessions`: anon + authenticated SELECT only. Writes go
+-- through the service-role key via the admin API route.
+--
+-- This file is the canonical record of the migration; it is also applied to the
+-- `court-vision` Supabase project (`ryxbnvhxxkrmsrmocume`) via the Supabase
+-- tooling. All DDL is idempotent so re-applying on a fresh dev project (or after
+-- a branch reset) is a safe no-op.
+
+create table if not exists public.otf_mileage_awards (
+  id uuid primary key default gen_random_uuid(),
+  label text not null unique,
+  miles numeric not null check (miles > 0),
+  color text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+comment on table public.otf_mileage_awards is
+  'Monthly-mileage milestone awards for the OTF "Marathon Month" view (#321). One row per badge tier: a label + a mileage threshold (miles) + optional display color. A calendar month earns every tier whose threshold its treadmill+rower mileage total reaches. Owner-editable at runtime via the admin API route; the label is unique so tiers do not collide. Read anon (SELECT); written only through the service-role admin route.';
+
+comment on column public.otf_mileage_awards.miles is
+  'Mileage threshold in miles. A month earns this badge when its cumulative treadmill (distance_mi) + rower (distance_m / 1609.344) total reaches this value. Must be positive.';
+
+comment on column public.otf_mileage_awards.color is
+  'Optional hex badge tint (e.g. #F97316). Null lets the UI fall back to a default accent.';
+
+-- The ladder is almost always scanned ordered by threshold.
+create index if not exists otf_mileage_awards_miles_idx
+  on public.otf_mileage_awards (miles);
+
+alter table public.otf_mileage_awards enable row level security;
+
+-- Postgres has no `create policy if not exists`; swallow the duplicate-object
+-- error so the migration stays re-runnable.
+do $$
+begin
+  create policy "anon and authenticated can read otf mileage awards"
+    on public.otf_mileage_awards
+    for select
+    to anon, authenticated
+    using (true);
+exception when duplicate_object then null;
+end $$;
+
+-- Seed the default ladder. `on conflict (label) do nothing` keeps re-applying
+-- idempotent and never clobbers a threshold the owner has since retuned.
+insert into public.otf_mileage_awards (label, miles, color)
+values
+  ('Half Marathon', 13.1, '#FBBF24'),
+  ('Marathon', 26.2, '#F97316'),
+  ('50K Ultra', 31.1, '#EA580C'),
+  ('50-Mile Ultra', 50, '#DC2626'),
+  ('Century', 100, '#A21CAF')
+on conflict (label) do nothing;

--- a/types/otf.ts
+++ b/types/otf.ts
@@ -133,3 +133,33 @@ export interface OtfData {
   /** Every OTF session, ascending by `started_at`. */
   sessions: OtfSession[]
 }
+
+/**
+ * One monthly-mileage milestone award tier (#321). Mirrors a row of
+ * `public.otf_mileage_awards`
+ * (`supabase/migrations/20260713120000_otf_mileage_awards.sql`).
+ *
+ * A calendar month "earns" this badge when its cumulative treadmill + rower
+ * mileage reaches {@link OtfMileageAward.miles}. The ladder is owner-editable
+ * at runtime via the admin settings page; the public OTF view reads it and
+ * recomputes which months earned which badges statelessly on every render.
+ *
+ * KEEP IN SYNC WITH: the Zod schemas in `lib/schemas/otf.ts`.
+ */
+export interface OtfMileageAward {
+  /** UUID primary key, generated server-side. */
+  id: string
+  /** Badge name, e.g. `Marathon`. Unique across the ladder. */
+  label: string
+  /**
+   * Mileage threshold in miles. A month earns this badge when its cumulative
+   * treadmill (`distance_mi`) + rower (`distance_m / 1609.344`) mileage reaches
+   * this value. Always positive.
+   */
+  miles: number
+  /**
+   * Optional hex badge tint (e.g. `#F97316`). Absent lets the UI apply a
+   * default accent rather than requiring a color per tier.
+   */
+  color?: string
+}


### PR DESCRIPTION
## Summary

"Marathon month" tracking for OrangeTheory, without the paid app. Totals each **calendar month's** OTF miles (treadmill `distance_mi` + rower `distance_m` → miles) and lights up **milestone badges** — half marathon, marathon, ultra… — as the month's total crosses each threshold.

- **Current month headlines** with miles-to-date, earned badges, and a progress bar to the next tier; **prior months scroll** below.
- **Filter-independent** by design — always the current month + full history, regardless of the page's date/class filters.
- Drops excluded/anomalous sessions (#268), matching every other OTF aggregate.
- **Stateless awards** — recomputed from the session data each render, so retuning a tier re-lights badges instantly (nothing persisted per month).

The milestone ladder lives in a new **`otf_mileage_awards`** table (anon `SELECT`, service-role writes) and is **owner-editable at runtime** via an admin-gated settings page + API routes, mirroring the Weight Room goals model. The public card and the admin **"Milestones"** link are gated by the existing `useAdminSession` hook.

### What's included
- Migration `20260713120000_otf_mileage_awards.sql` (idempotent; seeded Half Marathon → Century). **Already applied to the `court-vision` project** so the preview reads live data.
- Types + Zod schemas (read/create/update) in `types/otf.ts` and `lib/schemas/otf.ts`.
- Data layer: `assembleOtfMileageAwards` + browser/server readers.
- Pure helpers `lib/training-facility/otf-mileage.ts` (`monthlyOtfMileage`, `resolveAwards`, `buildOtfMileageView`) — fully unit-tested.
- Admin routes `POST /api/admin/otf/mileage-awards` + `PATCH`/`DELETE /[id]`.
- Admin settings page `/training-facility/gym/otf/settings` + editor island.
- `OtfMileageSection` wired into `OtfDetailView`.

## Test plan

- [ ] **Public OTF view** — visit `/training-facility/gym/otf`. The "Monthly mileage" card sits above the date filter; current month shows total miles, earned badges, and "X.X mi to <next>".
- [ ] **Filter independence** — change the date range / class-type filter; the mileage card does **not** change (it always reflects the current month + full history).
- [ ] **History scroll** — prior months list newest-first and scroll within the card.
- [ ] **No "Milestones" link when logged out** (admin-only).
- [ ] **Admin** — sign in as admin; the "Milestones" link appears and opens `/training-facility/gym/otf/settings`.
- [ ] **Settings editor** — add a tier (e.g. "10K", 6.2 mi), edit a threshold, delete a tier; each change reflects on the OTF card after refresh. Duplicate label → friendly 409 error.
- [ ] **Non-admin settings** — `/training-facility/gym/otf/settings` returns 404 when not an admin.

### Automated
- `npx tsc --noEmit` clean
- `npx eslint` clean on all changed files
- `npx next build` compiles (new routes + settings page in manifest)
- `npm test` — full vitest suite green (incl. new `otf-mileage` + `OtfMileageSection` tests)
- `npx playwright test training-facility-*` — 10 passed

Closes #321.