### PR TITLE
fix(otf): stop silently dropping classes with no class_type

### DIFF
--- a/components/training-facility/gym/OtfDetailView.tsx
+++ b/components/training-facility/gym/OtfDetailView.tsx
@@ -28,6 +28,7 @@ import {
   otfClassTypes,
   otfHighlights,
   otfLinearRegression,
+  otfClassTypeLabel,
   otfMetricTrend,
   resolveOtfClassTypeFilter,
   type OtfTrendPoint,
@@ -501,7 +502,7 @@ function ClassTypeFilter({
           onClick={() => onChange(opt)}
           className={pill(value === opt)}
         >
-          {opt}
+          {otfClassTypeLabel(opt)}
         </button>
       ))}
     </div>
@@ -624,9 +625,9 @@ function SessionLogTable({ sessions, range }: SessionLogTableProps): JSX.Element
   const excludedCount = useMemo(() => sessions.filter(s => s.excluded).length, [sessions])
   const activeCount = sessions.length - excludedCount
   // Counted classes that carry no class type still land in every aggregate, but
-  // they're only reachable through the "Unclassified" chip — so say how many
+  // they're only reachable through the "No class type" chip — so say how many
   // there are rather than letting them read as missing data.
-  const unclassifiedCount = useMemo(
+  const untypedCount = useMemo(
     () => sessions.filter(s => !s.excluded && !effectiveOtfClassType(s)).length,
     [sessions]
   )
@@ -642,8 +643,8 @@ function SessionLogTable({ sessions, range }: SessionLogTableProps): JSX.Element
           {excludedCount > 0 && (
             <span className="ml-1 text-[#f9a870]/80">· {excludedCount} excluded</span>
           )}
-          {unclassifiedCount > 0 && (
-            <span className="ml-1 text-white/45">· {unclassifiedCount} unclassified</span>
+          {untypedCount > 0 && (
+            <span className="ml-1 text-white/45">· {untypedCount} untyped</span>
           )}
           <span className="ml-2 text-white/35">
             ({formatBound(range.start)} → {formatBound(range.end)})

--- a/components/training-facility/gym/OtfDetailView.tsx
+++ b/components/training-facility/gym/OtfDetailView.tsx
@@ -623,6 +623,13 @@ function SessionLogTable({ sessions, range }: SessionLogTableProps): JSX.Element
   // classes drive the aggregates; excluded ones are called out separately.
   const excludedCount = useMemo(() => sessions.filter(s => s.excluded).length, [sessions])
   const activeCount = sessions.length - excludedCount
+  // Counted classes that carry no class type still land in every aggregate, but
+  // they're only reachable through the "Unclassified" chip — so say how many
+  // there are rather than letting them read as missing data.
+  const unclassifiedCount = useMemo(
+    () => sessions.filter(s => !s.excluded && !effectiveOtfClassType(s)).length,
+    [sessions]
+  )
 
   return (
     <section className="mt-8 rounded-[1.6rem] border border-white/10 bg-black/25 p-5">
@@ -634,6 +641,9 @@ function SessionLogTable({ sessions, range }: SessionLogTableProps): JSX.Element
           {sessions.length === 0 ? 'No classes in range' : `${activeCount} in range`}
           {excludedCount > 0 && (
             <span className="ml-1 text-[#f9a870]/80">· {excludedCount} excluded</span>
+          )}
+          {unclassifiedCount > 0 && (
+            <span className="ml-1 text-white/45">· {unclassifiedCount} unclassified</span>
           )}
           <span className="ml-2 text-white/35">
             ({formatBound(range.start)} → {formatBound(range.end)})

--- a/lib/training-facility/otf.test.ts
+++ b/lib/training-facility/otf.test.ts
@@ -10,6 +10,7 @@ import {
 } from '../../scripts/lib/otbeat-class-type.mjs'
 import {
   OTF_CLASS_TYPE_ORDER,
+  OTF_CLASS_TYPE_UNCLASSIFIED,
   aggregateOtfZoneMinutes,
   earliestOtfDate,
   effectiveOtfClassType,
@@ -110,18 +111,24 @@ describe('class-type helpers (#271)', () => {
         mk('c', { class_type: 'Tread + Row' }), // duplicate collapses
         mk('d', { class_type: 'Tread-focused' }),
         mk('e', { class_type: 'Tread + Row', class_type_override: 'Strength 50' }), // manual extra
-        mk('f'), // no type → omitted
+        mk('f'), // no type → the Unclassified sentinel, last
       ]
       expect(otfClassTypes(sessions)).toEqual([
         'Tread + Row',
         'Tread-focused',
         'Row-focused',
         'Strength 50',
+        OTF_CLASS_TYPE_UNCLASSIFIED,
       ])
     })
 
-    it('returns an empty list when no session has a type', () => {
-      expect(otfClassTypes([mk('a'), mk('b')])).toEqual([])
+    it('omits the Unclassified sentinel when every session has a type', () => {
+      const sessions = [mk('a', { class_type: 'Tread + Row' }), mk('b', { class_type: 'Row-focused' })]
+      expect(otfClassTypes(sessions)).toEqual(['Tread + Row', 'Row-focused'])
+    })
+
+    it('offers only the Unclassified sentinel when no session has a type', () => {
+      expect(otfClassTypes([mk('a'), mk('b')])).toEqual([OTF_CLASS_TYPE_UNCLASSIFIED])
     })
   })
 
@@ -197,6 +204,25 @@ describe('class-type helpers (#271)', () => {
       const result = filterOtfSessionsByClassType(sessions, null)
       expect(result).toHaveLength(3)
       expect(result).not.toBe(sessions)
+    })
+
+    it('selects the untyped sessions for the Unclassified sentinel', () => {
+      const withUntyped = [...sessions, mk('d'), mk('e', { class_type: '  ' })]
+      expect(
+        filterOtfSessionsByClassType(withUntyped, OTF_CLASS_TYPE_UNCLASSIFIED).map(s => s.started_at)
+      ).toEqual(['d', 'e'])
+    })
+
+    // The #271 regression: three real July classes were ingested with a null
+    // class_type, so every chip dropped them from the log and the aggregates
+    // with nothing to indicate it. The options must partition the window.
+    it('keeps every session reachable through some option', () => {
+      const withUntyped = [...sessions, mk('d')]
+      const options = otfClassTypes(withUntyped)
+      const reached = new Set(
+        options.flatMap(o => filterOtfSessionsByClassType(withUntyped, o).map(s => s.started_at))
+      )
+      expect(reached).toEqual(new Set(['a', 'b', 'c', 'd']))
     })
   })
 })

--- a/lib/training-facility/otf.test.ts
+++ b/lib/training-facility/otf.test.ts
@@ -10,7 +10,7 @@ import {
 } from '../../scripts/lib/otbeat-class-type.mjs'
 import {
   OTF_CLASS_TYPE_ORDER,
-  OTF_CLASS_TYPE_UNCLASSIFIED,
+  OTF_CLASS_TYPE_UNTYPED,
   aggregateOtfZoneMinutes,
   earliestOtfDate,
   effectiveOtfClassType,
@@ -21,6 +21,7 @@ import {
   formatOtfDate,
   mmssToSeconds,
   otfBlockTrend,
+  otfClassTypeLabel,
   otfClassTypes,
   otfHighlights,
   otfLinearRegression,
@@ -111,24 +112,24 @@ describe('class-type helpers (#271)', () => {
         mk('c', { class_type: 'Tread + Row' }), // duplicate collapses
         mk('d', { class_type: 'Tread-focused' }),
         mk('e', { class_type: 'Tread + Row', class_type_override: 'Strength 50' }), // manual extra
-        mk('f'), // no type → the Unclassified sentinel, last
+        mk('f'), // no type → the untyped sentinel, last
       ]
       expect(otfClassTypes(sessions)).toEqual([
         'Tread + Row',
         'Tread-focused',
         'Row-focused',
         'Strength 50',
-        OTF_CLASS_TYPE_UNCLASSIFIED,
+        OTF_CLASS_TYPE_UNTYPED,
       ])
     })
 
-    it('omits the Unclassified sentinel when every session has a type', () => {
+    it('omits the untyped sentinel when every session has a type', () => {
       const sessions = [mk('a', { class_type: 'Tread + Row' }), mk('b', { class_type: 'Row-focused' })]
       expect(otfClassTypes(sessions)).toEqual(['Tread + Row', 'Row-focused'])
     })
 
-    it('offers only the Unclassified sentinel when no session has a type', () => {
-      expect(otfClassTypes([mk('a'), mk('b')])).toEqual([OTF_CLASS_TYPE_UNCLASSIFIED])
+    it('offers only the untyped sentinel when no session has a type', () => {
+      expect(otfClassTypes([mk('a'), mk('b')])).toEqual([OTF_CLASS_TYPE_UNTYPED])
     })
   })
 
@@ -206,10 +207,10 @@ describe('class-type helpers (#271)', () => {
       expect(result).not.toBe(sessions)
     })
 
-    it('selects the untyped sessions for the Unclassified sentinel', () => {
+    it('selects the untyped sessions for the untyped sentinel', () => {
       const withUntyped = [...sessions, mk('d'), mk('e', { class_type: '  ' })]
       expect(
-        filterOtfSessionsByClassType(withUntyped, OTF_CLASS_TYPE_UNCLASSIFIED).map(s => s.started_at)
+        filterOtfSessionsByClassType(withUntyped, OTF_CLASS_TYPE_UNTYPED).map(s => s.started_at)
       ).toEqual(['d', 'e'])
     })
 
@@ -223,6 +224,45 @@ describe('class-type helpers (#271)', () => {
         options.flatMap(o => filterOtfSessionsByClassType(withUntyped, o).map(s => s.started_at))
       )
       expect(reached).toEqual(new Set(['a', 'b', 'c', 'd']))
+    })
+
+    // codex #334: `class_type_override` is unrestricted free text, so a readable
+    // sentinel could be typed in as a real override — the option list would carry
+    // two identical entries (duplicate React keys) and the overridden session
+    // would vanish under its own chip. The non-printable sentinel can't collide.
+    it('keeps a human-readable override distinct from the untyped sentinel', () => {
+      const withCollider = [
+        mk('a', { class_type: 'Tread + Row' }),
+        mk('b', { class_type_override: 'No class type' }), // the sentinel's *label*
+        mk('c'), // genuinely untyped
+      ]
+      const options = otfClassTypes(withCollider)
+      // Two distinct options, no duplicates — safe as React keys.
+      expect(options).toEqual(['Tread + Row', 'No class type', OTF_CLASS_TYPE_UNTYPED])
+      expect(new Set(options).size).toBe(options.length)
+      // Each chip selects only its own session.
+      expect(filterOtfSessionsByClassType(withCollider, 'No class type').map(s => s.started_at)).toEqual(
+        ['b']
+      )
+      expect(
+        filterOtfSessionsByClassType(withCollider, OTF_CLASS_TYPE_UNTYPED).map(s => s.started_at)
+      ).toEqual(['c'])
+    })
+  })
+
+  describe('otfClassTypeLabel', () => {
+    it('renders the untyped sentinel as readable text', () => {
+      expect(otfClassTypeLabel(OTF_CLASS_TYPE_UNTYPED)).toBe('No class type')
+    })
+
+    it('passes a real class type through unchanged', () => {
+      expect(otfClassTypeLabel('Tread + Row')).toBe('Tread + Row')
+      expect(otfClassTypeLabel('2G')).toBe('2G')
+    })
+
+    it('does not disguise an override that matches the sentinel label', () => {
+      // The override is a real, selectable type — it must not be relabelled.
+      expect(otfClassTypeLabel('No class type')).toBe('No class type')
     })
   })
 })

--- a/lib/training-facility/otf.ts
+++ b/lib/training-facility/otf.ts
@@ -110,16 +110,33 @@ export const OTF_CLASS_TYPE_ORDER: readonly string[] = [
 ]
 
 /**
- * Filter-only sentinel for sessions with no effective class type.
+ * Filter-only sentinel selecting the sessions with no effective class type.
  *
- * Not a `class_type` value the ingest path ever writes — it exists so untyped
- * sessions stay *reachable* in the UI. Without it, a session whose `class_type`
- * is null (an ingest that raced the #271 backfill, or a near-zero malfunction)
- * matched no chip and was silently dropped by every non-`null` selection, with
- * nothing in the log or the counts to say it had been. Selecting this option
- * filters to exactly those sessions; it sorts last in {@link otfClassTypes}.
+ * It exists so untyped sessions stay *reachable* in the UI. Without it, a
+ * session whose `class_type` is null (an ingest that raced the #271 backfill, or
+ * a near-zero malfunction) matched no chip and was silently dropped by every
+ * non-`null` selection, with nothing in the log or the counts to say it had
+ * been. Sorts last in {@link otfClassTypes}.
+ *
+ * The leading NUL is deliberate: `class_type_override` is unrestricted free text
+ * a human types into Supabase, so a *readable* sentinel like `'Untyped'` could
+ * collide with a real override — the option list would carry two identical
+ * entries (duplicate React keys) and the overridden session would vanish when
+ * its own chip was selected, since the filter would read the selection as the
+ * sentinel. No parsed or hand-entered value contains a NUL, so this cannot
+ * collide. Never stored in the database; render it via
+ * {@link otfClassTypeLabel}, never directly.
  */
-export const OTF_CLASS_TYPE_UNCLASSIFIED = 'Unclassified'
+export const OTF_CLASS_TYPE_UNTYPED = '\u0000otf-untyped'
+
+/**
+ * Human label for a class-type filter option — the value itself, except for the
+ * non-printable {@link OTF_CLASS_TYPE_UNTYPED} sentinel. Use for any option
+ * rendered to the user.
+ */
+export function otfClassTypeLabel(classType: string): string {
+  return classType === OTF_CLASS_TYPE_UNTYPED ? 'No class type' : classType
+}
 
 /**
  * The class type the view should treat a session as: the manual
@@ -141,7 +158,7 @@ export function effectiveOtfClassType(session: OtfSession): string | undefined {
  * alphabetically for a stable, session-order-independent result.
  *
  * Sessions with no effective type contribute the
- * {@link OTF_CLASS_TYPE_UNCLASSIFIED} sentinel, last — so the options always
+ * {@link OTF_CLASS_TYPE_UNTYPED} sentinel, last — so the options always
  * partition the window and no session is unreachable through the filter.
  */
 export function otfClassTypes(sessions: readonly OtfSession[]): string[] {
@@ -154,7 +171,7 @@ export function otfClassTypes(sessions: readonly OtfSession[]): string[] {
   }
   const known = OTF_CLASS_TYPE_ORDER.filter(t => present.has(t))
   const extras = [...present].filter(t => !OTF_CLASS_TYPE_ORDER.includes(t)).sort()
-  return [...known, ...extras, ...(hasUntyped ? [OTF_CLASS_TYPE_UNCLASSIFIED] : [])]
+  return [...known, ...extras, ...(hasUntyped ? [OTF_CLASS_TYPE_UNTYPED] : [])]
 }
 
 /**
@@ -163,7 +180,7 @@ export function otfClassTypes(sessions: readonly OtfSession[]): string[] {
  * returns every session (a fresh array). Composes with
  * {@link filterOtfSessionsInRange} and {@link excludeInvalidOtfSessions}.
  *
- * {@link OTF_CLASS_TYPE_UNCLASSIFIED} selects the sessions that have *no*
+ * {@link OTF_CLASS_TYPE_UNTYPED} selects the sessions that have *no*
  * effective type, which no real label can match — keeping untyped classes
  * reachable rather than silently filtered away.
  */
@@ -172,7 +189,7 @@ export function filterOtfSessionsByClassType(
   classType: string | null
 ): OtfSession[] {
   if (!classType) return [...sessions]
-  if (classType === OTF_CLASS_TYPE_UNCLASSIFIED) {
+  if (classType === OTF_CLASS_TYPE_UNTYPED) {
     return sessions.filter(s => !effectiveOtfClassType(s))
   }
   return sessions.filter(s => effectiveOtfClassType(s) === classType)

--- a/lib/training-facility/otf.ts
+++ b/lib/training-facility/otf.ts
@@ -110,6 +110,18 @@ export const OTF_CLASS_TYPE_ORDER: readonly string[] = [
 ]
 
 /**
+ * Filter-only sentinel for sessions with no effective class type.
+ *
+ * Not a `class_type` value the ingest path ever writes — it exists so untyped
+ * sessions stay *reachable* in the UI. Without it, a session whose `class_type`
+ * is null (an ingest that raced the #271 backfill, or a near-zero malfunction)
+ * matched no chip and was silently dropped by every non-`null` selection, with
+ * nothing in the log or the counts to say it had been. Selecting this option
+ * filters to exactly those sessions; it sorts last in {@link otfClassTypes}.
+ */
+export const OTF_CLASS_TYPE_UNCLASSIFIED = 'Unclassified'
+
+/**
  * The class type the view should treat a session as: the manual
  * `class_type_override` when set, otherwise the auto-inferred `class_type`
  * (#271). Blank/whitespace strings count as unset. `undefined` when the session
@@ -126,18 +138,23 @@ export function effectiveOtfClassType(session: OtfSession): string | undefined {
  * Distinct effective class types present across the sessions, for the filter
  * control's options. Known auto labels come first in {@link OTF_CLASS_TYPE_ORDER}
  * order; any manual-override values not in that list follow, sorted
- * alphabetically for a stable, session-order-independent result. Sessions with
- * no effective type are omitted.
+ * alphabetically for a stable, session-order-independent result.
+ *
+ * Sessions with no effective type contribute the
+ * {@link OTF_CLASS_TYPE_UNCLASSIFIED} sentinel, last — so the options always
+ * partition the window and no session is unreachable through the filter.
  */
 export function otfClassTypes(sessions: readonly OtfSession[]): string[] {
   const present = new Set<string>()
+  let hasUntyped = false
   for (const s of sessions) {
     const t = effectiveOtfClassType(s)
     if (t) present.add(t)
+    else hasUntyped = true
   }
   const known = OTF_CLASS_TYPE_ORDER.filter(t => present.has(t))
   const extras = [...present].filter(t => !OTF_CLASS_TYPE_ORDER.includes(t)).sort()
-  return [...known, ...extras]
+  return [...known, ...extras, ...(hasUntyped ? [OTF_CLASS_TYPE_UNCLASSIFIED] : [])]
 }
 
 /**
@@ -145,12 +162,19 @@ export function otfClassTypes(sessions: readonly OtfSession[]): string[] {
  * `classType`, preserving order. A `null` `classType` is the "All" sentinel and
  * returns every session (a fresh array). Composes with
  * {@link filterOtfSessionsInRange} and {@link excludeInvalidOtfSessions}.
+ *
+ * {@link OTF_CLASS_TYPE_UNCLASSIFIED} selects the sessions that have *no*
+ * effective type, which no real label can match — keeping untyped classes
+ * reachable rather than silently filtered away.
  */
 export function filterOtfSessionsByClassType(
   sessions: readonly OtfSession[],
   classType: string | null
 ): OtfSession[] {
   if (!classType) return [...sessions]
+  if (classType === OTF_CLASS_TYPE_UNCLASSIFIED) {
+    return sessions.filter(s => !effectiveOtfClassType(s))
+  }
   return sessions.filter(s => effectiveOtfClassType(s) === classType)
 }
 

--- a/scripts/import-otbeat.mjs
+++ b/scripts/import-otbeat.mjs
@@ -15,8 +15,12 @@
  *    weekly cron so a missed run self-heals via the overlap.
  *  - Reads each match's `text/html` body (the tread/rower stats live only
  *    there), parses it, and append-only upserts (dedupe by `started_at`,
- *    never prunes — see `upsertOtfSessions`).
+ *    never prunes — see `upsertOtfSessions`), backfilling a null `class_type`
+ *    on rows already present.
  *  - Idempotent: re-running over the overlap window adds 0.
+ *  - **Exits 1** when any counted session still lacks a `class_type` — such a
+ *    row matches no filter chip in the OTF view and reads as a missing workout,
+ *    so the run fails rather than letting the drift go unseen.
  *
  * Required env (CI: GitHub secrets → job env; local: `.env.local`):
  *   GMAIL_CLIENT_ID, GMAIL_CLIENT_SECRET, GMAIL_REFRESH_TOKEN,
@@ -27,7 +31,12 @@
  */
 
 import { parseOtbeatHtml } from './lib/otbeat-parser.mjs'
-import { createServiceRoleClient, loadEnv, upsertOtfSessions } from './lib/otbeat-supabase.mjs'
+import {
+  createServiceRoleClient,
+  findUntypedOtfSessions,
+  loadEnv,
+  upsertOtfSessions,
+} from './lib/otbeat-supabase.mjs'
 
 const OTBEAT_SENDER = 'OTbeatReport@orangetheoryfitness.com'
 const DEFAULT_LOOKBACK_DAYS = 8
@@ -176,9 +185,32 @@ async function main() {
   const summary = await upsertOtfSessions(supabase, records)
   console.log(
     `✓ otbeat ingest: added ${summary.added}, skipped ${summary.skipped} ` +
-      `(already present), ${summary.total} total in otf_sessions.`
+      `(already present), repaired ${summary.repaired} null class_type, ` +
+      `${summary.total} total in otf_sessions.`
   )
   console.log(JSON.stringify(summary))
+
+  // Data-quality gate: every counted session must carry a class_type, or it
+  // matches no filter chip and reads as a missing workout. The in-window
+  // backfill above fixes what this pull can see; anything left is an older
+  // orphan outside the lookback that needs a repair migration, so fail loudly
+  // rather than let it sit unnoticed (it took 20 days last time).
+  const untyped = await findUntypedOtfSessions(supabase)
+  if (untyped.length > 0) {
+    console.error(
+      `\n✗ ${untyped.length} counted session(s) have no class_type — they are ` +
+        `only reachable via the "Unclassified" filter and skew nothing but look missing:`
+    )
+    for (const s of untyped) {
+      console.error(`    ${s.started_at}  ${s.coach ?? '(no coach)'}  ${s.calories ?? '?'} cal`)
+    }
+    console.error(
+      `\n  These predate this pull's lookback window. Widen it with ` +
+        `OTBEAT_LOOKBACK_DAYS to let the backfill reach them, or add a repair ` +
+        `migration modelled on 20260724120000_otf_sessions_class_type_repair.sql.`
+    )
+    process.exit(1)
+  }
 }
 
 main().catch(err => {

--- a/scripts/import-otbeat.mjs
+++ b/scripts/import-otbeat.mjs
@@ -209,7 +209,11 @@ async function main() {
         `OTBEAT_LOOKBACK_DAYS to let the backfill reach them, or add a repair ` +
         `migration modelled on 20260724120000_otf_sessions_class_type_repair.sql.`
     )
-    process.exit(1)
+    // exitCode rather than process.exit(1): the diagnostic above is the whole
+    // point of failing, and an immediate exit can truncate buffered stderr when
+    // it's piped (CI log capture). Setting the code lets main() return and the
+    // stream drain on its own.
+    process.exitCode = 1
   }
 }
 

--- a/scripts/lib/otbeat-supabase.mjs
+++ b/scripts/lib/otbeat-supabase.mjs
@@ -4,7 +4,8 @@
  * Reuses the service-role client + env loader from `cardio-supabase.mjs`
  * (one place for the credential plumbing), and adds the OTbeat-specific
  * bits: turning a parsed {@link import('./otbeat-parser.mjs').OtbeatRecord}
- * into an `otf_sessions` row, and an **append-only** upsert.
+ * into an `otf_sessions` row, an **append-only** upsert, and the data-quality
+ * invariant check that guards it ({@link findUntypedOtfSessions}).
  *
  * Why a separate upsert from the cardio one: `upsertCardioData` mirrors the
  * full Apple-Health archive and prunes rows missing from the export. OTbeat
@@ -110,10 +111,14 @@ export function toStartedAt(date, time, timeZone) {
  * malfunction session (near-zero output, no machine block — #268) is flagged
  * at first insert. `class_type` is the coarse machine-signature label from
  * {@link classifyOtfClassType} (#271); `class_type_override` is left unset so a
- * manual Supabase edit owns it. Because {@link upsertOtfSessions} is
- * append-only (`ignoreDuplicates`), both auto columns only ever run on a row's
- * *first* write, so a manual override made later in Supabase is never clobbered
- * by a re-pull.
+ * manual Supabase edit owns it.
+ *
+ * `excluded` / `excluded_reason` are written only on a row's *first* insert,
+ * since {@link upsertOtfSessions} inserts-if-absent. `class_type` is the one
+ * exception: that same append-only property left three rows permanently null
+ * when an old importer raced the #271 backfill, so the upsert also backfills a
+ * *null* `class_type` on an existing row. A non-null label — and
+ * `class_type_override` in every case — is never touched by a re-pull.
  *
  * @param {import('./otbeat-parser.mjs').OtbeatRecord} rec Parsed session.
  * @param {string} [timeZone] Studio timezone for `started_at`.
@@ -159,19 +164,42 @@ export function recordToRow(rec, timeZone = DEFAULT_STUDIO_TZ) {
 }
 
 /**
- * Append-only upsert of parsed OTbeat sessions into `otf_sessions`.
+ * Append-only upsert of parsed OTbeat sessions into `otf_sessions`, plus a
+ * null-only backfill of `class_type` on rows that are already present.
  *
  * Reads the existing `started_at` keys, inserts only rows whose timestamp
  * isn't already present, and never deletes. Re-running over an overlapping
  * lookback window is therefore idempotent (adds 0 the second time) and can
  * never prune history — the opposite of the cardio mirror-and-prune import.
  *
+ * **The backfill pass** exists because append-only insertion alone cannot
+ * self-heal. `class_type` was previously written only on a row's first insert,
+ * so three classes ingested on 2026-07-04 by a pre-#271 importer — hours after
+ * the #271 migration had already backfilled — kept `class_type = null`
+ * indefinitely; no number of re-pulls could fix them, and a null class type is
+ * invisible to every filter chip. So after inserting, any *existing* row whose
+ * stored `class_type` is null gets the freshly-classified value written back.
+ *
+ * Deliberately narrow, to preserve the guarantee #268/#271 rely on:
+ * - Only `class_type`, and only when the stored value is null — a row that
+ *   already has a label is never rewritten, so a corrected label survives.
+ * - Never `class_type_override`, `excluded`, or `excluded_reason`. A targeted
+ *   per-row `update` of the single column, *not* a full-row upsert: supabase-js
+ *   `upsert` with `ignoreDuplicates: false` would `DO UPDATE SET` every column
+ *   and clobber a manual override.
+ * - Only when the classifier yields a non-null label, so the 2026-05-30
+ *   belt-malfunction row (no machine block → null, correctly `excluded`) is
+ *   left exactly as it is.
+ *
+ * Only reaches sessions still inside the caller's email lookback window. For an
+ * older orphan, {@link findUntypedOtfSessions} is the backstop that surfaces it.
+ *
  * @param {ReturnType<createServiceRoleClient>} supabase Service-role client.
  * @param {import('./otbeat-parser.mjs').OtbeatRecord[]} records Parsed sessions.
  * @param {{ timeZone?: string }} [opts] Studio timezone override.
- * @returns {Promise<{ added: number, skipped: number, total: number }>}
- *   `added` = newly inserted, `skipped` = already present, `total` = rows now
- *   in the table.
+ * @returns {Promise<{ added: number, skipped: number, repaired: number, total: number }>}
+ *   `added` = newly inserted, `skipped` = already present, `repaired` = existing
+ *   rows whose null `class_type` was backfilled, `total` = rows now in the table.
  * @throws {Error} on any Supabase read/write failure.
  */
 export async function upsertOtfSessions(supabase, records, opts = {}) {
@@ -186,13 +214,18 @@ export async function upsertOtfSessions(supabase, records, opts = {}) {
     if (!byKey.has(key)) byKey.set(key, row)
   }
 
+  // `class_type` comes along so the backfill pass can spot existing rows that
+  // are missing one. Keep the stored `started_at` verbatim — it's the filter
+  // value for the repair update, so it must match the row exactly.
   const { data: existingRows, error: readErr } = await supabase
     .from('otf_sessions')
-    .select('started_at')
+    .select('started_at, class_type')
   if (readErr) {
     throw new Error(`Failed to read existing otf_sessions: ${readErr.message}`)
   }
-  const existing = new Set((existingRows ?? []).map(r => new Date(r.started_at).getTime()))
+  const existing = new Map(
+    (existingRows ?? []).map(r => [new Date(r.started_at).getTime(), r])
+  )
 
   const toInsert = [...byKey.entries()].filter(([key]) => !existing.has(key)).map(([, row]) => row)
 
@@ -207,9 +240,59 @@ export async function upsertOtfSessions(supabase, records, opts = {}) {
     }
   }
 
+  // Backfill class_type on already-present rows that lack one (see above).
+  let repaired = 0
+  for (const [key, row] of byKey) {
+    const stored = existing.get(key)
+    if (!stored || stored.class_type != null || row.class_type == null) continue
+    const { error: repairErr } = await supabase
+      .from('otf_sessions')
+      .update({ class_type: row.class_type })
+      .eq('started_at', stored.started_at)
+    if (repairErr) {
+      throw new Error(
+        `Failed to backfill class_type for otf_session ${stored.started_at}: ${repairErr.message}`
+      )
+    }
+    repaired += 1
+  }
+
   return {
     added: toInsert.length,
     skipped: byKey.size - toInsert.length,
+    repaired,
     total: existing.size + toInsert.length,
   }
+}
+
+/**
+ * Find counted sessions that carry no `class_type` — the data-quality invariant
+ * the OTF view depends on.
+ *
+ * Every non-`excluded` row must have a class type, because a null one matches no
+ * filter chip: before the `Unclassified` sentinel existed, selecting any type
+ * silently dropped such rows from the session log *and* every aggregate, with
+ * nothing in the UI counts to say so. That drift went unnoticed for 20 days.
+ * Call this after a pull and fail the run on a non-empty result, so the next gap
+ * surfaces the same day instead of being spotted by eye in a chart.
+ *
+ * Excluded rows are exempt: a belt malfunction legitimately has no machine block
+ * and so no inferable type.
+ *
+ * @param {ReturnType<createServiceRoleClient>} supabase Service-role client.
+ * @returns {Promise<Array<{ started_at: string, coach: string | null, calories: number | null }>>}
+ *   The offending rows, oldest first; empty when the invariant holds.
+ * @throws {Error} on any Supabase read failure.
+ */
+export async function findUntypedOtfSessions(supabase) {
+  const { data, error } = await supabase
+    .from('otf_sessions')
+    .select('started_at, coach, calories')
+    .eq('excluded', false)
+    .is('class_type', null)
+    .order('started_at', { ascending: true })
+  if (error) {
+    throw new Error(`Failed to check otf_sessions class_type coverage: ${error.message}`)
+  }
+  return data ?? []
 }

--- a/scripts/lib/otbeat-supabase.mjs
+++ b/scripts/lib/otbeat-supabase.mjs
@@ -164,6 +164,51 @@ export function recordToRow(rec, timeZone = DEFAULT_STUDIO_TZ) {
 }
 
 /**
+ * Rows per page when reading the existing session keys. Below Supabase's
+ * default `max_rows` of 1000 so a page is never server-truncated.
+ */
+const READ_PAGE_SIZE = 500
+
+/**
+ * Read `started_at` + `class_type` for **every** row in `otf_sessions`, paging
+ * until a short page ends it.
+ *
+ * Pagination is not optional: PostgREST caps an unbounded `select` at
+ * `max_rows` (1000 on Supabase by default) and returns the first page with no
+ * error, so a single unranged read would silently look like the whole table.
+ * Past that cap the omitted rows would read as absent — re-offered to the
+ * insert (harmless, `ON CONFLICT DO NOTHING` absorbs it) but invisible to the
+ * `class_type` backfill and miscounted in `total`, which is exactly the kind of
+ * quiet drift this module now exists to prevent.
+ *
+ * Ordered by `started_at` so pages don't overlap or skip — without an explicit
+ * order PostgREST may use an unstable internal sort across requests. The stored
+ * `started_at` string is returned verbatim: it's the filter value for the repair
+ * update, so it has to match the row exactly.
+ *
+ * @param {ReturnType<createServiceRoleClient>} supabase Service-role client.
+ * @returns {Promise<Array<{ started_at: string, class_type: string | null }>>}
+ *   Every row, oldest first.
+ * @throws {Error} on any Supabase read failure.
+ */
+async function readAllOtfSessionKeys(supabase) {
+  const all = []
+  for (let from = 0; ; from += READ_PAGE_SIZE) {
+    const { data, error } = await supabase
+      .from('otf_sessions')
+      .select('started_at, class_type')
+      .order('started_at', { ascending: true })
+      .range(from, from + READ_PAGE_SIZE - 1)
+    if (error) {
+      throw new Error(`Failed to read existing otf_sessions: ${error.message}`)
+    }
+    const page = data ?? []
+    all.push(...page)
+    if (page.length < READ_PAGE_SIZE) return all
+  }
+}
+
+/**
  * Append-only upsert of parsed OTbeat sessions into `otf_sessions`, plus a
  * null-only backfill of `class_type` on rows that are already present.
  *
@@ -214,18 +259,8 @@ export async function upsertOtfSessions(supabase, records, opts = {}) {
     if (!byKey.has(key)) byKey.set(key, row)
   }
 
-  // `class_type` comes along so the backfill pass can spot existing rows that
-  // are missing one. Keep the stored `started_at` verbatim — it's the filter
-  // value for the repair update, so it must match the row exactly.
-  const { data: existingRows, error: readErr } = await supabase
-    .from('otf_sessions')
-    .select('started_at, class_type')
-  if (readErr) {
-    throw new Error(`Failed to read existing otf_sessions: ${readErr.message}`)
-  }
-  const existing = new Map(
-    (existingRows ?? []).map(r => [new Date(r.started_at).getTime(), r])
-  )
+  const existingRows = await readAllOtfSessionKeys(supabase)
+  const existing = new Map(existingRows.map(r => [new Date(r.started_at).getTime(), r]))
 
   const toInsert = [...byKey.entries()].filter(([key]) => !existing.has(key)).map(([, row]) => row)
 
@@ -278,6 +313,11 @@ export async function upsertOtfSessions(supabase, records, opts = {}) {
  *
  * Excluded rows are exempt: a belt malfunction legitimately has no machine block
  * and so no inferable type.
+ *
+ * Unpaginated, unlike {@link readAllOtfSessionKeys}: the filter is narrow enough
+ * that a healthy table returns zero rows, and PostgREST's `max_rows` cap can
+ * only ever shorten a *non-empty* result — it can't turn offenders into an empty
+ * one, so the pass/fail signal is never wrong, only the printed list.
  *
  * @param {ReturnType<createServiceRoleClient>} supabase Service-role client.
  * @returns {Promise<Array<{ started_at: string, coach: string | null, calories: number | null }>>}

--- a/scripts/lib/otbeat-supabase.test.ts
+++ b/scripts/lib/otbeat-supabase.test.ts
@@ -8,7 +8,12 @@
  */
 import { describe, expect, it } from 'vitest'
 
-import { recordToRow, toStartedAt, upsertOtfSessions } from './otbeat-supabase.mjs'
+import {
+  findUntypedOtfSessions,
+  recordToRow,
+  toStartedAt,
+  upsertOtfSessions,
+} from './otbeat-supabase.mjs'
 
 /** Local alias for the parser's JSDoc record type, for typing fixtures. */
 type OtbeatRecord = import('./otbeat-parser.mjs').OtbeatRecord
@@ -176,30 +181,82 @@ describe('recordToRow', () => {
  */
 type FakeClient = Parameters<typeof upsertOtfSessions>[0] & {
   inserted: Array<Record<string, unknown>>
+  /** Captured `update()` patches from the class_type backfill pass. */
+  updates: Array<Record<string, unknown>>
+  /** The seeded rows, mutated in place by the backfill, for post-assertions. */
+  rows: Array<Record<string, unknown>>
 }
 
+/** A seeded existing row. A bare string is shorthand for "already has a type". */
+type SeedRow = string | { started_at: string; class_type?: string | null; excluded?: boolean }
+
 /**
- * Minimal stand-in for the supabase-js client: `from().select()` resolves to
- * the seeded existing keys; `from().upsert()` records what was written. Cast
- * through `unknown` to the real client type — only the `from`/`select`/
- * `upsert` surface the upsert path touches is implemented.
+ * Minimal stand-in for the supabase-js client. `from().select()` returns a
+ * thenable builder so it serves both the upsert path's direct `await select()`
+ * and the `.eq().is().order()` chain in `findUntypedOtfSessions`;
+ * `from().upsert()` captures inserts, and `from().update().eq()` applies the
+ * class_type backfill to the seeded rows and captures it. Cast through
+ * `unknown` to the real client type — only the surface these paths touch is
+ * implemented.
  */
-function fakeClient(existingStartedAt: string[]): FakeClient {
+function fakeClient(existing: SeedRow[]): FakeClient {
+  // A bare string seeds a row that already has a class_type, so the backfill
+  // pass leaves it alone — that's the pre-existing tests' expectation.
+  const rows: Array<Record<string, unknown>> = existing.map((s) =>
+    typeof s === 'string'
+      ? { started_at: s, class_type: 'Tread + Row', excluded: false, coach: null, calories: null }
+      : { excluded: false, coach: null, calories: null, class_type: null, ...s }
+  )
   const inserted: Array<Record<string, unknown>> = []
+  const updates: Array<Record<string, unknown>> = []
+
+  /** Thenable query builder: collects filters, resolves to the matching rows. */
+  function builder() {
+    const filters: Array<(r: Record<string, unknown>) => boolean> = []
+    const self = {
+      eq(col: string, val: unknown) {
+        filters.push((r) => r[col] === val)
+        return self
+      },
+      is(col: string, val: unknown) {
+        filters.push((r) => (val === null ? r[col] == null : r[col] === val))
+        return self
+      },
+      order() {
+        return self
+      },
+      then<T>(
+        resolve: (v: { data: Array<Record<string, unknown>>; error: null }) => T,
+        reject?: (e: unknown) => T
+      ) {
+        const data = rows.filter((r) => filters.every((f) => f(r)))
+        return Promise.resolve({ data, error: null }).then(resolve, reject)
+      },
+    }
+    return self
+  }
+
   const client = {
     from() {
       return {
-        select: async () => ({
-          data: existingStartedAt.map((s) => ({ started_at: s })),
-          error: null,
-        }),
-        upsert: async (rows: Array<Record<string, unknown>>) => {
-          inserted.push(...rows)
+        select: () => builder(),
+        upsert: async (newRows: Array<Record<string, unknown>>) => {
+          inserted.push(...newRows)
           return { error: null }
         },
+        update: (patch: Record<string, unknown>) => ({
+          eq: async (col: string, val: unknown) => {
+            const target = rows.find((r) => r[col] === val)
+            if (target) Object.assign(target, patch)
+            updates.push({ ...patch, [col]: val })
+            return { error: null }
+          },
+        }),
       }
     },
     inserted,
+    updates,
+    rows,
   }
   return client as unknown as FakeClient
 }
@@ -212,7 +269,7 @@ describe('upsertOtfSessions (append-only)', () => {
     // recA already in the table; recB is new.
     const client = fakeClient(['2026-06-27T16:30:00+00:00'])
     const summary = await upsertOtfSessions(client, [recA, recB], { timeZone: TZ })
-    expect(summary).toEqual({ added: 1, skipped: 1, total: 2 })
+    expect(summary).toEqual({ added: 1, skipped: 1, repaired: 0, total: 2 })
     expect(client.inserted).toHaveLength(1)
     expect(client.inserted[0].started_at).toBe('2026-06-26T01:45:00.000Z') // recB (06/25 6:45PM PDT)
   })
@@ -220,8 +277,9 @@ describe('upsertOtfSessions (append-only)', () => {
   it('is idempotent — a re-pull with everything present adds 0 and writes nothing', async () => {
     const client = fakeClient(['2026-06-27T16:30:00+00:00', '2026-06-26T01:45:00+00:00'])
     const summary = await upsertOtfSessions(client, [recA, recB], { timeZone: TZ })
-    expect(summary).toEqual({ added: 0, skipped: 2, total: 2 })
+    expect(summary).toEqual({ added: 0, skipped: 2, repaired: 0, total: 2 })
     expect(client.inserted).toHaveLength(0)
+    expect(client.updates).toHaveLength(0)
   })
 
   it('dedupes duplicates within a single batch', async () => {
@@ -229,5 +287,69 @@ describe('upsertOtfSessions (append-only)', () => {
     const summary = await upsertOtfSessions(client, [recA, recA], { timeZone: TZ })
     expect(summary.added).toBe(1)
     expect(client.inserted).toHaveLength(1)
+  })
+})
+
+/**
+ * The #271 ingest race: rows inserted by a pre-#271 importer kept
+ * `class_type = null`, and append-only insertion could never fix them.
+ */
+describe('upsertOtfSessions (null class_type backfill)', () => {
+  const recA = bareRecord('06/27/2026', '9:30AM')
+  const KEY_A = '2026-06-27T16:30:00+00:00'
+
+  /** recA has no treadmill/rower and 0 calories, so give it a real machine block. */
+  function typedRecord(): OtbeatRecord {
+    return { ...bareRecord('06/27/2026', '9:30AM'), treadmill: { time: '20:00' } } as OtbeatRecord
+  }
+
+  it('backfills a null class_type on a row that is already present', async () => {
+    const client = fakeClient([{ started_at: KEY_A, class_type: null }])
+    const summary = await upsertOtfSessions(client, [typedRecord()], { timeZone: TZ })
+    expect(summary).toEqual({ added: 0, skipped: 1, repaired: 1, total: 1 })
+    // Only class_type is written — never the override or the excluded flags.
+    expect(client.updates).toEqual([{ class_type: 'Tread-focused', started_at: KEY_A }])
+    expect(client.rows[0].class_type).toBe('Tread-focused')
+  })
+
+  it('never overwrites a class_type that is already set', async () => {
+    const client = fakeClient([{ started_at: KEY_A, class_type: '2G' }])
+    const summary = await upsertOtfSessions(client, [typedRecord()], { timeZone: TZ })
+    expect(summary.repaired).toBe(0)
+    expect(client.updates).toHaveLength(0)
+    expect(client.rows[0].class_type).toBe('2G')
+  })
+
+  it('leaves a null class_type alone when the classifier also yields null', async () => {
+    // recA has no machine block and 0 calories — the belt-malfunction shape,
+    // which classifies to null and must stay null rather than churn an update.
+    const client = fakeClient([{ started_at: KEY_A, class_type: null, excluded: true }])
+    const summary = await upsertOtfSessions(client, [recA], { timeZone: TZ })
+    expect(summary.repaired).toBe(0)
+    expect(client.updates).toHaveLength(0)
+    expect(client.rows[0].class_type).toBeNull()
+  })
+})
+
+describe('findUntypedOtfSessions', () => {
+  it('returns counted sessions missing a class_type', async () => {
+    const client = fakeClient([
+      { started_at: '2026-07-02T16:30:00+00:00', class_type: null },
+      { started_at: '2026-07-03T16:30:00+00:00', class_type: 'Tread + Row' },
+    ])
+    const untyped = await findUntypedOtfSessions(client)
+    expect(untyped.map((s) => s.started_at)).toEqual(['2026-07-02T16:30:00+00:00'])
+  })
+
+  it('exempts excluded sessions — a malfunction has no inferable type', async () => {
+    const client = fakeClient([
+      { started_at: '2026-05-30T16:30:00+00:00', class_type: null, excluded: true },
+    ])
+    expect(await findUntypedOtfSessions(client)).toEqual([])
+  })
+
+  it('is empty when every counted session has a type', async () => {
+    const client = fakeClient(['2026-07-03T16:30:00+00:00'])
+    expect(await findUntypedOtfSessions(client)).toEqual([])
   })
 })

--- a/scripts/lib/otbeat-supabase.test.ts
+++ b/scripts/lib/otbeat-supabase.test.ts
@@ -185,6 +185,8 @@ type FakeClient = Parameters<typeof upsertOtfSessions>[0] & {
   updates: Array<Record<string, unknown>>
   /** The seeded rows, mutated in place by the backfill, for post-assertions. */
   rows: Array<Record<string, unknown>>
+  /** Every `[from, to]` page requested, to assert the read paginates. */
+  ranges: Array<[number, number]>
 }
 
 /** A seeded existing row. A bare string is shorthand for "already has a type". */
@@ -210,9 +212,15 @@ function fakeClient(existing: SeedRow[]): FakeClient {
   const inserted: Array<Record<string, unknown>> = []
   const updates: Array<Record<string, unknown>> = []
 
-  /** Thenable query builder: collects filters, resolves to the matching rows. */
+  /**
+   * Thenable query builder: collects filters, resolves to the matching rows.
+   * `range` slices like PostgREST's inclusive bounds so the paginated read of
+   * existing keys is exercised for real, and every page request is recorded.
+   */
+  const ranges: Array<[number, number]> = []
   function builder() {
     const filters: Array<(r: Record<string, unknown>) => boolean> = []
+    let slice: [number, number] | null = null
     const self = {
       eq(col: string, val: unknown) {
         filters.push((r) => r[col] === val)
@@ -225,11 +233,17 @@ function fakeClient(existing: SeedRow[]): FakeClient {
       order() {
         return self
       },
+      range(from: number, to: number) {
+        slice = [from, to]
+        ranges.push([from, to])
+        return self
+      },
       then<T>(
         resolve: (v: { data: Array<Record<string, unknown>>; error: null }) => T,
         reject?: (e: unknown) => T
       ) {
-        const data = rows.filter((r) => filters.every((f) => f(r)))
+        let data = rows.filter((r) => filters.every((f) => f(r)))
+        if (slice) data = data.slice(slice[0], slice[1] + 1) // `to` is inclusive
         return Promise.resolve({ data, error: null }).then(resolve, reject)
       },
     }
@@ -257,6 +271,7 @@ function fakeClient(existing: SeedRow[]): FakeClient {
     inserted,
     updates,
     rows,
+    ranges,
   }
   return client as unknown as FakeClient
 }
@@ -287,6 +302,57 @@ describe('upsertOtfSessions (append-only)', () => {
     const summary = await upsertOtfSessions(client, [recA, recA], { timeZone: TZ })
     expect(summary.added).toBe(1)
     expect(client.inserted).toHaveLength(1)
+  })
+})
+
+/**
+ * CodeRabbit #334: an unranged select is capped at PostgREST's `max_rows` and
+ * returns the first page with no error, so past that cap existing rows would
+ * look absent — invisible to the class_type backfill and miscounted in `total`.
+ */
+describe('upsertOtfSessions (paginated read of existing keys)', () => {
+  /** One more than a full 500-row page, so a second page is required. */
+  const PAGE = 500
+  const seeded = Array.from({ length: PAGE + 1 }, (_, i) => ({
+    // Distinct, ordered timestamps: 2026-01-01T00:00Z + i minutes.
+    started_at: new Date(Date.UTC(2026, 0, 1, 0, i)).toISOString(),
+    class_type: 'Tread + Row',
+  }))
+
+  it('pages until a short page, seeing every existing row', async () => {
+    const client = fakeClient(seeded)
+    // This record matches the first seeded row, so there is nothing new to add.
+    const rec = bareRecord('01/01/2026', '12:00AM')
+    const summary = await upsertOtfSessions(client, [rec], { timeZone: 'UTC' })
+
+    // Two pages requested: [0,499] then [500,999] (short → stop).
+    expect(client.ranges).toEqual([
+      [0, PAGE - 1],
+      [PAGE, 2 * PAGE - 1],
+    ])
+    // All 501 existing rows were seen, so `total` isn't truncated to 500.
+    expect(summary.total).toBe(PAGE + 1)
+    expect(summary.added).toBe(0)
+  })
+
+  it('finds a row beyond the first page, so the backfill is not truncated', async () => {
+    // The LAST seeded row (index 500, i.e. on page 2) is the one missing a type.
+    const withLateNull = seeded.map((r, i) =>
+      i === PAGE ? { ...r, class_type: null } : r
+    )
+    const client = fakeClient(withLateNull)
+    // A record matching that last row (00:00Z + 500 min = 08:20Z), carrying a
+    // treadmill block so the classifier yields 'Tread-focused'.
+    expect(withLateNull[PAGE].started_at).toBe('2026-01-01T08:20:00.000Z')
+    const rec = {
+      ...bareRecord('01/01/2026', '8:20AM'),
+      treadmill: { time: '20:00' },
+    } as OtbeatRecord
+    const summary = await upsertOtfSessions(client, [rec], { timeZone: 'UTC' })
+
+    expect(summary.added).toBe(0)
+    expect(summary.repaired).toBe(1) // would be 0 if the read stopped at page 1
+    expect(client.rows[PAGE].class_type).toBe('Tread-focused')
   })
 })
 

--- a/supabase/migrations/20260724120000_otf_sessions_class_type_repair.sql
+++ b/supabase/migrations/20260724120000_otf_sessions_class_type_repair.sql
@@ -1,0 +1,40 @@
+-- Repair `class_type` for sessions that raced the #271 backfill.
+--
+-- The original migration (20260704120000_otf_sessions_class_type.sql) added the
+-- columns and backfilled every then-existing row. It was applied at
+-- 2026-07-04 16:03 UTC. A pull at 2026-07-04 19:22 UTC — ~3h later, still
+-- running the pre-#271 importer, which did not yet stamp `class_type` — then
+-- inserted three real classes (2026-07-02, 07-03, 07-04, all 671-753 cal with a
+-- treadmill block). They landed in the gap: too late for the backfill, too early
+-- for the class-type-aware ingest. Every pull from 2026-07-09 on stamps
+-- correctly, so this is a one-time window, not an ongoing ingest bug.
+--
+-- Symptom this fixes: those rows matched no class-type chip, so selecting any
+-- type silently dropped them from the log *and* every aggregate, with nothing in
+-- the counts to indicate it. They read as missing workouts.
+--
+-- The CASE is the same expression as the original backfill (keep both in sync
+-- with classifyOtfClassType in scripts/lib/otbeat-class-type.mjs). The extra
+-- `treadmill is not null or rower is not null` guard is what makes this a repair
+-- rather than a re-run: it touches only rows with a machine block, so the
+-- 2026-05-30 belt malfunction — correctly `excluded`, correctly `class_type`
+-- null, no machine data — is left alone. Re-runnable and idempotent: once
+-- stamped, `class_type is null` no longer matches.
+
+update public.otf_sessions
+set class_type = case
+  when treadmill is not null and rower is null then 'Tread-focused'
+  when treadmill is null and rower is not null then 'Row-focused'
+  else case
+    when (
+      coalesce(nullif(split_part(rower ->> 'time', ':', 1), '')::int, 0) * 60
+        + coalesce(nullif(split_part(rower ->> 'time', ':', 2), '')::int, 0)
+    ) > (
+      coalesce(nullif(split_part(treadmill ->> 'time', ':', 1), '')::int, 0) * 60
+        + coalesce(nullif(split_part(treadmill ->> 'time', ':', 2), '')::int, 0)
+    ) then 'Row-focused'
+    else 'Tread + Row'
+  end
+end
+where class_type is null
+  and (treadmill is not null or rower is not null);


### PR DESCRIPTION
## What you were seeing

Nothing was over-excluding. Exactly **1 of 38** sessions carries the `excluded` flag — the 05-30 class where the belt died a minute in, which is correct and intended.

The real loss: **three real July classes had `class_type = null`** (07-02, 07-03, 07-04 — 671/753/695 cal, all with a treadmill block). Because `effectiveOtfClassType` returns `undefined` for them, they matched no filter chip *and* `otfClassTypes` left them out of the options — so **selecting any class type dropped all three from the log and every aggregate**, with neither the "in range" nor the "excluded" count acknowledging it. They read as excluded workouts when nothing had excluded them.

## Root cause

A one-time deploy-ordering race, now closed:

| When | What |
|---|---|
| 07-04 16:03 UTC | #271 backfill migration applied — stamped every then-existing row |
| 07-04 19:22 UTC | A pull still on the **pre-#271 importer** inserted the three classes — no `class_type` written |
| 07-09 onward | Ingest stamps correctly |

Too late for the backfill, too early for the class-type-aware ingest.

## Changes

**Reachability**
- `OTF_CLASS_TYPE_UNTYPED` filter sentinel — untyped sessions stay reachable, and the options now partition the window. Guarded by a test asserting every session is reached by some option.
- The sentinel is prefixed with `U+0000`. `class_type_override` is free text a human types into Supabase, so a readable sentinel could collide with a real override — producing duplicate options, duplicate React keys, and a session that vanishes under its own chip (codex caught this). `otfClassTypeLabel()` renders it as "No class type".
- Log header counts untyped classes next to the excluded count.

**Data repair**
- Migration stamping the three affected rows, guarded on a machine block being present so the 05-30 malfunction correctly stays `null` + `excluded`. Idempotent. **Already applied to production** — those rows now read `Tread-focused`, `Tread + Row`, `Tread + Row`.

**Prevention** — the gap survived 20 days silently, which is the part worth fixing
- The ingest now backfills a *null* `class_type` on an existing row, so a future race self-heals on the next pull. Deliberately narrow: only `class_type`, only when null, never an override or the excluded flags, and only when the classifier yields non-null (so the malfunction is untouched). A targeted per-row `update`, not a full-row upsert — supabase-js `upsert` with `ignoreDuplicates: false` would `DO UPDATE SET` every column and clobber `class_type_override`.
- `findUntypedOtfSessions` asserts the invariant after each pull; `import-otbeat` exits non-zero listing the offenders and pointing at the repair migration.
- The existing-keys read is now paginated over an explicit `started_at ASC` order. An unbounded select is capped at `max_rows` and returns page one with no error, which would have made the backfill silently size-dependent (CodeRabbit).

## Verification

- Full suite: **1415 passed**, 129 files
- `tsc --noEmit`: 0 errors in source; eslint clean
- The two pagination tests were checked against a mutant that returns after page one — both fail, so they detect truncation rather than just covering the line
- Production data verified after the migration: 30 `Tread + Row`, 5 `Tread-focused`, 2 `Row-focused`, and exactly 1 null (the excluded malfunction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
