### PR TITLE
fix(admin): answer 503 when a deployment has no write credentials

### DIFF
--- a/app/api/admin/cardio/trends/route.test.ts
+++ b/app/api/admin/cardio/trends/route.test.ts
@@ -12,14 +12,23 @@ const upsertMock = vi.fn()
 const selectMock = vi.fn()
 const fromMock = vi.fn()
 
+/**
+ * Whether this "deployment" holds write credentials. Mocked rather than driven
+ * by env vars so the preview-deployment case is exercised directly.
+ */
+const canWriteMock = vi.fn<() => boolean>()
+
 vi.mock('@/lib/supabase/admin', () => ({
   createAdminSupabaseClient: () => ({
     from: fromMock,
   }),
+  canPerformAdminWrites: () => canWriteMock(),
 }))
 
 beforeEach(() => {
   vi.resetAllMocks()
+  // Default: a deployment that can write (production). The 503 case overrides.
+  canWriteMock.mockReturnValue(true)
   // Default: successful upsert
   selectMock.mockResolvedValue({
     error: null,
@@ -222,6 +231,43 @@ describe('POST /api/admin/cardio/trends', () => {
       headers: {
         'Content-Type': 'application/json',
         'X-Cardio-Trends-Key': 'any-key',
+      },
+      body: JSON.stringify({ date: '2026-07-01', metric: 'body_mass', value: 233.8 }),
+    })
+    const res = await POST(req as NextRequest)
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 503 on a deployment without write credentials, never touching Supabase', async () => {
+    // The preview-deployment case: authenticated, but no service-role key. This
+    // route can't use requireAdmin (it authenticates by API key), so it carries
+    // the capability gate itself.
+    vi.stubEnv('CARDIO_TRENDS_API_KEY', 'valid-key')
+    canWriteMock.mockReturnValue(false)
+    const req = new Request('http://localhost:3000/api/admin/cardio/trends', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Cardio-Trends-Key': 'valid-key',
+      },
+      body: JSON.stringify({ date: '2026-07-01', metric: 'body_mass', value: 233.8 }),
+    })
+    const res = await POST(req as NextRequest)
+    expect(res.status).toBe(503)
+    const body = await res.json()
+    expect(body.error).toMatch(/unavailable on this deployment/i)
+    // Short-circuits before any client is built, so no write is attempted.
+    expect(fromMock).not.toHaveBeenCalled()
+  })
+
+  it('checks auth before write capability, so config is not disclosed unauthenticated', async () => {
+    vi.stubEnv('CARDIO_TRENDS_API_KEY', 'valid-key')
+    canWriteMock.mockReturnValue(false)
+    const req = new Request('http://localhost:3000/api/admin/cardio/trends', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Cardio-Trends-Key': 'wrong-key',
       },
       body: JSON.stringify({ date: '2026-07-01', metric: 'body_mass', value: 233.8 }),
     })

--- a/app/api/admin/cardio/trends/route.ts
+++ b/app/api/admin/cardio/trends/route.ts
@@ -18,11 +18,12 @@ import { ZodError } from 'zod'
 import { z } from 'zod'
 
 import { validateApiKey } from '@/lib/api/validate-api-key'
+import { ADMIN_WRITES_UNAVAILABLE } from '@/lib/auth/require-admin'
 import {
   CARDIO_METRIC_TABLES,
   type CardioMetric,
 } from '@/lib/schemas/cardio-sync'
-import { createAdminSupabaseClient } from '@/lib/supabase/admin'
+import { canPerformAdminWrites, createAdminSupabaseClient } from '@/lib/supabase/admin'
 
 /** The accepted metric keys, derived from the canonical table map. */
 const CARDIO_METRICS = Object.keys(CARDIO_METRIC_TABLES) as [
@@ -62,6 +63,15 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   // Auth check
   if (!validateApiKey(request, 'X-Cardio-Trends-Key', 'CARDIO_TRENDS_API_KEY')) {
     return NextResponse.json({ error: 'Unauthorized.' }, { status: 401 })
+  }
+
+  // This route authenticates by API key rather than session, so it can't use
+  // `requireAdmin` and needs the same write-capability gate explicitly — a
+  // preview deployment carries no service-role key, and the client factory would
+  // otherwise throw into a 500. Checked after auth so an unauthenticated caller
+  // learns nothing about how the deployment is configured.
+  if (!canPerformAdminWrites()) {
+    return NextResponse.json({ error: ADMIN_WRITES_UNAVAILABLE }, { status: 503 })
   }
 
   // Parse request body

--- a/lib/auth/require-admin.test.ts
+++ b/lib/auth/require-admin.test.ts
@@ -21,6 +21,10 @@ vi.mock('@/lib/supabase/server', () => ({
 
 beforeEach(() => {
   getUserMock.mockReset()
+  // The gate now also requires the service-role credential, so the default for
+  // every case is "writes are possible" — the 503 tests clear it explicitly.
+  vi.stubEnv('NEXT_PUBLIC_SUPABASE_URL', 'https://project.supabase.co')
+  vi.stubEnv('SUPABASE_SERVICE_ROLE_KEY', 'srv_key')
 })
 
 afterEach(() => {
@@ -37,6 +41,58 @@ describe('requireAdmin', () => {
     const result = await requireAdmin()
     expect(result.ok).toBe(true)
     if (result.ok) expect(result.email).toBe('lucas@example.com')
+  })
+
+  describe('write-capability gate (preview deployments)', () => {
+    it('returns 503 for an allowlisted admin when the service-role key is absent', async () => {
+      vi.stubEnv('ADMIN_EMAILS', 'lucas@example.com')
+      vi.stubEnv('SUPABASE_SERVICE_ROLE_KEY', '')
+      getUserMock.mockResolvedValueOnce({
+        data: { user: { email: 'lucas@example.com' } },
+        error: null,
+      })
+      const result = await requireAdmin()
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        // 503, not the opaque 500 the client factory used to throw into.
+        expect(result.response.status).toBe(503)
+        const body = await result.response.json()
+        expect(body.error).toMatch(/unavailable on this deployment/i)
+      }
+    })
+
+    it('returns 503 when the Supabase URL is absent', async () => {
+      vi.stubEnv('ADMIN_EMAILS', 'lucas@example.com')
+      vi.stubEnv('NEXT_PUBLIC_SUPABASE_URL', '')
+      getUserMock.mockResolvedValueOnce({
+        data: { user: { email: 'lucas@example.com' } },
+        error: null,
+      })
+      const result = await requireAdmin()
+      expect(result.ok).toBe(false)
+      if (!result.ok) expect(result.response.status).toBe(503)
+    })
+
+    it('still answers 401 before 503 — config is not disclosed to anonymous callers', async () => {
+      vi.stubEnv('ADMIN_EMAILS', 'lucas@example.com')
+      vi.stubEnv('SUPABASE_SERVICE_ROLE_KEY', '')
+      getUserMock.mockResolvedValueOnce({ data: { user: null }, error: null })
+      const result = await requireAdmin()
+      expect(result.ok).toBe(false)
+      if (!result.ok) expect(result.response.status).toBe(401)
+    })
+
+    it('still answers 403 before 503 for a signed-in non-admin', async () => {
+      vi.stubEnv('ADMIN_EMAILS', 'lucas@example.com')
+      vi.stubEnv('SUPABASE_SERVICE_ROLE_KEY', '')
+      getUserMock.mockResolvedValueOnce({
+        data: { user: { email: 'intruder@example.com' } },
+        error: null,
+      })
+      const result = await requireAdmin()
+      expect(result.ok).toBe(false)
+      if (!result.ok) expect(result.response.status).toBe(403)
+    })
   })
 
   it('returns 401 when no session is present', async () => {

--- a/lib/auth/require-admin.ts
+++ b/lib/auth/require-admin.ts
@@ -2,7 +2,17 @@ import 'server-only'
 
 import { NextResponse } from 'next/server'
 
+import { canPerformAdminWrites } from '@/lib/supabase/admin'
 import { resolveAdminSession } from './admin-session'
+
+/**
+ * Message returned with the 503 when a deployment has no write credentials.
+ * Shared so the API-key-authenticated routes, which don't use
+ * {@link requireAdmin}, answer identically.
+ */
+export const ADMIN_WRITES_UNAVAILABLE =
+  'Admin writes are unavailable on this deployment. Preview deployments read staging data ' +
+  'and intentionally carry no write credentials.'
 
 /**
  * Result of an admin-authorization check on an incoming request.
@@ -10,16 +20,18 @@ import { resolveAdminSession } from './admin-session'
  * - `ok: true` — the caller is signed in and on the allowlist; `email`
  *   is the verified admin email.
  * - `ok: false` — the caller is rejected; `response` is a ready-to-return
- *   `NextResponse` (401 if not signed in, 403 if signed in but not admin).
+ *   `NextResponse` (401 if not signed in, 403 if signed in but not admin,
+ *   503 if admin writes are unavailable on this deployment).
  */
 export type AdminCheck =
   | { ok: true; email: string }
   | { ok: false; response: NextResponse }
 
 /**
- * Verify the current request is from an admin. Reads the Supabase
- * session from cookies, then checks the user's verified email against
- * the {@link getAdminAllowlist} list.
+ * Verify the current request may perform an admin write. Reads the Supabase
+ * session from cookies, checks the user's verified email against the
+ * {@link getAdminAllowlist} list, then confirms this deployment actually holds
+ * the service-role credential such a write needs.
  *
  * Use at the top of every `/api/admin/*` route handler:
  *
@@ -29,8 +41,19 @@ export type AdminCheck =
  * // ... continue with admin-only work
  * ```
  *
- * @throws when Supabase env vars are missing (misconfiguration). Auth
- *   failure (no session, wrong email) is returned as `{ ok: false }`.
+ * **Why the capability check lives here.** Every caller goes on to build a
+ * service-role client, so a deployment without that credential can only fail —
+ * previously by throwing out of {@link createAdminSupabaseClient} into an opaque
+ * 500. Preview deployments are exactly that case *by design*: they ship without
+ * `SUPABASE_SERVICE_ROLE_KEY` so pull-request code, which is auto-deployed and
+ * unreviewed, cannot write any database. Answering 503 turns a stack trace into
+ * a stated limitation.
+ *
+ * Auth is checked **before** capability deliberately: an anonymous caller gets
+ * 401, never a 503 that would disclose how the deployment is configured.
+ *
+ * @throws when the Supabase *read* env vars are missing (misconfiguration). Auth
+ *   failure and absent write credentials are returned as `{ ok: false }`.
  */
 export async function requireAdmin(): Promise<AdminCheck> {
   const { signedIn, email, isAdmin } = await resolveAdminSession()
@@ -44,6 +67,12 @@ export async function requireAdmin(): Promise<AdminCheck> {
     return {
       ok: false,
       response: NextResponse.json({ error: 'Admin only.' }, { status: 403 }),
+    }
+  }
+  if (!canPerformAdminWrites()) {
+    return {
+      ok: false,
+      response: NextResponse.json({ error: ADMIN_WRITES_UNAVAILABLE }, { status: 503 }),
     }
   }
   // `isAdmin` is only true when the allowlist matched a non-null email.

--- a/lib/supabase/admin.test.ts
+++ b/lib/supabase/admin.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { createAdminSupabaseClient } from './admin'
+import { canPerformAdminWrites, createAdminSupabaseClient } from './admin'
 
 const createClientMock =
   vi.fn<(url: string, key: string, options?: unknown) => unknown>(() => ({
@@ -47,5 +47,33 @@ describe('createAdminSupabaseClient', () => {
         },
       },
     )
+  })
+})
+
+describe('canPerformAdminWrites', () => {
+  it('is true when both credentials are present', () => {
+    vi.stubEnv('NEXT_PUBLIC_SUPABASE_URL', 'https://abc.supabase.co')
+    vi.stubEnv('SUPABASE_SERVICE_ROLE_KEY', 'srv_key')
+    expect(canPerformAdminWrites()).toBe(true)
+  })
+
+  it('is false without a service-role key — the preview-deployment case', () => {
+    vi.stubEnv('NEXT_PUBLIC_SUPABASE_URL', 'https://abc.supabase.co')
+    vi.stubEnv('SUPABASE_SERVICE_ROLE_KEY', '')
+    expect(canPerformAdminWrites()).toBe(false)
+  })
+
+  it('is false without a URL', () => {
+    vi.stubEnv('NEXT_PUBLIC_SUPABASE_URL', '')
+    vi.stubEnv('SUPABASE_SERVICE_ROLE_KEY', 'srv_key')
+    expect(canPerformAdminWrites()).toBe(false)
+  })
+
+  it('treats whitespace-only values as absent, matching the client factory', () => {
+    vi.stubEnv('NEXT_PUBLIC_SUPABASE_URL', 'https://abc.supabase.co')
+    vi.stubEnv('SUPABASE_SERVICE_ROLE_KEY', '   ')
+    expect(canPerformAdminWrites()).toBe(false)
+    // The factory rejects the same value, so the two can never disagree.
+    expect(() => createAdminSupabaseClient()).toThrow(/SUPABASE_SERVICE_ROLE_KEY/)
   })
 })

--- a/lib/supabase/admin.ts
+++ b/lib/supabase/admin.ts
@@ -4,6 +4,24 @@ import { createClient } from '@supabase/supabase-js'
 import type { SupabaseClient } from '@supabase/supabase-js'
 
 /**
+ * Whether this deployment holds the credentials {@link createAdminSupabaseClient}
+ * needs — i.e. whether admin writes are possible here at all.
+ *
+ * Preview deployments deliberately ship **without** `SUPABASE_SERVICE_ROLE_KEY`:
+ * they're built from pull-request code and auto-deployed, so a write credential
+ * there is reachable by unreviewed code. Previews therefore read the staging
+ * project and cannot write anywhere. Callers use this to answer with a clean 503
+ * instead of letting {@link createAdminSupabaseClient} throw into a 500.
+ *
+ * Checks the same two vars the factory does, so the two can't disagree.
+ */
+export function canPerformAdminWrites(): boolean {
+  return Boolean(
+    process.env.NEXT_PUBLIC_SUPABASE_URL?.trim() && process.env.SUPABASE_SERVICE_ROLE_KEY?.trim()
+  )
+}
+
+/**
  * Service-role Supabase client. Bypasses RLS — only call from
  * server-side code (route handlers, server actions). Importing this
  * module from a client component would bundle the secret key into the


### PR DESCRIPTION
## Why

Preview deployments no longer carry `SUPABASE_SERVICE_ROLE_KEY` (removed from Vercel Preview just now), so `createAdminSupabaseClient()` threw out of every admin write route into an opaque **500**. Reviewing a preview, the admin UI looked broken rather than deliberately limited.

## Fix

`requireAdmin()` now also verifies the deployment holds the credential, returning a **503** that says previews read staging and intentionally cannot write.

**Why there and not at each call site.** All 15 `requireAdmin()` callers are admin write routes that go on to build a service-role client, so a deployment without that credential can only fail. There is no caller the check would falsely reject. The page guard (`require-admin-page`) and the `/api/admin/check` probe use different functions and are untouched — so the admin UI still correctly reports *who you are*, it just can't write.

**Order is deliberate:** auth first, capability second. An anonymous caller gets 401, never a 503 that would disclose how the deployment is configured. Tested in both directions (401-before-503 and 403-before-503).

## Two things I considered and rejected

**`withTelemetry`** wraps every admin route and looked like a tempting single chokepoint. Its contract explicitly promises that wrapping "cannot change a handler's behavior: responses pass through untouched and thrown errors re-throw" — converting a throw into a 503 would break that, and telemetry has no business owning configuration semantics.

**A guard at each call site** (17 sites / 14 files) would have been mechanical churn for the same result, with the risk of one route being missed.

## Scope note

`cardio/admin/trends` authenticates by API key rather than session, so it can't use `requireAdmin` and carries the gate explicitly, sharing the message constant so both paths answer identically. It's the only such route.

`canPerformAdminWrites()` checks the same two vars the client factory does, including the whitespace trim — with a test asserting both reject the same value, so the predicate and the factory can't drift apart.

## Verification

- Full suite **1551 passed**, 133 files (up from 1540; 11 new tests)
- `tsc --noEmit` 0 errors in source; eslint clean
- The `cardio/trends` 503 test asserts `fromMock` was never called — it short-circuits before any client is built

🤖 Generated with [Claude Code](https://claude.com/claude-code)