### PR TITLE
feat(weight-room): GTG rotation history — stitched heatmaps + past-focus cards (#361)

### DIFF
--- a/app/training-facility/weight-room/history/page.tsx
+++ b/app/training-facility/weight-room/history/page.tsx
@@ -4,7 +4,9 @@ import { notFound } from 'next/navigation'
 
 import { BackToCourtButton } from '@/components/common/BackToCourtButton'
 import { FacilityBackLink } from '@/components/training-facility/FacilityBackLink'
+import { FocusLaneHeatmap } from '@/components/training-facility/weight-room/FocusLaneHeatmap'
 import { LoadManagementPanel } from '@/components/training-facility/weight-room/LoadManagementPanel'
+import { PastFocusCard } from '@/components/training-facility/weight-room/PastFocusCard'
 import { StrengthHeatmap } from '@/components/training-facility/weight-room/StrengthHeatmap'
 import { StrengthStats } from '@/components/training-facility/weight-room/StrengthStats'
 import { StrengthVsBodyweightChart } from '@/components/training-facility/weight-room/StrengthVsBodyweightChart'
@@ -16,6 +18,12 @@ import { getCardioDataServer } from '@/lib/data/cardio-server'
 import { getWeightRoomDataServer } from '@/lib/data/weight-room-server'
 import { isWeightRoomEnabled } from '@/lib/feature-flags'
 import { buildMovementLoads } from '@/lib/training-facility/load-management'
+import {
+  buildFocusLaneCells,
+  computeFocusAdherence,
+  computeFocusLoadStats,
+} from '@/lib/training-facility/monthly-focus'
+import { toLocalDateKey } from '@/lib/training-facility/strength-today'
 import { computeStrengthStats } from '@/lib/training-facility/weight-room-history'
 import type { ExerciseGoal } from '@/types/weight-room'
 
@@ -54,15 +62,34 @@ export default async function WeightRoomHistoryPage(): Promise<JSX.Element> {
   ])
   const goals: readonly ExerciseGoal[] = data?.goals ?? []
   const sets = data?.sets ?? []
+  const focuses = data?.monthly_focus ?? []
+
+  // Separate permanent heatmap goals from focus anchors (#361). Focus
+  // anchors are time-boxed campaigns whose window closes; keeping them in
+  // the per-exercise heatmap loop produces a "graveyard" of mostly-empty
+  // year-long charts once a rotation ends. The dedicated GTG section below
+  // shows their history instead.
+  const permanentGoals = goals.filter((g) => g.kind !== 'focus')
+
   const stats = computeStrengthStats(sets, goals)
-  const loads = buildMovementLoads(sets, goals)
+  const loads = buildMovementLoads(sets, permanentGoals)
   const bodyMass = cardio?.body_mass_trend ?? []
 
   // The relative-strength overlay is featured for pull-ups specifically —
   // the most bodyweight-sensitive movement, where reps up + weight down
   // is the clearest "improving on two fronts" story. Only render it when
   // both halves exist: a configured pull-ups goal and bodyweight data.
-  const pullupsGoal = goals.find(g => g.exercise.toLowerCase() === 'pullups')
+  const pullupsGoal = permanentGoals.find((g) => g.exercise.toLowerCase() === 'pullups')
+
+  // GTG rotation: sort newest-first so the latest campaign leads (#361).
+  const sortedFocuses = [...focuses].sort((a, b) => b.start_date.localeCompare(a.start_date))
+
+  // Combined lane heatmaps — one series per body-region spanning all
+  // focus windows stitched together. Built once server-side so the SVG
+  // renderer receives a flat cells array.
+  const today = toLocalDateKey(new Date())
+  const upperCells = buildFocusLaneCells(focuses, sets, 'upper', today)
+  const lowerCells = buildFocusLaneCells(focuses, sets, 'lower', today)
 
   return (
     <div className="relative min-h-svh overflow-hidden bg-[#120d0a] text-[#f7ead9]">
@@ -85,14 +112,15 @@ export default async function WeightRoomHistoryPage(): Promise<JSX.Element> {
             Heatmap &amp; stats
           </h1>
           <p className="mt-3 max-w-xl text-sm leading-7 text-[#e8d5be] sm:text-base">
-            One row per day for the trailing 52 weeks, colored by how close that day got to the
-            daily goal. Hover any cell for the day&rsquo;s breakdown. Stats below summarize the
-            current week, month, and all-time totals.
+            Per-exercise heatmaps, grease-the-groove rotation history, and all-time stats. Each
+            heatmap cell represents one day colored by adherence to the daily goal — hover for
+            the breakdown. GTG focuses are shown as a stitched timeline so each rotation&rsquo;s
+            exercise lines up with its own window.
           </p>
           <WeightRoomSubNav active="history" className="mt-5" isAdmin={isAdmin} />
         </header>
 
-        {goals.length === 0 ? (
+        {permanentGoals.length === 0 && focuses.length === 0 ? (
           <section
             data-testid="weight-room-history-empty"
             className="mt-10 rounded-[1.2rem] border border-white/10 bg-white/5 p-6 text-sm text-[#e8d5be]"
@@ -129,12 +157,43 @@ export default async function WeightRoomHistoryPage(): Promise<JSX.Element> {
               </div>
             </section>
 
+            {sortedFocuses.length > 0 && (
+              <section
+                aria-label="Grease the Groove rotation"
+                data-testid="weight-room-gtg-rotation"
+                className="mt-10"
+              >
+                <h2 className="font-mono text-[11px] uppercase tracking-[0.32em] text-amber-300/80">
+                  Grease the Groove Rotation
+                </h2>
+                <p className="mt-2 max-w-xl text-sm leading-7 text-[#e8d5be]">
+                  Each time-boxed focus in the rotation, newest first. The ring shows overall
+                  adherence — how many days in the window hit the daily target. Weighted focuses
+                  also show top set, average load, and cumulative tonnage.
+                </p>
+                <div className="mt-4 space-y-3">
+                  {sortedFocuses.map((focus) => (
+                    <PastFocusCard
+                      key={focus.id}
+                      focus={focus}
+                      adherence={computeFocusAdherence(focus, sets)}
+                      loadStats={computeFocusLoadStats(
+                        focus,
+                        sets,
+                        goals.find((g) => g.exercise === focus.exercise)?.load_multiplier ?? 1,
+                      )}
+                    />
+                  ))}
+                </div>
+              </section>
+            )}
+
             <section
               aria-label="Per-exercise heatmaps"
               data-testid="weight-room-heatmaps"
               className="mt-10 space-y-8"
             >
-              {goals.map(goal => (
+              {permanentGoals.map(goal => (
                 <article
                   key={goal.exercise}
                   className="rounded-[1.2rem] border border-white/10 bg-white/5 p-5"
@@ -194,6 +253,37 @@ export default async function WeightRoomHistoryPage(): Promise<JSX.Element> {
                 <StrengthStats stats={stats} />
               </div>
             </section>
+
+            {(upperCells.length > 0 || lowerCells.length > 0) && (
+              <section
+                aria-label="Combined focus-lane heatmaps"
+                data-testid="weight-room-focus-lanes"
+                className="mt-10"
+              >
+                <h2 className="font-mono text-[11px] uppercase tracking-[0.32em] text-amber-300/80">
+                  Focus Lane History
+                </h2>
+                <p className="mt-2 max-w-xl text-sm leading-7 text-[#e8d5be]">
+                  One stitched heatmap per body region, spanning the full rotation. Each day is
+                  colored by how close that day got to the active focus&rsquo;s daily target —
+                  so shrugs in July and a new exercise in August sit on the same timeline.
+                </p>
+                {upperCells.length > 0 && (
+                  <div className="mt-4 rounded-[1.2rem] border border-white/10 bg-white/5 p-5">
+                    <div className="overflow-x-auto">
+                      <FocusLaneHeatmap cells={upperCells} label="Upper Focus Lane" />
+                    </div>
+                  </div>
+                )}
+                {lowerCells.length > 0 && (
+                  <div className="mt-4 rounded-[1.2rem] border border-white/10 bg-white/5 p-5">
+                    <div className="overflow-x-auto">
+                      <FocusLaneHeatmap cells={lowerCells} label="Lower Focus Lane" />
+                    </div>
+                  </div>
+                )}
+              </section>
+            )}
           </>
         )}
       </div>

--- a/app/training-facility/weight-room/history/page.tsx
+++ b/app/training-facility/weight-room/history/page.tsx
@@ -17,13 +17,12 @@ import { isAdminRequest } from '@/lib/auth/admin-session'
 import { getCardioDataServer } from '@/lib/data/cardio-server'
 import { getWeightRoomDataServer } from '@/lib/data/weight-room-server'
 import { isWeightRoomEnabled } from '@/lib/feature-flags'
-import { buildMovementLoads } from '@/lib/training-facility/load-management'
+import { buildMovementLoads, pacificDayKey } from '@/lib/training-facility/load-management'
 import {
   buildFocusLaneCells,
   computeFocusAdherence,
   computeFocusLoadStats,
 } from '@/lib/training-facility/monthly-focus'
-import { toLocalDateKey } from '@/lib/training-facility/strength-today'
 import { computeStrengthStats } from '@/lib/training-facility/weight-room-history'
 import type { ExerciseGoal } from '@/types/weight-room'
 
@@ -71,8 +70,8 @@ export default async function WeightRoomHistoryPage(): Promise<JSX.Element> {
   // shows their history instead.
   const permanentGoals = goals.filter((g) => g.kind !== 'focus')
 
-  const stats = computeStrengthStats(sets, goals)
-  const loads = buildMovementLoads(sets, permanentGoals)
+  const stats = computeStrengthStats(sets, permanentGoals)
+  const loads = buildMovementLoads(sets, goals)
   const bodyMass = cardio?.body_mass_trend ?? []
 
   // The relative-strength overlay is featured for pull-ups specifically —
@@ -87,7 +86,7 @@ export default async function WeightRoomHistoryPage(): Promise<JSX.Element> {
   // Combined lane heatmaps — one series per body-region spanning all
   // focus windows stitched together. Built once server-side so the SVG
   // renderer receives a flat cells array.
-  const today = toLocalDateKey(new Date())
+  const today = pacificDayKey(new Date())
   const upperCells = buildFocusLaneCells(focuses, sets, 'upper', today)
   const lowerCells = buildFocusLaneCells(focuses, sets, 'lower', today)
 

--- a/components/training-facility/weight-room/FocusLaneHeatmap.tsx
+++ b/components/training-facility/weight-room/FocusLaneHeatmap.tsx
@@ -1,0 +1,319 @@
+import type { JSX } from 'react'
+
+import { intensityFromPct } from '@/lib/training-facility/weight-room-history'
+import type { FocusDayCell } from '@/lib/training-facility/monthly-focus'
+import type { MonthlyFocus } from '@/types/weight-room'
+
+// ---------------------------------------------------------------------------
+// Layout constants — match StrengthHeatmap.tsx so the two components sit in
+// the same visual lane system (same row heights, same label widths, same
+// legend strip height).
+// ---------------------------------------------------------------------------
+
+/** Pixel width reserved for the day-of-week label column. */
+const DAY_LABEL_WIDTH = 32
+/** Pixel height reserved for the month label row above the grid. */
+const MONTH_LABEL_HEIGHT = 18
+/**
+ * Per-intensity opacity applied to the focus color — index matches the
+ * value returned by `intensityFromPct`: 0 = no fill (empty), 1 = 1–49%
+ * of goal, 2 = 50–99%, 3 = ≥100%.
+ */
+const INTENSITY_OPACITY = [0, 0.28, 0.62, 1] as const
+/** Background fill for gap cells (no active focus) and padding cells. */
+const EMPTY_CELL_FILL = 'rgba(247, 234, 217, 0.07)'
+/** Soft cream label color for month and day-of-week labels. */
+const LABEL_FILL = 'rgba(247, 234, 217, 0.55)'
+const DAY_LABELS = ['Mon', '', 'Wed', '', 'Fri', '', ''] as const
+const MONTH_LABELS = [
+  'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+  'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+] as const
+const DAY_MS = 86_400_000
+
+// ---------------------------------------------------------------------------
+// Internal grid helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert a `Date` to a `YYYY-MM-DD` key using local-time components.
+ * Private — callers outside this file use `toLocalDateKey` from
+ * `strength-today`. Kept here so the component has no runtime import from
+ * the lib layer (the cells already carry `dayKey`).
+ */
+function toDateKey(d: Date): string {
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  return `${y}-${m}-${day}`
+}
+
+/**
+ * Return the Monday on or before `dayKey`, as a `Date` at local noon.
+ * Mirrors the private `getMondayOf` in `weight-room-history.ts`.
+ */
+function getMondayOf(dayKey: string): Date {
+  const d = new Date(dayKey + 'T12:00:00')
+  const m = new Date(d.getFullYear(), d.getMonth(), d.getDate(), 12, 0, 0)
+  const dow = m.getDay() // 0 = Sun
+  m.setDate(m.getDate() - (dow === 0 ? 6 : dow - 1))
+  return m
+}
+
+/** One column slot in the SVG grid. */
+interface GridSlot {
+  /** Local `YYYY-MM-DD` key. */
+  dayKey: string
+  /**
+   * The matching cell from `buildFocusLaneCells`, or `null` for padding
+   * slots (before the first cell or after the last).
+   */
+  cell: FocusDayCell | null
+}
+
+/** Pre-computed grid arrays + metadata returned by {@link buildLaneGrid}. */
+interface LaneGrid {
+  /** 7 rows (Mon–Sun) × N columns; row 0 = Monday. */
+  grid: GridSlot[][]
+  /** Month label positions for the top axis. */
+  monthLabels: { col: number; label: string }[]
+  /**
+   * Unique focuses in first-appearance order, used to build the legend
+   * strip (one colored swatch per rotation segment).
+   */
+  uniqueFocuses: MonthlyFocus[]
+  /** Total column count (= `grid[0].length`). */
+  cols: number
+}
+
+/**
+ * Build the 7-row × N-col grid from an ordered array of
+ * {@link FocusDayCell}s. The grid starts on the Monday on/before the first
+ * cell and ends on the Sunday on/after the last cell, padding any empty
+ * slots at the start or end with `null`.
+ */
+function buildLaneGrid(cells: readonly FocusDayCell[]): LaneGrid {
+  const empty: LaneGrid = { grid: Array.from({ length: 7 }, () => []), monthLabels: [], uniqueFocuses: [], cols: 0 }
+  if (cells.length === 0) return empty
+
+  const cellByDay = new Map(cells.map((c) => [c.dayKey, c]))
+
+  // Find Monday on/before the first cell.
+  const startMonday = getMondayOf(cells[0].dayKey)
+
+  // Find Sunday on/after the last cell.
+  const lastDate = new Date(cells[cells.length - 1].dayKey + 'T12:00:00')
+  const lastDow = lastDate.getDay() // 0 = Sun
+  const daysToSunday = lastDow === 0 ? 0 : 7 - lastDow
+  const endDate = new Date(lastDate.getFullYear(), lastDate.getMonth(), lastDate.getDate() + daysToSunday, 12, 0, 0)
+
+  const startMs = startMonday.getTime()
+  const totalCols = Math.round((endDate.getTime() - startMs) / (7 * DAY_MS)) + 1
+
+  const grid: GridSlot[][] = Array.from({ length: 7 }, () => [])
+  const monthLabels: { col: number; label: string }[] = []
+  let lastMonth = -1
+
+  for (let col = 0; col < totalCols; col++) {
+    for (let row = 0; row < 7; row++) {
+      const date = new Date(startMs + (col * 7 + row) * DAY_MS)
+      const dk = toDateKey(date)
+      grid[row].push({ dayKey: dk, cell: cellByDay.get(dk) ?? null })
+      if (row === 0 && date.getMonth() !== lastMonth) {
+        lastMonth = date.getMonth()
+        monthLabels.push({ col, label: MONTH_LABELS[date.getMonth()] })
+      }
+    }
+  }
+
+  // Collect unique focuses in first-appearance order for the legend.
+  const seen = new Set<string>()
+  const uniqueFocuses: MonthlyFocus[] = []
+  for (const cell of cells) {
+    if (cell.focus !== null && !seen.has(cell.focus.id)) {
+      seen.add(cell.focus.id)
+      uniqueFocuses.push(cell.focus)
+    }
+  }
+
+  return { grid, monthLabels, uniqueFocuses, cols: totalCols }
+}
+
+/**
+ * Compose the per-cell SVG `<title>` tooltip string. Shows the local date,
+ * the focus exercise, and the day's volume + percentage when a set was
+ * logged. Reads naturally for sighted hover and screen-reader keyboard nav.
+ */
+function describeSlot(slot: GridSlot): string {
+  const date = new Date(slot.dayKey + 'T12:00:00')
+  const dateLabel = date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+
+  if (slot.cell === null) return dateLabel
+  const { cell } = slot
+  if (cell.focus === null) return `${dateLabel} (no focus)`
+  if (cell.volume === 0) return `${dateLabel}: ${cell.focus.exercise} — none logged`
+
+  const unit = cell.focus.target_kind === 'sets' ? 'sets' : 'reps'
+  const pctLabel = `${Math.round(cell.pct * 100)}% of daily goal`
+  return `${dateLabel}: ${cell.volume} ${unit} ${cell.focus.exercise} (${pctLabel})`
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+/** Props for {@link FocusLaneHeatmap}. */
+export interface FocusLaneHeatmapProps {
+  /**
+   * Ordered cells for one body-region lane, built by
+   * `buildFocusLaneCells`. Cells span `[earliestStart, today]`; each
+   * carries the active focus (or `null` for a gap) and the normalized
+   * volume for that day.
+   */
+  cells: FocusDayCell[]
+  /**
+   * Accessible label for the SVG `role="img"` wrapper, e.g.
+   * `"Upper Focus Lane"`. Also shown as the lane header.
+   */
+  label: string
+  /**
+   * Pixel stride per cell (including the trailing inter-cell gap).
+   * Defaults to `14` — same default as {@link import('./StrengthHeatmap').StrengthHeatmap}.
+   */
+  cellSize?: number
+  /** Pixel gap between cells. Defaults to `2`. */
+  cellGap?: number
+}
+
+/**
+ * Stitched calendar heatmap for one body-region focus lane (#361). Plots
+ * the daily goal attainment (% of `daily_target`) across all past and
+ * current focus rotations for the lane, coloring each cell by the
+ * exercise's own focus color so transitions are visually distinct. Gap
+ * periods between focus windows appear as faint grey cells.
+ *
+ * Unlike {@link import('./StrengthHeatmap').StrengthHeatmap}, which
+ * anchors to the trailing 52 weeks of one exercise, this heatmap spans the
+ * full focus history for a lane so the rotation story is legible at a
+ * glance.
+ *
+ * Plain `<rect>` SVG cells so the grid renders instantly even on mobile.
+ */
+export function FocusLaneHeatmap({
+  cells,
+  label,
+  cellSize = 14,
+  cellGap = 2,
+}: FocusLaneHeatmapProps): JSX.Element | null {
+  if (cells.length === 0) return null
+
+  const { grid, monthLabels, uniqueFocuses, cols } = buildLaneGrid(cells)
+  const cellInner = cellSize - cellGap
+  const gridWidth = cols * cellSize
+  const gridHeight = 7 * cellSize
+
+  // Legend height: one row at 22 px, plus 16 px per additional row (up to
+  // ⌈uniqueFocuses.length / 3⌉ rows at 3 items per row).
+  const legendRows = Math.max(1, Math.ceil(uniqueFocuses.length / 3))
+  const legendHeight = 22 + (legendRows - 1) * 16
+  const totalWidth = DAY_LABEL_WIDTH + gridWidth
+  const totalHeight = MONTH_LABEL_HEIGHT + gridHeight + legendHeight
+
+  return (
+    <svg
+      viewBox={`0 0 ${totalWidth} ${totalHeight}`}
+      width={totalWidth}
+      height={totalHeight}
+      role="img"
+      aria-label={label}
+    >
+      {/* Month labels along the top */}
+      <g transform={`translate(${DAY_LABEL_WIDTH}, ${MONTH_LABEL_HEIGHT - 4})`}>
+        {monthLabels.map((m) => (
+          <text
+            key={`month-${m.col}-${m.label}`}
+            x={m.col * cellSize}
+            y={0}
+            fontSize={11}
+            fill={LABEL_FILL}
+          >
+            {m.label}
+          </text>
+        ))}
+      </g>
+
+      {/* Day-of-week labels along the left */}
+      <g transform={`translate(0, ${MONTH_LABEL_HEIGHT})`}>
+        {DAY_LABELS.map((dayLabel, row) =>
+          dayLabel ? (
+            <text
+              key={`day-${row}`}
+              x={DAY_LABEL_WIDTH - 6}
+              y={row * cellSize + cellSize / 2 + 3}
+              textAnchor="end"
+              fontSize={10}
+              fill={LABEL_FILL}
+            >
+              {dayLabel}
+            </text>
+          ) : null,
+        )}
+      </g>
+
+      {/* Heatmap cells — colored by the active focus, grey for gaps */}
+      <g transform={`translate(${DAY_LABEL_WIDTH}, ${MONTH_LABEL_HEIGHT})`}>
+        {grid.map((row, rowIdx) =>
+          row.map((slot, colIdx) => {
+            const focus = slot.cell?.focus ?? null
+            const pct = slot.cell?.pct ?? 0
+            const isGap = focus === null
+            const level = isGap ? 0 : intensityFromPct(pct)
+
+            return (
+              <rect
+                key={`cell-${colIdx}-${rowIdx}`}
+                x={colIdx * cellSize}
+                y={rowIdx * cellSize}
+                width={cellInner}
+                height={cellInner}
+                rx={2}
+                ry={2}
+                fill={isGap ? EMPTY_CELL_FILL : focus.color}
+                fillOpacity={isGap ? 1 : INTENSITY_OPACITY[level]}
+              >
+                <title>{describeSlot(slot)}</title>
+              </rect>
+            )
+          }),
+        )}
+      </g>
+
+      {/* Legend — one swatch + exercise label per rotation segment */}
+      <g transform={`translate(${DAY_LABEL_WIDTH}, ${MONTH_LABEL_HEIGHT + gridHeight + 14})`}>
+        {uniqueFocuses.map((focus, i) => {
+          const col = i % 3
+          const row = Math.floor(i / 3)
+          const x = col * Math.floor(gridWidth / 3)
+          const y = row * 16
+          return (
+            <g key={focus.id} transform={`translate(${x}, ${y})`}>
+              <rect
+                x={0}
+                y={-9}
+                width={cellInner}
+                height={cellInner}
+                rx={2}
+                ry={2}
+                fill={focus.color}
+                fillOpacity={1}
+              />
+              <text x={cellSize + 2} y={0} fontSize={10} fill={LABEL_FILL}>
+                {focus.exercise}
+              </text>
+            </g>
+          )
+        })}
+      </g>
+    </svg>
+  )
+}

--- a/components/training-facility/weight-room/PastFocusCard.tsx
+++ b/components/training-facility/weight-room/PastFocusCard.tsx
@@ -1,0 +1,219 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import type { JSX } from 'react'
+
+import {
+  formatFocusWindow,
+  type FocusAdherence,
+  type FocusLoadStats,
+} from '@/lib/training-facility/monthly-focus'
+import type { MonthlyFocus } from '@/types/weight-room'
+
+// ---------------------------------------------------------------------------
+// Ring animation constants
+// ---------------------------------------------------------------------------
+
+/** Radius of the adherence ring arc in SVG user-units. */
+const RING_RADIUS = 36
+/** `2π × RING_RADIUS` — full stroke length for `stroke-dasharray`. */
+const RING_CIRCUMFERENCE = 2 * Math.PI * RING_RADIUS
+
+// ---------------------------------------------------------------------------
+// Internal helpers (shared with MonthlyFocusCard pattern)
+// ---------------------------------------------------------------------------
+
+/** Round to one decimal and strip a trailing `.0` so `95.0` reads `"95"`. */
+function trim1(n: number): string {
+  return n.toFixed(1).replace(/\.0$/, '')
+}
+
+/**
+ * The second reading of a load for a multi-implement movement, e.g. `×2 · 120 lb`
+ * under a `60 lb` top set.
+ *
+ * `topSetLbs` / `avgLoadLbs` are per *implement* — how the load is read off the
+ * equipment. "How much was actually in my hands" isn't stated until multiplied.
+ * Showing both here means neither surface has to be translated.
+ *
+ * @returns `undefined` for a single-implement movement, where the two readings
+ *   are the same number and a second line would be noise.
+ */
+function totalLoadNote(perImplementLbs: number | null, loadMultiplier: number): string | undefined {
+  if (perImplementLbs === null || loadMultiplier <= 1) return undefined
+  return `×${loadMultiplier} · ${trim1(perImplementLbs * loadMultiplier)} lb`
+}
+
+/** Single labelled stat cell inside the focus card's `<dl>` grids. */
+function FocusStat({
+  label,
+  value,
+  sub,
+}: {
+  /** Label rendered under the value. */
+  label: string
+  /** Primary metric value. */
+  value: string
+  /** Optional secondary reading rendered under the value, e.g. total-load note. */
+  sub?: string
+}): JSX.Element {
+  return (
+    <div className="flex flex-col gap-1">
+      <dd className="font-mono text-base font-semibold tabular-nums text-white">
+        {value}
+        {sub ? (
+          <span className="mt-0.5 block text-[9px] font-normal tracking-[0.08em] text-white/45">
+            {sub}
+          </span>
+        ) : null}
+      </dd>
+      <dt className="font-mono text-[9px] uppercase tracking-[0.18em] text-white/45">{label}</dt>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+/** Props for {@link PastFocusCard}. */
+export interface PastFocusCardProps {
+  /** The focus to display — may be active or fully elapsed. */
+  focus: MonthlyFocus
+  /** Windowed adherence computed by `computeFocusAdherence`. */
+  adherence: FocusAdherence
+  /** Load summary computed by `computeFocusLoadStats`. Null metrics shown when bodyweight. */
+  loadStats: FocusLoadStats
+}
+
+/**
+ * History-page card for one GTG rotation segment (#361). Shows an animated
+ * SVG adherence ring (overall days-hit rate), the campaign window, days hit
+ * vs elapsed, current streak, and — for weighted focuses — top set, average
+ * load, and tonnage.
+ *
+ * Uses `'use client'` for the `requestAnimationFrame`-triggered ring
+ * animation. Everything else is static data passed down from the Server
+ * Component page, so no fetch or subscription occurs in this component.
+ */
+export function PastFocusCard({ focus, adherence, loadStats }: PastFocusCardProps): JSX.Element {
+  // Drive the ring animation from 0% → adherence.percent on mount.
+  const [animated, setAnimated] = useState(false)
+
+  useEffect(() => {
+    // One rAF defers the state flip just past the browser's first paint so
+    // the CSS transition actually runs (setting state synchronously on mount
+    // would skip the from-state entirely).
+    const raf = requestAnimationFrame(() => setAnimated(true))
+    return () => cancelAnimationFrame(raf)
+  }, [])
+
+  const pct = Math.min(1, adherence.percent)
+  const dashoffset = RING_CIRCUMFERENCE * (1 - (animated ? pct : 0))
+  const unit = focus.target_kind === 'sets' ? 'sets' : 'reps'
+  const categoryLabel = focus.category === 'lower' ? 'Lower Focus' : 'Upper Focus'
+  const hasLoad = loadStats.weightedSets > 0
+
+  return (
+    <div
+      data-testid={`past-focus-${focus.exercise}`}
+      className="flex gap-4 rounded-[1.4rem] border border-white/10 bg-white/5 p-5"
+      style={{ boxShadow: `inset 3px 0 0 0 ${focus.color}` }}
+    >
+      {/* Animated adherence ring */}
+      <div className="flex shrink-0 flex-col items-center gap-1.5">
+        <svg
+          width={88}
+          height={88}
+          viewBox="0 0 88 88"
+          role="img"
+          aria-label={`${Math.round(pct * 100)}% adherence for ${focus.exercise}`}
+        >
+          {/* Background track */}
+          <circle
+            cx={44}
+            cy={44}
+            r={RING_RADIUS}
+            fill="none"
+            stroke="rgba(247,234,217,0.07)"
+            strokeWidth={7}
+          />
+          {/* Animated progress arc */}
+          <circle
+            cx={44}
+            cy={44}
+            r={RING_RADIUS}
+            fill="none"
+            stroke={focus.color}
+            strokeWidth={7}
+            strokeLinecap="round"
+            strokeDasharray={RING_CIRCUMFERENCE}
+            strokeDashoffset={dashoffset}
+            transform="rotate(-90 44 44)"
+            style={{ transition: 'stroke-dashoffset 1s ease-out' }}
+          />
+          {/* Percentage label */}
+          <text
+            x={44}
+            y={44}
+            textAnchor="middle"
+            dominantBaseline="central"
+            fontSize={14}
+            fontWeight="bold"
+            fill="white"
+          >
+            {Math.round(pct * 100)}%
+          </text>
+        </svg>
+        <span className="font-mono text-[9px] uppercase tracking-[0.16em] text-white/40">
+          adherence
+        </span>
+      </div>
+
+      {/* Stats panel */}
+      <div className="flex min-w-0 flex-1 flex-col gap-3">
+        {/* Exercise label + category chip */}
+        <div className="flex items-center justify-between gap-3">
+          <span className="font-mono text-[10px] uppercase tracking-[0.28em] text-white/55">
+            {categoryLabel}
+          </span>
+          <span
+            className="font-mono text-[10px] font-semibold uppercase tracking-[0.2em]"
+            style={{ color: focus.color }}
+          >
+            {focus.exercise}
+          </span>
+        </div>
+
+        {/* Window + daily target */}
+        <span className="font-mono text-[10px] uppercase tracking-[0.18em] tabular-nums text-white/45">
+          {formatFocusWindow(focus)} · {focus.daily_target} {unit}/day
+        </span>
+
+        {/* Adherence stats */}
+        <dl className="grid grid-cols-3 gap-3 text-center">
+          <FocusStat label="Days hit" value={`${adherence.daysHit}/${adherence.daysElapsed}`} />
+          <FocusStat label="Streak" value={`${adherence.currentStreak}d`} />
+          <FocusStat label="Window" value={`${adherence.daysInWindow}d`} />
+        </dl>
+
+        {/* Load stats — only for weighted focuses */}
+        {hasLoad ? (
+          <dl className="grid grid-cols-3 gap-3 border-t border-white/10 pt-3 text-center">
+            <FocusStat
+              label="Top set"
+              value={`${trim1(loadStats.topSetLbs ?? 0)} lb`}
+              sub={totalLoadNote(loadStats.topSetLbs, loadStats.loadMultiplier)}
+            />
+            <FocusStat
+              label="Avg load"
+              value={`${trim1(loadStats.avgLoadLbs ?? 0)} lb`}
+              sub={totalLoadNote(loadStats.avgLoadLbs, loadStats.loadMultiplier)}
+            />
+            <FocusStat label="Tonnage" value={`${loadStats.tonnageLbs.toLocaleString()} lb`} />
+          </dl>
+        ) : null}
+      </div>
+    </div>
+  )
+}

--- a/components/training-facility/weight-room/StrengthVsBodyweightChart.test.tsx
+++ b/components/training-facility/weight-room/StrengthVsBodyweightChart.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
 
 import type { CardioTimePoint } from '@/types/cardio'
@@ -59,11 +59,20 @@ describe('StrengthVsBodyweightChart legend', () => {
 
   it('omits the legend when there are too few weeks to plot', () => {
     // Below two completed weeks the chart renders its empty-state line instead,
-    // so there are no series to name.
+    // so there are no series to name. Freeze the clock so the set date
+    // (2026-07-13, a Monday) always falls in the current in-progress week and
+    // is excluded by the `slice(0, -1)` trim — without this the test breaks
+    // once real time advances past that week.
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-17T12:00:00.000Z'))
     const oneWeek: StrengthSet[] = [
       { id: 'a', logged_at: '2026-07-13T19:00:00Z', exercise: 'pullups', reps: 40 },
     ]
-    render(<StrengthVsBodyweightChart sets={oneWeek} goal={GOAL} bodyMass={BODY_MASS} />)
-    expect(screen.queryByText('pullups / week')).not.toBeInTheDocument()
+    try {
+      render(<StrengthVsBodyweightChart sets={oneWeek} goal={GOAL} bodyMass={BODY_MASS} />)
+      expect(screen.queryByText('pullups / week')).not.toBeInTheDocument()
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/lib/training-facility/monthly-focus.test.ts
+++ b/lib/training-facility/monthly-focus.test.ts
@@ -13,9 +13,10 @@ import {
 } from './monthly-focus'
 
 /**
- * Unit tests for the monthly-focus helpers (#255). All dates use local
- * construction (`new Date(y, mIndex, d, …)`) so the local-timezone day
- * bucketing in `toLocalDateKey` matches the `YYYY-MM-DD` window keys.
+ * Unit tests for the monthly-focus helpers (#255). Set timestamps use
+ * ISO strings with a UTC noon offset so `pacificDayKey` maps them to the
+ * expected Pacific calendar day (noon UTC = 5 am PDT, well within the
+ * same calendar day in both zones).
  */
 
 const JULY_SHRUGS: MonthlyFocus = {
@@ -52,7 +53,11 @@ const JULY_NORDICS: MonthlyFocus = {
   end_date: '2026-07-31',
 }
 
-/** Build a set on a given local calendar day at noon (stable bucketing). */
+/**
+ * Build a set at UTC noon on the given calendar date. UTC noon = 5 am PDT,
+ * which `pacificDayKey` resolves to the same `YYYY-MM-DD` as the arguments,
+ * so tests are stable on any CI timezone.
+ */
 function setOn(
   exercise: string,
   year: number,
@@ -63,7 +68,7 @@ function setOn(
 ): StrengthSet {
   return {
     id: `${exercise}-${year}-${monthIndex}-${day}-${reps}-${weight_lbs ?? 'bw'}`,
-    logged_at: new Date(year, monthIndex, day, 12, 0, 0).toISOString(),
+    logged_at: new Date(Date.UTC(year, monthIndex, day, 12, 0, 0)).toISOString(),
     exercise,
     reps,
     ...(weight_lbs != null ? { weight_lbs } : {}),

--- a/lib/training-facility/monthly-focus.test.ts
+++ b/lib/training-facility/monthly-focus.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it } from 'vitest'
+﻿import { describe, expect, it } from 'vitest'
 
 import type { MonthlyFocus, StrengthSet } from '@/types/weight-room'
 
 import {
   activeFocusesForDay,
+  buildFocusLaneCells,
   computeFocusAdherence,
   computeFocusLoadStats,
   formatFocusWindow,
@@ -285,8 +286,120 @@ describe('computeFocusLoadStats', () => {
     expect(computeFocusLoadStats(JULY_SHRUGS, sets, 1).tonnageLbs).toBe(500)
   })
 
-  it('clamps a non-positive multiplier so tonnage can’t be erased', () => {
+  it("clamps a non-positive multiplier so tonnage can't be erased", () => {
     const sets: StrengthSet[] = [setOn('shrugs', 2026, 6, 1, 10, 50)]
     expect(computeFocusLoadStats(JULY_SHRUGS, sets, 0).tonnageLbs).toBe(500)
+  })
+})
+
+describe('buildFocusLaneCells', () => {
+  it('returns empty when focuses list is empty', () => {
+    expect(buildFocusLaneCells([], [], 'upper', '2026-07-10')).toEqual([])
+  })
+
+  it('returns empty when no focuses exist for the requested category', () => {
+    // AUGUST_CALVES is lower; asking for upper should produce nothing.
+    expect(buildFocusLaneCells([AUGUST_CALVES], [], 'upper', '2026-08-10')).toEqual([])
+  })
+
+  it('returns empty when today is before the earliest focus start_date', () => {
+    expect(buildFocusLaneCells([JULY_SHRUGS], [], 'upper', '2026-06-30')).toEqual([])
+  })
+
+  it('returns empty when today is an empty string', () => {
+    expect(buildFocusLaneCells([JULY_SHRUGS], [], 'upper', '')).toEqual([])
+  })
+
+  it('builds one cell per day from start_date through today', () => {
+    const cells = buildFocusLaneCells([JULY_SHRUGS], [], 'upper', '2026-07-03')
+    expect(cells).toHaveLength(3)
+    expect(cells[0].dayKey).toBe('2026-07-01')
+    expect(cells[1].dayKey).toBe('2026-07-02')
+    expect(cells[2].dayKey).toBe('2026-07-03')
+  })
+
+  it('assigns the correct focus and computes pct from focus.daily_target', () => {
+    const sets: StrengthSet[] = [
+      setOn('shrugs', 2026, 6, 1, 100), // 100 reps — hits the 100-rep target exactly
+      setOn('shrugs', 2026, 6, 2, 50), //  50 reps — 50 % of target
+    ]
+    const cells = buildFocusLaneCells([JULY_SHRUGS], sets, 'upper', '2026-07-03')
+
+    expect(cells[0]).toMatchObject({ dayKey: '2026-07-01', focus: JULY_SHRUGS, volume: 100, pct: 1 })
+    expect(cells[1]).toMatchObject({ dayKey: '2026-07-02', focus: JULY_SHRUGS, volume: 50, pct: 0.5 })
+    // Jul 3: no sets logged — volume 0, pct 0
+    expect(cells[2]).toMatchObject({ dayKey: '2026-07-03', focus: JULY_SHRUGS, volume: 0, pct: 0 })
+  })
+
+  it('counts set count (not reps) for target_kind = sets', () => {
+    const setsFocus: MonthlyFocus = {
+      ...JULY_SHRUGS,
+      id: 'sets-focus',
+      target_kind: 'sets',
+      daily_target: 3,
+    }
+    const sets: StrengthSet[] = [
+      setOn('shrugs', 2026, 6, 1, 30), // set 1: 30 reps
+      setOn('shrugs', 2026, 6, 1, 25), // set 2: 25 reps
+    ]
+    const cells = buildFocusLaneCells([setsFocus], sets, 'upper', '2026-07-01')
+    expect(cells[0].volume).toBe(2) // 2 sets, not 55 reps
+    expect(cells[0].pct).toBeCloseTo(2 / 3)
+  })
+
+  it('emits explicit gap cells for days between focus windows', () => {
+    // earlyFocus: upper, ends Jun 28 → gap Jun 29 & 30 → JULY_SHRUGS starts Jul 1
+    const earlyFocus: MonthlyFocus = {
+      ...JULY_SHRUGS,
+      id: 'early-upper',
+      exercise: 'rows',
+      start_date: '2026-06-01',
+      end_date: '2026-06-28',
+    }
+    const cells = buildFocusLaneCells([earlyFocus, JULY_SHRUGS], [], 'upper', '2026-07-02')
+    const gapCells = cells.filter((c) => c.focus === null)
+    expect(gapCells).toHaveLength(2)
+    expect(gapCells[0].dayKey).toBe('2026-06-29')
+    expect(gapCells[1].dayKey).toBe('2026-06-30')
+    // Cells outside the gap should have their focus
+    const julyCells = cells.filter((c) => c.focus?.id === JULY_SHRUGS.id)
+    expect(julyCells.map((c) => c.dayKey)).toEqual(['2026-07-01', '2026-07-02'])
+  })
+
+  it('ignores sets for other exercises and other lanes', () => {
+    const sets: StrengthSet[] = [
+      setOn('shrugs', 2026, 6, 1, 80),        // correct
+      setOn('pushups', 2026, 6, 1, 50),        // wrong exercise
+      setOn('nordic-curls', 2026, 6, 1, 40),   // lower-lane exercise, not this lane
+    ]
+    // Both focuses present; asking for upper isolates shrugs
+    const cells = buildFocusLaneCells([JULY_SHRUGS, JULY_NORDICS], sets, 'upper', '2026-07-01')
+    expect(cells).toHaveLength(1)
+    expect(cells[0].volume).toBe(80)
+    expect(cells[0].pct).toBeCloseTo(0.8)
+  })
+
+  it('lower lane returns only lower-category focus data', () => {
+    const sets: StrengthSet[] = [
+      setOn('shrugs', 2026, 6, 1, 100),      // upper — ignored
+      setOn('nordic-curls', 2026, 6, 1, 20), // lower — counted
+    ]
+    const cells = buildFocusLaneCells([JULY_SHRUGS, JULY_NORDICS], sets, 'lower', '2026-07-01')
+    expect(cells[0].focus?.exercise).toBe('nordic-curls')
+    expect(cells[0].volume).toBe(20)
+    expect(cells[0].pct).toBeCloseTo(20 / 40)
+  })
+
+  it('does not exceed today even when end_date is later', () => {
+    // JULY_SHRUGS ends Jul 31 but today is Jul 5
+    const cells = buildFocusLaneCells([JULY_SHRUGS], [], 'upper', '2026-07-05')
+    expect(cells[cells.length - 1].dayKey).toBe('2026-07-05')
+    expect(cells).toHaveLength(5)
+  })
+
+  it('pct over 1 is allowed (over-day)', () => {
+    const sets: StrengthSet[] = [setOn('shrugs', 2026, 6, 1, 200)] // 200 reps vs 100 target
+    const cells = buildFocusLaneCells([JULY_SHRUGS], sets, 'upper', '2026-07-01')
+    expect(cells[0].pct).toBe(2)
   })
 })

--- a/lib/training-facility/monthly-focus.ts
+++ b/lib/training-facility/monthly-focus.ts
@@ -1,5 +1,5 @@
 import type { FocusCategory, MonthlyFocus, StrengthSet } from '@/types/weight-room'
-import { toLocalDateKey } from './strength-today'
+import { pacificDayKey } from './load-management'
 
 export type { FocusCategory }
 
@@ -11,17 +11,30 @@ export type { FocusCategory }
  * mirroring `strength-today.ts` / `strength-streaks.ts`.
  *
  * All window math compares bare `YYYY-MM-DD` keys. PostgREST renders a
- * Postgres `date` in that canonical form, and `toLocalDateKey` produces
- * it for set timestamps, so lexicographic string comparison is exactly
- * chronological comparison — no `Date` parsing (and no UTC-midnight
- * timezone hazard) needed for the inclusive `start <= day <= end` test.
+ * Postgres `date` in that canonical form, and {@link pacificDayKey}
+ * produces it for set timestamps, so lexicographic string comparison is
+ * exactly chronological comparison — no `Date` parsing needed for the
+ * inclusive `start <= day <= end` test. Pacific is used throughout (same
+ * anchor as `load-management.ts` and `achievements.ts`, #319) so a set
+ * logged at 10 pm Pacific isn't displaced onto the following UTC day when
+ * this module runs inside a Vercel Server Component.
  */
+
+/**
+ * Convert an ISO timestamp string to a Pacific `YYYY-MM-DD` key, or `''`
+ * when the string doesn't parse. Mirrors `safePacificDayKey` in
+ * `achievements.ts`.
+ */
+function safePacificDayKey(ts: string): string {
+  const d = new Date(ts)
+  return Number.isFinite(d.getTime()) ? pacificDayKey(d) : ''
+}
 
 /**
  * Whether a focus window covers `dayKey` (inclusive on both ends).
  *
  * @param focus The focus whose `[start_date, end_date]` window to test.
- * @param dayKey `YYYY-MM-DD` key, e.g. from {@link toLocalDateKey}. An
+ * @param dayKey `YYYY-MM-DD` key, e.g. from {@link pacificDayKey}. An
  *   empty string (unparseable "today") is never in-window.
  */
 export function isFocusActiveOnDay(focus: MonthlyFocus, dayKey: string): boolean {
@@ -103,14 +116,16 @@ export function formatFocusWindow(focus: MonthlyFocus): string {
 }
 
 /**
- * Add `n` days to a `YYYY-MM-DD` key, returning a new key. Local-noon
- * base time so DST transitions don't shift the calendar day. Same helper
- * shape as `strength-streaks.addDays`.
+ * Add `n` days to a `YYYY-MM-DD` key, returning a new key. UTC-noon base
+ * time anchors the arithmetic so DST transitions don't shift the calendar
+ * day — the input key is already a resolved Pacific day, and pure date
+ * arithmetic doesn't re-introduce a zone. Same helper shape as
+ * `strength-streaks.addDays` / `achievements.addDays`.
  */
 function addDays(dateKey: string, n: number): string {
-  const d = new Date(dateKey + 'T12:00:00')
-  d.setDate(d.getDate() + n)
-  return toLocalDateKey(d)
+  const d = new Date(dateKey + 'T12:00:00Z')
+  d.setUTCDate(d.getUTCDate() + n)
+  return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}-${String(d.getUTCDate()).padStart(2, '0')}`
 }
 
 /**
@@ -162,9 +177,10 @@ export interface FocusAdherence {
  * @param focus The focus to score.
  * @param sets All logged sets, usually `WeightRoomData.sets`; filtered to
  *   this focus's `exercise` and window internally.
- * @param now Clock for "today" (local). Defaults to `new Date()`; pass
- *   the viewer's clock from server-rendered surfaces so UTC doesn't
- *   disagree with their timezone (#197).
+ * @param now Clock for "today". Defaults to `new Date()`; pass a fixed
+ *   instant in unit tests to keep assertions stable over real time. The
+ *   day key is derived via {@link pacificDayKey} so that server-rendered
+ *   pages (Vercel UTC) and the user's browser agree on "today" (#319).
  */
 export function computeFocusAdherence(
   focus: MonthlyFocus,
@@ -172,7 +188,7 @@ export function computeFocusAdherence(
   now: Date = new Date(),
 ): FocusAdherence {
   const daysInWindow = inclusiveDaySpan(focus.start_date, focus.end_date)
-  const today = toLocalDateKey(now)
+  const today = pacificDayKey(now)
 
   // Last elapsed day = min(today, end_date); nothing elapsed if today is
   // before the window opens.
@@ -193,7 +209,7 @@ export function computeFocusAdherence(
   const volumeByDay = new Map<string, number>()
   for (const s of sets) {
     if (s.exercise !== focus.exercise) continue
-    const day = toLocalDateKey(s.logged_at)
+    const day = safePacificDayKey(s.logged_at)
     if (day === '' || day < focus.start_date || day > lastElapsed) continue
     const increment = focus.target_kind === 'sets' ? 1 : s.reps
     volumeByDay.set(day, (volumeByDay.get(day) ?? 0) + increment)
@@ -295,7 +311,7 @@ export function computeFocusLoadStats(
 
   for (const s of sets) {
     if (s.exercise !== focus.exercise) continue
-    const day = toLocalDateKey(s.logged_at)
+    const day = safePacificDayKey(s.logged_at)
     if (day === '' || day < focus.start_date || day > focus.end_date) continue
     if (s.weight_lbs == null) continue
     weightedSets++
@@ -388,7 +404,7 @@ export function buildFocusLaneCells(
   const repsByKey = new Map<string, number>()
   const setCountByKey = new Map<string, number>()
   for (const s of sets) {
-    const day = toLocalDateKey(s.logged_at)
+    const day = safePacificDayKey(s.logged_at)
     if (day === '') continue
     const k = `${s.exercise}|${day}`
     repsByKey.set(k, (repsByKey.get(k) ?? 0) + s.reps)

--- a/lib/training-facility/monthly-focus.ts
+++ b/lib/training-facility/monthly-focus.ts
@@ -1,6 +1,7 @@
 import type { FocusCategory, MonthlyFocus, StrengthSet } from '@/types/weight-room'
-
 import { toLocalDateKey } from './strength-today'
+
+export type { FocusCategory }
 
 /**
  * Pure helpers for the "grease the groove" monthly focus (#255) — which
@@ -310,4 +311,111 @@ export function computeFocusLoadStats(
     weightedSets,
     loadMultiplier: implements_,
   }
+}
+
+// ---------------------------------------------------------------------------
+// Combined lane heatmap helpers (#361)
+// ---------------------------------------------------------------------------
+
+/**
+ * One day's slot in a stitched focus-lane heatmap. Each cell carries the
+ * calendar day, which focus was active in the lane on that day (or `null`
+ * for a gap between windows), and the normalized volume so the renderer
+ * can pick an intensity bucket without re-running the arithmetic.
+ */
+export interface FocusDayCell {
+  /** Local `YYYY-MM-DD` key for this calendar day. */
+  dayKey: string
+  /**
+   * The focus active in this cell's body-region lane on `dayKey`, or
+   * `null` when no focus window covers the day (a gap between rotations).
+   * Gap cells still appear in the returned array so the renderer can emit
+   * a visible break rather than silently collapsing the timeline.
+   */
+  focus: MonthlyFocus | null
+  /**
+   * Volume logged for `focus.exercise` on `dayKey`, interpreted per
+   * `focus.target_kind`: total reps for `'reps'`, distinct set count for
+   * `'sets'`. Always `0` for gap cells and days with no sets logged.
+   */
+  volume: number
+  /**
+   * `volume / focus.daily_target` — un-clamped so `1.0` means "exactly
+   * hit the goal" and `>1.0` is an over-day. Always `0` for gap cells and
+   * days with no sets logged.
+   */
+  pct: number
+}
+
+/**
+ * Build the ordered sequence of {@link FocusDayCell}s for one body-region
+ * lane (`category`), running from the earliest focus `start_date` through
+ * `today`. Used by the History page's "Grease the Groove Rotation" combined
+ * heatmap lane (#361).
+ *
+ * **Performance:** `sets` is pre-bucketed into `Map<string, number>` keyed
+ * by `${exercise}|${dayKey}` before the day-iteration loop, keeping the
+ * overall cost at O(sets + days) rather than O(sets × days).
+ *
+ * **Gap cells:** if no focus window covers a day in `[earliestStart, today]`,
+ * the cell is emitted with `focus: null, volume: 0, pct: 0` so the renderer
+ * can draw a visible gap rather than silently collapsing the timeline.
+ *
+ * @param focuses All configured focuses (across all categories); filtered to
+ *   `category` internally.
+ * @param sets All logged sets, usually `WeightRoomData.sets`.
+ * @param category Body-region lane to build — `'upper'` or `'lower'`.
+ * @param today Local `YYYY-MM-DD` key for the viewed day. An empty string
+ *   or a key before the earliest focus window returns an empty array.
+ */
+export function buildFocusLaneCells(
+  focuses: readonly MonthlyFocus[],
+  sets: readonly StrengthSet[],
+  category: FocusCategory,
+  today: string,
+): FocusDayCell[] {
+  const laneFocuses = focuses.filter((f) => f.category === category)
+  if (laneFocuses.length === 0 || today === '') return []
+
+  let earliestStart = laneFocuses[0].start_date
+  for (const f of laneFocuses) {
+    if (f.start_date < earliestStart) earliestStart = f.start_date
+  }
+
+  if (today < earliestStart) return []
+
+  // Pre-bucket sets by `${exercise}|${dayKey}` for O(sets + days) performance.
+  const repsByKey = new Map<string, number>()
+  const setCountByKey = new Map<string, number>()
+  for (const s of sets) {
+    const day = toLocalDateKey(s.logged_at)
+    if (day === '') continue
+    const k = `${s.exercise}|${day}`
+    repsByKey.set(k, (repsByKey.get(k) ?? 0) + s.reps)
+    setCountByKey.set(k, (setCountByKey.get(k) ?? 0) + 1)
+  }
+
+  const cells: FocusDayCell[] = []
+  let cursor = earliestStart
+
+  while (cursor <= today) {
+    // `activeFocusesForDay` handles within-lane resolution; since `laneFocuses`
+    // is already filtered to one category, at most one element is returned.
+    const active = activeFocusesForDay(laneFocuses, cursor)
+    const focus = active[0] ?? null
+
+    if (focus === null) {
+      cells.push({ dayKey: cursor, focus: null, volume: 0, pct: 0 })
+    } else {
+      const k = `${focus.exercise}|${cursor}`
+      const volume =
+        focus.target_kind === 'sets' ? (setCountByKey.get(k) ?? 0) : (repsByKey.get(k) ?? 0)
+      const pct = focus.daily_target > 0 ? volume / focus.daily_target : 0
+      cells.push({ dayKey: cursor, focus, volume, pct })
+    }
+
+    cursor = addDays(cursor, 1)
+  }
+
+  return cells
 }


### PR DESCRIPTION
## Summary

- Adds a **GTG Rotation** section to the History page: one card per time-boxed focus (newest first), each with an animated SVG adherence ring (days-hit ÷ days-in-window), campaign window, streak, and — for weighted focuses — top set, avg load, and tonnage.
- Adds two **stitched heatmap lanes** (upper / lower body region) spanning the full rotation. Each cell is coloured by %-of-that-focus's-daily-target so exercises across windows (shrugs in July, whatever in August, …) are directly comparable on the same timeline.
- Filters `kind: 'focus'` goals out of the per-exercise heatmap loop so closed campaigns no longer leave empty year-long grids.
- Fixes a pre-existing time-dependent `StrengthVsBodyweightChart` test that went stale once its hardcoded set date became a completed week.

## Test plan

- [ ] Navigate to `/training-facility/weight-room/history`
- [ ] **GTG Rotation section** appears below the Load Management chart and above the per-exercise heatmaps; each focus card shows exercise name, category chip, window + daily target, animated ring filling to the adherence %, days-hit/days-elapsed, streak, and window-length
- [ ] Weighted focuses (shrugs with a loaded set logged) also show the load stats row (top set / avg / tonnage)
- [ ] Ring animates on mount from 0 → adherence % with a 1 s ease-out
- [ ] **Focus Lane History section** shows upper and/or lower heatmap grids spanning from the earliest focus to today; cells are grey (gap) when no focus is active on that day, and colour-scaled by %-of-target when a focus is active
- [ ] Hovering a heatmap cell shows a `<title>` tooltip with date, exercise, reps/sets, and % info
- [ ] Per-exercise heatmaps no longer include a shrugs row (or any `kind: 'focus'` goal row)
- [ ] `npx vitest run` — all 1 581 tests pass
- [ ] `npx tsc --noEmit` — clean

Closes #361.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Focus Lane History heatmaps for upper- and lower-body training.
  * Added past focus cards showing adherence and, where applicable, top set, average load, and tonnage.
  * Updated exercise heatmaps to display permanent goals separately from time-boxed focuses.
  * Added detailed heatmap tooltips, focus legends, and improved empty-state handling.

* **Tests**
  * Expanded coverage for focus timelines, lane filtering, goal tracking, gaps, and date limits.
  * Stabilized chart tests involving time-sensitive data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->