### PR TITLE
fix(court): inline the centre-court logo so its ring text renders on mobile

### DIFF
--- a/components/common/LogoSvg.test.tsx
+++ b/components/common/LogoSvg.test.tsx
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+import { render } from '@testing-library/react'
+
+import { LogoSvg } from './LogoSvg'
+
+/**
+ * The regression these pin: the logo used to render as
+ * `<use href="/common/LogoSvg.svg#LogoSvg">`, whose shadow tree resolved its
+ * `textPath` and `filter` fragments against the host document — where those ids
+ * did not exist. iOS Safari dropped them, so the ring text disappeared on
+ * mobile while the rest of the mark still drew.
+ *
+ * Every assertion here is really one question: does each fragment reference
+ * point at an element that is present in the same rendered output?
+ */
+describe('LogoSvg', () => {
+  it('renders the mark inline rather than referencing an external file', () => {
+    const { container } = render(<LogoSvg />)
+    expect(container.querySelector('use')).toBeNull()
+    expect(container.querySelector('svg')).toBeInTheDocument()
+  })
+
+  it('resolves every fragment reference within its own output', () => {
+    const { container } = render(<LogoSvg />)
+    const svg = container.querySelector('svg') as SVGSVGElement
+
+    const referenced = [
+      ...[...svg.querySelectorAll('[filter]')].map(el =>
+        (el.getAttribute('filter') ?? '').replace(/^url\(#/, '').replace(/\)$/, ''),
+      ),
+      ...[...svg.querySelectorAll('textPath')].map(el =>
+        (el.getAttribute('href') ?? '').replace(/^#/, ''),
+      ),
+    ].filter(Boolean)
+
+    // Sanity: the mark does use fragments, so an empty list would mean this
+    // test silently stopped checking anything.
+    expect(referenced.length).toBeGreaterThan(0)
+
+    for (const id of referenced) {
+      expect(svg.querySelector(`#${CSS.escape(id)}`)).not.toBeNull()
+    }
+  })
+
+  it('puts the ring text on the circular path', () => {
+    const { container } = render(<LogoSvg />)
+    const textPath = container.querySelector('textPath')
+    expect(textPath?.textContent).toMatch(/HOOPER/)
+    expect(textPath?.textContent).toMatch(/CODE STORYTELLER/)
+  })
+
+  it('keeps the two centred name lines', () => {
+    const { container } = render(<LogoSvg />)
+    const lines = [...container.querySelectorAll('text')]
+      .map(t => t.textContent?.trim())
+      .filter(t => t === 'LUCAS' || t === 'LAWRENCE')
+    expect(lines).toEqual(['LUCAS', 'LAWRENCE'])
+  })
+
+  it('is announced as a single labelled image', () => {
+    const { container } = render(<LogoSvg />)
+    const svg = container.querySelector('svg')
+    expect(svg).toHaveAttribute('role', 'img')
+    expect(svg).toHaveAttribute('aria-label', 'Lucas Lawrence')
+  })
+})

--- a/components/common/LogoSvg.tsx
+++ b/components/common/LogoSvg.tsx
@@ -1,27 +1,98 @@
 import { JSX } from 'react'
 
-import { SvgUse } from '@/components/common/SvgUse'
+/**
+ * ID prefix for this logo's internal defs.
+ *
+ * The ring text, the drop shadows and the arc all reference each other by
+ * document fragment, so the ids have to be unique within the page. They're
+ * namespaced rather than generated (`useId`) so this stays renderable from a
+ * Server Component — the court draws exactly one logo, so a fixed prefix is
+ * sufficient.
+ */
+const ID = 'lucas-logo'
+
+/** Phrases that circle the name. Trailing separator closes the loop visually. */
+const RING_TEXT =
+  'HOOPER • PATENT HOLDER • CREATIVE ENGINEER • HIP-HOP HEAD • ' +
+  'SYSTEMS THINKER • CODE STORYTELLER • FANTASY GM • RHYTHM FOCUSED •'
 
 /**
- * Renders a centered SVG logo for "Lucas Lawrence" with circular ring text.
+ * Centered "Lucas Lawrence" logo with circular ring text, drawn over centre
+ * court.
  *
- * - The name "LUCAS LAWRENCE" is centered in two lines.
- * - A circular path wraps descriptive phrases around the name using <textPath>.
- * - Designed to overlay cleanly on a basketball-themed SVG court.
- * - Uses non-breaking spaces to preserve spacing.
+ * - "LUCAS LAWRENCE" sits on two centred lines.
+ * - Descriptive phrases wrap around them on a circular `<textPath>`.
  *
- * Font: League Spartan (must be loaded separately via CSS or Google Fonts)
+ * **Inlined rather than referenced** from `/common/LogoSvg.svg` (#345
+ * follow-up). It used to render as `<use href="/common/LogoSvg.svg#LogoSvg">`,
+ * but a `<use>` pointing at an *external* file builds a shadow tree whose
+ * internal fragment references — `textPath href="#circlePath"`, and both
+ * `filter="url(…)"` — resolve against the *host* document, where those ids do
+ * not exist. Browsers disagree wildly about this and iOS Safari drops them, so
+ * the ring text vanished on mobile while the plain circle and the two straight
+ * lines (which reference nothing) still drew. Inlining puts the defs in the
+ * page that uses them, which is the only reliably portable arrangement.
  *
- * @returns {JSX.Element} SVG element representing the personal logo.
+ * Font: League Spartan, loaded globally; falls back to the system sans.
  */
 export function LogoSvg(): JSX.Element {
   return (
-    <SvgUse
-      href="/common/LogoSvg.svg#LogoSvg"
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 500 500"
       width="100%"
       height="100%"
       preserveAspectRatio="xMidYMid meet"
-    />
+      role="img"
+      aria-label="Lucas Lawrence"
+    >
+      <defs>
+        <filter id={`${ID}-text-shadow`} x="-50%" y="-50%" width="200%" height="200%">
+          <feDropShadow dx="0" dy="0" stdDeviation="1" floodColor="#fff" floodOpacity="0.15" />
+        </filter>
+        <filter id={`${ID}-ring-glow`} x="-50%" y="-50%" width="200%" height="200%">
+          <feDropShadow dx="0" dy="0" stdDeviation="10" floodColor="#fff" floodOpacity="0.3" />
+        </filter>
+        {/* Circle drawn as two arcs so the text has a continuous path to follow. */}
+        <path id={`${ID}-ring`} d="M50 250a200 200 0 1 1 400 0 200 200 0 1 1-400 0" />
+      </defs>
+
+      <circle cx="250" cy="250" r="200" fill="#3e1f0e" opacity="0.85" />
+
+      <text
+        fill="#f5f5f5"
+        filter={`url(#${ID}-ring-glow)`}
+        fontFamily="'League Spartan', sans-serif"
+        fontSize="13"
+        letterSpacing="2"
+      >
+        <textPath href={`#${ID}-ring`} startOffset="50%" textAnchor="middle">
+          {RING_TEXT}
+        </textPath>
+      </text>
+
+      <text
+        x="250"
+        y="235"
+        fill="#fff"
+        filter={`url(#${ID}-text-shadow)`}
+        fontFamily="'League Spartan', sans-serif"
+        fontSize="55"
+        textAnchor="middle"
+      >
+        LUCAS
+      </text>
+      <text
+        x="250"
+        y="295"
+        fill="#fff"
+        filter={`url(#${ID}-text-shadow)`}
+        fontFamily="'League Spartan', sans-serif"
+        fontSize="55"
+        textAnchor="middle"
+      >
+        LAWRENCE
+      </text>
+    </svg>
   )
 }


### PR DESCRIPTION
The circular text around "LUCAS LAWRENCE" was missing on iOS while the brown circle and the two straight name lines still drew.

## Cause

The reference mechanism, not the artwork. The logo rendered as:

```jsx
<use href="/common/LogoSvg.svg#LogoSvg" />
```

A `<use>` pointing at an **external** file builds a shadow tree whose internal fragment references resolve against the **host** document — where `#circlePath`, `#ringGlow` and `#textShadow` don't exist. Browsers disagree badly about this and iOS Safari drops them.

That predicts exactly the reported symptom: the parts depending on a fragment vanish (`textPath` and both drop shadows), and everything referencing nothing keeps rendering. Which is why the mark looked *almost* right rather than broken.

## Fix

Inlined the SVG into the component so the defs live in the page that uses them — the only reliably portable arrangement. Ids are namespaced `lucas-logo-*` rather than generated: the court draws exactly one logo, and a fixed prefix keeps this renderable from a Server Component.

No visual change intended on desktop; the artwork is byte-for-byte the same shapes.

## Tests

Assert the property that actually broke — every `filter` and `textPath` reference resolves to an element present in the same rendered output — with a guard so the check can't pass by finding no references at all.

## Swept for the same pattern

Only two SVGs under `public/` use fragments: this one, and `globe.svg` (an unused Next template asset). The training-facility equipment illustrations are flat fills with no `<defs>`, so the room scenes were never affected — worth stating explicitly since they went live today.

**Verification:** 1,566 unit tests, `tsc`, `eslint` clean. Worth a look on a phone once the preview builds — that's the only place the original bug was visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved logo accessibility with a descriptive image label for assistive technologies.

* **Bug Fixes**
  * Updated the logo to render reliably inline, including its ring text and visual effects.
  * Ensured all logo elements display correctly without relying on external SVG references.

* **Tests**
  * Added coverage verifying logo rendering, accessibility, text content, and internal SVG references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->