### PR TITLE
fix(otf): make the chart width floor breakpoint-aware, not global

### DIFF
--- a/components/training-facility/gym/OtfDetailView.test.tsx
+++ b/components/training-facility/gym/OtfDetailView.test.tsx
@@ -247,6 +247,32 @@ describe('OtfDetailView chart width', () => {
     expect(chartWidth(container)).toBeGreaterThan(330)
   })
 
+  it('asks the browser about the same breakpoint the CSS uses', () => {
+    // Tailwind v4 defines `lg` as `64rem`, so a px query would disagree with
+    // the grid whenever the root font size is not 16px — and reapply the
+    // mobile floor to a desktop column.
+    const seen: string[] = []
+    vi.stubGlobal('matchMedia', (query: string) => {
+      seen.push(query)
+      return {
+        matches: true,
+        media: query,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+      }
+    })
+    vi.stubGlobal(
+      'ResizeObserver',
+      class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      },
+    )
+    renderView({ otf: DATA })
+    expect(seen).toContain('(min-width: 64rem)')
+  })
+
   it('never exceeds the 412px column on desktop', () => {
     stubLayout(true)
     const { container } = renderView({ otf: DATA })

--- a/components/training-facility/gym/OtfDetailView.test.tsx
+++ b/components/training-facility/gym/OtfDetailView.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, within } from '@testing-library/react'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { OtfData } from '@/types/otf'
 
@@ -21,7 +21,13 @@ function renderView(props: Partial<React.ComponentProps<typeof OtfDetailView>> =
   )
 }
 
-vi.mock('./OtfZoneBars', () => ({ OtfZoneBars: () => null }))
+vi.mock('./OtfZoneBars', () => ({
+  // Reports the width it receives so chart sizing stays observable while the
+  // real SVG stays stubbed out.
+  OtfZoneBars: ({ width }: { width: number }) => (
+    <div data-testid="chart-probe" data-chart-width={width} />
+  ),
+}))
 vi.mock('./OtfSparklineSummary', () => ({ OtfSparklineSummary: () => null }))
 vi.mock('@/components/training-facility/shared/charts/RoughLine', () => ({ RoughLine: () => null }))
 vi.mock('next/navigation', () => ({
@@ -173,5 +179,78 @@ describe('OtfDetailView', () => {
   it('shows the error panel when the load throws', () => {
     renderView({ loadError: 'boom' })
     expect(screen.getByRole('alert')).toHaveTextContent(/boom/)
+  })
+})
+
+/**
+ * Chart sizing across the two layouts (#355 and its follow-up).
+ *
+ * The floor has been wrong in both directions now: too low, so mobile squeezed
+ * a season of classes into ~330px with nothing to scroll; then too high, so
+ * every desktop chart overflowed its 412px column and hid its right edge. The
+ * two card widths are only ~80px apart, so the rule keys off the *breakpoint*
+ * rather than the measured width — these pin both ends.
+ */
+describe('OtfDetailView chart width', () => {
+  /** Stub `matchMedia` for a given two-column verdict, plus a no-op observer. */
+  function stubLayout(twoColumn: boolean) {
+    const listeners: Array<() => void> = []
+    vi.stubGlobal(
+      'matchMedia',
+      (query: string) => ({
+        matches: twoColumn,
+        media: query,
+        addEventListener: (_: string, fn: () => void) => listeners.push(fn),
+        removeEventListener: () => {},
+      }),
+    )
+    // jsdom has no ResizeObserver; report a realistic card width for the layout.
+    const width = twoColumn ? 412 : 330
+    vi.stubGlobal(
+      'ResizeObserver',
+      class {
+        constructor(private cb: ResizeObserverCallback) {}
+        observe() {
+          this.cb(
+            [{ contentRect: { width } } as unknown as ResizeObserverEntry],
+            this as unknown as ResizeObserver,
+          )
+        }
+        unobserve() {}
+        disconnect() {}
+      },
+    )
+  }
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  /**
+   * Width handed to the charts, read off the stubbed child.
+   *
+   * Throws rather than defaulting when no probe rendered: an earlier draft of
+   * this suite measured `svg[width]`, found nothing (the charts are stubbed),
+   * and the desktop assertion passed on `0 <= 412` while checking nothing at
+   * all.
+   */
+  function chartWidth(container: HTMLElement): number {
+    const probe = container.querySelector('[data-chart-width]')
+    if (!probe) throw new Error('no chart rendered — the assertion would be vacuous')
+    return Number(probe.getAttribute('data-chart-width'))
+  }
+
+  it('overflows its card on a phone so the scroll container has something to scroll', () => {
+    stubLayout(false)
+    const { container } = renderView({ otf: DATA })
+    // Wider than the ~330px card: that overflow is what makes it draggable.
+    expect(chartWidth(container)).toBeGreaterThan(330)
+  })
+
+  it('never exceeds the 412px column on desktop', () => {
+    stubLayout(true)
+    const { container } = renderView({ otf: DATA })
+    // Anything wider clips the chart's right edge behind a scrollbar.
+    expect(chartWidth(container)).toBeLessThanOrEqual(412)
   })
 })

--- a/components/training-facility/gym/OtfDetailView.tsx
+++ b/components/training-facility/gym/OtfDetailView.tsx
@@ -40,20 +40,30 @@ import { OtfZoneBars } from './OtfZoneBars'
 const CHART_HEIGHT = 280
 
 /**
- * Narrowest a chart is allowed to get before it stops shrinking and starts
- * overflowing its card instead.
+ * Narrowest a chart may get before it stops shrinking and overflows its card
+ * instead — and the floor is **breakpoint-dependent**, because the two layouts
+ * want opposite things.
  *
- * At 280 this sat below every phone width, so on mobile the charts always
- * squeezed to fit — a season of classes crushed into ~330px, with nothing to
- * scroll because nothing overflowed. `ChartCard` already wraps its children in
- * `overflow-x-auto`; the charts simply never grew past it.
+ * Stacked (below `lg`) the card spans the viewport, so on a phone the chart
+ * area is ~330px and a season of classes gets crushed into it. There is nothing
+ * to drag sideways either: `ChartCard` wraps its children in `overflow-x-auto`,
+ * but the chart never grows past it. A floor above phone width makes the chart
+ * legible and lets that scroll container do its job — matching the Weight Room
+ * heatmap, which has always sized itself from its data and scrolled.
  *
- * 480 is above a phone viewport and below a desktop column in the
- * `lg:grid-cols-2` grid, so phones now scroll a legible chart (matching the
- * Weight Room heatmap, which has always sized itself from its data and
- * scrolled) while desktop keeps filling its column exactly as before.
+ * Two-column (`lg` and up) the arithmetic is tight and a floor is actively
+ * harmful: `max-w-5xl` (1024) less `lg:px-12` (96) is 928, less the grid's
+ * `gap-6` (24) halves to 452 per column, less `ChartCard`'s `p-5` (40) leaves
+ * **412px**. Any floor above that clips the right edge of every desktop chart
+ * behind a scrollbar. So desktop keeps a floor low enough to never bind, and
+ * the chart simply fills its column.
  */
-const MIN_CHART_WIDTH = 480
+const MOBILE_MIN_CHART_WIDTH = 480
+const DESKTOP_MIN_CHART_WIDTH = 280
+
+/** Tailwind's `lg` — the breakpoint where the chart grid becomes two columns. */
+const TWO_COLUMN_QUERY = '(min-width: 1024px)'
+
 const DEFAULT_CHART_WIDTH = 560
 const EARLIEST_FALLBACK = new Date(2026, 0, 1)
 const FONT_FAMILY = "'Patrick Hand', system-ui, sans-serif"
@@ -105,7 +115,14 @@ export function OtfDetailView({
   // view lands on its empty state rather than null-checking at every use site.
   const data = useMemo<OtfData>(() => otf ?? EMPTY_OTF, [otf])
   const [range, setRange] = useState<DateRange>(() => rangeForPreset('ALL', EARLIEST_FALLBACK))
-  const [chartWidth, setChartWidth] = useState(DEFAULT_CHART_WIDTH)
+  // Raw container width; the legibility floor is applied at render (below), so
+  // a breakpoint change re-derives the width without the observer holding a
+  // stale floor in its closure.
+  const [measuredWidth, setMeasuredWidth] = useState(DEFAULT_CHART_WIDTH)
+  // Start `true` so the server and first client render agree: SSR has no
+  // viewport, and the desktop floor never binds, so the chart renders at its
+  // measured width either way and hydration can't mismatch.
+  const [isTwoColumn, setIsTwoColumn] = useState(true)
   // Coarse class-type filter (#271); `null` = "All". Scopes both the log and
   // every aggregate, composing with the date range and the #268 exclusion.
   const [classType, setClassType] = useState<string | null>(null)
@@ -119,13 +136,30 @@ export function OtfDetailView({
     if (!node || typeof ResizeObserver === 'undefined') return
     const observer = new ResizeObserver(entries => {
       for (const entry of entries) {
-        const next = Math.max(MIN_CHART_WIDTH, Math.floor(entry.contentRect.width))
-        setChartWidth(prev => (prev === next ? prev : next))
+        const next = Math.floor(entry.contentRect.width)
+        setMeasuredWidth(prev => (prev === next ? prev : next))
       }
     })
     observer.observe(node)
     observerRef.current = observer
   }, [])
+
+  // Which floor applies is a question about the *layout*, not the container:
+  // a stacked card and a two-column card can be within ~80px of each other, so
+  // a width threshold could not tell them apart. Track the breakpoint itself.
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return
+    const query = window.matchMedia(TWO_COLUMN_QUERY)
+    const sync = () => setIsTwoColumn(query.matches)
+    sync()
+    query.addEventListener('change', sync)
+    return () => query.removeEventListener('change', sync)
+  }, [])
+
+  const chartWidth = Math.max(
+    isTwoColumn ? DESKTOP_MIN_CHART_WIDTH : MOBILE_MIN_CHART_WIDTH,
+    measuredWidth,
+  )
 
   // Track manual range edits so the post-load re-anchor doesn't stomp them.
   const userAdjustedRange = useRef(false)

--- a/components/training-facility/gym/OtfDetailView.tsx
+++ b/components/training-facility/gym/OtfDetailView.tsx
@@ -61,8 +61,18 @@ const CHART_HEIGHT = 280
 const MOBILE_MIN_CHART_WIDTH = 480
 const DESKTOP_MIN_CHART_WIDTH = 280
 
-/** Tailwind's `lg` — the breakpoint where the chart grid becomes two columns. */
-const TWO_COLUMN_QUERY = '(min-width: 1024px)'
+/**
+ * Tailwind's `lg` — the breakpoint where the chart grid becomes two columns.
+ *
+ * Expressed in `rem`, not `px`, because that is how Tailwind v4 defines it
+ * (`--breakpoint-lg: 64rem`). A hard-coded `1024px` agrees only while the
+ * browser's root font size is the default 16px. At 12px the CSS grid would
+ * switch to two columns at 768px while this query still reported "stacked",
+ * applying the mobile floor to a ~300px column and clipping the charts —
+ * exactly the bug this floor exists to avoid, just for users who scale their
+ * text.
+ */
+const TWO_COLUMN_QUERY = '(min-width: 64rem)'
 
 const DEFAULT_CHART_WIDTH = 560
 const EARLIEST_FALLBACK = new Date(2026, 0, 1)


### PR DESCRIPTION
Follow-up to #355, which raised the chart floor to 480 for mobile and broke desktop. **Both reviewers caught it on that PR and I merged past them** — this restores desktop while keeping the mobile fix.

## What went wrong

The floor applied at every viewport, but the two layouts want opposite things.

Two-column, the arithmetic is tight:

```
max-w-5xl            1024
  less lg:px-12       -96   =  928
  less gap-6          -24   ÷2 =  452 per column
  less ChartCard p-5  -40   =  412  ← chart area
```

A 480 floor clipped the right edge of every desktop chart behind a scrollbar — the exact problem #355 set out to remove, moved to a different viewport.

## Fix

The two card widths are only ~80px apart (330 stacked, 412 two-column), so no width threshold separates them reliably. The rule now keys off the **breakpoint** via `matchMedia('(min-width: 1024px)')`:

- **stacked** → floor 480, chart overflows its ~330px card, `overflow-x-auto` scrolls
- **two-column** → floor 280, never binds, chart fills its 412px column

Restructured so the observer stores the raw measured width and the floor is applied at render — otherwise the observer closes over a floor that goes stale when the breakpoint changes.

## Tests

Pin both ends. Worth noting how the first draft failed: it measured `svg[width]`, found nothing because the chart children are stubbed to `null`, and **passed the desktop case on `0 <= 412` while checking nothing**. The stub now reports the width it receives, and the helper throws rather than defaulting when no chart rendered.

**Verification:** 1,568 unit tests, `tsc`, `eslint` clean. The rendered result still wants a phone and a desktop window — the automated coverage asserts the width decision, not the pixels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved responsive chart sizing in training facility details by applying different minimum widths for mobile vs two-column layouts.
  * Charts now fit more reliably across breakpoints while honoring the available container width.

* **Tests**
  * Added assertions for chart width behavior on phone and desktop layouts.
  * Introduced breakpoint and measured-size simulations to validate sizing across viewport scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->