### PR TITLE
fix(otf): let the OrangeTheory charts scroll on mobile instead of squeezing

### DIFF
--- a/components/training-facility/gym/OtfDetailView.tsx
+++ b/components/training-facility/gym/OtfDetailView.tsx
@@ -38,7 +38,22 @@ import { OtfSparklineSummary, type OtfSparklineRow } from './OtfSparklineSummary
 import { OtfZoneBars } from './OtfZoneBars'
 
 const CHART_HEIGHT = 280
-const MIN_CHART_WIDTH = 280
+
+/**
+ * Narrowest a chart is allowed to get before it stops shrinking and starts
+ * overflowing its card instead.
+ *
+ * At 280 this sat below every phone width, so on mobile the charts always
+ * squeezed to fit — a season of classes crushed into ~330px, with nothing to
+ * scroll because nothing overflowed. `ChartCard` already wraps its children in
+ * `overflow-x-auto`; the charts simply never grew past it.
+ *
+ * 480 is above a phone viewport and below a desktop column in the
+ * `lg:grid-cols-2` grid, so phones now scroll a legible chart (matching the
+ * Weight Room heatmap, which has always sized itself from its data and
+ * scrolled) while desktop keeps filling its column exactly as before.
+ */
+const MIN_CHART_WIDTH = 480
 const DEFAULT_CHART_WIDTH = 560
 const EARLIEST_FALLBACK = new Date(2026, 0, 1)
 const FONT_FAMILY = "'Patrick Hand', system-ui, sans-serif"


### PR DESCRIPTION
On a phone the OTF charts crushed a season of classes into ~330px, with nothing to drag sideways — unlike the Weight Room history heatmap, which scrolls.

## Not a missing style

`ChartCard` already wraps its children in `overflow-x-auto`. The charts simply never overflowed it.

Every OTF chart takes `width={chartWidth}`, computed as `max(MIN_CHART_WIDTH, containerWidth)`. `MIN_CHART_WIDTH` was **280** — below any phone viewport — so on mobile the charts shrank to fit and the scroll container had nothing to scroll.

The heatmap behaves differently because it sizes itself from its *data* (52 weeks of cells) and has always overflowed. `StrengthHeatmap` even carries a comment about not squashing 364 cells into a phone width — so the two pages had opposite philosophies, and only one of them was right for mobile.

## Fix

Raised the floor to **480**: above a phone viewport, below a desktop column in the `lg:grid-cols-2` grid. Phones now scroll a legible chart; desktop still fills its column exactly as before.

One constant, so it's easy to retune if 480 reads too wide or too narrow in practice.

**Verification:** `tsc` and the OTF suite pass. The behaviour itself needs a phone — automated coverage for "does this overflow its container at 390px" would need a WebKit/mobile viewport project in Playwright, which the repo doesn't have yet (happy to add it separately — it would also have caught the centre-court logo bug from #353).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chart readability on smaller screens by allowing charts to scroll horizontally instead of becoming overly compressed.
  * Preserved the existing desktop layout and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->