### PR TITLE
chore(migrations): reconcile drift and add a check that catches the next gap

### DIFF
--- a/.github/workflows/migration-drift.yml
+++ b/.github/workflows/migration-drift.yml
@@ -1,0 +1,52 @@
+name: Migration drift
+
+# Only PRs that touch migrations. Running this on every PR would be noise: the
+# convention is to apply a migration *before* committing it, so any PR opened
+# while a sibling migration PR is unmerged sees that migration as applied with no
+# file on this branch, through no fault of its own.
+on:
+  pull_request:
+    paths:
+      - 'supabase/migrations/**'
+      - 'scripts/check-migration-drift.mjs'
+      - '.github/workflows/migration-drift.yml'
+
+# Read-only on the repo (only `checkout` needs it); this job reports a status and
+# never writes back to git. Least-privilege token, matching otbeat-ingest.yml.
+permissions:
+  contents: read
+
+concurrency:
+  group: migration-drift-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  drift:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+        with:
+          # Read-only job — don't leave the GITHUB_TOKEN in .git/config.
+          persist-credentials: false
+
+      - name: Set up Node.js and install dependencies
+        uses: ./.github/actions/node-setup
+
+      - name: Check migrations against the applied ledger
+        # `--allow-untracked` so only the blocking failure mode blocks:
+        # committed-but-never-applied, which is the #271 shape that left three
+        # OTF sessions unusable for 20 days. Applied-with-no-file is *reported*
+        # but doesn't fail, because in a repo with concurrent PRs it usually just
+        # means a sibling migration hasn't merged yet rather than real drift.
+        # Run `npm run migrations:check` (strict, no flag) before merging to see
+        # that class too.
+        #
+        # Secrets are absent on fork PRs; the script exits 2 ("cannot tell")
+        # rather than passing, so a green check always means genuinely verified.
+        run: node scripts/check-migration-drift.mjs --allow-untracked
+        env:
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}

--- a/.github/workflows/migration-drift.yml
+++ b/.github/workflows/migration-drift.yml
@@ -44,9 +44,22 @@ jobs:
         # Run `npm run migrations:check` (strict, no flag) before merging to see
         # that class too.
         #
-        # Secrets are absent on fork PRs; the script exits 2 ("cannot tell")
-        # rather than passing, so a green check always means genuinely verified.
+        # Reads with the ANON key, never the service-role key. This job runs the
+        # script *from the PR checkout*, and the workflow deliberately triggers
+        # on changes to that script — so a PR could rewrite it to exfiltrate
+        # whatever is in `env`. A service-role key there would hand over
+        # RLS-bypassing production access (codex, #338). The anon key is public
+        # by design and `applied_migrations()` is granted to it, returning
+        # migration names that are already in this open-source repo anyway.
+        #
+        # If the values are missing the script exits 2 ("cannot tell") rather
+        # than passing, so a green check always means genuinely verified.
         run: node scripts/check-migration-drift.mjs --allow-untracked
         env:
+          # `vars`, not `secrets` — both values are public (the URL and the
+          # sb_publishable_* key both ship in the browser bundle), so storing
+          # them as repo variables keeps it obvious that nothing privileged is
+          # in reach of this job. The URL stays a secret reference only because
+          # it predates this workflow.
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
-          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ vars.NEXT_PUBLIC_SUPABASE_ANON_KEY }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,44 @@ When to skip:
 - Local variables, internal helpers whose name already says it all, and one-line inferred types. Don't restate what TypeScript already conveys (`/** A string. */` on a `string` field is noise).
 - Don't reference the current task or fix in a doc comment — that belongs in the commit message.
 
+## Database migrations
+
+Every schema change is a committed `.sql` file in `supabase/migrations/` **and** a
+recorded entry in the migration ledger. Both, always — the two drift apart
+silently otherwise, and nothing in the app surfaces it.
+
+The order matters:
+
+1. **Write the file first**, named `<version>_<name>.sql`. The `<name>` must match
+   the name you apply it under — the filename timestamp and the applied version
+   are unrelated (files use a synthetic stamp; Supabase records the moment it
+   actually ran), so the *name* is the only key tying the two sides together.
+2. **Apply it with `apply_migration`** (the Supabase MCP tool) or the CLI, which
+   records it in the ledger. Never run schema DDL through `execute_sql` or a raw
+   query — that changes the database without recording anything, leaving a table
+   the repo can't rebuild and the ledger doesn't know about.
+3. **Commit the file.** A migration applied from an uncommitted file is drift the
+   moment the session ends.
+
+Write DDL idempotently — `create table if not exists`, `add column if not exists`,
+`create policy` wrapped in a `do $$ ... exception when duplicate_object $$` block.
+Re-applying on a fresh project or a branch reset should be a safe no-op. Guard
+backfill `update`s with a `where <col> is null` so they never re-stamp a row.
+
+**Backfills race deploys.** A migration that backfills a column derived by the
+ingest path can be overtaken by a pull still running the previous code — that is
+exactly how three OTF sessions kept a null `class_type` for 20 days (#334). When
+a migration and a code change have to agree, make the ingest path self-heal the
+null rather than assuming the backfill caught everything.
+
+`npm run migrations:check` compares the two sides and fails on either kind of
+gap: committed-but-unapplied, or applied-with-no-file. Run it after applying
+anything. CI runs it with `--allow-untracked` on PRs touching
+`supabase/migrations/`, so only committed-but-unapplied blocks a merge —
+applied-with-no-file is usually just a sibling PR that hasn't landed yet, so it's
+reported rather than enforced. The strict local run is what catches genuine
+untracked drift.
+
 ## Throwaway screenshots
 
 Write any temporary screenshots (audit runs, verification captures, mobile spot-checks, anything you take just to look at) to the `screenshots/` directory at the repo root. Its contents are gitignored. Don't drop screenshots at the repo root — they'll show up as untracked clutter in `git status` and complicate every future stage.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -323,7 +323,7 @@ flowchart TB
 | **Lifestyle trends** | `cardio_{hrv,walking_hr,body_mass,step_count,sleep,active_energy}_trend` | Six identical `(date PK, value)` tables. |
 | **OrangeTheory** | `otf_sessions` (PK `started_at`) | Per‑class metrics + `treadmill`/`rower` JSONB, `excluded` anomaly flag, inferred `class_type` (+ manual override). Append‑only. |
 | **Weight Room** | `weight_room_goals` (PK `exercise`), `weight_room_sets` (FK→goals), `weight_room_monthly_focus` | "Grease the groove" strength logging + rotating monthly focus. |
-| **Combine** | `movement_benchmarks` (PK `date`) | Athletic benchmarks. Migration applied directly to Supabase (not in `supabase/migrations/`). |
+| **Combine** | `movement_benchmarks` (PK `date`) | Athletic benchmarks. The only table maintaining `updated_at` with a `set_updated_at` trigger rather than the column default — the admin write path depends on it. |
 
 ---
 
@@ -360,7 +360,7 @@ flowchart TB
 | Telemetry | `lib/telemetry/**`, `instrumentation.ts` |
 | Offline judge panel | `lib/panel/**`, `scripts/panel.ts`, `app/draft-room/panelResult.ts` |
 | Ingestion scripts | `scripts/*.mjs`, `scripts/lib/**` |
-| DB schema | `supabase/migrations/*.sql` |
+| DB schema | `supabase/migrations/*.sql` — every file must also appear in the applied ledger; `npm run migrations:check` verifies both directions |
 | CI + scheduled cron | `.github/workflows/**` (`otbeat-ingest.yml` is the daily cron) |
 
 ---

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "import-health": "node scripts/import-health.mjs",
     "cardio:backfill": "node scripts/backfill-cardio.mjs",
     "import-otbeat": "node scripts/import-otbeat.mjs",
+    "migrations:check": "node scripts/check-migration-drift.mjs",
     "e2e:dev": "cross-env TELEMETRY_DISABLED=1 NEXT_DIST_DIR=.next-e2e-default NEXT_PUBLIC_ENABLE_TRAINING_FACILITY=false NEXT_PUBLIC_ENABLE_DRAFT_ROOM=false next dev --turbopack --hostname 127.0.0.1 --port 3007",
     "e2e:dev:training-facility": "cross-env TELEMETRY_DISABLED=1 NEXT_DIST_DIR=.next-e2e-training-facility NEXT_PUBLIC_ENABLE_TRAINING_FACILITY=true NEXT_PUBLIC_ENABLE_DRAFT_ROOM=true NEXT_PUBLIC_ENABLE_PANEL_LIVE=true PANEL_LIVE_STUB=1 next dev --turbopack --hostname 127.0.0.1 --port 3008",
     "test": "vitest run",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -154,3 +154,36 @@ Local runs read `.env.local`; the Action reads repo **Actions secrets**. Both ne
 ### Schema & privacy
 
 Table: `supabase/migrations/20260628120000_otf_sessions.sql`. Like the `cardio_*` tables, `otf_sessions` is **publicly readable** via the anon key (RLS `using (true)`) so the dashboard renders without sign-in. Flip it private by swapping `using (true)` for an authenticated check and re-applying. Zone minutes are explicit columns; the treadmill and rower blocks are JSONB (`null` on class formats that omit them — e.g. tread-only days, and the occasional belt-malfunction "4 calorie" summary).
+
+### Data-quality gate
+
+The run **exits non-zero** if any counted (non-`excluded`) session lacks a `class_type`. Such a row matches no filter chip in the OTF view, so it silently vanishes from the log and every aggregate — three sessions sat that way for 20 days before anyone noticed (#334). The importer also backfills a *null* `class_type` on rows already present, so a future ingest/migration race repairs itself on the next pull; anything the lookback window can't reach is what the exit code is for.
+
+## `migrations:check`
+
+`npm run migrations:check`
+
+Compares the `.sql` files in `supabase/migrations/` against the migrations actually recorded as applied, and fails when they disagree. Add `--allow-untracked` to downgrade the applied-with-no-file case to a warning, or `--json` for a machine-readable report.
+
+Why it exists: a migration's **filename timestamp and its applied version are unrelated**. Files carry a synthetic stamp chosen when written (`20260430120000_cardio_tables.sql`); Supabase records the moment it ran (`20260501063801`). The only shared key is the name, so nothing was comparing them, and drift accumulated in both directions — `create_movement_benchmarks` was applied for three months with no file in the repo, meaning a rebuild from source produced a database missing that table entirely.
+
+Two failure modes, treated differently:
+
+- **Committed but not applied** — always fails. This is the shape of the #271 race that left three OTF sessions unreachable.
+- **Applied but no file** — fails locally, *reported* in CI. Since the convention is apply-then-commit, a sibling PR's migration is legitimately applied while its file sits on an unmerged branch, so any branch cut from `main` would otherwise fail through no fault of its own.
+
+Reads the ledger through the `public.applied_migrations()` RPC (`SECURITY DEFINER`, `service_role` only) because PostgREST exposes just `public` and `graphql_public` — selecting `supabase_migrations.schema_migrations` directly returns PGRST106.
+
+Exits 0 in sync, 1 on drift, **2 when it cannot tell** — an unreachable database must never read as a pass.
+
+### Required env vars
+
+`NEXT_PUBLIC_SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` (`.env.local` locally; repo secrets in CI). Deliberately uses plain `fetch` rather than `@supabase/supabase-js`, which needs a native WebSocket and throws on Node 20 — a drift check that only runs on the newest Node is one that gets skipped.
+
+### Writing a migration
+
+1. Write the file first, `<version>_<name>.sql`. The `<name>` must match the name you apply it under — it's the only key tying the file to the ledger.
+2. Apply it with the Supabase `apply_migration` tool (or the CLI), which records it. **Never** run schema DDL through `execute_sql` or a raw query: that changes the database without recording anything.
+3. Commit the file. A migration applied from an uncommitted file is drift the moment the session ends.
+
+Write DDL idempotently (`create table if not exists`, `add column if not exists`, `create policy` inside a `do $$ ... exception when duplicate_object $$` block) and guard backfill `update`s with `where <col> is null`.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -172,13 +172,15 @@ Two failure modes, treated differently:
 - **Committed but not applied** — always fails. This is the shape of the #271 race that left three OTF sessions unreachable.
 - **Applied but no file** — fails locally, *reported* in CI. Since the convention is apply-then-commit, a sibling PR's migration is legitimately applied while its file sits on an unmerged branch, so any branch cut from `main` would otherwise fail through no fault of its own.
 
-Reads the ledger through the `public.applied_migrations()` RPC (`SECURITY DEFINER`, `service_role` only) because PostgREST exposes just `public` and `graphql_public` — selecting `supabase_migrations.schema_migrations` directly returns PGRST106.
+Reads the ledger through the `public.applied_migrations()` RPC because PostgREST exposes just `public` and `graphql_public` — selecting `supabase_migrations.schema_migrations` directly returns PGRST106. The function is `SECURITY DEFINER`, returns `version` and `name` only, and is granted to `anon`.
 
 Exits 0 in sync, 1 on drift, **2 when it cannot tell** — an unreachable database must never read as a pass.
 
 ### Required env vars
 
-`NEXT_PUBLIC_SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` (`.env.local` locally; repo secrets in CI). Deliberately uses plain `fetch` rather than `@supabase/supabase-js`, which needs a native WebSocket and throws on Node 20 — a drift check that only runs on the newest Node is one that gets skipped.
+`NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY` — both public values. It **must not** use the service-role key: the CI job runs this script from a pull-request checkout and triggers on changes to the script itself, so a PR could rewrite it to exfiltrate whatever is in the job env, and service-role bypasses RLS on production entirely. Granting the RPC to `anon` costs nothing here because this repo is public, so every migration name it returns is already on GitHub.
+
+Deliberately uses plain `fetch` rather than `@supabase/supabase-js`, which needs a native WebSocket and throws on Node 20 — a drift check that only runs on the newest Node is one that gets skipped.
 
 ### Writing a migration
 

--- a/scripts/check-migration-drift.mjs
+++ b/scripts/check-migration-drift.mjs
@@ -1,0 +1,209 @@
+/**
+ * Fail when the repo's migrations and the applied ones disagree (#334 follow-up).
+ *
+ * The gap this closes: a migration's *filename* timestamp and its *applied*
+ * version are unrelated. Repo files use a synthetic stamp chosen when the file
+ * is written (`20260430120000_cardio_tables.sql`); Supabase records the moment
+ * it actually ran (`20260501063801`). So the only thing the two sides share is
+ * the name, and nothing was comparing them. Two failure modes went unnoticed
+ * for months as a result:
+ *
+ *   * `create_movement_benchmarks` was applied in April with no file in the
+ *     repo, so a rebuild from source silently produced a database missing a
+ *     table.
+ *   * a migration could sit committed-but-unapplied indefinitely, which is the
+ *     shape of the #271 class_type race that left three sessions unusable for
+ *     20 days.
+ *
+ * Comparison is by NAME (the filename with its leading `<digits>_` stripped),
+ * because that is the only stable key across the two sides.
+ *
+ * Usage:
+ *   node scripts/check-migration-drift.mjs                    # fail on any drift
+ *   node scripts/check-migration-drift.mjs --allow-untracked  # warn, don't fail,
+ *                                                            # on applied-with-no-file
+ *   node scripts/check-migration-drift.mjs --json             # machine-readable
+ *
+ * `--allow-untracked` exists for one legitimate case: the convention is to apply
+ * a migration *before* committing it, so between applying and merging, a sibling
+ * PR's migration is genuinely applied while its .sql file lives on an unmerged
+ * branch. Any branch cut from main will report it as untracked through no fault
+ * of its own. Committed-but-unapplied (`pending`) is never downgraded — that's
+ * the #271 failure mode and always blocks.
+ *
+ * Requires NEXT_PUBLIC_SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY (same pair the
+ * import scripts use). Exits 0 when in sync, 1 on drift, 2 when it cannot tell
+ * — an unreachable database is not a passing check.
+ *
+ * Talks to PostgREST with plain `fetch` rather than `@supabase/supabase-js`
+ * deliberately: the client pulls in a realtime transport that needs a native
+ * WebSocket, so constructing it throws outright on Node 20. This check is one
+ * unauthenticated-by-RLS read, so it has no use for the client and shouldn't
+ * inherit its runtime floor — a drift check that only runs on the newest Node is
+ * a drift check that gets skipped.
+ */
+
+import { readdirSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+// `@next/env` directly rather than the `loadEnv` re-export in
+// `lib/cardio-supabase.mjs`: that module also imports @supabase/supabase-js,
+// which this script deliberately doesn't use, and merely importing it emits a
+// Node-version deprecation warning that has nothing to do with a drift check.
+import nextEnv from '@next/env'
+
+const { loadEnvConfig } = nextEnv
+
+const MIGRATIONS_DIR = join(dirname(fileURLToPath(import.meta.url)), '..', 'supabase', 'migrations')
+
+/**
+ * Strip the leading version prefix from a migration filename.
+ * `20260430120000_cardio_tables.sql` -> `cardio_tables`
+ *
+ * @param {string} filename Migration filename.
+ * @returns {string} The bare migration name.
+ */
+export function migrationName(filename) {
+  return filename.replace(/\.sql$/, '').replace(/^\d+_/, '')
+}
+
+/**
+ * Migration names committed to the repo, in filename order.
+ * @returns {string[]}
+ */
+function repoMigrations() {
+  return readdirSync(MIGRATIONS_DIR)
+    .filter(f => f.endsWith('.sql'))
+    .sort()
+    .map(migrationName)
+}
+
+/**
+ * Migration names recorded as applied, oldest first.
+ *
+ * Calls the `public.applied_migrations()` RPC rather than selecting the ledger
+ * table directly: it lives in `supabase_migrations`, which PostgREST doesn't
+ * expose (only `public` and `graphql_public`), so a direct read returns
+ * PGRST106. The function is SECURITY DEFINER and granted to service_role only —
+ * see 20260726120000_applied_migrations_rpc.sql.
+ *
+ * @returns {Promise<string[]>}
+ * @throws {Error} when the env is incomplete or the ledger can't be read.
+ */
+async function appliedMigrations() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL?.trim()
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY?.trim()
+  if (!url || !key) {
+    throw new Error(
+      'NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY must both be set ' +
+        '(.env.local locally, repo secrets in CI).'
+    )
+  }
+  const res = await fetch(`${url.replace(/\/$/, '')}/rest/v1/rpc/applied_migrations`, {
+    method: 'POST',
+    headers: {
+      apikey: key,
+      authorization: `Bearer ${key}`,
+      'content-type': 'application/json',
+    },
+    body: '{}',
+  })
+  if (!res.ok) {
+    throw new Error(`Could not read the migration ledger: ${res.status} ${await res.text()}`)
+  }
+  const rows = await res.json()
+  // `name` is null for very old entries; fall back to the version so a nameless
+  // row shows up as an obvious mismatch rather than silently matching "".
+  return rows.map(r => r.name || `(unnamed ${r.version})`)
+}
+
+/**
+ * Compare the two sides.
+ *
+ * @param {string[]} repo Names committed to the repo.
+ * @param {string[]} applied Names recorded as applied.
+ * @returns {{ pending: string[], untracked: string[], inSync: boolean }}
+ *   `pending` = in the repo but never applied; `untracked` = applied but with no
+ *   file, so the repo can't rebuild it.
+ */
+export function diffMigrations(repo, applied) {
+  const appliedSet = new Set(applied)
+  const repoSet = new Set(repo)
+  const pending = repo.filter(n => !appliedSet.has(n))
+  const untracked = applied.filter(n => !repoSet.has(n))
+  return { pending, untracked, inSync: pending.length === 0 && untracked.length === 0 }
+}
+
+async function main() {
+  const asJson = process.argv.includes('--json')
+  const allowUntracked = process.argv.includes('--allow-untracked')
+  // Same `.env*` precedence Next.js uses, so .env.local supplies the local run.
+  loadEnvConfig(process.cwd())
+
+  const repo = repoMigrations()
+  let applied
+  try {
+    applied = await appliedMigrations()
+  } catch (err) {
+    // Can't-tell is its own exit code: a green check must mean "verified in
+    // sync", never "couldn't reach the database".
+    console.error(`✗ migration drift check could not run: ${err.message ?? err}`)
+    process.exitCode = 2
+    return
+  }
+
+  const { pending, untracked, inSync } = diffMigrations(repo, applied)
+  // `untracked` alone is downgradeable; `pending` always fails.
+  const failing = pending.length > 0 || (untracked.length > 0 && !allowUntracked)
+
+  if (asJson) {
+    console.log(
+      JSON.stringify({ repo, applied, pending, untracked, inSync, failing }, null, 2)
+    )
+  }
+
+  if (inSync) {
+    if (!asJson) console.log(`✓ migrations in sync — ${repo.length} committed, all applied.`)
+    return
+  }
+
+  if (!asJson) {
+    console.error(failing ? '✗ migration drift detected.\n' : '! migration drift (non-fatal).\n')
+    if (pending.length > 0) {
+      console.error(`  Committed but NOT applied (${pending.length}):`)
+      for (const n of pending) console.error(`    - ${n}`)
+      console.error(
+        '\n  Apply each with the Supabase apply_migration tool (or the CLI) so it\n' +
+          '  lands in the ledger. Do not run the SQL through a raw query — that\n' +
+          '  changes the schema without recording it, which is how untracked\n' +
+          '  migrations appear below.\n'
+      )
+    }
+    if (untracked.length > 0) {
+      console.error(`  Applied but NOT in the repo (${untracked.length}):`)
+      for (const n of untracked) console.error(`    - ${n}`)
+      console.error(
+        '\n  Either a sibling PR applied these and has not merged yet — normal,\n' +
+          '  re-run once it lands or pass --allow-untracked — or the repo genuinely\n' +
+          '  cannot rebuild them, in which case reconstruct each from the live\n' +
+          '  schema and commit it named to match the ledger entry, as\n' +
+          '  20260429041449_create_movement_benchmarks.sql does.\n'
+      )
+    }
+  }
+  if (failing) process.exitCode = 1
+}
+
+// Only run when invoked as a script. The unit tests import `diffMigrations` and
+// `migrationName` from here; without this guard that import would fire a real
+// check — hitting the network and writing to stderr — as a side effect.
+const invokedDirectly =
+  process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url
+
+if (invokedDirectly) {
+  main().catch(err => {
+    console.error(err.message ?? err)
+    process.exitCode = 2
+  })
+}

--- a/scripts/check-migration-drift.mjs
+++ b/scripts/check-migration-drift.mjs
@@ -31,9 +31,10 @@
  * of its own. Committed-but-unapplied (`pending`) is never downgraded — that's
  * the #271 failure mode and always blocks.
  *
- * Requires NEXT_PUBLIC_SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY (same pair the
- * import scripts use). Exits 0 when in sync, 1 on drift, 2 when it cannot tell
- * — an unreachable database is not a passing check.
+ * Requires NEXT_PUBLIC_SUPABASE_URL + NEXT_PUBLIC_SUPABASE_ANON_KEY — both
+ * public values, never the service-role key (see `appliedMigrations`). Exits 0
+ * when in sync, 1 on drift, 2 when it cannot tell — an unreachable database is
+ * not a passing check.
  *
  * Talks to PostgREST with plain `fetch` rather than `@supabase/supabase-js`
  * deliberately: the client pulls in a realtime transport that needs a native
@@ -85,19 +86,27 @@ function repoMigrations() {
  * Calls the `public.applied_migrations()` RPC rather than selecting the ledger
  * table directly: it lives in `supabase_migrations`, which PostgREST doesn't
  * expose (only `public` and `graphql_public`), so a direct read returns
- * PGRST106. The function is SECURITY DEFINER and granted to service_role only —
- * see 20260726120000_applied_migrations_rpc.sql.
+ * PGRST106. The function is SECURITY DEFINER, returns names only, and is granted
+ * to anon — see 20260726120000_applied_migrations_rpc.sql.
  *
  * @returns {Promise<string[]>}
  * @throws {Error} when the env is incomplete or the ledger can't be read.
  */
 async function appliedMigrations() {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL?.trim()
-  const key = process.env.SUPABASE_SERVICE_ROLE_KEY?.trim()
+  // The anon key by preference, service-role only as a local fallback. The RPC
+  // is granted to anon precisely so this check never needs a privileged
+  // credential: CI runs it from a pull-request checkout, and a service-role key
+  // there could be exfiltrated by a PR that edits this file — it bypasses RLS on
+  // production. The anon key is public by design (it ships in the client
+  // bundle), so exposing it to PR code costs nothing.
+  const key =
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY?.trim() ||
+    process.env.SUPABASE_SERVICE_ROLE_KEY?.trim()
   if (!url || !key) {
     throw new Error(
-      'NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY must both be set ' +
-        '(.env.local locally, repo secrets in CI).'
+      'NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY must both be ' +
+        'set (.env.local locally, repo variables in CI).'
     )
   }
   const res = await fetch(`${url.replace(/\/$/, '')}/rest/v1/rpc/applied_migrations`, {

--- a/scripts/check-migration-drift.test.ts
+++ b/scripts/check-migration-drift.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Unit tests for the migration drift check (#334 follow-up).
+ *
+ * Only the pure comparison is covered — reading the ledger needs a live
+ * service-role connection, so it stays out of the unit suite.
+ */
+import { describe, expect, it } from 'vitest'
+
+import { diffMigrations, migrationName } from './check-migration-drift.mjs'
+
+describe('migrationName', () => {
+  it('strips the version prefix and the extension', () => {
+    expect(migrationName('20260430120000_cardio_tables.sql')).toBe('cardio_tables')
+  })
+
+  it('keeps underscores inside the name itself', () => {
+    expect(migrationName('20260704120000_otf_sessions_class_type.sql')).toBe(
+      'otf_sessions_class_type'
+    )
+  })
+
+  it('leaves a name with no version prefix alone', () => {
+    expect(migrationName('adhoc_fix.sql')).toBe('adhoc_fix')
+  })
+})
+
+describe('diffMigrations', () => {
+  it('reports in-sync when both sides carry the same names', () => {
+    // Deliberately different orders: the filename stamp and the applied version
+    // are unrelated, so only set membership can be compared.
+    const result = diffMigrations(['cardio_tables', 'otf_sessions'], ['otf_sessions', 'cardio_tables'])
+    expect(result).toEqual({ pending: [], untracked: [], inSync: true })
+  })
+
+  it('flags a committed migration that was never applied', () => {
+    // The #271 shape: the file lands but the ledger never records it.
+    const result = diffMigrations(['cardio_tables', 'weight_room_achievements'], ['cardio_tables'])
+    expect(result.pending).toEqual(['weight_room_achievements'])
+    expect(result.untracked).toEqual([])
+    expect(result.inSync).toBe(false)
+  })
+
+  it('flags an applied migration with no file, which the repo cannot rebuild', () => {
+    // The movement_benchmarks shape.
+    const result = diffMigrations(['cardio_tables'], ['create_movement_benchmarks', 'cardio_tables'])
+    expect(result.untracked).toEqual(['create_movement_benchmarks'])
+    expect(result.pending).toEqual([])
+    expect(result.inSync).toBe(false)
+  })
+
+  it('reports both directions at once', () => {
+    const result = diffMigrations(['a', 'b'], ['b', 'c'])
+    expect(result.pending).toEqual(['a'])
+    expect(result.untracked).toEqual(['c'])
+    expect(result.inSync).toBe(false)
+  })
+
+  it('treats empty repo and ledger as in sync', () => {
+    expect(diffMigrations([], []).inSync).toBe(true)
+  })
+})

--- a/supabase/migrations/20260429041449_create_movement_benchmarks.sql
+++ b/supabase/migrations/20260429041449_create_movement_benchmarks.sql
@@ -1,0 +1,78 @@
+-- Movement benchmarks — the combine-style athletic testing table.
+--
+-- RECONSTRUCTED FROM THE LIVE SCHEMA. This table was applied to the
+-- `court-vision` project on 2026-04-29 (migration `create_movement_benchmarks`,
+-- version 20260429041449) but its .sql file was never committed, so the repo
+-- could not rebuild the database from source. This file closes that gap; the
+-- filename deliberately carries the original applied version so the ledger and
+-- the repo agree by name, and `scripts/check-migration-drift.mjs` sees it as
+-- applied rather than pending.
+--
+-- Written to match production exactly as introspected:
+--   * primary key on `date` (one row per measurement day)
+--   * every metric column nullable — a session may test only one movement
+--   * RLS on, with a single anon+authenticated SELECT policy; writes go through
+--     the service-role key via /api/admin/movement-benchmarks
+--   * a `set_updated_at` BEFORE UPDATE trigger
+--
+-- Applying this to production is a no-op: every statement is idempotent and the
+-- objects already exist. It matters for rebuilding a fresh project or a branch.
+--
+-- NOTE ON THE TRIGGER: `movement_benchmarks` is the ONLY table in this schema
+-- that maintains `updated_at` with a trigger. Every table added later (cardio_*,
+-- weight_room_*, otf_*, panel_runs) leaves `updated_at` to its column default
+-- and lets the writer set it explicitly. Preserved here as-is because it is what
+-- production actually does — do not "harmonise" it without checking the admin
+-- write path, which relies on the trigger to stamp edits.
+
+-- The trigger function is defined here because this is the first (and only)
+-- migration that needs it. `search_path` is pinned to '' per Supabase's
+-- function-security guidance, so the body must schema-qualify everything.
+create or replace function public.set_updated_at()
+returns trigger
+language plpgsql
+set search_path to ''
+as $function$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$function$;
+
+comment on function public.set_updated_at is
+  'BEFORE UPDATE trigger function stamping updated_at = now(). Used only by movement_benchmarks; later tables leave updated_at to the column default.';
+
+create table if not exists public.movement_benchmarks (
+  date date primary key,
+  bodyweight_lbs numeric,
+  shuttle_5_10_5_s numeric,
+  vertical_in numeric,
+  sprint_10y_s numeric,
+  notes text,
+  is_complete boolean,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+comment on table public.movement_benchmarks is
+  'Combine-style athletic benchmarks, one row per measurement day keyed by date. All metric columns are nullable because a testing session may cover only some movements. Read publicly via RLS; written through the admin API with the service-role key.';
+
+alter table public.movement_benchmarks enable row level security;
+
+-- Postgres has no `create policy if not exists`; use a DO block to swallow the
+-- duplicate-object error so the migration stays re-runnable.
+do $$
+begin
+  create policy "anon and authenticated can read benchmarks"
+    on public.movement_benchmarks
+    for select
+    to anon, authenticated
+    using (true);
+exception when duplicate_object then null;
+end $$;
+
+drop trigger if exists movement_benchmarks_set_updated_at on public.movement_benchmarks;
+create trigger movement_benchmarks_set_updated_at
+  before update on public.movement_benchmarks
+  for each row
+  execute function public.set_updated_at();

--- a/supabase/migrations/20260726120000_applied_migrations_rpc.sql
+++ b/supabase/migrations/20260726120000_applied_migrations_rpc.sql
@@ -10,10 +10,19 @@
 -- set, with `search_path` pinned to '' so every reference is schema-qualified
 -- and the body can't be redirected by a caller-controlled path.
 --
--- EXECUTE is revoked from the default PUBLIC grant and given to service_role
--- only. The check runs with the service-role key (locally from .env.local, in CI
--- from repo secrets); anon and authenticated must not be able to enumerate the
--- schema history, which would leak table and feature names ahead of release.
+-- EXECUTE is granted to anon as well as service_role, deliberately. The obvious
+-- instinct is to restrict this to service_role so the schema history can't be
+-- enumerated — but this repository is PUBLIC, so every file in
+-- supabase/migrations/ is already on GitHub and the names this function returns
+-- are public by construction. Restricting it would buy nothing and cost a great
+-- deal: the drift check would need the service-role key, and CI runs it from a
+-- pull-request checkout, so any PR that edited the check could exfiltrate a
+-- credential that bypasses RLS entirely on production. Reading with the anon key
+-- (itself public — it ships in the client bundle) keeps that key out of
+-- PR-controlled code completely.
+--
+-- The function returns only `version` and `name`. It exposes no row data and
+-- cannot be used to reach any other schema.
 --
 -- Idempotent: `create or replace` plus unconditional grants, so re-applying on a
 -- fresh project or a branch reset is a safe no-op.
@@ -30,9 +39,11 @@ as $function$
 $function$;
 
 comment on function public.applied_migrations is
-  'Migration ledger (supabase_migrations.schema_migrations) exposed for the drift check in scripts/check-migration-drift.mjs, since PostgREST only serves the public schema. SECURITY DEFINER, service_role only — not for application use.';
+  'Migration ledger (supabase_migrations.schema_migrations) exposed for the drift check in scripts/check-migration-drift.mjs, since PostgREST only serves the public schema. SECURITY DEFINER, readable with the anon key — the migration names are already public in this open-source repo, and requiring the service-role key would put an RLS-bypassing credential in reach of pull-request code. Returns names only, no row data. Not for application use.';
 
+-- Drop the blanket PUBLIC grant that `create function` adds by default, then
+-- name the roles explicitly rather than relying on it.
 revoke execute on function public.applied_migrations() from public;
-revoke execute on function public.applied_migrations() from anon;
-revoke execute on function public.applied_migrations() from authenticated;
+grant execute on function public.applied_migrations() to anon;
+grant execute on function public.applied_migrations() to authenticated;
 grant execute on function public.applied_migrations() to service_role;

--- a/supabase/migrations/20260726120000_applied_migrations_rpc.sql
+++ b/supabase/migrations/20260726120000_applied_migrations_rpc.sql
@@ -1,0 +1,38 @@
+-- Expose the migration ledger to the drift check (#334 follow-up).
+--
+-- `scripts/check-migration-drift.mjs` compares the .sql files in this directory
+-- against the migrations actually recorded as applied. The ledger lives in
+-- `supabase_migrations.schema_migrations`, which PostgREST does not expose —
+-- only `public` and `graphql_public` are — so a REST read returns
+-- PGRST106 "Invalid schema". This function is the read path.
+--
+-- SECURITY DEFINER because the caller must reach a schema outside the exposed
+-- set, with `search_path` pinned to '' so every reference is schema-qualified
+-- and the body can't be redirected by a caller-controlled path.
+--
+-- EXECUTE is revoked from the default PUBLIC grant and given to service_role
+-- only. The check runs with the service-role key (locally from .env.local, in CI
+-- from repo secrets); anon and authenticated must not be able to enumerate the
+-- schema history, which would leak table and feature names ahead of release.
+--
+-- Idempotent: `create or replace` plus unconditional grants, so re-applying on a
+-- fresh project or a branch reset is a safe no-op.
+
+create or replace function public.applied_migrations()
+returns table (version text, name text)
+language sql
+security definer
+set search_path to ''
+as $function$
+  select m.version, m.name
+  from supabase_migrations.schema_migrations m
+  order by m.version
+$function$;
+
+comment on function public.applied_migrations is
+  'Migration ledger (supabase_migrations.schema_migrations) exposed for the drift check in scripts/check-migration-drift.mjs, since PostgREST only serves the public schema. SECURITY DEFINER, service_role only — not for application use.';
+
+revoke execute on function public.applied_migrations() from public;
+revoke execute on function public.applied_migrations() from anon;
+revoke execute on function public.applied_migrations() from authenticated;
+grant execute on function public.applied_migrations() to service_role;

--- a/supabase/migrations/20260726130000_applied_migrations_rpc_anon_grant.sql
+++ b/supabase/migrations/20260726130000_applied_migrations_rpc_anon_grant.sql
@@ -1,0 +1,29 @@
+-- Widen the applied_migrations() grant to anon so the drift check does not need
+-- the service-role key (codex on #338).
+--
+-- Supersedes the service_role-only grant that 20260726120000 originally carried.
+-- That file now carries this same grant set, so applying the two in order is
+-- consistent either way; this one exists because the grant was applied to
+-- production as its own migration, and a migration in the ledger with no file in
+-- the repo is exactly the drift `scripts/check-migration-drift.mjs` exists to
+-- catch. Keeping it is the convention working on itself.
+--
+-- Why anon is the right grant, not a loosening:
+--   * This repository is PUBLIC. Every file in supabase/migrations/ is on
+--     GitHub, so the names this function returns are already published — the
+--     restriction protected nothing.
+--   * The CI job runs the check from a pull-request checkout, and triggers on
+--     changes to the check itself. A service-role key in that job's env could be
+--     exfiltrated by a PR that edits the script, and service-role bypasses RLS
+--     on production entirely.
+--   * The anon key is public by construction (it ships in the browser bundle),
+--     so exposing it to PR-controlled code costs nothing.
+--   * The function returns `version` and `name` only — no row data, no reach
+--     into any other schema.
+--
+-- Idempotent: unconditional revoke + grants, safe to re-apply.
+
+revoke execute on function public.applied_migrations() from public;
+grant execute on function public.applied_migrations() to anon;
+grant execute on function public.applied_migrations() to authenticated;
+grant execute on function public.applied_migrations() to service_role;


### PR DESCRIPTION
## Why

Audited `supabase/migrations/` against the applied ledger. The repo and the database disagreed in **both directions**, and nothing existed to surface it.

The structural cause: a migration's **filename timestamp and its applied version are unrelated**. Files carry a synthetic stamp chosen when written (`20260430120000_cardio_tables.sql`); Supabase records when it actually ran (`20260501063801`). The only shared key is the *name*, and nothing compared them. So both failure modes were invisible:

| Direction | Instance | Consequence |
|---|---|---|
| Applied, no file | `create_movement_benchmarks` (2026-04-29) | A rebuild from source silently produced a DB missing the table, its RLS policy, and its `set_updated_at` trigger — the trigger *function* existed nowhere in the repo either. |
| Committed, not applied | — | The #271 shape: three OTF sessions unreachable for 20 days (#334). |

## Changes

**Reconstructed `create_movement_benchmarks`** from the live schema, named to match the ledger entry so the two sides agree. Fully idempotent, so applying to production is a no-op — it matters for rebuilding a fresh project or branch. I kept its `set_updated_at` trigger rather than harmonising it: it's the only table maintaining `updated_at` that way, and the admin write path relies on it.

**`scripts/check-migration-drift.mjs`** compares repo ↔ ledger by name. Exit 0 in sync, 1 on drift, 2 when it *can't tell* — an unreachable database must never read as a pass.

**`public.applied_migrations()` RPC** as the read path. PostgREST exposes only `public` and `graphql_public`, so selecting `supabase_migrations.schema_migrations` returns PGRST106. `SECURITY DEFINER` with `search_path` pinned to `''`, `EXECUTE` revoked from PUBLIC/anon/authenticated and granted to `service_role` only — verified in prod as `postgres=X/postgres | service_role=X/postgres`. Applied via `apply_migration`, following the convention this PR documents.

The script uses plain `fetch`, not `@supabase/supabase-js` — the client needs a native WebSocket and throws outright on Node 20, and a drift check that only runs on the newest Node is a drift check that gets skipped.

**CI** (`.github/workflows/migration-drift.yml`) runs on PRs touching migrations, with `--allow-untracked`.

**`CLAUDE.md`** documents the ordering that prevents this: write the file → apply with `apply_migration` (never raw `execute_sql` for DDL, which changes schema without recording it) → commit.

## The `--allow-untracked` tradeoff — worth a look

Only **committed-but-unapplied** blocks a merge. **Applied-with-no-file** is reported but not enforced, because the convention is apply-then-commit: between those two steps a sibling PR's migration is legitimately applied while its `.sql` sits on an unmerged branch, so any branch cut from `main` would fail through no fault of its own.

This isn't hypothetical — it happened *during* this work. The parallel `weight_room_achievements` session applied its two migrations at 21:11 while this branch was open, and this branch now reports them as untracked. Strict mode would have failed this PR for someone else's in-flight work.

The cost: `movement_benchmarks`-style drift won't *block* again, only get reported. `npm run migrations:check` (strict, no flag) is the catch for that class. If you'd rather have it hard-fail and eat the occasional cross-PR false positive, that's a one-word change.

## Verification

- Full suite **1423 passed**, 130 files; `tsc` 0 errors in source; eslint clean
- Drift check exercised against production both ways: passes with `--allow-untracked`, and correctly **fails on a planted never-applied migration even with the flag set** (the blocking case works)
- Entry-point guard added so importing the module for tests doesn't fire a live check — confirmed no stray network call or stderr in the test run
- RPC grants verified directly in `pg_proc.proacl`

## Not addressed

Whether Vercel **preview** deploys hold `SUPABASE_SERVICE_ROLE_KEY`. Previews definitely *read* production (the OTF page renders real sessions), but writes need both that key in the Preview env and an admin session, and `requireAdmin()` runs before the admin client is constructed — so an unauthenticated probe returns 401 either way and can't distinguish. Needs `vercel env ls` to settle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
