### PR TITLE
fix(weight-room): render every goal ring on the scene wall fixture

### DIFF
--- a/components/training-facility/scenes/assets/weight-room-fixtures.test.tsx
+++ b/components/training-facility/scenes/assets/weight-room-fixtures.test.tsx
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+import { render } from '@testing-library/react'
+
+import type { ExerciseGoal, WeightRoomData } from '@/types/weight-room'
+
+import { WallActivityRings } from './weight-room-fixtures'
+
+/**
+ * Regression coverage for the Weight Room scene's wall fixture. The
+ * original fixed geometry (`OUTER_RADIUS - i * (STROKE + GAP)` with a
+ * hard `radius < STROKE / 2` cutoff) plus a `rings.slice(0, 2)` tally cap
+ * silently dropped every goal past the third: a real 4-goal wall
+ * (pullups, pushups, a shrugs focus lane, squats) rendered only three
+ * rings and labeled just two. These tests pin the auto-fit so every
+ * configured goal earns a ring *and* a label.
+ *
+ * `WallActivityRings` returns an SVG `<g>`, so it renders inside an
+ * `<svg>` the way it lives inside the scene viewBox.
+ */
+function makeGoal(exercise: string, color: string): ExerciseGoal {
+  return { exercise, daily_target: 100, color, kind: 'permanent' }
+}
+
+const FOUR_GOALS: ExerciseGoal[] = [
+  makeGoal('pullups', '#0EA5A1'),
+  makeGoal('pushups', '#EA580C'),
+  makeGoal('shrugs', '#C9A268'),
+  makeGoal('squats', '#2563EB'),
+]
+
+function makeData(goals: ExerciseGoal[]): WeightRoomData {
+  return { imported_at: '', sets: [], goals, monthly_focus: [] }
+}
+
+function renderInScene(data: WeightRoomData | null) {
+  return render(
+    <svg viewBox="0 0 1600 900" data-testid="scene">
+      <WallActivityRings data={data} />
+    </svg>,
+  )
+}
+
+describe('WallActivityRings', () => {
+  it('renders a ring for every configured goal, not just the first three', () => {
+    const { getByTestId } = renderInScene(makeData(FOUR_GOALS))
+    for (const goal of FOUR_GOALS) {
+      expect(getByTestId(`wall-ring-${goal.exercise}`)).toBeInTheDocument()
+    }
+  })
+
+  it('keeps the fourth ring (a permanent goal behind a focus lane) visible', () => {
+    // The squats ring is the one the fixed geometry used to drop; assert
+    // it renders with its own color so a regression can't hide it again.
+    const { getByTestId } = renderInScene(makeData(FOUR_GOALS))
+    const squats = getByTestId('wall-ring-squats')
+    const arc = squats.querySelectorAll('circle')[1]
+    expect(arc.getAttribute('stroke')).toBe('#2563EB')
+  })
+
+  it('labels every ring instead of capping the tallies at two', () => {
+    const { getByTestId } = renderInScene(makeData(FOUR_GOALS))
+    for (const goal of FOUR_GOALS) {
+      expect(getByTestId(`wall-tally-${goal.exercise}`)).toBeInTheDocument()
+    }
+  })
+
+  it('falls back to ghost rings and a "no goals yet" note when no goals exist', () => {
+    const { getByText, queryByTestId } = renderInScene(null)
+    expect(getByText(/no goals yet/i)).toBeInTheDocument()
+    expect(queryByTestId('wall-ring-pushups')).not.toBeInTheDocument()
+  })
+})

--- a/components/training-facility/scenes/assets/weight-room-fixtures.tsx
+++ b/components/training-facility/scenes/assets/weight-room-fixtures.tsx
@@ -34,7 +34,36 @@ const RING_CY = FRAME_Y + 130
 const OUTER_RADIUS = 58
 const RING_STROKE = 14
 const RING_GAP = 4
+const MIN_RING_STROKE = 4
+const MIN_RING_GAP = 1
 const TRACK_OPACITY = 0.2
+
+/**
+ * Pick a `stroke` + `gap` that fit every configured ring inside
+ * {@link OUTER_RADIUS}. Mirrors `fitRingDimensions` in the Log View's
+ * {@link import('../../weight-room/ActivityRings').ActivityRings} so this
+ * decorative wall fixture renders *every* goal instead of silently
+ * dropping the inner rings once the count passes three — pushups,
+ * pullups, squats plus an active monthly-focus lane already make four,
+ * and the fixed geometry pushed the fourth ring below the render cutoff.
+ * Defaults to the generous (`RING_STROKE`, `RING_GAP`) sizes for the
+ * common 1–2 goal case and shrinks toward (`MIN_RING_STROKE`,
+ * `MIN_RING_GAP`) as goals accumulate.
+ *
+ * @param availableRadius Radius of the outermost ring's centerline —
+ *   {@link OUTER_RADIUS} for this fixture.
+ * @param ringCount Number of concentric rings to fit.
+ */
+function fitRingDimensions(
+  availableRadius: number,
+  ringCount: number,
+): { stroke: number; gap: number } {
+  if (ringCount <= 0) return { stroke: RING_STROKE, gap: RING_GAP }
+  const requiredStroke = Math.floor(availableRadius / (ringCount * 1.6))
+  const stroke = Math.max(MIN_RING_STROKE, Math.min(RING_STROKE, requiredStroke))
+  const gap = Math.max(MIN_RING_GAP, Math.min(RING_GAP, Math.floor(stroke * 0.3)))
+  return { stroke, gap }
+}
 
 /**
  * Wall-mounted "today's progress" fixture for the Weight Room scene
@@ -88,6 +117,26 @@ export function WallActivityRings({
       ? Math.min(1, primary.total / primary.target)
       : 0
 
+  // Auto-fit stroke/gap so every configured goal renders a ring. The old
+  // fixed geometry dropped any ring past the third (a permanent squats
+  // goal vanished the moment the shrugs focus lane pushed the count to
+  // four); this mirrors the Log View's auto-fit.
+  const { stroke: ringStroke, gap: ringGap } = fitRingDimensions(
+    OUTER_RADIUS,
+    rings.length,
+  )
+
+  // Tally band — the per-exercise labels stack below the rings inside the
+  // board's lower margin. Spacing + font shrink with the goal count so a
+  // 4-goal wall labels every ring instead of the old hard `slice(0, 2)`,
+  // which left the inner rings anonymous.
+  const ringsBottom = RING_CY + OUTER_RADIUS + ringStroke / 2
+  const tallyTop = ringsBottom + 6
+  const tallyBandHeight = Math.max(0, FRAME_Y + FRAME_H - 12 - tallyTop)
+  const tallySpacing =
+    rings.length > 0 ? Math.min(22, tallyBandHeight / rings.length) : 22
+  const tallyFontSize = Math.max(10, Math.min(16, Math.round(tallySpacing * 0.72)))
+
   return (
     <g aria-hidden="true">
       {/* Board frame */}
@@ -133,15 +182,20 @@ export function WallActivityRings({
       {rings.length > 0 ? (
         <g transform={`rotate(-90 ${RING_CX} ${RING_CY})`}>
           {rings.map((ring, i) => {
-            const radius = OUTER_RADIUS - i * (RING_STROKE + RING_GAP)
-            if (radius < RING_STROKE / 2) return null
+            // Clamp to a positive radius so the innermost ring still
+            // renders for pathological goal counts; `fitRingDimensions`
+            // already shrank stroke/gap to keep this in range.
+            const radius = Math.max(
+              ringStroke / 2,
+              OUTER_RADIUS - i * (ringStroke + ringGap),
+            )
             const circumference = 2 * Math.PI * radius
             const rawPercent =
               ring.target > 0 ? ring.total / ring.target : 0
             const clamped = Math.min(1, Math.max(0, rawPercent))
             const dashOffset = circumference * (1 - clamped)
             return (
-              <g key={ring.exercise}>
+              <g key={ring.exercise} data-testid={`wall-ring-${ring.exercise}`}>
                 {/* Track */}
                 <circle
                   cx={RING_CX}
@@ -150,7 +204,7 @@ export function WallActivityRings({
                   fill="none"
                   stroke={ring.color}
                   strokeOpacity={TRACK_OPACITY}
-                  strokeWidth={RING_STROKE}
+                  strokeWidth={ringStroke}
                 />
                 {/* Progress arc */}
                 <circle
@@ -159,7 +213,7 @@ export function WallActivityRings({
                   r={radius}
                   fill="none"
                   stroke={ring.color}
-                  strokeWidth={RING_STROKE}
+                  strokeWidth={ringStroke}
                   strokeLinecap="round"
                   strokeDasharray={circumference}
                   strokeDashoffset={dashOffset}
@@ -223,15 +277,16 @@ export function WallActivityRings({
 
       {/* Per-exercise tallies + streak under the rings */}
       {rings.length > 0 ? (
-        rings.slice(0, 2).map((ring, i) => (
+        rings.map((ring, i) => (
           <text
             key={`tally-${ring.exercise}`}
+            data-testid={`wall-tally-${ring.exercise}`}
             x={RING_CX}
-            y={FRAME_Y + FRAME_H - 50 + i * 22}
+            y={tallyTop + tallySpacing * (i + 0.85)}
             textAnchor="middle"
             fill={ring.color}
             fontFamily={HANDWRITING_FONT}
-            fontSize={16}
+            fontSize={tallyFontSize}
           >
             {ring.exercise} {ring.total}/{ring.target}
             {ring.streak > 0 ? `  ·  🔥${ring.streak}d` : ''}


### PR DESCRIPTION
## What

The Weight Room scene's wall fixture (`WallActivityRings`) only rendered the first three configured goals as rings and labeled just two. With the current four goals — `pullups`, `pushups`, a `shrugs` focus lane, and `squats` — the **blue `squats` ring never appeared** and `squats`/`shrugs` had no tally. It read as "only two rings."

## Root cause

The fixture stepped each ring inward by a constant `RING_STROKE + RING_GAP` (18px) from a 58px outer radius and dropped any ring whose radius fell below `RING_STROKE / 2` (7px):

| ring | exercise | radius | rendered |
|---|---|---|---|
| 1 | pullups | 58 | ✓ |
| 2 | pushups | 40 | ✓ |
| 3 | shrugs | 22 | ✓ |
| 4 | **squats** | **4** | ✗ dropped |

The tallies were separately hard-capped at `rings.slice(0, 2)`.

The interactive log-view rings (`ActivityRings`) already solved this exact silent-drop in #80 via an auto-fit; the scene fixture never got the same treatment.

## Fix

- Port the log view's `fitRingDimensions()` auto-fit into the fixture so ring `stroke`/`gap` shrink as the goal count grows — every goal renders. For 1–2 goals the geometry is unchanged (backward compatible).
- Scale the tally spacing/font to the goal count and label **all** rings, dropping the `slice(0, 2)` cap.
- Add `weight-room-fixtures.test.tsx` regression coverage: every goal gets a ring and a label; the fourth ring stays visible; empty state still shows ghost rings + "no goals yet".

## Verification

Rendered against real production data on a local training-facility build — all four rings now show (teal `pullups`, orange `pushups`, gold `shrugs`, blue `squats`) with all four labeled. `vitest` 10/10 pass, eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)