### PR TITLE
feat(staging): weekly production → staging sync, and teach the docs it exists

### DIFF
--- a/.github/workflows/staging-sync.yml
+++ b/.github/workflows/staging-sync.yml
@@ -1,0 +1,51 @@
+name: Staging sync
+
+# Weekly, not daily. Staging exists so preview deploys render realistic data;
+# nobody reads it for an answer, so being up to seven days behind costs nothing.
+# Daily would burn a run every night to copy ~45k rows that almost never get
+# looked at. Sunday 08:00 UTC lands an hour after the OTbeat ingest (07:00), so
+# a refresh always includes that morning's classes.
+on:
+  schedule:
+    - cron: '0 8 * * 0'
+  # Manual trigger for "I want staging current before reviewing this preview".
+  workflow_dispatch: {}
+
+# Read-only on the repo; this job writes to Supabase, never back to git.
+permissions:
+  contents: read
+
+# Never overlap a scheduled refresh with a manual one — they'd upsert the same
+# keys concurrently for no benefit.
+concurrency:
+  group: staging-sync
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Set up Node.js and install dependencies
+        uses: ./.github/actions/node-setup
+
+      - name: Copy production data into staging
+        # Production is read with the ANON key: every synced table has an RLS
+        # `using (true)` SELECT policy, so nothing here needs production's
+        # service-role key — and this job must never hold one, since a
+        # workflow that can write production defeats the point of staging.
+        #
+        # The staging secret key is scoped to a throwaway project holding a copy
+        # of data that is public-by-design on the live site.
+        env:
+          PROD_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+          PROD_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+          STAGING_SUPABASE_URL: ${{ secrets.STAGING_SUPABASE_URL }}
+          STAGING_SUPABASE_SECRET_KEY: ${{ secrets.STAGING_SUPABASE_SECRET_KEY }}
+        run: npm run staging:sync

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,32 @@ applied-with-no-file is usually just a sibling PR that hasn't landed yet, so it'
 reported rather than enforced. The strict local run is what catches genuine
 untracked drift.
 
+## Two Supabase projects
+
+| | ref | Holds |
+|---|---|---|
+| **production** | `ryxbnvhxxkrmsrmocume` | The real data. Source of truth. |
+| **staging** | `tztrsfefesacnbreerhp` | A point-in-time copy, for preview deploys. |
+
+**Everything that writes, writes to production.** The OTbeat cron, the
+`log-workout` and `log-weight` skills (both hardcode the production ref), and the
+Apple Health import. Nothing dual-writes. So:
+
+- **Never read staging to answer a question about the data.** "How many classes
+  in July", "what did I lift yesterday" — always production. Staging is stale by
+  design and looks convincingly current, which is the trap.
+- **Apply every migration to both.** `apply_migration` takes a `project_id`, so
+  one session can do both; run `migrations:check` against each afterwards
+  (point `NEXT_PUBLIC_SUPABASE_URL` / `_ANON_KEY` at whichever you're checking).
+  Production usually runs *ahead* of `main`, because a feature branch's migration
+  is applied before its PR merges — that's expected, not drift.
+- **Refresh staging with `npm run staging:sync`**, or the weekly
+  `staging-sync` workflow. Upsert-based: production edits propagate,
+  staging-only rows survive, deletions do **not** propagate.
+
+Staging is also the place to rehearse a destructive migration — a `drop`, a type
+change, a `not null` backfill — before running it anywhere near production.
+
 ## Throwaway screenshots
 
 Write any temporary screenshots (audit runs, verification captures, mobile spot-checks, anything you take just to look at) to the `screenshots/` directory at the repo root. Its contents are gitignored. Don't drop screenshots at the repo root — they'll show up as untracked clutter in `git status` and complicate every future stage.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -333,6 +333,7 @@ flowchart TB
 |---|---|
 | **Anon reads, gated writes** | Public dashboards read Supabase directly (anon key, RLS `SELECT`) — no bespoke read API to maintain. Writes are impossible with the anon key; they must pass through a server route holding the service‑role key. Security lives in RLS + one app‑layer gate. |
 | **Three Supabase clients** | browser (anon) · server (anon + cookie) · admin (service‑role, `server-only`). The service‑role key never reaches the browser and is only reachable behind `requireAdmin` or the auto‑sync secret. |
+| **Two Supabase projects** | production (`ryxbnvhxxkrmsrmocume`) is the source of truth and the target of every write — the OTbeat cron, the log‑workout/log‑weight skills, the Health import. Staging (`tztrsfefesacnbreerhp`) is a point‑in‑time **copy** for preview deploys and for rehearsing destructive migrations; nothing dual‑writes to it, so it is stale by design. Never read staging to answer a question about the data. |
 | **`server / shared / browser` data split** | `*-shared.ts` holds the pure row→view logic and imports no client, guaranteeing the server and browser read paths produce identical shapes and neither bundle leaks into the other. |
 | **Feature flags for dark launch** | `NEXT_PUBLIC_ENABLE_TRAINING_FACILITY` and `NEXT_PUBLIC_ENABLE_DRAFT_ROOM` (both default **off**) gate whole areas to 404, so in‑progress features ship to `main` without being publicly reachable. |
 | **No middleware** | Route protection is per‑route (`requireAdmin` / `requireAdminPage`), keeping auth logic beside the code it protects and off the edge. |
@@ -360,7 +361,8 @@ flowchart TB
 | Telemetry | `lib/telemetry/**`, `instrumentation.ts` |
 | Offline judge panel | `lib/panel/**`, `scripts/panel.ts`, `app/draft-room/panelResult.ts` |
 | Ingestion scripts | `scripts/*.mjs`, `scripts/lib/**` |
-| DB schema | `supabase/migrations/*.sql` — every file must also appear in the applied ledger; `npm run migrations:check` verifies both directions |
+| DB schema | `supabase/migrations/*.sql` — every file must also appear in the applied ledger; `npm run migrations:check` verifies both directions. Apply to **both** Supabase projects (see below) |
+| Staging refresh | `scripts/sync-staging.mjs` (`npm run staging:sync`), weekly via `.github/workflows/staging-sync.yml` |
 | CI + scheduled cron | `.github/workflows/**` (`otbeat-ingest.yml` is the daily cron) |
 
 ---

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "cardio:backfill": "node scripts/backfill-cardio.mjs",
     "import-otbeat": "node scripts/import-otbeat.mjs",
     "migrations:check": "node scripts/check-migration-drift.mjs",
+    "staging:sync": "node scripts/sync-staging.mjs",
     "e2e:dev": "cross-env TELEMETRY_DISABLED=1 NEXT_DIST_DIR=.next-e2e-default NEXT_PUBLIC_ENABLE_TRAINING_FACILITY=false NEXT_PUBLIC_ENABLE_DRAFT_ROOM=false next dev --turbopack --hostname 127.0.0.1 --port 3007",
     "e2e:dev:training-facility": "cross-env TELEMETRY_DISABLED=1 NEXT_DIST_DIR=.next-e2e-training-facility NEXT_PUBLIC_ENABLE_TRAINING_FACILITY=true NEXT_PUBLIC_ENABLE_DRAFT_ROOM=true NEXT_PUBLIC_ENABLE_PANEL_LIVE=true PANEL_LIVE_STUB=1 next dev --turbopack --hostname 127.0.0.1 --port 3008",
     "test": "vitest run",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -184,6 +184,39 @@ Both are stored as **repo secrets**, not variables. Despite the `NEXT_PUBLIC_` p
 
 Deliberately uses plain `fetch` rather than `@supabase/supabase-js`, which needs a native WebSocket and throws on Node 20 — a drift check that only runs on the newest Node is one that gets skipped.
 
+## `staging:sync`
+
+`npm run staging:sync`
+
+Copies production data into the staging Supabase project (`court-vision-preview`, ref `tztrsfefesacnbreerhp`), which exists so preview deploys can render realistic data without holding a credential that can write production.
+
+Rows stream directly between the two PostgREST endpoints — a full refresh is ~45k rows, dominated by `cardio_session_hr_samples`, and none of it passes through a CI log or an agent's memory.
+
+**Staging is a snapshot, not a mirror.** Nothing dual-writes to it: the OTbeat cron, the `log-workout` / `log-weight` skills, and the Apple Health import all target production only. So staging is stale from the moment a sync finishes, and it looks convincingly current — never read it to answer a question about the data.
+
+Semantics:
+
+- **Upsert** on each table's key, so production edits propagate (a corrected weight, a manual `class_type_override`, a hand-flipped `excluded`).
+- Rows existing **only** in staging survive, so hand-made test data isn't clobbered.
+- **Deletions do not propagate.** Accepted deliberately — a delete-aware sync needs a prune pass or a truncate-and-reload, and truncating would destroy the staging-only rows the previous point protects. Rebuild the project if that matters.
+
+Production often runs *ahead* of `main` (a branch's migration gets applied before its PR merges), so each row is projected onto the columns staging actually has; unknown columns are dropped and reported rather than 400-ing the table.
+
+`panel_runs` is deliberately not synced: it's service-role-only in production, and live-panel history doesn't affect what a preview renders.
+
+### Required env vars
+
+| Var | Why |
+|---|---|
+| `PROD_SUPABASE_URL` | Read source. |
+| `PROD_SUPABASE_ANON_KEY` | Anon suffices — every synced table has an RLS `using (true)` SELECT policy. The job must **never** hold production's service-role key; a workflow that can write production defeats the point of staging. |
+| `STAGING_SUPABASE_URL` | Write target. |
+| `STAGING_SUPABASE_SECRET_KEY` | Staging RLS grants anon SELECT only, and the OpenAPI schema endpoint used for column discovery requires a secret key. |
+
+Exits 0 on success, 1 if any table failed, 2 on missing config — including a guard that refuses to run when both URLs point at the same project.
+
+The `staging-sync` workflow runs it Sundays at 08:00 UTC (an hour after the OTbeat ingest, so a refresh includes that morning's classes) and on `workflow_dispatch` for "make staging current before I review this preview".
+
 ### Writing a migration
 
 1. Write the file first, `<version>_<name>.sql`. The `<name>` must match the name you apply it under — it's the only key tying the file to the ledger.

--- a/scripts/sync-staging.mjs
+++ b/scripts/sync-staging.mjs
@@ -1,0 +1,207 @@
+/**
+ * Refresh the staging Supabase project from production.
+ *
+ * Staging (`court-vision-preview`) exists so preview deploys can render real
+ * data without holding a credential that can write production. Its contents are
+ * a **point-in-time copy**, not a live mirror — nothing dual-writes to it. The
+ * nightly OTbeat ingest, the log-workout/log-weight skills, and the Apple Health
+ * import all target production only, so staging goes stale between runs of this
+ * script. Treat it as a rehearsal dataset, never as a source of truth: if you
+ * want to know how many classes you did in July, ask production.
+ *
+ * Rows stream directly between the two PostgREST endpoints, so a full refresh
+ * (~45k rows, dominated by cardio_session_hr_samples) never passes through a
+ * caller's memory or a CI log.
+ *
+ * Semantics, and their limits:
+ * - **Upsert**, resolving on each table's key, so edits made in production
+ *   propagate — a corrected weight, a manual `class_type_override`, an
+ *   `excluded` flag flipped by hand.
+ * - Rows that exist **only** in staging are left alone, so hand-made test data
+ *   survives a refresh.
+ * - **Deletions do not propagate.** A row deleted in production lingers in
+ *   staging until the project is rebuilt. Accepted deliberately: a delete-aware
+ *   sync means either a prune pass or a truncate-and-reload, and truncating
+ *   would destroy the staging-only test rows the previous point protects.
+ *
+ * Column drift is handled: production frequently runs *ahead* of `main`, because
+ * a feature branch's migration is applied to production before its PR merges.
+ * Each row is projected onto the columns staging actually has, so an unknown
+ * column is dropped rather than 400-ing the whole table.
+ *
+ * Requires (see scripts/README.md):
+ *   PROD_SUPABASE_URL, PROD_SUPABASE_ANON_KEY   — read; anon suffices, every
+ *                                                 synced table is anon-readable
+ *   STAGING_SUPABASE_URL, STAGING_SUPABASE_SECRET_KEY — write; RLS grants anon
+ *                                                 SELECT only, and the OpenAPI
+ *                                                 schema endpoint requires a
+ *                                                 secret key
+ */
+
+const PROD_URL = process.env.PROD_SUPABASE_URL?.replace(/\/$/, '')
+const PROD_KEY = process.env.PROD_SUPABASE_ANON_KEY
+const STAGING_URL = process.env.STAGING_SUPABASE_URL?.replace(/\/$/, '')
+const STAGING_KEY = process.env.STAGING_SUPABASE_SECRET_KEY
+
+/** PostgREST caps an unbounded select at `max_rows`; always page explicitly. */
+const READ_PAGE = 1000
+
+/** Rows per write request — keeps bodies comfortably under the size limit. */
+const WRITE_BATCH = 500
+
+/**
+ * Tables to copy, **parents before children** so foreign keys resolve
+ * (cardio_sessions → cardio_session_hr_samples, weight_room_goals →
+ * weight_room_sets). `conflict` is the key upserts resolve on.
+ *
+ * `panel_runs` is deliberately absent: it's service-role-only in production so
+ * the anon read would return nothing, and live-panel run history has no bearing
+ * on what a preview deploy renders.
+ */
+const TABLES = [
+  { name: 'movement_benchmarks', conflict: 'date' },
+  { name: 'cardio_sessions', conflict: 'started_at' },
+  { name: 'cardio_session_hr_samples', conflict: 'session_started_at,sample_at' },
+  { name: 'cardio_resting_hr', conflict: 'date' },
+  { name: 'cardio_vo2max', conflict: 'date' },
+  { name: 'cardio_hrv_trend', conflict: 'date' },
+  { name: 'cardio_walking_hr_trend', conflict: 'date' },
+  { name: 'cardio_body_mass_trend', conflict: 'date' },
+  { name: 'cardio_step_count_trend', conflict: 'date' },
+  { name: 'cardio_sleep_trend', conflict: 'date' },
+  { name: 'cardio_active_energy_trend', conflict: 'date' },
+  { name: 'otf_sessions', conflict: 'started_at' },
+  { name: 'otf_mileage_awards', conflict: 'label' },
+  { name: 'weight_room_goals', conflict: 'exercise' },
+  { name: 'weight_room_achievements', conflict: 'id' },
+  { name: 'weight_room_monthly_focus', conflict: 'id' },
+  { name: 'weight_room_sets', conflict: 'id' },
+]
+
+/**
+ * Column names per table as they exist in **staging**, read from PostgREST's
+ * OpenAPI document. That endpoint requires a secret key, which is why the
+ * staging side can't run on the publishable key.
+ *
+ * @returns {Promise<Record<string, string[]>>} table name → column names.
+ * @throws {Error} when the schema can't be read.
+ */
+async function stagingColumns() {
+  const res = await fetch(`${STAGING_URL}/rest/v1/`, {
+    headers: { apikey: STAGING_KEY, authorization: `Bearer ${STAGING_KEY}` },
+  })
+  if (!res.ok) {
+    throw new Error(`Could not read the staging schema: ${res.status} ${await res.text()}`)
+  }
+  const spec = await res.json()
+  const out = {}
+  for (const [table, def] of Object.entries(spec.definitions ?? {})) {
+    out[table] = Object.keys(def.properties ?? {})
+  }
+  return out
+}
+
+/** One page of rows from production. */
+async function readPage(table, offset) {
+  const res = await fetch(
+    `${PROD_URL}/rest/v1/${table}?select=*&limit=${READ_PAGE}&offset=${offset}`,
+    { headers: { apikey: PROD_KEY, authorization: `Bearer ${PROD_KEY}` } }
+  )
+  if (!res.ok) throw new Error(`read ${table} @${offset}: ${res.status} ${await res.text()}`)
+  return res.json()
+}
+
+/** Upsert a batch into staging, overwriting rows that share the conflict key. */
+async function writeBatch(table, conflict, rows) {
+  const res = await fetch(`${STAGING_URL}/rest/v1/${table}?on_conflict=${conflict}`, {
+    method: 'POST',
+    headers: {
+      apikey: STAGING_KEY,
+      authorization: `Bearer ${STAGING_KEY}`,
+      'content-type': 'application/json',
+      prefer: 'resolution=merge-duplicates,return=minimal',
+    },
+    body: JSON.stringify(rows),
+  })
+  if (!res.ok) throw new Error(`write ${table}: ${res.status} ${await res.text()}`)
+}
+
+/** Drop keys staging doesn't have, so production running ahead can't 400 a table. */
+function project(row, allowed) {
+  const out = {}
+  for (const k of allowed) if (k in row) out[k] = row[k]
+  return out
+}
+
+async function copyTable({ name, conflict }, allowed) {
+  let copied = 0
+  const dropped = new Set()
+  for (let offset = 0; ; offset += READ_PAGE) {
+    const page = await readPage(name, offset)
+    if (page.length === 0) break
+    for (const row of page) {
+      for (const k of Object.keys(row)) if (!allowed.includes(k)) dropped.add(k)
+    }
+    const rows = page.map((r) => project(r, allowed))
+    for (let i = 0; i < rows.length; i += WRITE_BATCH) {
+      await writeBatch(name, conflict, rows.slice(i, i + WRITE_BATCH))
+    }
+    copied += page.length
+    if (page.length < READ_PAGE) break
+  }
+  return { copied, dropped: [...dropped] }
+}
+
+async function main() {
+  const missing = [
+    ['PROD_SUPABASE_URL', PROD_URL],
+    ['PROD_SUPABASE_ANON_KEY', PROD_KEY],
+    ['STAGING_SUPABASE_URL', STAGING_URL],
+    ['STAGING_SUPABASE_SECRET_KEY', STAGING_KEY],
+  ]
+    .filter(([, v]) => !v)
+    .map(([k]) => k)
+  if (missing.length > 0) {
+    console.error(`✗ staging sync: missing ${missing.join(', ')}`)
+    process.exitCode = 2
+    return
+  }
+
+  // Refuse to run backwards. Overwriting production from staging would be
+  // unrecoverable, and the two URLs are one copy-paste apart.
+  if (PROD_URL === STAGING_URL) {
+    console.error('✗ staging sync: PROD and STAGING point at the same project — refusing.')
+    process.exitCode = 2
+    return
+  }
+
+  const schema = await stagingColumns()
+  let failed = 0
+  let total = 0
+
+  for (const table of TABLES) {
+    const allowed = schema[table.name]
+    if (!allowed) {
+      console.error(`✗ ${table.name}: not present in staging — apply the migration first`)
+      failed += 1
+      continue
+    }
+    try {
+      const { copied, dropped } = await copyTable(table, allowed)
+      total += copied
+      const note = dropped.length > 0 ? `  (dropped ahead-of-staging columns: ${dropped.join(', ')})` : ''
+      console.log(`${copied === 0 ? '·' : '✓'} ${table.name}: ${copied}${note}`)
+    } catch (err) {
+      console.error(`✗ ${table.name}: ${err.message}`)
+      failed += 1
+    }
+  }
+
+  console.log(`\n${failed === 0 ? '✓' : '!'} staging sync: ${total} rows across ${TABLES.length - failed}/${TABLES.length} tables.`)
+  if (failed > 0) process.exitCode = 1
+}
+
+main().catch((err) => {
+  console.error(err.message ?? err)
+  process.exitCode = 2
+})


### PR DESCRIPTION
## Answering the three questions that prompted this

**When does staging data get updated?** Previously: never. It was a hand-run snapshot. Now: weekly, plus on demand.

**Does the GitHub Action write to both?** No, and it shouldn't. `otbeat-ingest.yml` targets production only, as do `log-workout` and `log-weight` (both hardcode `ryxbnvhxxkrmsrmocume`). Dual-writing would mean deciding which project's failure fails the cron — and since staging tracks `main` while production tracks main-plus-unmerged-branches, a run healthy against production could fail against staging for reasons that aren't real. That's a recurring false alarm bolted onto the only scheduled job.

**Shadow or staging?** Neither, precisely — and that ambiguity was the actual risk. A shadow receives the same writes continuously. A staging environment usually has its own data. This is a **point-in-time copy**: staging's purpose with a shadow's content, so it *looks* authoritative and won't be. The docs now say "never read staging to answer a question about the data" in as many words.

## What's here

- **`scripts/sync-staging.mjs`** — streams rows directly between the two PostgREST endpoints, so a ~45k-row refresh never lands in a CI log or an agent's context.
- **`.github/workflows/staging-sync.yml`** — Sundays 08:00 UTC (an hour after the OTbeat ingest, so a refresh includes that morning's classes) plus `workflow_dispatch`.
- **Docs in three places** so a future session can't miss it: `CLAUDE.md` (always in context), `scripts/README.md`, `docs/architecture.md`.

## Semantics, and their limits

- **Upsert** — production edits propagate (a corrected weight, a manual `class_type_override`, a hand-flipped `excluded`).
- Staging-only rows **survive**, so hand-made test data isn't clobbered.
- **Deletions do not propagate.** Deliberate: a delete-aware sync needs a prune pass or truncate-and-reload, and truncating would destroy the test rows the previous point protects.

## Two things worth reviewing

**Reads use production's ANON key, never its service-role key.** A scheduled workflow that can write production defeats the entire point of standing up staging. Every synced table has an RLS `using (true)` SELECT policy, so anon is sufficient.

**Production routinely runs ahead of `main`** — a branch's migration is applied before its PR merges. That's how the first hand-run seed hit a 400 on `weight_room_goals.load_multiplier`. Rows are now projected onto the columns staging actually has, with dropped columns reported rather than silently swallowed.

## Also done outside this diff

Applied `main`'s five outstanding weight-room migrations to staging — the drift check named them exactly, which is what makes two projects tractable rather than guesswork. Staging now reports `✓ migrations in sync — 22 committed, all applied`.

## Verification

- Full suite **1521 passed**, 132 files; `tsc` 0 errors in source; eslint clean
- Config guard and same-project refusal both exit 2 as intended
- Workflow confirmed to reference no production service-role secret

**Untested end to end.** The copy path needs `STAGING_SUPABASE_SECRET_KEY`, which only exists in the Supabase dashboard — the staging RLS grants anon SELECT only, and PostgREST's OpenAPI endpoint (used for column discovery) requires a secret key. Add it as a repo secret along with `STAGING_SUPABASE_URL`, then the first `workflow_dispatch` is the real test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)