### PR TITLE
fix(training-facility): repair cardio chart axes, density, and pace outliers

### DIFF
--- a/components/training-facility/gym/AvgHrBars.test.tsx
+++ b/components/training-facility/gym/AvgHrBars.test.tsx
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest'
+import { pickEvenlySpacedIndices } from './AvgHrBars'
+
+describe('pickEvenlySpacedIndices', () => {
+  it('returns [] for a non-positive total', () => {
+    expect(pickEvenlySpacedIndices(0, 12)).toEqual([])
+    expect(pickEvenlySpacedIndices(-3, 12)).toEqual([])
+  })
+
+  it('keeps every index when the total fits under the cap', () => {
+    expect(pickEvenlySpacedIndices(5, 12)).toEqual([0, 1, 2, 3, 4])
+  })
+
+  it('returns just the first index for a single point or a cap of one', () => {
+    expect(pickEvenlySpacedIndices(1, 12)).toEqual([0])
+    expect(pickEvenlySpacedIndices(40, 1)).toEqual([0])
+  })
+
+  it('thins a large total to at most maxLabels, spanning first→last', () => {
+    const out = pickEvenlySpacedIndices(100, 12)
+    expect(out.length).toBeLessThanOrEqual(12)
+    expect(out[0]).toBe(0)
+    expect(out[out.length - 1]).toBe(99)
+  })
+
+  it('returns a sorted, de-duplicated list of indices', () => {
+    const out = pickEvenlySpacedIndices(100, 12)
+    const sorted = [...out].sort((a, b) => a - b)
+    expect(out).toEqual(sorted)
+    expect(new Set(out).size).toBe(out.length)
+  })
+})

--- a/components/training-facility/gym/AvgHrBars.tsx
+++ b/components/training-facility/gym/AvgHrBars.tsx
@@ -23,6 +23,29 @@ export interface AvgHrBarsProps extends ChartCommonProps {
   points: readonly SessionAvgHrPoint[]
   /** Inner padding between bars (0–1). Defaults to 0.3. */
   padding?: number
+  /** Max x-axis labels before thinning kicks in. Defaults to 12. */
+  maxXLabels?: number
+}
+
+/**
+ * Pick up to `maxLabels` evenly-spaced indices from `[0, total)`, always
+ * including the first and last. Used to thin the x-axis so a wide window
+ * doesn't render an unreadable picket fence of overlapping date labels; every
+ * bar still draws, only its label may be dropped. Returns fewer than
+ * `maxLabels` indices when `total` is smaller (each point keeps its label).
+ *
+ * @param total - Number of bars/points.
+ * @param maxLabels - Ceiling on rendered labels (must be ≥ 1).
+ */
+export function pickEvenlySpacedIndices(total: number, maxLabels: number): number[] {
+  if (total <= 0) return []
+  const count = Math.min(total, Math.max(1, maxLabels))
+  if (count <= 1) return [0]
+  const seen = new Set<number>()
+  for (let k = 0; k < count; k++) {
+    seen.add(Math.round((k * (total - 1)) / (count - 1)))
+  }
+  return [...seen].sort((a, b) => a - b)
 }
 
 /**
@@ -40,6 +63,7 @@ export function AvgHrBars({
   height,
   margin,
   padding = 0.3,
+  maxXLabels = 12,
   roughness = 1.4,
   seed = 8,
   fontFamily = 'inherit',
@@ -87,10 +111,15 @@ export function AvgHrBars({
 
   const gen = getGenerator()
 
-  const xTicks: AxisTick[] = points.map((p, i) => ({
-    value: p.label,
-    offset: (xScale(i) ?? 0) + xScale.bandwidth() / 2,
-  }))
+  // Thin the x labels: on a wide window (weekly/monthly buckets over years)
+  // one label per bar overlaps into an unreadable smear. Every bar still
+  // renders below; only its label may be dropped.
+  const labelIndices = new Set(pickEvenlySpacedIndices(points.length, maxXLabels))
+  const xTicks: AxisTick[] = points.flatMap((p, i) =>
+    labelIndices.has(i)
+      ? [{ value: p.label, offset: (xScale(i) ?? 0) + xScale.bandwidth() / 2 }]
+      : [],
+  )
 
   const yTicks: AxisTick[] = yScale.ticks(5).map((tick) => ({
     value: String(tick),

--- a/components/training-facility/gym/StairDetailView.tsx
+++ b/components/training-facility/gym/StairDetailView.tsx
@@ -24,7 +24,12 @@ import {
   parseSessionDate,
   perSessionAvgHr,
 } from '@/lib/training-facility/stair'
-import { sessionDetailHref } from '@/lib/training-facility/cardio-shared'
+import {
+  avgHrGranularityForSpanDays,
+  bucketAvgHr,
+  rangeSpanDays,
+  sessionDetailHref,
+} from '@/lib/training-facility/cardio-shared'
 import { computePreviousRange } from '@/lib/training-facility/period-comparison'
 import { BackToCourtButton } from '@/components/common/BackToCourtButton'
 import {
@@ -318,7 +323,13 @@ export function StairDetailView(): JSX.Element {
     [data, previousRange],
   )
   const buckets = useMemo(() => aggregateHrZoneSeconds(stairSessions), [stairSessions])
-  const avgHrPoints = useMemo(() => perSessionAvgHr(stairSessions), [stairSessions])
+  // Avg-HR bars aggregate to weekly/monthly means on wide windows so a
+  // multi-year "All" view doesn't collapse into an unreadable picket fence of
+  // per-session bars (granularity keyed off the visible span).
+  const avgHrPoints = useMemo(
+    () => bucketAvgHr(perSessionAvgHr(stairSessions), avgHrGranularityForSpanDays(rangeSpanDays(range))),
+    [stairSessions, range],
+  )
 
   // Training load aggregates ALL cardio activities (stair, running, walking) —
   // TRIMP / ATL / CTL is a whole-athlete metric and excluding modalities would

--- a/components/training-facility/gym/StairDetailView.tsx
+++ b/components/training-facility/gym/StairDetailView.tsx
@@ -437,7 +437,7 @@ export function StairDetailView(): JSX.Element {
 
               <ChartCard
                 title="Avg HR per session"
-                helper="One bar per session — y-axis padded to the visible range so trends pop."
+                helper="One bar per session, bucketed to weekly/monthly means on wider ranges. Y-axis padded to the visible range so trends pop."
               >
                 <AvgHrBars
                   points={avgHrPoints}

--- a/components/training-facility/gym/TrackDetailView.tsx
+++ b/components/training-facility/gym/TrackDetailView.tsx
@@ -321,7 +321,7 @@ export function TrackDetailView(): JSX.Element {
 
               <ChartCard
                 title="Avg HR per session"
-                helper="One bar per walk — a steady or downward trend means the engine is getting more efficient at the same pace."
+                helper="One bar per walk, bucketed to weekly/monthly means on wider ranges; a steady or downward trend means the engine is getting more efficient at the same pace."
               >
                 <AvgHrBars
                   points={avgHrPoints}

--- a/components/training-facility/gym/TrackDetailView.tsx
+++ b/components/training-facility/gym/TrackDetailView.tsx
@@ -20,9 +20,12 @@ import {
 } from '@/components/training-facility/shared/DateFilter'
 import {
   aggregateHrZoneSeconds,
+  avgHrGranularityForSpanDays,
+  bucketAvgHr,
   formatDuration,
   parseSessionDate,
   perSessionAvgHr,
+  rangeSpanDays,
   sessionDetailHref,
 } from '@/lib/training-facility/cardio-shared'
 import {
@@ -189,7 +192,13 @@ export function TrackDetailView(): JSX.Element {
     [data],
   )
   const buckets = useMemo(() => aggregateHrZoneSeconds(walkingSessions), [walkingSessions])
-  const avgHrPoints = useMemo(() => perSessionAvgHr(walkingSessions), [walkingSessions])
+  // Avg-HR bars aggregate to weekly/monthly means on wide windows so a
+  // multi-year "All" view doesn't collapse into an unreadable picket fence of
+  // per-session bars (granularity keyed off the visible span).
+  const avgHrPoints = useMemo(
+    () => bucketAvgHr(perSessionAvgHr(walkingSessions), avgHrGranularityForSpanDays(rangeSpanDays(range))),
+    [walkingSessions, range],
+  )
   const paceTrend = useMemo(() => paceTrendPoints(walkingSessions), [walkingSessions])
   const efficiencyTrend = useMemo(
     () => cardiacEfficiencyPoints(walkingSessions),

--- a/components/training-facility/gym/TreadmillDetailView.tsx
+++ b/components/training-facility/gym/TreadmillDetailView.tsx
@@ -323,7 +323,7 @@ export function TreadmillDetailView(): JSX.Element {
 
               <ChartCard
                 title="Avg HR per session"
-                helper="One bar per session — y-axis padded to the visible range so trends pop."
+                helper="One bar per session, bucketed to weekly/monthly means on wider ranges. Y-axis padded to the visible range so trends pop."
               >
                 <AvgHrBars
                   points={avgHrPoints}

--- a/components/training-facility/gym/TreadmillDetailView.tsx
+++ b/components/training-facility/gym/TreadmillDetailView.tsx
@@ -20,9 +20,12 @@ import {
 } from '@/components/training-facility/shared/DateFilter'
 import {
   aggregateHrZoneSeconds,
+  avgHrGranularityForSpanDays,
+  bucketAvgHr,
   formatDuration,
   parseSessionDate,
   perSessionAvgHr,
+  rangeSpanDays,
   sessionDetailHref,
 } from '@/lib/training-facility/cardio-shared'
 import {
@@ -192,7 +195,13 @@ export function TreadmillDetailView(): JSX.Element {
     [data],
   )
   const buckets = useMemo(() => aggregateHrZoneSeconds(runningSessions), [runningSessions])
-  const avgHrPoints = useMemo(() => perSessionAvgHr(runningSessions), [runningSessions])
+  // Avg-HR bars aggregate to weekly/monthly means on wide windows so a
+  // multi-year "All" view doesn't collapse into an unreadable picket fence of
+  // per-session bars (granularity keyed off the visible span).
+  const avgHrPoints = useMemo(
+    () => bucketAvgHr(perSessionAvgHr(runningSessions), avgHrGranularityForSpanDays(rangeSpanDays(range))),
+    [runningSessions, range],
+  )
   const paceTrend = useMemo(() => paceTrendPoints(runningSessions), [runningSessions])
   const efficiencyTrend = useMemo(
     () => cardiacEfficiencyPoints(runningSessions),

--- a/components/training-facility/shared/charts/RoughLine.tsx
+++ b/components/training-facility/shared/charts/RoughLine.tsx
@@ -54,9 +54,11 @@ const YEAR_LABEL_THRESHOLD_MS = 400 * 24 * 60 * 60 * 1000
  * @param spanMs - Full domain width in milliseconds.
  */
 export function formatDateAxisTick(tick: Date, spanMs: number): string {
+  // Pin the locale so axis labels read identically for every viewer instead of
+  // following the runtime locale (`janv.` / `1月`).
   return spanMs > YEAR_LABEL_THRESHOLD_MS
-    ? tick.toLocaleDateString(undefined, { month: 'short', year: 'numeric' })
-    : tick.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
+    ? tick.toLocaleDateString('en-US', { month: 'short', year: 'numeric' })
+    : tick.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
 }
 
 export function RoughLine<T>({

--- a/components/training-facility/shared/charts/RoughLine.tsx
+++ b/components/training-facility/shared/charts/RoughLine.tsx
@@ -40,6 +40,25 @@ function isDateValue(v: number | Date): v is Date {
   return v instanceof Date
 }
 
+/** Domain span past which date ticks carry a year, in ms (~13 months). */
+const YEAR_LABEL_THRESHOLD_MS = 400 * 24 * 60 * 60 * 1000
+
+/**
+ * Default label formatter for a time axis. `d3` places multi-year `.ticks()` on
+ * January-1 boundaries, so a bare `month day` formatter renders a useless row
+ * of identical "Jan 1" labels. Once the visible span exceeds ~a year, switch to
+ * `month year` (e.g. `Jan 2024`) so each tick is distinguishable; keep the
+ * compact `month day` for shorter spans.
+ *
+ * @param tick - Tick date to label.
+ * @param spanMs - Full domain width in milliseconds.
+ */
+export function formatDateAxisTick(tick: Date, spanMs: number): string {
+  return spanMs > YEAR_LABEL_THRESHOLD_MS
+    ? tick.toLocaleDateString(undefined, { month: 'short', year: 'numeric' })
+    : tick.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
+}
+
 export function RoughLine<T>({
   data,
   x,
@@ -107,10 +126,9 @@ export function RoughLine<T>({
       .domain([new Date(tMin), new Date(tMax)])
       .range([0, innerW])
     scaleX = (v) => timeScale(v as Date)
+    const spanMs = tMax - tMin
     xTicks = timeScale.ticks(xTickCount).map((tick) => ({
-      value: xTickFormat
-        ? xTickFormat(tick)
-        : tick.toLocaleDateString(undefined, { month: 'short', day: 'numeric' }),
+      value: xTickFormat ? xTickFormat(tick) : formatDateAxisTick(tick, spanMs),
       offset: timeScale(tick),
     }))
   } else {

--- a/components/training-facility/shared/charts/primitives.test.tsx
+++ b/components/training-facility/shared/charts/primitives.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { RoughBar, RoughLine, RoughScatter, RoughSparkline } from './'
+import { formatDateAxisTick } from './RoughLine'
 
 /**
  * Minimal render coverage for the chart primitives. Per the issue's P2 list:
@@ -149,6 +150,56 @@ describe('RoughLine', () => {
       />,
     )
     expect(container.querySelector('[data-testid="rough-line-overlay"]')).toBeNull()
+  })
+
+  it('labels multi-year date ticks with a year so they are not all "Jan"', () => {
+    // A >1yr Date domain: d3 lands ticks on year boundaries. Without a year in
+    // the label every tick reads identically ("Jan 1"); the span-aware default
+    // formatter must include the year instead.
+    render(
+      <RoughLine
+        data={[
+          { x: new Date(2023, 0, 1), y: 1 },
+          { x: new Date(2024, 6, 1), y: 2 },
+          { x: new Date(2025, 11, 1), y: 3 },
+        ]}
+        x={(d) => d.x}
+        y={(d) => d.y}
+        width={600}
+        height={200}
+        ariaLabel="multi-year trend"
+      />,
+    )
+    expect(screen.getAllByText(/20\d\d/).length).toBeGreaterThan(0)
+  })
+
+  it('omits the year on sub-year date spans (compact month/day labels)', () => {
+    render(
+      <RoughLine
+        data={[
+          { x: new Date(2026, 0, 1), y: 1 },
+          { x: new Date(2026, 1, 15), y: 2 },
+        ]}
+        x={(d) => d.x}
+        y={(d) => d.y}
+        width={400}
+        height={200}
+        ariaLabel="two-month trend"
+      />,
+    )
+    expect(screen.queryAllByText(/20\d\d/)).toHaveLength(0)
+  })
+})
+
+describe('formatDateAxisTick', () => {
+  const DAY = 24 * 60 * 60 * 1000
+
+  it('includes the year once the span exceeds ~13 months', () => {
+    expect(formatDateAxisTick(new Date(2024, 0, 1), 500 * DAY)).toMatch(/2024/)
+  })
+
+  it('uses a compact month/day label for sub-year spans', () => {
+    expect(formatDateAxisTick(new Date(2026, 3, 1), 60 * DAY)).not.toMatch(/20\d\d/)
   })
 })
 

--- a/lib/training-facility/cardio-shared.test.ts
+++ b/lib/training-facility/cardio-shared.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest'
+import {
+  avgHrGranularityForSpanDays,
+  bucketAvgHr,
+  rangeSpanDays,
+  type SessionAvgHrPoint,
+} from './cardio-shared'
+
+const pt = (date: string, avgHr: number): SessionAvgHrPoint => ({
+  date,
+  label: '',
+  avgHr,
+})
+
+describe('rangeSpanDays', () => {
+  it('measures the whole-day span between range bounds', () => {
+    const span = rangeSpanDays({
+      start: new Date('2026-04-01T00:00:00'),
+      end: new Date('2026-04-11T00:00:00'),
+    })
+    expect(span).toBe(10)
+  })
+})
+
+describe('avgHrGranularityForSpanDays', () => {
+  it('keeps per-session bars for short windows (1M / 3M)', () => {
+    expect(avgHrGranularityForSpanDays(0)).toBe('session')
+    expect(avgHrGranularityForSpanDays(30)).toBe('session')
+    expect(avgHrGranularityForSpanDays(100)).toBe('session')
+  })
+
+  it('rolls up to weekly for mid windows (6M / 1Y)', () => {
+    expect(avgHrGranularityForSpanDays(101)).toBe('week')
+    expect(avgHrGranularityForSpanDays(182)).toBe('week')
+    expect(avgHrGranularityForSpanDays(365)).toBe('week')
+    expect(avgHrGranularityForSpanDays(400)).toBe('week')
+  })
+
+  it('rolls up to monthly for multi-year windows (All)', () => {
+    expect(avgHrGranularityForSpanDays(401)).toBe('month')
+    expect(avgHrGranularityForSpanDays(1200)).toBe('month')
+  })
+})
+
+describe('bucketAvgHr', () => {
+  it('returns a fresh copy unchanged at session granularity', () => {
+    const input = [pt('2026-04-06', 140), pt('2026-04-08', 160)]
+    const out = bucketAvgHr(input, 'session')
+    expect(out).toEqual(input)
+    expect(out).not.toBe(input)
+  })
+
+  it('returns [] for empty input regardless of granularity', () => {
+    expect(bucketAvgHr([], 'month')).toEqual([])
+  })
+
+  it('averages sessions that fall in the same Mon–Sun week', () => {
+    // 2026-04-06 is a Monday; 04-08 is the same week; 04-13 is the next Monday.
+    const out = bucketAvgHr(
+      [pt('2026-04-06', 140), pt('2026-04-08', 160), pt('2026-04-13', 150)],
+      'week',
+    )
+    expect(out).toEqual([
+      { date: '2026-04-06', label: '4/6', avgHr: 150 },
+      { date: '2026-04-13', label: '4/13', avgHr: 150 },
+    ])
+  })
+
+  it('anchors a Sunday session to the preceding Monday', () => {
+    // 2026-04-12 is a Sunday → same week as Monday 2026-04-06.
+    const out = bucketAvgHr([pt('2026-04-12', 130)], 'week')
+    expect(out).toEqual([{ date: '2026-04-12', label: '4/6', avgHr: 130 }])
+  })
+
+  it("averages sessions in the same month and labels them Mon 'YY", () => {
+    const out = bucketAvgHr(
+      [pt('2026-04-06', 140), pt('2026-04-20', 160), pt('2026-05-02', 150)],
+      'month',
+    )
+    expect(out).toEqual([
+      { date: '2026-04-06', label: "Apr '26", avgHr: 150 },
+      { date: '2026-05-02', label: "May '26", avgHr: 150 },
+    ])
+  })
+
+  it('preserves chronological bucket order and keeps each bucket first date', () => {
+    const out = bucketAvgHr(
+      [pt('2026-01-05', 120), pt('2026-01-19', 130), pt('2026-03-02', 140)],
+      'month',
+    )
+    expect(out.map((b) => b.date)).toEqual(['2026-01-05', '2026-03-02'])
+  })
+
+  it('skips points whose date string cannot be parsed', () => {
+    const out = bucketAvgHr([pt('garbage', 999), pt('2026-04-06', 150)], 'month')
+    expect(out).toEqual([{ date: '2026-04-06', label: "Apr '26", avgHr: 150 }])
+  })
+})

--- a/lib/training-facility/cardio-shared.ts
+++ b/lib/training-facility/cardio-shared.ts
@@ -224,7 +224,10 @@ export function bucketAvgHr(
     const g = groups.get(key)!
     const label =
       granularity === 'month'
-        ? `${g.anchor.toLocaleDateString(undefined, { month: 'short' })} '${String(g.anchor.getFullYear()).slice(-2)}`
+        ? // Pin the locale so month buckets read the same for every viewer (a
+          // runtime locale would render `avr.` / `4月`) and the label is stable
+          // for tests.
+          `${g.anchor.toLocaleDateString('en-US', { month: 'short' })} '${String(g.anchor.getFullYear()).slice(-2)}`
         : `${g.anchor.getMonth() + 1}/${g.anchor.getDate()}`
     return { date: g.date, label, avgHr: g.sum / g.count }
   })

--- a/lib/training-facility/cardio-shared.ts
+++ b/lib/training-facility/cardio-shared.ts
@@ -110,7 +110,10 @@ export function aggregateHrZoneSeconds(sessions: readonly CardioSession[]): HrZo
 export interface SessionAvgHrPoint {
   /** Original session date string (ISO or `YYYY-MM-DD`). */
   date: string
-  /** Short label rendered on the x-axis — `M/D` in local time. */
+  /**
+   * Short label rendered on the x-axis. `M/D` in local time for per-session /
+   * weekly points; `Mon 'YY` for monthly buckets (see {@link bucketAvgHr}).
+   */
   label: string
   /** Average heart rate, BPM. Sessions missing `avg_hr` are excluded upstream. */
   avgHr: number
@@ -135,6 +138,96 @@ export function perSessionAvgHr(sessions: readonly CardioSession[]): SessionAvgH
     out.push({ date: s.date, label, avgHr: s.avg_hr })
   }
   return out
+}
+
+/**
+ * Aggregation granularity for the avg-HR bar chart.
+ *
+ * - `session` — one bar per session (the raw {@link perSessionAvgHr} output).
+ * - `week` — sessions collapsed to weekly means.
+ * - `month` — sessions collapsed to monthly means.
+ */
+export type AvgHrGranularity = 'session' | 'week' | 'month'
+
+/** Milliseconds in a day, for span math. */
+const MS_PER_DAY = 86_400_000
+
+/**
+ * Whole-day span of a {@link DateRange}, used to pick chart aggregation.
+ * Fractional because range bounds are local day edges, not whole days.
+ *
+ * @param range - Inclusive date window from the `DateFilter`.
+ */
+export function rangeSpanDays(range: DateRange): number {
+  return (range.end.getTime() - range.start.getTime()) / MS_PER_DAY
+}
+
+/**
+ * Choose avg-HR bar granularity from the visible span. Per-session bars stay
+ * legible for a few months (`1M`/`3M`); past that they smear into an unreadable
+ * picket fence, so wider windows roll up to weekly (`6M`/`1Y`) then monthly
+ * (multi-year `All`) means.
+ *
+ * Thresholds: ≤ ~100 days → `session`, ≤ ~13 months → `week`, else `month`.
+ *
+ * @param spanDays - Visible window width in days (see {@link rangeSpanDays}).
+ */
+export function avgHrGranularityForSpanDays(spanDays: number): AvgHrGranularity {
+  if (spanDays > 400) return 'month'
+  if (spanDays > 100) return 'week'
+  return 'session'
+}
+
+/** Local Monday 00:00 of the week containing `d` — the weekly bucket anchor. */
+function weekStart(d: Date): Date {
+  const out = new Date(d.getFullYear(), d.getMonth(), d.getDate())
+  const dayOffset = (out.getDay() + 6) % 7 // Mon=0 … Sun=6
+  out.setDate(out.getDate() - dayOffset)
+  return out
+}
+
+/**
+ * Collapse per-session avg-HR points into time buckets, averaging `avgHr`
+ * within each bucket. `session` granularity (or an empty input) returns the
+ * points unchanged. Input must be chronologically sorted; buckets come out in
+ * that same order. Each bucket's `date` is its first session's date and its
+ * `label` reflects the granularity — `M/D` of the week start for `week`,
+ * `Mon 'YY` for `month`.
+ *
+ * @param points - Per-session points from {@link perSessionAvgHr}, sorted ascending.
+ * @param granularity - Bucket size, typically from {@link avgHrGranularityForSpanDays}.
+ */
+export function bucketAvgHr(
+  points: readonly SessionAvgHrPoint[],
+  granularity: AvgHrGranularity,
+): SessionAvgHrPoint[] {
+  if (granularity === 'session' || points.length === 0) return [...points]
+
+  const groups = new Map<string, { sum: number; count: number; anchor: Date; date: string }>()
+  const order: string[] = []
+  for (const p of points) {
+    const d = parseSessionDate(p.date)
+    if (!Number.isFinite(d.getTime())) continue
+    const anchor = granularity === 'month' ? new Date(d.getFullYear(), d.getMonth(), 1) : weekStart(d)
+    const key = `${anchor.getFullYear()}-${anchor.getMonth()}-${anchor.getDate()}`
+    let g = groups.get(key)
+    if (!g) {
+      g = { sum: 0, count: 0, anchor, date: p.date }
+      groups.set(key, g)
+      order.push(key)
+    }
+    g.sum += p.avgHr
+    g.count += 1
+  }
+
+  return order.map((key) => {
+    const g = groups.get(key)!
+    const label =
+      granularity === 'month'
+        ? `${g.anchor.toLocaleDateString(undefined, { month: 'short' })} '${String(g.anchor.getFullYear()).slice(-2)}`
+        : `${g.anchor.getMonth() + 1}/${g.anchor.getDate()}`
+    return { date: g.date, label, avgHr: g.sum / g.count }
+  })
 }
 
 /**

--- a/lib/training-facility/running.test.ts
+++ b/lib/training-facility/running.test.ts
@@ -76,6 +76,22 @@ describe('paceTrendPoints', () => {
     const out = paceTrendPoints(sessions)
     expect(out.map((p) => p.rawDate)).toEqual(['2026-04-05'])
   })
+
+  it('drops implausible pace outliers that would flatten the y-domain', () => {
+    const sessions: CardioSession[] = [
+      run('2026-04-01', { pace_seconds_per_km: 40000 }), // ~1072:00 /mi — paused/artifact
+      run('2026-04-02', { pace_seconds_per_km: 50 }), // ~1:20 /mi — impossibly fast
+      run('2026-04-03', { pace_seconds_per_km: 360 }), // ~9:39 /mi — real
+    ]
+    const out = paceTrendPoints(sessions)
+    expect(out.map((p) => p.rawDate)).toEqual(['2026-04-03'])
+  })
+
+  it('keeps a slow-but-plausible walking pace (helper is reused for the track view)', () => {
+    // 745 sec/km ≈ 19:59 /mi — a real slow walk, under the 40:00 /mi ceiling.
+    const out = paceTrendPoints([run('2026-04-01', { pace_seconds_per_km: 745 })])
+    expect(out).toHaveLength(1)
+  })
 })
 
 describe('cardiacEfficiencyPoints', () => {
@@ -106,6 +122,15 @@ describe('cardiacEfficiencyPoints', () => {
     ]
     const out = cardiacEfficiencyPoints(sessions)
     expect(out.map((p) => p.rawDate)).toEqual(['2026-04-05'])
+  })
+
+  it('drops implausibly high m/heartbeat (bad-HR artifact spiking the y-domain)', () => {
+    const sessions: CardioSession[] = [
+      run('2026-04-01', { meters_per_heartbeat: 60 }), // artifact
+      run('2026-04-02', { meters_per_heartbeat: 1.6 }), // real
+    ]
+    const out = cardiacEfficiencyPoints(sessions)
+    expect(out.map((p) => p.rawDate)).toEqual(['2026-04-02'])
   })
 })
 
@@ -154,6 +179,15 @@ describe('paceAtHrPoints', () => {
     ]
     const out = paceAtHrPoints(sessions)
     expect(out.map((p) => p.rawDate)).toEqual(['2026-04-05'])
+  })
+
+  it('drops points whose converted pace is an implausible outlier', () => {
+    const sessions: CardioSession[] = [
+      run('2026-04-01', { avg_hr: 150, pace_seconds_per_km: 40000 }), // artifact pace
+      run('2026-04-02', { avg_hr: 150, pace_seconds_per_km: 350 }), // real
+    ]
+    const out = paceAtHrPoints(sessions)
+    expect(out.map((p) => p.rawDate)).toEqual(['2026-04-02'])
   })
 })
 

--- a/lib/training-facility/running.ts
+++ b/lib/training-facility/running.ts
@@ -19,6 +19,35 @@ import { filterCardioSessionsByActivity, parseSessionDate } from './cardio-share
 export const METERS_PER_MILE = 1609.344
 
 /**
+ * Fastest pace we treat as real, in sec/mi (2:30/mi). Faster than any
+ * human-sustainable treadmill/track pace, so anything below is a bad import.
+ */
+const MIN_PLAUSIBLE_PACE_SEC_PER_MILE = 150
+
+/**
+ * Slowest pace we treat as real, in sec/mi (40:00/mi). Covers slow walking on
+ * the track view (which reuses these helpers) while rejecting the paused /
+ * zero-distance artifacts that surface as absurd `1000:00 /mi` outliers and
+ * flatten the whole y-domain.
+ */
+const MAX_PLAUSIBLE_PACE_SEC_PER_MILE = 2400
+
+/**
+ * Largest cardiac-efficiency value we treat as real, in m/heartbeat. Normal
+ * running is ~0.5–2.5 m/beat; a value above this needs implausibly fast travel
+ * per beat and comes from a session with a bad HR reading, not real fitness.
+ */
+const MAX_PLAUSIBLE_METERS_PER_HEARTBEAT = 10
+
+/** True when a converted pace (sec/mi) falls in the human-plausible band. */
+function isPlausiblePaceSecPerMile(secPerMile: number): boolean {
+  return (
+    secPerMile >= MIN_PLAUSIBLE_PACE_SEC_PER_MILE &&
+    secPerMile <= MAX_PLAUSIBLE_PACE_SEC_PER_MILE
+  )
+}
+
+/**
  * Convert a pace from `sec/km` (the format `cardio.json` stores) to `sec/mi`
  * (the format the UI renders). Exported so the data helpers and the table-row
  * formatter share the conversion without duplicating the constant.
@@ -59,9 +88,10 @@ export interface PaceTrendPoint {
  *
  * Source data is `pace_seconds_per_km`; conversion is `× 1609.344 / 1000`.
  * Sessions without a numeric pace, with non-positive pace (sentinel for
- * "missing" in some Apple Health exports), or with an unparseable date are
- * dropped — the chart renders gaps as missing points rather than zero-pace
- * outliers that would compress the y-domain.
+ * "missing" in some Apple Health exports), with a converted pace outside the
+ * human-plausible band (see {@link isPlausiblePaceSecPerMile}), or with an
+ * unparseable date are dropped — the chart renders gaps as missing points
+ * rather than outliers that would compress the y-domain.
  *
  * @param sessions - Filtered, sorted running sessions.
  */
@@ -70,13 +100,11 @@ export function paceTrendPoints(sessions: readonly CardioSession[]): PaceTrendPo
   for (const s of sessions) {
     const secPerKm = s.pace_seconds_per_km
     if (typeof secPerKm !== 'number' || !Number.isFinite(secPerKm) || secPerKm <= 0) continue
+    const paceSecondsPerMile = secPerKmToSecPerMile(secPerKm)
+    if (!isPlausiblePaceSecPerMile(paceSecondsPerMile)) continue
     const date = parseSessionDate(s.date)
     if (!Number.isFinite(date.getTime())) continue
-    out.push({
-      date,
-      rawDate: s.date,
-      paceSecondsPerMile: secPerKmToSecPerMile(secPerKm),
-    })
+    out.push({ date, rawDate: s.date, paceSecondsPerMile })
   }
   return out
 }
@@ -94,7 +122,9 @@ export interface CardiacEfficiencyPoint {
 /**
  * Project running sessions to cardiac-efficiency points (m/heartbeat over
  * time). Sessions missing `meters_per_heartbeat`, with non-positive values,
- * or with an unparseable date are dropped.
+ * with an implausibly high value (see {@link MAX_PLAUSIBLE_METERS_PER_HEARTBEAT}
+ * — a bad-HR artifact that spikes the y-domain), or with an unparseable date
+ * are dropped.
  *
  * @param sessions - Filtered, sorted running sessions.
  */
@@ -105,6 +135,7 @@ export function cardiacEfficiencyPoints(
   for (const s of sessions) {
     const mph = s.meters_per_heartbeat
     if (typeof mph !== 'number' || !Number.isFinite(mph) || mph <= 0) continue
+    if (mph > MAX_PLAUSIBLE_METERS_PER_HEARTBEAT) continue
     const date = parseSessionDate(s.date)
     if (!Number.isFinite(date.getTime())) continue
     out.push({ date, rawDate: s.date, metersPerHeartbeat: mph })
@@ -124,9 +155,11 @@ export interface PaceAtHrPoint {
 
 /**
  * Project running sessions to scatter-plot points (avg HR vs pace). Both
- * fields must be present and positive — there's no defensible value to plot
- * for a session that's missing either coordinate. The lower-left quadrant is
- * "fast at low effort" (most efficient).
+ * fields must be present and positive, and the converted pace must fall in the
+ * human-plausible band (see {@link isPlausiblePaceSecPerMile}) — there's no
+ * defensible value to plot for a session missing either coordinate or carrying
+ * an artifact pace. The lower-left quadrant is "fast at low effort" (most
+ * efficient).
  *
  * @param sessions - Filtered, sorted running sessions.
  */
@@ -136,11 +169,9 @@ export function paceAtHrPoints(sessions: readonly CardioSession[]): PaceAtHrPoin
     if (typeof s.avg_hr !== 'number' || !Number.isFinite(s.avg_hr) || s.avg_hr <= 0) continue
     const secPerKm = s.pace_seconds_per_km
     if (typeof secPerKm !== 'number' || !Number.isFinite(secPerKm) || secPerKm <= 0) continue
-    out.push({
-      rawDate: s.date,
-      avgHr: s.avg_hr,
-      paceSecondsPerMile: secPerKmToSecPerMile(secPerKm),
-    })
+    const paceSecondsPerMile = secPerKmToSecPerMile(secPerKm)
+    if (!isPlausiblePaceSecPerMile(paceSecondsPerMile)) continue
+    out.push({ rawDate: s.date, avgHr: s.avg_hr, paceSecondsPerMile })
   }
   return out
 }


### PR DESCRIPTION
## What

The cardio charts on the treadmill / track / stair detail views (and the wide "All" range especially) rendered badly. Three independent root causes, all in **shared chart code**, so every cardio surface was affected:

1. **Time axes collapsed to "Jan 1 · Jan 1 · Jan 1…"** on multi-year spans. d3 places `.ticks()` on year boundaries, and the default `RoughLine` formatter omitted the year, so every tick read identically. Now the formatter switches to `Mon YYYY` (e.g. `Jan 2024`) once the domain spans more than ~13 months, and stays compact `Mon D` below that. This fixes the pace-trend, cardiac-efficiency, OTF, lifestyle, and session-detail date axes in one place.
2. **Avg-HR bar chart drew one bar per session** → an unreadable picket fence on wide ranges. Avg-HR points now **bucket to weekly/monthly means** keyed off the visible span (per-session ≤ ~100d, weekly ≤ ~13mo, monthly beyond), and the x-axis **thins labels to ~12** evenly-spaced ticks. Every bar still renders; only crowded labels drop.
3. **Pace and efficiency admitted absurd outliers.** Paused / zero-distance imports surfaced as ~`1000:00 /mi` and bad-HR sessions spiked `m/heartbeat`, flattening every real point against the axis. The projections now drop values outside a human-plausible band (2:30–40:00 /mi; ≤ 10 m/beat). The slow ceiling is deliberately generous so the track view's real slow walks survive.

## Files

- `components/training-facility/shared/charts/RoughLine.tsx` — span-aware default date-tick formatter (`formatDateAxisTick`, exported + tested).
- `components/training-facility/gym/AvgHrBars.tsx` — x-label thinning (`pickEvenlySpacedIndices`, exported + tested) + `maxXLabels` prop.
- `lib/training-facility/cardio-shared.ts` — `avgHrGranularityForSpanDays`, `bucketAvgHr`, `rangeSpanDays` (new pure helpers).
- `lib/training-facility/running.ts` — plausibility bounds on `paceTrendPoints` / `paceAtHrPoints` / `cardiacEfficiencyPoints`.
- `TreadmillDetailView` / `TrackDetailView` / `StairDetailView` — bucket avg-HR by the active range span.
- Co-located tests for every new helper + `RoughLine` multi-year render.

## Test plan

- [ ] Open `/training-facility/gym/treadmill` and switch to the **All** range.
  - [ ] X-axis on the pace and efficiency charts shows **years** (e.g. `Jan 2024`), not a row of `Jan 1`.
  - [ ] The **Avg HR** chart shows a manageable number of bars (monthly buckets), not one skinny bar per session, and x-labels don't overlap.
  - [ ] No single pace point sits at an absurd value that squashes the rest of the line flat; the efficiency line has no lone 60× spike.
- [ ] Switch to **1M / 3M** — avg-HR reverts to **per-session** bars; axes stay compact `Mon D`.
- [ ] Repeat on `/training-facility/gym/track` and `/training-facility/gym/stair` (same shared components).

### Local verification

- `npx tsc --noEmit` — clean (a stale local `.next` validator referencing a deleted scratch route is unrelated; Vercel builds from a clean checkout).
- `npx next build` — **compiled successfully**.
- `npx vitest run lib/training-facility components/training-facility` — 793 pass; 57 in the touched areas.
- `npx eslint` on changed files — clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Average heart-rate charts now bucket values by session, week, or month depending on the selected date range.
  * X-axis tick labels are now formatted to include years only for longer time spans, and dense charts can limit label density.
* **Bug Fixes**
  * Improved chart accuracy by filtering implausible pace and heart-rate-derived outliers.
* **Tests**
  * Added/expanded test coverage for heart-rate bucketing, date-axis tick formatting, and running data filtering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->