### PR TITLE
fix(ci): store the anon key as a secret, not a repo variable

### DIFF
--- a/.github/workflows/migration-drift.yml
+++ b/.github/workflows/migration-drift.yml
@@ -48,18 +48,23 @@ jobs:
         # script *from the PR checkout*, and the workflow deliberately triggers
         # on changes to that script — so a PR could rewrite it to exfiltrate
         # whatever is in `env`. A service-role key there would hand over
-        # RLS-bypassing production access (codex, #338). The anon key is public
-        # by design and `applied_migrations()` is granted to it, returning
-        # migration names that are already in this open-source repo anyway.
+        # RLS-bypassing write access to production (codex, #338); the anon key is
+        # read-only and bounded by RLS, which is why the swap mattered.
+        # `applied_migrations()` is granted to anon, and returns only migration
+        # names that are already in this open-source repo.
         #
         # If the values are missing the script exits 2 ("cannot tell") rather
         # than passing, so a green check always means genuinely verified.
         run: node scripts/check-migration-drift.mjs --allow-untracked
         env:
-          # `vars`, not `secrets` — both values are public (the URL and the
-          # sb_publishable_* key both ship in the browser bundle), so storing
-          # them as repo variables keeps it obvious that nothing privileged is
-          # in reach of this job. The URL stays a secret reference only because
-          # it predates this workflow.
+          # Both as `secrets`, so GitHub redacts them from logs. This repo is
+          # public, which makes its Actions logs public too, and the anon key
+          # is not currently published anywhere: the training-facility routes
+          # that would put it in a client bundle are flag-gated off in
+          # production. Since RLS is `using (true)` for reads, that key is today
+          # the only thing between the internet and the fitness data — so it gets
+          # masked, even though a determined PR could still print it (see above:
+          # what the earlier fix bought was removing the *privileged* key, not
+          # making this job safe to hand any credential).
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
-          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ vars.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -178,7 +178,9 @@ Exits 0 in sync, 1 on drift, **2 when it cannot tell** — an unreachable databa
 
 ### Required env vars
 
-`NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY` — both public values. It **must not** use the service-role key: the CI job runs this script from a pull-request checkout and triggers on changes to the script itself, so a PR could rewrite it to exfiltrate whatever is in the job env, and service-role bypasses RLS on production entirely. Granting the RPC to `anon` costs nothing here because this repo is public, so every migration name it returns is already on GitHub.
+`NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY`. It **must not** use the service-role key: the CI job runs this script from a pull-request checkout and triggers on changes to the script itself, so a PR could rewrite it to exfiltrate whatever is in the job env, and service-role bypasses RLS on production entirely. The anon key is read-only and bounded by RLS, and granting the RPC to `anon` leaks nothing extra — every migration name it returns is already on GitHub in this public repo.
+
+Both are stored as **repo secrets**, not variables. Despite the `NEXT_PUBLIC_` prefix the anon key isn't actually published today: the training-facility routes that would inline it into a client bundle are flag-gated off in production, and RLS is `using (true)` for reads, so that key is currently the only thing between the internet and the fitness data. A public repo has public Actions logs, and secrets get redacted from them where variables don't. (Masking only stops *accidental* logging — a deliberately malicious PR can print anything in its env either way. What protects this job is that nothing privileged is in it.)
 
 Deliberately uses plain `fetch` rather than `@supabase/supabase-js`, which needs a native WebSocket and throws on Node 20 — a drift check that only runs on the newest Node is one that gets skipped.
 

--- a/scripts/check-migration-drift.mjs
+++ b/scripts/check-migration-drift.mjs
@@ -31,10 +31,9 @@
  * of its own. Committed-but-unapplied (`pending`) is never downgraded — that's
  * the #271 failure mode and always blocks.
  *
- * Requires NEXT_PUBLIC_SUPABASE_URL + NEXT_PUBLIC_SUPABASE_ANON_KEY — both
- * public values, never the service-role key (see `appliedMigrations`). Exits 0
- * when in sync, 1 on drift, 2 when it cannot tell — an unreachable database is
- * not a passing check.
+ * Requires NEXT_PUBLIC_SUPABASE_URL + NEXT_PUBLIC_SUPABASE_ANON_KEY, never the
+ * service-role key (see `appliedMigrations`). Exits 0 when in sync, 1 on drift,
+ * 2 when it cannot tell — an unreachable database is not a passing check.
  *
  * Talks to PostgREST with plain `fetch` rather than `@supabase/supabase-js`
  * deliberately: the client pulls in a realtime transport that needs a native
@@ -97,9 +96,12 @@ async function appliedMigrations() {
   // The anon key by preference, service-role only as a local fallback. The RPC
   // is granted to anon precisely so this check never needs a privileged
   // credential: CI runs it from a pull-request checkout, and a service-role key
-  // there could be exfiltrated by a PR that edits this file — it bypasses RLS on
-  // production. The anon key is public by design (it ships in the client
-  // bundle), so exposing it to PR code costs nothing.
+  // there could be exfiltrated by a PR that edits this file — it bypasses RLS
+  // entirely and grants writes. The anon key is read-only and bounded by RLS,
+  // which is the whole point of the swap. It is still stored as a secret rather
+  // than a variable: the training-facility routes that would publish it in a
+  // client bundle are flag-gated off in production, so it isn't public today,
+  // and this repo's Actions logs are.
   const key =
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY?.trim() ||
     process.env.SUPABASE_SERVICE_ROLE_KEY?.trim()

--- a/supabase/migrations/20260726120000_applied_migrations_rpc.sql
+++ b/supabase/migrations/20260726120000_applied_migrations_rpc.sql
@@ -17,9 +17,11 @@
 -- are public by construction. Restricting it would buy nothing and cost a great
 -- deal: the drift check would need the service-role key, and CI runs it from a
 -- pull-request checkout, so any PR that edited the check could exfiltrate a
--- credential that bypasses RLS entirely on production. Reading with the anon key
--- (itself public — it ships in the client bundle) keeps that key out of
--- PR-controlled code completely.
+-- credential that bypasses RLS entirely and grants writes on production. The
+-- anon key is read-only and bounded by RLS, so reading with it keeps the
+-- privileged credential out of PR-controlled code entirely. (The anon key is
+-- still handled as a secret rather than a public value — the routes that would
+-- publish it in a client bundle are flag-gated off in production.)
 --
 -- The function returns only `version` and `name`. It exposes no row data and
 -- cannot be used to reach any other schema.

--- a/supabase/migrations/20260726130000_applied_migrations_rpc_anon_grant.sql
+++ b/supabase/migrations/20260726130000_applied_migrations_rpc_anon_grant.sql
@@ -16,8 +16,11 @@
 --     changes to the check itself. A service-role key in that job's env could be
 --     exfiltrated by a PR that edits the script, and service-role bypasses RLS
 --     on production entirely.
---   * The anon key is public by construction (it ships in the browser bundle),
---     so exposing it to PR-controlled code costs nothing.
+--   * The anon key is read-only and bounded by RLS, so a PR that exfiltrated it
+--     could read what the site already serves publicly — not write, and not
+--     bypass a policy. It is still stored as a repo secret rather than a public
+--     value: the routes that would inline it into a client bundle are
+--     flag-gated off in production, so it isn't actually published yet.
 --   * The function returns `version` and `name` only — no row data, no reach
 --     into any other schema.
 --


### PR DESCRIPTION
## Correcting a bad call from #338

I stored `NEXT_PUBLIC_SUPABASE_ANON_KEY` as a repo **variable**, reasoning it was "public by design — it ships in the browser bundle." I checked that claim instead of assuming it, and it's false.

I scanned every JS chunk served from production: **the key is in none of them.** The training-facility routes that would inline it are flag-gated off in prod — `/training-facility/gym/otf` returns 404 there. So the anon key has no public consumer today.

That matters because RLS is `using (true)` for reads on the cardio, OTF, and benchmark tables. Right now that key is the only thing between the internet and the fitness data.

And this repo is public, which makes its **Actions logs public**. GitHub redacts secrets from logs; variables it prints verbatim. Storing an unpublished credential as a variable traded real protection for a tidier-looking reference.

## Changes

- Moved the key to a repo secret; deleted the variable (both already done on the repo).
- Workflow now reads `secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY`.
- Corrected the wrong rationale everywhere it had propagated: the workflow comment, the script, `scripts/README.md`, and both RPC migration comments. **Comment-only in the `.sql` files** — the applied DDL is unchanged, so the ledger still matches and `migrations:check` stays green.

## What this does and doesn't buy

Worth being precise, because it's easy to overclaim: masking stops **accidental** logging, not a malicious PR — that can print anything in its env either way. What actually protects this job is that nothing privileged is in it, which was the point of the service-role swap in #338.

The distinction that carries the weight: service-role **bypasses RLS and can write**; the anon key is **read-only and policy-bounded**. Swapping those was the security fix. Secret-vs-variable is the smaller, cheap improvement on top.

## Note

The key was printed in my session transcript via `gh variable list` before this change. If you'd rather not rely on that being private, rotating the publishable key in the Supabase dashboard is quick and I can update the secret after.

## Verification

- Drift check runs green against production with the anon key
- 8 drift unit tests pass; eslint clean
- Grep confirms no remaining "public by design / ships in the bundle" claims (the one surviving "public by construction" refers to *migration names*, which is accurate — they're on GitHub)

🤖 Generated with [Claude Code](https://claude.com/claude-code)