### PR TITLE
fix(staging): replace, don't upsert, the uuid-keyed seeded tables

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -200,6 +200,12 @@ Semantics:
 - Rows existing **only** in staging survive, so hand-made test data isn't clobbered.
 - **Deletions do not propagate.** Accepted deliberately — a delete-aware sync needs a prune pass or a truncate-and-reload, and truncating would destroy the staging-only rows the previous point protects. Rebuild the project if that matters.
 
+Two tables use `mode: 'replace'` (clear staging, then insert production verbatim) rather than upsert: `weight_room_achievements` and `weight_room_monthly_focus`. Both have a `gen_random_uuid()` primary key **and** are seeded by a migration, so each project generates its *own* id for the same logical row. Upserting on `id` therefore never matches, and the follow-up insert either trips a unique business-key index or — where none exists — silently duplicates the row. That's not hypothetical: the first real run 409'd on `weight_room_achievements` and had quietly left staging with two July shrugs focuses against production's one.
+
+Conflicting on the natural key instead isn't available: `weight_room_achievements` enforces uniqueness through two *partial* indexes (`where exercise is not null` / `where exercise is null`), and PostgREST's `on_conflict` can't supply an index predicate. Replace avoids inference entirely and carries production's ids over, so row identity is stable across projects.
+
+Only mark a table `replace` if losing staging-only rows in it is acceptable — these two are reference data nobody hand-edits.
+
 Production often runs *ahead* of `main` (a branch's migration gets applied before its PR merges), so each row is projected onto the columns staging actually has; unknown columns are dropped and reported rather than 400-ing the table.
 
 `panel_runs` is deliberately not synced: it's service-role-only in production, and live-panel history doesn't affect what a preview renders.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -204,7 +204,9 @@ Two tables use `mode: 'replace'` (clear staging, then insert production verbatim
 
 Conflicting on the natural key instead isn't available: `weight_room_achievements` enforces uniqueness through two *partial* indexes (`where exercise is not null` / `where exercise is null`), and PostgREST's `on_conflict` can't supply an index predicate. Replace avoids inference entirely and carries production's ids over, so row identity is stable across projects.
 
-Only mark a table `replace` if losing staging-only rows in it is acceptable — these two are reference data nobody hand-edits.
+Replace reads the entire replacement set from production *before* deleting anything, so a transient read failure can't leave staging's reference table empty — which would render as "no badges" in a preview rather than as an error. That leaves one clear-then-insert window; closing it completely would take a transactional delete-and-insert RPC on staging, deliberately not built, since that's a migration on both projects to protect a table that a re-run rebuilds.
+
+Only mark a table `replace` if losing staging-only rows in it is acceptable — these two are reference data nobody hand-edits. It also buffers the whole table in memory, which is fine at ~93 rows and would not be for `cardio_session_hr_samples`.
 
 Production often runs *ahead* of `main` (a branch's migration gets applied before its PR merges), so each row is projected onto the columns staging actually has; unknown columns are dropped and reported rather than 400-ing the table.
 

--- a/scripts/sync-staging.mjs
+++ b/scripts/sync-staging.mjs
@@ -52,7 +52,33 @@ const WRITE_BATCH = 500
 /**
  * Tables to copy, **parents before children** so foreign keys resolve
  * (cardio_sessions → cardio_session_hr_samples, weight_room_goals →
- * weight_room_sets). `conflict` is the key upserts resolve on.
+ * weight_room_sets).
+ *
+ * `mode` picks how a table reconciles, and the choice follows from its key:
+ *
+ * - `upsert` (default) — resolve on `conflict`, a **natural** key that means the
+ *   same thing in both projects (`date`, `started_at`, `exercise`, `label`).
+ *   Safe because the same logical row carries the same key everywhere.
+ *
+ * - `replace` — delete staging's rows, then insert production's verbatim. For
+ *   tables whose primary key is a **`gen_random_uuid()` surrogate** *and* whose
+ *   rows are seeded by a migration: both projects run that migration
+ *   independently, so the same logical row gets a different id in each. Upserting
+ *   on `id` then never matches, and the insert either trips a unique business-key
+ *   index (weight_room_achievements: 409 on
+ *   `(exercise, scope, measure, threshold)`) or, worse, silently duplicates the
+ *   row where no such index exists — which is how staging ended up with two July
+ *   shrugs focuses against production's one.
+ *
+ *   PostgREST can't fix this by conflicting on the natural key instead:
+ *   weight_room_achievements' uniqueness lives in two *partial* indexes
+ *   (`where exercise is not null` / `where exercise is null`), and `on_conflict`
+ *   has no way to supply an index predicate. Replace sidesteps inference
+ *   entirely and has the side benefit of carrying production's ids across, so a
+ *   row's identity is stable between the two projects.
+ *
+ *   Only safe because these are reference tables nobody hand-edits in staging.
+ *   Never mark a table `replace` if you'd mind losing staging-only rows in it.
  *
  * `panel_runs` is deliberately absent: it's service-role-only in production so
  * the anon read would return nothing, and live-panel run history has no bearing
@@ -73,8 +99,10 @@ const TABLES = [
   { name: 'otf_sessions', conflict: 'started_at' },
   { name: 'otf_mileage_awards', conflict: 'label' },
   { name: 'weight_room_goals', conflict: 'exercise' },
-  { name: 'weight_room_achievements', conflict: 'id' },
-  { name: 'weight_room_monthly_focus', conflict: 'id' },
+  { name: 'weight_room_achievements', mode: 'replace', key: 'id' },
+  { name: 'weight_room_monthly_focus', mode: 'replace', key: 'id' },
+  // Real logged data, not migration-seeded: its uuids originate in production
+  // and nothing regenerates them in staging, so upserting on id is correct.
   { name: 'weight_room_sets', conflict: 'id' },
 ]
 
@@ -126,6 +154,39 @@ async function writeBatch(table, conflict, rows) {
   if (!res.ok) throw new Error(`write ${table}: ${res.status} ${await res.text()}`)
 }
 
+/** Plain insert, no conflict resolution — for `replace` tables, post-clear. */
+async function insertBatch(table, rows) {
+  const res = await fetch(`${STAGING_URL}/rest/v1/${table}`, {
+    method: 'POST',
+    headers: {
+      apikey: STAGING_KEY,
+      authorization: `Bearer ${STAGING_KEY}`,
+      'content-type': 'application/json',
+      prefer: 'return=minimal',
+    },
+    body: JSON.stringify(rows),
+  })
+  if (!res.ok) throw new Error(`insert ${table}: ${res.status} ${await res.text()}`)
+}
+
+/**
+ * Empty a staging table ahead of a `replace` copy.
+ *
+ * PostgREST refuses an unfiltered DELETE, so filter on the key being non-null —
+ * true for every row, since it's the primary key.
+ */
+async function clearTable(table, key) {
+  const res = await fetch(`${STAGING_URL}/rest/v1/${table}?${key}=not.is.null`, {
+    method: 'DELETE',
+    headers: {
+      apikey: STAGING_KEY,
+      authorization: `Bearer ${STAGING_KEY}`,
+      prefer: 'return=minimal',
+    },
+  })
+  if (!res.ok) throw new Error(`clear ${table}: ${res.status} ${await res.text()}`)
+}
+
 /** Drop keys staging doesn't have, so production running ahead can't 400 a table. */
 function project(row, allowed) {
   const out = {}
@@ -133,9 +194,12 @@ function project(row, allowed) {
   return out
 }
 
-async function copyTable({ name, conflict }, allowed) {
+async function copyTable({ name, conflict, mode, key }, allowed) {
   let copied = 0
   const dropped = new Set()
+  // Clear before the first insert, not after reading — a `replace` table is
+  // small reference data, so the window where staging is empty is negligible.
+  if (mode === 'replace') await clearTable(name, key)
   for (let offset = 0; ; offset += READ_PAGE) {
     const page = await readPage(name, offset)
     if (page.length === 0) break
@@ -144,12 +208,14 @@ async function copyTable({ name, conflict }, allowed) {
     }
     const rows = page.map((r) => project(r, allowed))
     for (let i = 0; i < rows.length; i += WRITE_BATCH) {
-      await writeBatch(name, conflict, rows.slice(i, i + WRITE_BATCH))
+      const batch = rows.slice(i, i + WRITE_BATCH)
+      if (mode === 'replace') await insertBatch(name, batch)
+      else await writeBatch(name, conflict, batch)
     }
     copied += page.length
     if (page.length < READ_PAGE) break
   }
-  return { copied, dropped: [...dropped] }
+  return { copied, dropped: [...dropped], mode: mode ?? 'upsert' }
 }
 
 async function main() {
@@ -187,10 +253,11 @@ async function main() {
       continue
     }
     try {
-      const { copied, dropped } = await copyTable(table, allowed)
+      const { copied, dropped, mode } = await copyTable(table, allowed)
       total += copied
       const note = dropped.length > 0 ? `  (dropped ahead-of-staging columns: ${dropped.join(', ')})` : ''
-      console.log(`${copied === 0 ? '·' : '✓'} ${table.name}: ${copied}${note}`)
+      const how = mode === 'replace' ? ' [replaced]' : ''
+      console.log(`${copied === 0 ? '·' : '✓'} ${table.name}: ${copied}${how}${note}`)
     } catch (err) {
       console.error(`✗ ${table.name}: ${err.message}`)
       failed += 1

--- a/scripts/sync-staging.mjs
+++ b/scripts/sync-staging.mjs
@@ -195,27 +195,53 @@ function project(row, allowed) {
 }
 
 async function copyTable({ name, conflict, mode, key }, allowed) {
-  let copied = 0
   const dropped = new Set()
-  // Clear before the first insert, not after reading — a `replace` table is
-  // small reference data, so the window where staging is empty is negligible.
-  if (mode === 'replace') await clearTable(name, key)
-  for (let offset = 0; ; offset += READ_PAGE) {
-    const page = await readPage(name, offset)
-    if (page.length === 0) break
+  const noteDropped = (page) => {
     for (const row of page) {
       for (const k of Object.keys(row)) if (!allowed.includes(k)) dropped.add(k)
     }
+  }
+
+  if (mode === 'replace') {
+    // Read the whole replacement set BEFORE deleting anything (codex/CodeRabbit
+    // #344). Clearing first meant a transient read failure left staging's
+    // reference table empty until the next successful sync — and since these
+    // tables drive the Trophy Room, empty renders as "no badges" in a preview
+    // rather than as an error. Buffering is fine here and nowhere else: replace
+    // is reserved for small reference tables (~93 rows), while the streaming
+    // path below has to cope with 37k HR samples.
+    const rows = []
+    for (let offset = 0; ; offset += READ_PAGE) {
+      const page = await readPage(name, offset)
+      if (page.length === 0) break
+      noteDropped(page)
+      rows.push(...page.map((r) => project(r, allowed)))
+      if (page.length < READ_PAGE) break
+    }
+    await clearTable(name, key)
+    for (let i = 0; i < rows.length; i += WRITE_BATCH) {
+      await insertBatch(name, rows.slice(i, i + WRITE_BATCH))
+    }
+    // Residual exposure is now one clear + one insert request for a table this
+    // size. Closing it fully would need a transactional delete-and-insert RPC on
+    // staging — deliberately not built: that's a migration on both projects to
+    // protect a rebuildable staging table, and re-running the sync fixes it.
+    return { copied: rows.length, dropped: [...dropped], mode }
+  }
+
+  let copied = 0
+  for (let offset = 0; ; offset += READ_PAGE) {
+    const page = await readPage(name, offset)
+    if (page.length === 0) break
+    noteDropped(page)
     const rows = page.map((r) => project(r, allowed))
     for (let i = 0; i < rows.length; i += WRITE_BATCH) {
-      const batch = rows.slice(i, i + WRITE_BATCH)
-      if (mode === 'replace') await insertBatch(name, batch)
-      else await writeBatch(name, conflict, batch)
+      await writeBatch(name, conflict, rows.slice(i, i + WRITE_BATCH))
     }
     copied += page.length
     if (page.length < READ_PAGE) break
   }
-  return { copied, dropped: [...dropped], mode: mode ?? 'upsert' }
+  return { copied, dropped: [...dropped], mode: 'upsert' }
 }
 
 async function main() {


### PR DESCRIPTION
## What the first real run caught

Dispatching #343's workflow for the first time surfaced a bug no dry run could have. Tables whose primary key is a `gen_random_uuid()` surrogate **and** whose rows come from a migration seed get a **different id in each project** — both run the same migration independently.

Upserting on `id` therefore never matches an existing row, and the follow-up insert fails one of two ways:

| Table | Failure |
|---|---|
| `weight_room_achievements` | **409**, unique index on `(exercise, scope, measure, threshold)` |
| `weight_room_monthly_focus` | no such index — **silently duplicated** |

The quiet one is the reason to fix the class rather than special-case the 409. Staging was sitting at **2 July shrugs focuses against production's 1**, which would have rendered as a real bug in a preview and been blamed on the feature rather than the sync.

## Fix

Both now use `mode: 'replace'` — clear staging, insert production verbatim.

Conflicting on the natural key instead isn't available: `weight_room_achievements` enforces uniqueness through two **partial** indexes (`where exercise is not null` / `where exercise is null`), and PostgREST's `on_conflict` can't supply an index predicate. Replace avoids inference entirely, and carries production's ids across so row identity is finally stable between projects.

`weight_room_sets` deliberately keeps upserting on `id` — its uuids originate in production and nothing regenerates them in staging, so the key means the same thing on both sides.

## Verified against the real thing

Dispatched this branch's workflow directly (the file is on `main` now, so `--ref` works):

```
✓ weight_room_achievements: 93 [replaced]
✓ weight_room_monthly_focus: 1 [replaced]
✓ staging sync: 48514 rows across 17/17 tables.
```

Previous run: 16/17, exit 1. Row counts then confirmed identical between staging and production across `weight_room_achievements` (93), `weight_room_monthly_focus` (1 — duplicate gone), `otf_sessions` (38), `weight_room_sets` (1060), `cardio_session_hr_samples` (37296).

`scripts/README.md` documents the distinction, including when **not** to mark a table `replace` — it discards staging-only rows, so it suits reference data only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved staging synchronization for selected reference tables by replacing existing rows before copying data.
  * Prevented duplicate records and conflicts caused by mismatched generated identifiers across environments.

* **Documentation**
  * Clarified when replacement synchronization is used and documented its handling of staging-only data.
  * Added clearer runtime indicators for tables synchronized using replacement mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->