### PR TITLE
feat(weight-room): effective-dated goal targets (#362)

### DIFF
--- a/app/api/admin/weight-room/goals/route.test.ts
+++ b/app/api/admin/weight-room/goals/route.test.ts
@@ -21,19 +21,12 @@ vi.mock('@/lib/auth/require-admin', () => ({
  * naming each step lets a test program exactly the one it cares about and
  * leave the rest on sensible defaults.
  */
-type QueryKind =
-  | 'existingGoal'
-  | 'insertGoal'
-  | 'upsertGoal'
-  | 'historyCount'
-  | 'historyUpsert'
-  | 'currentTarget'
+type QueryKind = 'existingGoal' | 'insertGoal' | 'upsertGoal' | 'historyRead' | 'historyUpsert'
 
-/** A Supabase-shaped result. `count` is only read by the history-count query. */
+/** A Supabase-shaped result. */
 interface QueryResult {
   data?: unknown
   error?: unknown
-  count?: number
 }
 
 /** Programmed responses per query kind; anything unset falls back to a benign default. */
@@ -45,9 +38,8 @@ const DEFAULTS: Record<QueryKind, QueryResult> = {
   existingGoal: { data: null, error: null },
   insertGoal: { data: null, error: null },
   upsertGoal: { data: null, error: null },
-  historyCount: { count: 1, error: null },
+  historyRead: { data: [], error: null },
   historyUpsert: { data: null, error: null },
-  currentTarget: { data: null, error: null },
 }
 
 /**
@@ -68,10 +60,9 @@ function makeChain(table: string) {
   }
 
   const chain = {
-    select: vi.fn((_cols?: unknown, opts?: { count?: string; head?: boolean }) => {
+    select: vi.fn(() => {
       if (kind === undefined) {
-        if (table === 'weight_room_goals') kind = 'existingGoal'
-        else kind = opts?.head === true ? 'historyCount' : 'currentTarget'
+        kind = table === 'weight_room_goals' ? 'existingGoal' : 'historyRead'
         record.kind = kind
       }
       return chain
@@ -135,6 +126,16 @@ function makeRequest(body: unknown): Request {
 describe('POST /api/admin/weight-room/goals', () => {
   const validGoal = { exercise: 'pushups', daily_target: 100, color: '#EA580C' }
 
+  /** Steady state for pushups: goal on file at 100, one matching history row. */
+  function pushupsOnFile() {
+    responses.existingGoal = { data: { exercise: 'pushups', daily_target: 100 }, error: null }
+    responses.historyRead = {
+      data: [{ daily_target: 100, effective_from: '2020-01-01' }],
+      error: null,
+    }
+    responses.upsertGoal = { data: validGoal, error: null }
+  }
+
   it('returns 401 when not signed in', async () => {
     requireAdminMock.mockResolvedValueOnce({
       ok: false,
@@ -162,6 +163,7 @@ describe('POST /api/admin/weight-room/goals', () => {
 
   it('returns 500 on unexpected Supabase errors', async () => {
     requireAdminMock.mockResolvedValue({ ok: true, email: 'a@b.com' })
+    pushupsOnFile()
     responses.upsertGoal = { data: null, error: { code: 'XX001', message: 'data corruption' } }
     const res = await POST(makeRequest(validGoal) as never)
     expect(res.status).toBe(500)
@@ -169,9 +171,7 @@ describe('POST /api/admin/weight-room/goals', () => {
 
   it('returns 200 with the upserted row on success', async () => {
     requireAdminMock.mockResolvedValue({ ok: true, email: 'a@b.com' })
-    responses.existingGoal = { data: { exercise: 'pushups', daily_target: 100 }, error: null }
-    responses.currentTarget = { data: { daily_target: 100 }, error: null }
-    responses.upsertGoal = { data: validGoal, error: null }
+    pushupsOnFile()
     const res = await POST(makeRequest(validGoal) as never)
     expect(res.status).toBe(200)
     const body = await res.json()
@@ -184,9 +184,7 @@ describe('POST /api/admin/weight-room/goals', () => {
 
   it('stamps updated_at so edits advance the row freshness', async () => {
     requireAdminMock.mockResolvedValue({ ok: true, email: 'a@b.com' })
-    responses.existingGoal = { data: { exercise: 'pushups', daily_target: 100 }, error: null }
-    responses.currentTarget = { data: { daily_target: 100 }, error: null }
-    responses.upsertGoal = { data: validGoal, error: null }
+    pushupsOnFile()
     await POST(makeRequest(validGoal) as never)
     expect(callFor('upsertGoal')?.payload).toEqual(
       // Loose ISO-8601 check: starts with YYYY-MM-DD.
@@ -203,12 +201,18 @@ describe('POST /api/admin/weight-room/goals', () => {
       vi.setSystemTime(new Date('2026-08-15T19:00:00Z'))
     })
 
-    it('appends a history row dated today when the target changes', async () => {
+    /** Pullups on file at 30 with a single seed row — the common starting point. */
+    function pullupsAt30() {
       responses.existingGoal = { data: { exercise: 'pullups', daily_target: 30 }, error: null }
-      responses.historyCount = { count: 1, error: null }
-      responses.currentTarget = { data: { daily_target: 50 }, error: null }
+      responses.historyRead = {
+        data: [{ daily_target: 30, effective_from: '2020-01-01' }],
+        error: null,
+      }
       responses.upsertGoal = { data: { exercise: 'pullups' }, error: null }
+    }
 
+    it('appends a history row dated today when the target changes', async () => {
+      pullupsAt30()
       const res = await POST(
         makeRequest({ exercise: 'pullups', daily_target: 50, color: '#0EA5A1' }) as never,
       )
@@ -226,11 +230,7 @@ describe('POST /api/admin/weight-room/goals', () => {
     })
 
     it('honours a backdated effective_from', async () => {
-      responses.existingGoal = { data: { exercise: 'pullups', daily_target: 30 }, error: null }
-      responses.historyCount = { count: 1, error: null }
-      responses.currentTarget = { data: { daily_target: 50 }, error: null }
-      responses.upsertGoal = { data: { exercise: 'pullups' }, error: null }
-
+      pullupsAt30()
       await POST(
         makeRequest({
           exercise: 'pullups',
@@ -241,6 +241,35 @@ describe('POST /api/admin/weight-room/goals', () => {
       )
       expect(callFor('historyUpsert')?.payload).toEqual([
         expect.objectContaining({ effective_from: '2026-08-01', daily_target: 50 }),
+      ])
+    })
+
+    it('appends a backdate whose value matches the current mirror', async () => {
+      // History says 30 until Aug 10, then 50 — so the mirror reads 50.
+      // "The 50 actually started Aug 1" must still append, even though the
+      // payload target equals the mirror. Gating on the mirror dropped this
+      // silently and returned 200, defeating the point of backdating.
+      responses.existingGoal = { data: { exercise: 'pullups', daily_target: 50 }, error: null }
+      responses.historyRead = {
+        data: [
+          { daily_target: 30, effective_from: '2020-01-01' },
+          { daily_target: 50, effective_from: '2026-08-10' },
+        ],
+        error: null,
+      }
+      responses.upsertGoal = { data: { exercise: 'pullups' }, error: null }
+
+      const res = await POST(
+        makeRequest({
+          exercise: 'pullups',
+          daily_target: 50,
+          color: '#0EA5A1',
+          effective_from: '2026-08-01',
+        }) as never,
+      )
+      expect(res.status).toBe(200)
+      expect(callFor('historyUpsert')?.payload).toEqual([
+        expect.objectContaining({ daily_target: 50, effective_from: '2026-08-01' }),
       ])
     })
 
@@ -260,10 +289,7 @@ describe('POST /api/admin/weight-room/goals', () => {
     })
 
     it('does not append history for a colour-only edit', async () => {
-      responses.existingGoal = { data: { exercise: 'pullups', daily_target: 30 }, error: null }
-      responses.currentTarget = { data: { daily_target: 30 }, error: null }
-      responses.upsertGoal = { data: { exercise: 'pullups' }, error: null }
-
+      pullupsAt30()
       const res = await POST(
         makeRequest({ exercise: 'pullups', daily_target: 30, color: '#123456' }) as never,
       )
@@ -273,8 +299,7 @@ describe('POST /api/admin/weight-room/goals', () => {
 
     it('seeds a baseline row when an existing goal has no history yet', async () => {
       responses.existingGoal = { data: { exercise: 'pullups', daily_target: 30 }, error: null }
-      responses.historyCount = { count: 0, error: null }
-      responses.currentTarget = { data: { daily_target: 50 }, error: null }
+      responses.historyRead = { data: [], error: null }
       responses.upsertGoal = { data: { exercise: 'pullups' }, error: null }
 
       await POST(
@@ -288,13 +313,31 @@ describe('POST /api/admin/weight-room/goals', () => {
       ])
     })
 
+    it('repairs a history-less goal even when the target is unchanged', async () => {
+      // Reachable after a create whose history write failed: the goal row
+      // exists, history does not, and a retry with the same payload would
+      // never append under change-gated logic — leaving the goal permanently
+      // without history.
+      responses.existingGoal = { data: { exercise: 'pullups', daily_target: 50 }, error: null }
+      responses.historyRead = { data: [], error: null }
+      responses.upsertGoal = { data: { exercise: 'pullups' }, error: null }
+
+      await POST(
+        makeRequest({ exercise: 'pullups', daily_target: 50, color: '#0EA5A1' }) as never,
+      )
+      expect(callFor('historyUpsert')?.payload).toEqual([
+        expect.objectContaining({ daily_target: 50, effective_from: '1970-01-01' }),
+      ])
+    })
+
     it('seeds history for a brand-new goal', async () => {
       responses.existingGoal = { data: null, error: null }
-      responses.currentTarget = { data: { daily_target: 40 }, error: null }
+      responses.historyRead = { data: [], error: null }
       responses.upsertGoal = { data: { exercise: 'dips' }, error: null }
 
       await POST(makeRequest({ exercise: 'dips', daily_target: 40, color: '#123456' }) as never)
       expect(callFor('insertGoal')).toBeDefined()
+      // No retroactive baseline — a brand-new goal has no past to protect.
       expect(callFor('historyUpsert')?.payload).toEqual([
         expect.objectContaining({ daily_target: 40, effective_from: '2026-08-15' }),
       ])
@@ -302,10 +345,15 @@ describe('POST /api/admin/weight-room/goals', () => {
 
     it('mirrors the resolved current target, not the payload, when backdating behind a newer entry', async () => {
       responses.existingGoal = { data: { exercise: 'pullups', daily_target: 50 }, error: null }
-      responses.historyCount = { count: 2, error: null }
       // A newer entry (50, effective Aug 10) already governs today, so
       // backdating a 40 to Aug 1 must leave the mirror at 50.
-      responses.currentTarget = { data: { daily_target: 50 }, error: null }
+      responses.historyRead = {
+        data: [
+          { daily_target: 30, effective_from: '2020-01-01' },
+          { daily_target: 50, effective_from: '2026-08-10' },
+        ],
+        error: null,
+      }
       responses.upsertGoal = { data: { exercise: 'pullups' }, error: null }
 
       await POST(
@@ -321,9 +369,18 @@ describe('POST /api/admin/weight-room/goals', () => {
       )
     })
 
+    it('advances the mirror when the change is the newest entry', async () => {
+      pullupsAt30()
+      await POST(
+        makeRequest({ exercise: 'pullups', daily_target: 50, color: '#0EA5A1' }) as never,
+      )
+      expect(callFor('upsertGoal')?.payload).toEqual(
+        expect.objectContaining({ daily_target: 50 }),
+      )
+    })
+
     it('returns 500 and writes no mirror when the history write fails', async () => {
-      responses.existingGoal = { data: { exercise: 'pullups', daily_target: 30 }, error: null }
-      responses.historyCount = { count: 1, error: null }
+      pullupsAt30()
       responses.historyUpsert = { data: null, error: { message: 'conflict' } }
 
       const res = await POST(
@@ -333,6 +390,17 @@ describe('POST /api/admin/weight-room/goals', () => {
       // History is written first precisely so a failure here leaves the goal
       // row untouched rather than half-applied.
       expect(callFor('upsertGoal')).toBeUndefined()
+    })
+
+    it('returns 500 when the history read fails', async () => {
+      responses.existingGoal = { data: { exercise: 'pullups', daily_target: 30 }, error: null }
+      responses.historyRead = { data: null, error: { message: 'unavailable' } }
+
+      const res = await POST(
+        makeRequest({ exercise: 'pullups', daily_target: 50, color: '#0EA5A1' }) as never,
+      )
+      expect(res.status).toBe(500)
+      expect(callFor('historyUpsert')).toBeUndefined()
     })
   })
 })

--- a/app/api/admin/weight-room/goals/route.test.ts
+++ b/app/api/admin/weight-room/goals/route.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { NextResponse } from 'next/server'
 
 import { POST } from './route'
@@ -6,8 +6,8 @@ import { POST } from './route'
 /**
  * Tests for `POST /api/admin/weight-room/goals`. Auth gate + Supabase
  * service-role client are mocked; the route's own logic (JSON parsing,
- * Zod validation, hex-color enforcement, upsert success path) is
- * exercised in isolation.
+ * Zod validation, hex-color enforcement, effective-dated target history,
+ * upsert success path) is exercised in isolation.
  */
 
 const requireAdminMock = vi.fn()
@@ -15,28 +15,113 @@ vi.mock('@/lib/auth/require-admin', () => ({
   requireAdmin: () => requireAdminMock(),
 }))
 
-const upsertMock = vi.fn()
-const supabaseChain = {
-  from: vi.fn(() => supabaseChain),
-  upsert: vi.fn(() => supabaseChain),
-  select: vi.fn(() => supabaseChain),
-  single: vi.fn(() => upsertMock()),
+/**
+ * Which logical query a chain represents, derived from the table plus the
+ * first operation called on it. The route issues a deterministic sequence, so
+ * naming each step lets a test program exactly the one it cares about and
+ * leave the rest on sensible defaults.
+ */
+type QueryKind =
+  | 'existingGoal'
+  | 'insertGoal'
+  | 'upsertGoal'
+  | 'historyCount'
+  | 'historyUpsert'
+  | 'currentTarget'
+
+/** A Supabase-shaped result. `count` is only read by the history-count query. */
+interface QueryResult {
+  data?: unknown
+  error?: unknown
+  count?: number
 }
+
+/** Programmed responses per query kind; anything unset falls back to a benign default. */
+let responses: Partial<Record<QueryKind, QueryResult>>
+/** Every chain the route built, in order — the assertion surface for writes. */
+let calls: { kind: QueryKind; table: string; payload?: unknown; options?: unknown }[]
+
+const DEFAULTS: Record<QueryKind, QueryResult> = {
+  existingGoal: { data: null, error: null },
+  insertGoal: { data: null, error: null },
+  upsertGoal: { data: null, error: null },
+  historyCount: { count: 1, error: null },
+  historyUpsert: { data: null, error: null },
+  currentTarget: { data: null, error: null },
+}
+
+/**
+ * Build a chainable, thenable query stub. Every filter/order method returns
+ * `this`; awaiting the chain (or calling `single`/`maybeSingle`) resolves the
+ * response programmed for its {@link QueryKind}.
+ */
+function makeChain(table: string) {
+  let kind: QueryKind | undefined
+  const record: { kind: QueryKind; table: string; payload?: unknown; options?: unknown } = {
+    kind: 'existingGoal',
+    table,
+  }
+
+  const settle = (): Promise<QueryResult> => {
+    const resolved = kind ?? 'existingGoal'
+    return Promise.resolve(responses[resolved] ?? DEFAULTS[resolved])
+  }
+
+  const chain = {
+    select: vi.fn((_cols?: unknown, opts?: { count?: string; head?: boolean }) => {
+      if (kind === undefined) {
+        if (table === 'weight_room_goals') kind = 'existingGoal'
+        else kind = opts?.head === true ? 'historyCount' : 'currentTarget'
+        record.kind = kind
+      }
+      return chain
+    }),
+    insert: vi.fn((payload: unknown) => {
+      kind = 'insertGoal'
+      record.kind = kind
+      record.payload = payload
+      calls.push(record)
+      return chain
+    }),
+    upsert: vi.fn((payload: unknown, options?: unknown) => {
+      kind = table === 'weight_room_goals' ? 'upsertGoal' : 'historyUpsert'
+      record.kind = kind
+      record.payload = payload
+      record.options = options
+      calls.push(record)
+      return chain
+    }),
+    eq: vi.fn(() => chain),
+    lte: vi.fn(() => chain),
+    order: vi.fn(() => chain),
+    limit: vi.fn(() => chain),
+    maybeSingle: vi.fn(() => settle()),
+    single: vi.fn(() => settle()),
+    then: (onFulfilled: (v: QueryResult) => unknown, onRejected?: (e: unknown) => unknown) =>
+      settle().then(onFulfilled, onRejected),
+  }
+  return chain
+}
+
+const fromMock = vi.fn((table: string) => makeChain(table))
 vi.mock('@/lib/supabase/admin', () => ({
-  createAdminSupabaseClient: () => supabaseChain,
+  createAdminSupabaseClient: () => ({ from: fromMock }),
 }))
+
+/** The write recorded for a given query kind, or `undefined` if it never ran. */
+function callFor(kind: QueryKind) {
+  return calls.find((c) => c.kind === kind)
+}
 
 beforeEach(() => {
   requireAdminMock.mockReset()
-  upsertMock.mockReset()
-  supabaseChain.from.mockClear()
-  supabaseChain.upsert.mockClear()
-  supabaseChain.select.mockClear()
-  supabaseChain.single.mockClear()
-  supabaseChain.from.mockReturnValue(supabaseChain)
-  supabaseChain.upsert.mockReturnValue(supabaseChain)
-  supabaseChain.select.mockReturnValue(supabaseChain)
-  supabaseChain.single.mockImplementation(() => upsertMock())
+  fromMock.mockClear()
+  responses = {}
+  calls = []
+})
+
+afterEach(() => {
+  vi.useRealTimers()
 })
 
 function makeRequest(body: unknown): Request {
@@ -77,38 +162,177 @@ describe('POST /api/admin/weight-room/goals', () => {
 
   it('returns 500 on unexpected Supabase errors', async () => {
     requireAdminMock.mockResolvedValue({ ok: true, email: 'a@b.com' })
-    upsertMock.mockResolvedValueOnce({
-      data: null,
-      error: { code: 'XX001', message: 'data corruption' },
-    })
+    responses.upsertGoal = { data: null, error: { code: 'XX001', message: 'data corruption' } }
     const res = await POST(makeRequest(validGoal) as never)
     expect(res.status).toBe(500)
   })
 
   it('returns 200 with the upserted row on success', async () => {
     requireAdminMock.mockResolvedValue({ ok: true, email: 'a@b.com' })
-    upsertMock.mockResolvedValueOnce({ data: validGoal, error: null })
+    responses.existingGoal = { data: { exercise: 'pushups', daily_target: 100 }, error: null }
+    responses.currentTarget = { data: { daily_target: 100 }, error: null }
+    responses.upsertGoal = { data: validGoal, error: null }
     const res = await POST(makeRequest(validGoal) as never)
     expect(res.status).toBe(200)
     const body = await res.json()
     expect(body).toEqual(validGoal)
-    // Route stamps `updated_at` so edits advance the row's audit
-    // timestamp; the value is `new Date().toISOString()` so we just
-    // assert it's an ISO-shaped string.
-    expect(supabaseChain.upsert).toHaveBeenCalledWith(
+    expect(callFor('upsertGoal')?.payload).toEqual(
       expect.objectContaining({ ...validGoal, updated_at: expect.any(String) }),
-      { onConflict: 'exercise' },
     )
+    expect(callFor('upsertGoal')?.options).toEqual({ onConflict: 'exercise' })
   })
 
   it('stamps updated_at so edits advance the row freshness', async () => {
     requireAdminMock.mockResolvedValue({ ok: true, email: 'a@b.com' })
-    upsertMock.mockResolvedValueOnce({ data: validGoal, error: null })
+    responses.existingGoal = { data: { exercise: 'pushups', daily_target: 100 }, error: null }
+    responses.currentTarget = { data: { daily_target: 100 }, error: null }
+    responses.upsertGoal = { data: validGoal, error: null }
     await POST(makeRequest(validGoal) as never)
-    expect(supabaseChain.upsert).toHaveBeenCalledWith(
+    expect(callFor('upsertGoal')?.payload).toEqual(
       // Loose ISO-8601 check: starts with YYYY-MM-DD.
       expect.objectContaining({ updated_at: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T/) }),
-      { onConflict: 'exercise' },
     )
+  })
+
+  describe('effective-dated target history (#362)', () => {
+    beforeEach(() => {
+      requireAdminMock.mockResolvedValue({ ok: true, email: 'a@b.com' })
+      // Fixed clock so "today" is deterministic. 19:00Z is midday Pacific
+      // year-round, so the Pacific day key is unambiguously 2026-08-15.
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026-08-15T19:00:00Z'))
+    })
+
+    it('appends a history row dated today when the target changes', async () => {
+      responses.existingGoal = { data: { exercise: 'pullups', daily_target: 30 }, error: null }
+      responses.historyCount = { count: 1, error: null }
+      responses.currentTarget = { data: { daily_target: 50 }, error: null }
+      responses.upsertGoal = { data: { exercise: 'pullups' }, error: null }
+
+      const res = await POST(
+        makeRequest({ exercise: 'pullups', daily_target: 50, color: '#0EA5A1' }) as never,
+      )
+      expect(res.status).toBe(200)
+      expect(callFor('historyUpsert')?.payload).toEqual([
+        expect.objectContaining({
+          exercise: 'pullups',
+          daily_target: 50,
+          effective_from: '2026-08-15',
+        }),
+      ])
+      expect(callFor('historyUpsert')?.options).toEqual({
+        onConflict: 'exercise,effective_from',
+      })
+    })
+
+    it('honours a backdated effective_from', async () => {
+      responses.existingGoal = { data: { exercise: 'pullups', daily_target: 30 }, error: null }
+      responses.historyCount = { count: 1, error: null }
+      responses.currentTarget = { data: { daily_target: 50 }, error: null }
+      responses.upsertGoal = { data: { exercise: 'pullups' }, error: null }
+
+      await POST(
+        makeRequest({
+          exercise: 'pullups',
+          daily_target: 50,
+          color: '#0EA5A1',
+          effective_from: '2026-08-01',
+        }) as never,
+      )
+      expect(callFor('historyUpsert')?.payload).toEqual([
+        expect.objectContaining({ effective_from: '2026-08-01', daily_target: 50 }),
+      ])
+    })
+
+    it('rejects a future effective_from', async () => {
+      const res = await POST(
+        makeRequest({
+          exercise: 'pullups',
+          daily_target: 50,
+          color: '#0EA5A1',
+          effective_from: '2026-09-01',
+        }) as never,
+      )
+      expect(res.status).toBe(400)
+      const body = await res.json()
+      expect(body.error).toMatch(/future/i)
+      expect(callFor('historyUpsert')).toBeUndefined()
+    })
+
+    it('does not append history for a colour-only edit', async () => {
+      responses.existingGoal = { data: { exercise: 'pullups', daily_target: 30 }, error: null }
+      responses.currentTarget = { data: { daily_target: 30 }, error: null }
+      responses.upsertGoal = { data: { exercise: 'pullups' }, error: null }
+
+      const res = await POST(
+        makeRequest({ exercise: 'pullups', daily_target: 30, color: '#123456' }) as never,
+      )
+      expect(res.status).toBe(200)
+      expect(callFor('historyUpsert')).toBeUndefined()
+    })
+
+    it('seeds a baseline row when an existing goal has no history yet', async () => {
+      responses.existingGoal = { data: { exercise: 'pullups', daily_target: 30 }, error: null }
+      responses.historyCount = { count: 0, error: null }
+      responses.currentTarget = { data: { daily_target: 50 }, error: null }
+      responses.upsertGoal = { data: { exercise: 'pullups' }, error: null }
+
+      await POST(
+        makeRequest({ exercise: 'pullups', daily_target: 50, color: '#0EA5A1' }) as never,
+      )
+      // Old target anchored at the epoch so no logged day is left uncovered
+      // and the past keeps scoring against 30.
+      expect(callFor('historyUpsert')?.payload).toEqual([
+        expect.objectContaining({ daily_target: 30, effective_from: '1970-01-01' }),
+        expect.objectContaining({ daily_target: 50, effective_from: '2026-08-15' }),
+      ])
+    })
+
+    it('seeds history for a brand-new goal', async () => {
+      responses.existingGoal = { data: null, error: null }
+      responses.currentTarget = { data: { daily_target: 40 }, error: null }
+      responses.upsertGoal = { data: { exercise: 'dips' }, error: null }
+
+      await POST(makeRequest({ exercise: 'dips', daily_target: 40, color: '#123456' }) as never)
+      expect(callFor('insertGoal')).toBeDefined()
+      expect(callFor('historyUpsert')?.payload).toEqual([
+        expect.objectContaining({ daily_target: 40, effective_from: '2026-08-15' }),
+      ])
+    })
+
+    it('mirrors the resolved current target, not the payload, when backdating behind a newer entry', async () => {
+      responses.existingGoal = { data: { exercise: 'pullups', daily_target: 50 }, error: null }
+      responses.historyCount = { count: 2, error: null }
+      // A newer entry (50, effective Aug 10) already governs today, so
+      // backdating a 40 to Aug 1 must leave the mirror at 50.
+      responses.currentTarget = { data: { daily_target: 50 }, error: null }
+      responses.upsertGoal = { data: { exercise: 'pullups' }, error: null }
+
+      await POST(
+        makeRequest({
+          exercise: 'pullups',
+          daily_target: 40,
+          color: '#0EA5A1',
+          effective_from: '2026-08-01',
+        }) as never,
+      )
+      expect(callFor('upsertGoal')?.payload).toEqual(
+        expect.objectContaining({ daily_target: 50 }),
+      )
+    })
+
+    it('returns 500 and writes no mirror when the history write fails', async () => {
+      responses.existingGoal = { data: { exercise: 'pullups', daily_target: 30 }, error: null }
+      responses.historyCount = { count: 1, error: null }
+      responses.historyUpsert = { data: null, error: { message: 'conflict' } }
+
+      const res = await POST(
+        makeRequest({ exercise: 'pullups', daily_target: 50, color: '#0EA5A1' }) as never,
+      )
+      expect(res.status).toBe(500)
+      // History is written first precisely so a failure here leaves the goal
+      // row untouched rather than half-applied.
+      expect(callFor('upsertGoal')).toBeUndefined()
+    })
   })
 })

--- a/app/api/admin/weight-room/goals/route.ts
+++ b/app/api/admin/weight-room/goals/route.ts
@@ -23,7 +23,9 @@ import { requireAdmin } from '@/lib/auth/require-admin'
 import { WeightRoomGoalUpsertSchema } from '@/lib/schemas/weight-room'
 import { createAdminSupabaseClient } from '@/lib/supabase/admin'
 import { withTelemetry } from '@/lib/telemetry/with-telemetry'
+import { targetForDay } from '@/lib/training-facility/goal-targets'
 import { pacificDayKey } from '@/lib/training-facility/load-management'
+import type { GoalTargetPoint } from '@/types/weight-room'
 
 /**
  * Synthetic floor date for a retroactive baseline row.
@@ -37,6 +39,54 @@ import { pacificDayKey } from '@/lib/training-facility/load-management'
  * the baseline rather than a change.
  */
 const BASELINE_EFFECTIVE_FROM = '1970-01-01'
+
+/**
+ * The target recorded as in effect on `dayKey`, or `undefined` when no entry
+ * covers it.
+ *
+ * Distinct from {@link targetForDay}, which is a *read* helper and therefore
+ * always answers with something usable (falling back to the earliest entry, or
+ * to the goal's current target). The write path needs to tell "no entry covers
+ * this day" apart from "an entry covers it and happens to match", because only
+ * the former should append.
+ *
+ * @param history Target entries for one exercise, any order.
+ * @param dayKey `YYYY-MM-DD` day to resolve.
+ */
+function resolveRecordedTarget(
+  history: readonly GoalTargetPoint[],
+  dayKey: string
+): number | undefined {
+  let best: GoalTargetPoint | undefined
+  for (const point of history) {
+    if (point.effective_from > dayKey) continue
+    if (best === undefined || point.effective_from > best.effective_from) best = point
+  }
+  return best?.daily_target
+}
+
+/**
+ * Fold the rows just written into the history read a moment ago, so the mirror
+ * can be resolved without a second round trip. Rows written win on a
+ * `effective_from` collision, matching the upsert's `onConflict` behavior.
+ *
+ * @param existing History as read before the write.
+ * @param written Rows passed to the upsert (may be empty).
+ */
+function mergeHistory(
+  existing: readonly GoalTargetPoint[],
+  written: readonly { daily_target: number; effective_from: string }[]
+): GoalTargetPoint[] {
+  const byDate = new Map<string, GoalTargetPoint>()
+  for (const point of existing) byDate.set(point.effective_from, point)
+  for (const row of written) {
+    byDate.set(row.effective_from, {
+      daily_target: row.daily_target,
+      effective_from: row.effective_from,
+    })
+  }
+  return [...byDate.values()]
+}
 
 /**
  * Upsert a goal — create-or-replace by `exercise`. Body must conform
@@ -112,8 +162,8 @@ async function handlePOST(request: NextRequest): Promise<NextResponse> {
   const nowIso = new Date().toISOString()
 
   // What's on file already? Distinguishes a create (seed history alongside
-  // the row) from an edit (append only when the target actually moved), and
-  // a colour-only edit must not manufacture a history entry.
+  // the row) from an edit, and supplies the value a retroactive baseline
+  // carries when a goal somehow has no history.
   const { data: existing, error: existingError } = await supabase
     .from('weight_room_goals')
     .select('exercise, daily_target')
@@ -126,6 +176,28 @@ async function handlePOST(request: NextRequest): Promise<NextResponse> {
       { status: 500 }
     )
   }
+
+  // The whole history for this exercise. It's a handful of rows (a target
+  // moves a few times a year), so fetching it beats three separate probes —
+  // and it lets the decisions below reuse the same tested resolver the read
+  // path uses instead of reimplementing resolution in SQL.
+  const { data: historyRaw, error: historyReadError } = await supabase
+    .from('weight_room_goal_targets')
+    .select('daily_target, effective_from')
+    .eq('exercise', goalFields.exercise)
+    .order('effective_from', { ascending: true })
+
+  if (historyReadError) {
+    return NextResponse.json(
+      { error: `Failed to read goal target history: ${historyReadError.message}` },
+      { status: 500 }
+    )
+  }
+
+  const history: GoalTargetPoint[] = (historyRaw ?? []).map((row) => ({
+    daily_target: row.daily_target,
+    effective_from: row.effective_from,
+  }))
 
   // The history table is FK'd to weight_room_goals, so a brand-new goal's row
   // has to exist before its seed entry can be written.
@@ -141,44 +213,48 @@ async function handlePOST(request: NextRequest): Promise<NextResponse> {
     }
   }
 
-  const targetChanged = existing !== null && existing.daily_target !== goalFields.daily_target
+  const historyRows: {
+    exercise: string
+    daily_target: number
+    effective_from: string
+    updated_at: string
+  }[] = []
 
-  if (existing === null || targetChanged) {
-    const historyRows = [
-      {
-        exercise: goalFields.exercise,
-        daily_target: goalFields.daily_target,
-        effective_from: effectiveFrom,
-        updated_at: nowIso,
-      },
-    ]
+  // Retroactive baseline: a goal with no history at all needs its *old* target
+  // anchored before everything, or the resolver's before-first fallback scores
+  // the entire past against the new value — the exact re-scoring this feature
+  // exists to prevent. Writing it unconditionally (not only when the target
+  // moves) also repairs a goal left history-less by an earlier failed write,
+  // which a change-gated version could never revisit.
+  if (history.length === 0 && existing !== null) {
+    historyRows.push({
+      exercise: goalFields.exercise,
+      daily_target: existing.daily_target,
+      effective_from: BASELINE_EFFECTIVE_FROM,
+      updated_at: nowIso,
+    })
+  }
 
-    // Defensive baseline: an existing goal whose target is changing but which
-    // carries no history would leave every day before `effectiveFrom`
-    // uncovered, and the resolver's before-first fallback would score them
-    // against the *new* target — the very re-scoring this feature exists to
-    // prevent. Anchor the old value at the epoch so the past stays intact.
-    if (targetChanged) {
-      const { count, error: countError } = await supabase
-        .from('weight_room_goal_targets')
-        .select('id', { count: 'exact', head: true })
-        .eq('exercise', goalFields.exercise)
-      if (countError) {
-        return NextResponse.json(
-          { error: `Failed to read goal target history: ${countError.message}` },
-          { status: 500 }
-        )
-      }
-      if ((count ?? 0) === 0) {
-        historyRows.unshift({
-          exercise: goalFields.exercise,
-          daily_target: existing.daily_target,
-          effective_from: BASELINE_EFFECTIVE_FROM,
-          updated_at: nowIso,
-        })
-      }
-    }
+  // Append when the requested target differs from whatever was *already in
+  // effect on `effectiveFrom`* — not from the current mirror. Comparing
+  // against the mirror silently dropped a backdate whose value matched it
+  // ("the 50 actually started Aug 1" while the mirror already read 50), which
+  // is precisely the backdating case this endpoint exists to support.
+  const targetOnEffectiveFrom =
+    history.length === 0
+      ? existing?.daily_target
+      : resolveRecordedTarget(history, effectiveFrom)
 
+  if (targetOnEffectiveFrom !== goalFields.daily_target) {
+    historyRows.push({
+      exercise: goalFields.exercise,
+      daily_target: goalFields.daily_target,
+      effective_from: effectiveFrom,
+      updated_at: nowIso,
+    })
+  }
+
+  if (historyRows.length > 0) {
     const { error: historyError } = await supabase
       .from('weight_room_goal_targets')
       .upsert(historyRows, { onConflict: 'exercise,effective_from' })
@@ -190,25 +266,15 @@ async function handlePOST(request: NextRequest): Promise<NextResponse> {
     }
   }
 
-  // Re-derive the mirror from history rather than trusting the payload: a
-  // backdated change can land *behind* a newer entry, in which case the
-  // current target is unchanged and writing the payload value would wrongly
-  // advance it.
-  const { data: currentTarget, error: currentError } = await supabase
-    .from('weight_room_goal_targets')
-    .select('daily_target')
-    .eq('exercise', goalFields.exercise)
-    .lte('effective_from', today)
-    .order('effective_from', { ascending: false })
-    .limit(1)
-    .maybeSingle()
-
-  if (currentError) {
-    return NextResponse.json(
-      { error: `Failed to resolve current goal target: ${currentError.message}` },
-      { status: 500 }
-    )
-  }
+  // Re-derive the mirror from the post-write history rather than trusting the
+  // payload: a backdated change can land *behind* a newer entry, in which case
+  // the current target is unchanged and writing the payload value would
+  // wrongly advance it. Merged in memory so this costs no extra round trip.
+  const mergedHistory = mergeHistory(history, historyRows)
+  const currentDailyTarget = targetForDay(
+    { ...goalFields, target_history: mergedHistory },
+    today
+  )
 
   // Stamp `updated_at` explicitly so the upsert advances the row's audit
   // timestamp on edits — without this, the existing-row branch keeps
@@ -217,7 +283,7 @@ async function handlePOST(request: NextRequest): Promise<NextResponse> {
   // Mirrors the pattern used by the cardio import script's upserts.
   const upsertRow = {
     ...goalFields,
-    daily_target: currentTarget?.daily_target ?? goalFields.daily_target,
+    daily_target: currentDailyTarget,
     updated_at: nowIso,
   }
   const { data, error } = await supabase

--- a/app/api/admin/weight-room/goals/route.ts
+++ b/app/api/admin/weight-room/goals/route.ts
@@ -6,6 +6,13 @@
  * primary key, so a single POST with `onConflict: 'exercise'` covers
  * both create and update — no separate PUT.
  *
+ * Changing a target is an **append**, not a destructive update (#362): the
+ * new value lands in `weight_room_goal_targets` dated from `effective_from`
+ * (today unless backdated), and `weight_room_goals.daily_target` is
+ * re-derived from that history as a current-value mirror. Overwriting in
+ * place is what made a goal change re-score every past day — same reasoning
+ * as the append-only OTF upsert in #268.
+ *
  * Pair with `[exercise]/route.ts` for DELETE.
  */
 
@@ -16,6 +23,20 @@ import { requireAdmin } from '@/lib/auth/require-admin'
 import { WeightRoomGoalUpsertSchema } from '@/lib/schemas/weight-room'
 import { createAdminSupabaseClient } from '@/lib/supabase/admin'
 import { withTelemetry } from '@/lib/telemetry/with-telemetry'
+import { pacificDayKey } from '@/lib/training-facility/load-management'
+
+/**
+ * Synthetic floor date for a retroactive baseline row.
+ *
+ * Only reachable when an existing goal has no target history at all — the
+ * migration backfilled every goal, and every create through this route seeds
+ * one, so in practice this is dead defensive code. If it ever does fire,
+ * dating the *old* target from the epoch means no logged day is left
+ * uncovered, which is what stops the new target from silently re-scoring the
+ * past. It is never rendered: `goalTargetChanges` treats the oldest entry as
+ * the baseline rather than a change.
+ */
+const BASELINE_EFFECTIVE_FROM = '1970-01-01'
 
 /**
  * Upsert a goal — create-or-replace by `exercise`. Body must conform
@@ -23,9 +44,24 @@ import { withTelemetry } from '@/lib/telemetry/with-telemetry'
  * `Pushups` and `pushups` collapse onto the same row instead of
  * creating duplicates.
  *
+ * A `daily_target` change appends a `weight_room_goal_targets` row rather
+ * than overwriting history (#362). `effective_from` in the body declares the
+ * day the new target takes effect and may be **backdated** ("the 50 goal
+ * actually started Aug 1"); omitted, it defaults to today. Future dates are
+ * rejected — the mirror column below records the target in effect *now*, and
+ * a future-dated change would leave it stale from the moment that date
+ * arrived with nothing to re-sync it.
+ *
+ * Write order is deliberate: history first, mirror second. If the history
+ * write fails, nothing has changed and the request is cleanly retryable; if
+ * only the mirror update fails, the historical scoring is still correct and
+ * the next save repairs the label. The reverse order could leave a target
+ * change recorded nowhere but the mirror.
+ *
  * Status codes:
  * - 200 — upserted (response echoes the merged row)
- * - 400 — payload failed Zod validation or wasn't valid JSON
+ * - 400 — payload failed Zod validation, wasn't valid JSON, or
+ *   `effective_from` is in the future
  * - 401 — not signed in
  * - 403 — signed in but email not on the allowlist
  * - 500 — unexpected Supabase error
@@ -59,13 +95,131 @@ async function handlePOST(request: NextRequest): Promise<NextResponse> {
     throw err
   }
 
+  const { effective_from: requestedEffectiveFrom, ...goalFields } = goal
+  const today = pacificDayKey(new Date())
+  const effectiveFrom = requestedEffectiveFrom ?? today
+  if (effectiveFrom > today) {
+    return NextResponse.json(
+      {
+        error:
+          'effective_from cannot be in the future — a target change takes effect on or before today.',
+      },
+      { status: 400 }
+    )
+  }
+
   const supabase = createAdminSupabaseClient()
+  const nowIso = new Date().toISOString()
+
+  // What's on file already? Distinguishes a create (seed history alongside
+  // the row) from an edit (append only when the target actually moved), and
+  // a colour-only edit must not manufacture a history entry.
+  const { data: existing, error: existingError } = await supabase
+    .from('weight_room_goals')
+    .select('exercise, daily_target')
+    .eq('exercise', goalFields.exercise)
+    .maybeSingle()
+
+  if (existingError) {
+    return NextResponse.json(
+      { error: `Failed to read goal: ${existingError.message}` },
+      { status: 500 }
+    )
+  }
+
+  // The history table is FK'd to weight_room_goals, so a brand-new goal's row
+  // has to exist before its seed entry can be written.
+  if (existing === null) {
+    const { error: insertError } = await supabase
+      .from('weight_room_goals')
+      .insert({ ...goalFields, updated_at: nowIso })
+    if (insertError) {
+      return NextResponse.json(
+        { error: `Failed to create goal: ${insertError.message}` },
+        { status: 500 }
+      )
+    }
+  }
+
+  const targetChanged = existing !== null && existing.daily_target !== goalFields.daily_target
+
+  if (existing === null || targetChanged) {
+    const historyRows = [
+      {
+        exercise: goalFields.exercise,
+        daily_target: goalFields.daily_target,
+        effective_from: effectiveFrom,
+        updated_at: nowIso,
+      },
+    ]
+
+    // Defensive baseline: an existing goal whose target is changing but which
+    // carries no history would leave every day before `effectiveFrom`
+    // uncovered, and the resolver's before-first fallback would score them
+    // against the *new* target — the very re-scoring this feature exists to
+    // prevent. Anchor the old value at the epoch so the past stays intact.
+    if (targetChanged) {
+      const { count, error: countError } = await supabase
+        .from('weight_room_goal_targets')
+        .select('id', { count: 'exact', head: true })
+        .eq('exercise', goalFields.exercise)
+      if (countError) {
+        return NextResponse.json(
+          { error: `Failed to read goal target history: ${countError.message}` },
+          { status: 500 }
+        )
+      }
+      if ((count ?? 0) === 0) {
+        historyRows.unshift({
+          exercise: goalFields.exercise,
+          daily_target: existing.daily_target,
+          effective_from: BASELINE_EFFECTIVE_FROM,
+          updated_at: nowIso,
+        })
+      }
+    }
+
+    const { error: historyError } = await supabase
+      .from('weight_room_goal_targets')
+      .upsert(historyRows, { onConflict: 'exercise,effective_from' })
+    if (historyError) {
+      return NextResponse.json(
+        { error: `Failed to record goal target history: ${historyError.message}` },
+        { status: 500 }
+      )
+    }
+  }
+
+  // Re-derive the mirror from history rather than trusting the payload: a
+  // backdated change can land *behind* a newer entry, in which case the
+  // current target is unchanged and writing the payload value would wrongly
+  // advance it.
+  const { data: currentTarget, error: currentError } = await supabase
+    .from('weight_room_goal_targets')
+    .select('daily_target')
+    .eq('exercise', goalFields.exercise)
+    .lte('effective_from', today)
+    .order('effective_from', { ascending: false })
+    .limit(1)
+    .maybeSingle()
+
+  if (currentError) {
+    return NextResponse.json(
+      { error: `Failed to resolve current goal target: ${currentError.message}` },
+      { status: 500 }
+    )
+  }
+
   // Stamp `updated_at` explicitly so the upsert advances the row's audit
   // timestamp on edits — without this, the existing-row branch keeps
   // `updated_at` frozen at the original insert time and the data layer's
   // `MAX(updated_at)` freshness computation never reflects goal edits.
   // Mirrors the pattern used by the cardio import script's upserts.
-  const upsertRow = { ...goal, updated_at: new Date().toISOString() }
+  const upsertRow = {
+    ...goalFields,
+    daily_target: currentTarget?.daily_target ?? goalFields.daily_target,
+    updated_at: nowIso,
+  }
   const { data, error } = await supabase
     .from('weight_room_goals')
     .upsert(upsertRow, { onConflict: 'exercise' })

--- a/components/training-facility/weight-room/GoalChangeMarker.tsx
+++ b/components/training-facility/weight-room/GoalChangeMarker.tsx
@@ -1,0 +1,77 @@
+import type { JSX } from 'react'
+
+import {
+  type GoalTargetChange,
+  describeGoalTargetChange,
+  formatGoalTargetChange,
+} from '@/lib/training-facility/goal-targets'
+
+/** Props for {@link GoalChangeMarker}. */
+export interface GoalChangeMarkerProps {
+  /** The change being marked — supplies the `30 → 50` label and its date. */
+  change: GoalTargetChange
+  /** X offset, in the parent SVG's user units, of the boundary this marks. */
+  x: number
+  /** Y offset where the rule starts (usually the top of the plot area). */
+  y: number
+  /** Length of the vertical rule in user units — normally the plot height. */
+  height: number
+  /**
+   * Stroke/text color. Defaults to a soft cream that reads on the Weight
+   * Room's dark surface without competing with the data itself.
+   */
+  color?: string
+  /**
+   * Where to place the text relative to the rule. `'above'` (default) sits it
+   * over the plot; `'below'` drops it under, for charts whose top edge is
+   * already crowded.
+   */
+  labelPosition?: 'above' | 'below'
+}
+
+/** Soft cream that reads as chrome rather than data on the dark card. */
+const MARKER_COLOR = 'rgba(247, 234, 217, 0.55)'
+
+/**
+ * A "the bar moved here" boundary marker for goal-relative charts (#362) —
+ * a dashed vertical rule at the day a target changed, labelled `30 → 50`.
+ *
+ * Exists so a step in adherence reads as *the goal changed* rather than as a
+ * mysterious cliff in the data. Deliberately generic about its geometry (it
+ * takes `x` / `y` / `height` rather than dates or scales) so the rotation
+ * timeline in #361, which needs the same "what I was measuring against
+ * changed on this date" treatment for a *different* x-axis, can reuse it
+ * without inheriting the heatmap's week-column layout.
+ *
+ * Renders as an SVG `<g>`; mount it inside the parent chart's `<svg>`, after
+ * the data marks so the rule sits on top.
+ */
+export function GoalChangeMarker({
+  change,
+  x,
+  y,
+  height,
+  color = MARKER_COLOR,
+  labelPosition = 'above',
+}: GoalChangeMarkerProps): JSX.Element {
+  const labelY = labelPosition === 'above' ? y - 4 : y + height + 10
+  return (
+    <g data-testid={`goal-change-${change.effective_from}`}>
+      <line
+        x1={x}
+        y1={y}
+        x2={x}
+        y2={y + height}
+        stroke={color}
+        strokeWidth={1}
+        strokeDasharray="3 2"
+      />
+      <text x={x + 3} y={labelY} fontSize={9} fill={color}>
+        {formatGoalTargetChange(change)}
+      </text>
+      {/* Native tooltip + screen-reader text carries the date, which the
+          visible label omits to stay narrow enough for a one-week column. */}
+      <title>{`Goal ${describeGoalTargetChange(change)}`}</title>
+    </g>
+  )
+}

--- a/components/training-facility/weight-room/LogDataIsland.tsx
+++ b/components/training-facility/weight-room/LogDataIsland.tsx
@@ -9,6 +9,7 @@ import {
   computeFocusLoadStats,
   upcomingFocuses,
 } from '@/lib/training-facility/monthly-focus'
+import { targetForDay } from '@/lib/training-facility/goal-targets'
 import { computeStrengthStreaks } from '@/lib/training-facility/strength-streaks'
 import {
   filterSetsForDay,
@@ -17,7 +18,12 @@ import {
   toLocalDateKey,
   totalsByExercise,
 } from '@/lib/training-facility/strength-today'
-import type { MonthlyFocus, StrengthSet, WeightRoomData } from '@/types/weight-room'
+import type {
+  ExerciseGoal,
+  MonthlyFocus,
+  StrengthSet,
+  WeightRoomData,
+} from '@/types/weight-room'
 
 import { ActivityRings, type RingProgress } from './ActivityRings'
 import { LogDayPicker } from './LogDayPicker'
@@ -152,16 +158,31 @@ export function LogDataIsland(): JSX.Element {
   )
   const upcoming = upcomingFocuses(surfaceData.monthly_focus, todayKey)
 
+  // Score the viewed day against the target that was live *that* day (#362).
+  // The picker can point this whole surface at a past date, so reading the
+  // current target would render a completed July day as 30/50 instead of the
+  // 30/30 it actually was — the same retroactive re-scoring the history view
+  // fixes. `target_history` is deliberately preserved so anything downstream
+  // that resolves per-day (streaks) still sees the full series.
+  const forSelectedDay = (goal: ExerciseGoal): ExerciseGoal => ({
+    ...goal,
+    daily_target: targetForDay(goal, selectedDay),
+  })
+
   const rings: RingProgress[] = visibleGoals.map((goal) => ({
-    goal,
+    goal: forSelectedDay(goal),
     totalReps: totals.get(goal.exercise) ?? 0,
   }))
+  // Streaks get the unmodified goals: they span the whole log and resolve
+  // each day's bar themselves, so pinning one day's target here would be
+  // exactly wrong.
   const streaks = computeStrengthStreaks(surfaceData.sets, visibleGoals)
   // SetList color/label lookup spans *all* goals (incl. inactive focuses)
   // so a backfilled out-of-window set still resolves its exercise.
   const goalsByExercise = Object.fromEntries(
-    surfaceData.goals.map((g) => [g.exercise, g]),
+    surfaceData.goals.map((g) => [g.exercise, forSelectedDay(g)]),
   )
+  const quickLogGoals = visibleGoals.map(forSelectedDay)
 
   // Focus card inputs per active focus: today's progress in the focus's
   // own unit (reps or distinct sets), plus windowed adherence and load
@@ -217,7 +238,7 @@ export function LogDataIsland(): JSX.Element {
         <div className="flex flex-col gap-6">
           {visibleGoals.length > 0 ? (
             <QuickLog
-              goals={visibleGoals}
+              goals={quickLogGoals}
               lastReps={lastReps}
               variantSuggestions={variantSuggestions}
               onLog={({ exercise, reps, variant }) => {

--- a/components/training-facility/weight-room/StrengthHeatmap.test.tsx
+++ b/components/training-facility/weight-room/StrengthHeatmap.test.tsx
@@ -92,7 +92,9 @@ describe('StrengthHeatmap', () => {
     const populated = titles.find((t) => t.includes('100 reps'))
     expect(populated).toBeDefined()
     expect(populated).toContain('2 sets')
-    expect(populated).toContain('100% of pushups goal')
+    // The tooltip names the target that applied on that day (#362), so a
+    // cell can explain its own colour after the goal later moves.
+    expect(populated).toContain('100% of 100 pushups goal')
   })
 
   it('renders empty days with a non-color wash, not the exercise tint', () => {
@@ -129,5 +131,77 @@ describe('StrengthHeatmap', () => {
     const rects = Array.from(container.querySelectorAll('svg rect'))
     const exerciseColored = rects.filter((r) => /EA580C/i.test(r.getAttribute('fill') ?? ''))
     expect(exerciseColored.length).toBe(3)
+  })
+})
+
+describe('StrengthHeatmap — goal-change markers (#362)', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  /** Pullups seeded at 30, raised to 50 on Aug 1 2026. */
+  const PULLUPS_RAISED: ExerciseGoal = {
+    exercise: 'pullups',
+    daily_target: 50,
+    color: '#0EA5A1',
+    target_history: [
+      { daily_target: 30, effective_from: '2026-05-01' },
+      { daily_target: 50, effective_from: '2026-08-01' },
+    ],
+  }
+
+  it('renders no marker for a goal that has never changed', () => {
+    const { container } = render(
+      <StrengthHeatmap
+        sets={[]}
+        goal={PUSHUPS}
+        dateFrom={new Date(2026, 6, 1)}
+        dateTo={new Date(2026, 7, 31)}
+      />,
+    )
+    expect(container.querySelectorAll('[data-testid^="goal-change-"]')).toHaveLength(0)
+  })
+
+  it('marks the boundary when the change falls inside the window', () => {
+    const { container } = render(
+      <StrengthHeatmap
+        sets={[]}
+        goal={PULLUPS_RAISED}
+        dateFrom={new Date(2026, 6, 1)}
+        dateTo={new Date(2026, 7, 31)}
+      />,
+    )
+    const marker = container.querySelector('[data-testid="goal-change-2026-08-01"]')
+    expect(marker).not.toBeNull()
+    expect(marker?.textContent).toContain('30')
+    expect(marker?.textContent).toContain('50')
+  })
+
+  it('omits a change that falls entirely outside the rendered window', () => {
+    // Window is well after the Aug 1 change, so there's no column to anchor
+    // it to — better to draw nothing than to clamp it onto the wrong week.
+    const { container } = render(
+      <StrengthHeatmap
+        sets={[]}
+        goal={PULLUPS_RAISED}
+        dateFrom={new Date(2026, 9, 1)}
+        dateTo={new Date(2026, 10, 30)}
+      />,
+    )
+    expect(container.querySelectorAll('[data-testid^="goal-change-"]')).toHaveLength(0)
+  })
+
+  it('reports the per-day target in a cell tooltip', () => {
+    const { container } = render(
+      <StrengthHeatmap
+        sets={[set('2026-07-15', 'pullups', 30)]}
+        goal={PULLUPS_RAISED}
+        dateFrom={new Date(2026, 6, 1)}
+        dateTo={new Date(2026, 7, 31)}
+      />,
+    )
+    const titles = Array.from(container.querySelectorAll('title')).map((t) => t.textContent ?? '')
+    // 30 reps on a July day was 100% of the 30 goal live at the time.
+    expect(titles.some((t) => t.includes('30 reps') && t.includes('100% of 30'))).toBe(true)
   })
 })

--- a/components/training-facility/weight-room/StrengthHeatmap.tsx
+++ b/components/training-facility/weight-room/StrengthHeatmap.tsx
@@ -1,11 +1,15 @@
 import type { JSX } from 'react'
 
+import { type GoalTargetChange, goalTargetChanges } from '@/lib/training-facility/goal-targets'
 import {
   buildStrengthHeatmap,
   intensityFromPct,
   type StrengthHeatmapCell,
+  type StrengthHeatmapGrid,
 } from '@/lib/training-facility/weight-room-history'
 import type { ExerciseGoal, StrengthSet } from '@/types/weight-room'
+
+import { GoalChangeMarker } from './GoalChangeMarker'
 
 /** Props for {@link StrengthHeatmap}. */
 export interface StrengthHeatmapProps {
@@ -92,7 +96,8 @@ export function StrengthHeatmap({
   fontFamily = 'inherit',
   ariaLabel,
 }: StrengthHeatmapProps): JSX.Element {
-  const { grid, monthLabels } = buildStrengthHeatmap(sets, goal, dateFrom, dateTo)
+  const heatmap = buildStrengthHeatmap(sets, goal, dateFrom, dateTo)
+  const { grid, monthLabels } = heatmap
   const cols = grid[0]?.length ?? 0
   const cellInner = cellSize - cellGap
   const gridWidth = cols * cellSize
@@ -100,6 +105,14 @@ export function StrengthHeatmap({
   const totalWidth = DAY_LABEL_WIDTH + gridWidth
   const totalHeight = MONTH_LABEL_HEIGHT + gridHeight + LEGEND_HEIGHT
   const label = ariaLabel ?? `${goal.exercise} heatmap`
+
+  // Boundary markers for target changes (#362), dropped to whichever column
+  // holds the effective date. Changes outside the visible window resolve to
+  // `null` and are filtered out rather than clamped to an edge, which would
+  // plant a marker on a week the change didn't happen in.
+  const visibleChanges = goalTargetChanges(goal)
+    .map((change) => ({ change, col: columnForDayKey(heatmap, change.effective_from) }))
+    .filter((entry): entry is { change: GoalTargetChange; col: number } => entry.col !== null)
 
   return (
     // No `maxWidth: 100%` on the SVG — the page wraps each heatmap in
@@ -172,6 +185,20 @@ export function StrengthHeatmap({
         )}
       </g>
 
+      {/* Goal-change boundary markers, drawn over the cells so the rule
+          reads as an annotation rather than another data mark (#362). */}
+      <g transform={`translate(${DAY_LABEL_WIDTH}, ${MONTH_LABEL_HEIGHT})`}>
+        {visibleChanges.map(({ change, col }) => (
+          <GoalChangeMarker
+            key={`goal-change-${change.effective_from}`}
+            change={change}
+            x={col * cellSize - cellGap / 2}
+            y={0}
+            height={gridHeight}
+          />
+        ))}
+      </g>
+
       {/* Legend strip — "Less" + 4 swatches + "More" */}
       <g
         transform={`translate(${DAY_LABEL_WIDTH + Math.max(0, gridWidth - 140)}, ${MONTH_LABEL_HEIGHT + gridHeight + 14})`}
@@ -208,6 +235,9 @@ export function StrengthHeatmap({
  * of goal)` for active days, just the formatted date for empty days.
  * Reads naturally for both sighted users (browser title-tooltip on
  * hover) and screen readers.
+ *
+ * The percentage is against the target in effect *that* day, so a cell on
+ * the far side of a goal change explains its own colour (#362).
  */
 function describeCell(cell: StrengthHeatmapCell, goal: ExerciseGoal): string {
   const dateLabel = cell.date.toLocaleDateString('en-US', {
@@ -218,5 +248,43 @@ function describeCell(cell: StrengthHeatmapCell, goal: ExerciseGoal): string {
   if (cell.reps === 0) return dateLabel
   const setNoun = cell.setCount === 1 ? 'set' : 'sets'
   const pctLabel = `${Math.round(cell.pct * 100)}%`
-  return `${dateLabel}: ${cell.reps} reps (${cell.setCount} ${setNoun}, ${pctLabel} of ${goal.exercise} goal)`
+  return `${dateLabel}: ${cell.reps} reps (${cell.setCount} ${setNoun}, ${pctLabel} of ${cell.dailyTarget} ${goal.exercise} goal)`
+}
+
+/**
+ * Column index whose week contains `dayKey`, or `null` when the day falls
+ * outside the rendered window.
+ *
+ * Scans the Monday row and returns the last column that starts on or before
+ * the target day — the grid's columns are contiguous weeks, so that column is
+ * the one containing it. Comparing `YYYY-MM-DD` keys keeps this consistent
+ * with the rest of the day math (no `Date` arithmetic, no DST edge).
+ *
+ * @param heatmap The built grid to locate the day within.
+ * @param dayKey `YYYY-MM-DD` day to find.
+ */
+function columnForDayKey(heatmap: StrengthHeatmapGrid, dayKey: string): number | null {
+  const mondays = heatmap.grid[0]
+  if (mondays === undefined || mondays.length === 0) return null
+
+  const keyOf = (d: Date): string =>
+    `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+
+  // Before the first rendered week — the change predates the window.
+  if (dayKey < keyOf(mondays[0].date)) return null
+
+  let found = -1
+  for (let col = 0; col < mondays.length; col++) {
+    if (keyOf(mondays[col].date) <= dayKey) found = col
+    else break
+  }
+  if (found === -1) return null
+
+  // Past the final week's Sunday — the change is after the window.
+  const lastRow = heatmap.grid[6]
+  if (lastRow !== undefined && found === mondays.length - 1) {
+    const sunday = lastRow[found]
+    if (sunday !== undefined && dayKey > keyOf(sunday.date)) return null
+  }
+  return found
 }

--- a/components/training-facility/weight-room/StrengthHeatmap.tsx
+++ b/components/training-facility/weight-room/StrengthHeatmap.tsx
@@ -20,9 +20,14 @@ export interface StrengthHeatmapProps {
    */
   sets: readonly StrengthSet[]
   /**
-   * The exercise to render — supplies the color (used as the cell
-   * fill at full intensity) and `daily_target` (the denominator that
-   * decides which intensity bucket each cell falls into).
+   * The exercise to render — supplies the color (used as the cell fill at
+   * full intensity) and the daily target behind each cell's intensity
+   * bucket.
+   *
+   * That denominator is resolved **per day** from `target_history` (#362),
+   * not read off the current `daily_target`, so cells on either side of a
+   * goal change keep the intensity they earned. Any change in the history
+   * that falls inside the rendered window also draws a boundary marker.
    */
   goal: ExerciseGoal
   /** Inclusive start of the visible window. Omit for the trailing 52 weeks. */

--- a/components/training-facility/weight-room/StrengthStats.test.tsx
+++ b/components/training-facility/weight-room/StrengthStats.test.tsx
@@ -17,6 +17,7 @@ const PUSHUP_STATS: StrengthExerciseStats = {
   lastMonthReps: 980,
   avgSetsPerActiveDay: 3.5,
   allTimeReps: 12_400,
+  targetChanges: [],
 }
 
 describe('StrengthStats', () => {
@@ -81,5 +82,51 @@ describe('StrengthStats', () => {
     // jsdom canonicalizes inline `style` to lowercase rgb(); accept either.
     const styleAttr = heading.getAttribute('style') ?? ''
     expect(styleAttr).toMatch(/#EA580C|rgb\(\s*234,\s*88,\s*12\s*\)/i)
+  })
+})
+
+describe('StrengthStats — goal changes (#362)', () => {
+  it('renders no goal-changes footer when the target has never moved', () => {
+    const { queryByTestId } = render(<StrengthStats stats={[PUSHUP_STATS]} />)
+    expect(queryByTestId('strength-stat-goal-changes-pushups')).toBeNull()
+  })
+
+  it('lists each target change with its old value, new value, and date', () => {
+    const { getByTestId } = render(
+      <StrengthStats
+        stats={[
+          {
+            ...PUSHUP_STATS,
+            exercise: 'pullups',
+            dailyTarget: 50,
+            targetChanges: [{ from: 30, to: 50, effective_from: '2026-08-01' }],
+          },
+        ]}
+      />,
+    )
+    const footer = getByTestId('strength-stat-goal-changes-pullups')
+    expect(footer).toHaveTextContent('30')
+    expect(footer).toHaveTextContent('50')
+    expect(footer).toHaveTextContent('Aug 1')
+  })
+
+  it('lists multiple changes oldest-first', () => {
+    const { getByTestId } = render(
+      <StrengthStats
+        stats={[
+          {
+            ...PUSHUP_STATS,
+            targetChanges: [
+              { from: 100, to: 150, effective_from: '2026-06-01' },
+              { from: 150, to: 200, effective_from: '2026-09-01' },
+            ],
+          },
+        ]}
+      />,
+    )
+    const items = getByTestId('strength-stat-goal-changes-pushups').querySelectorAll('li')
+    expect(items).toHaveLength(2)
+    expect(items[0].textContent).toContain('Jun 1')
+    expect(items[1].textContent).toContain('Sep 1')
   })
 })

--- a/components/training-facility/weight-room/StrengthStats.tsx
+++ b/components/training-facility/weight-room/StrengthStats.tsx
@@ -1,5 +1,6 @@
 import type { JSX } from 'react'
 
+import { describeGoalTargetChange } from '@/lib/training-facility/goal-targets'
 import type { StrengthExerciseStats } from '@/lib/training-facility/weight-room-history'
 
 /** Props for {@link StrengthStats}. */
@@ -91,6 +92,30 @@ function ExerciseStatCard({ stat }: ExerciseStatCardProps): JSX.Element {
         />
         <SimpleCell label="all-time reps" value={stat.allTimeReps.toLocaleString('en-US')} />
       </div>
+
+      {stat.targetChanges.length > 0 ? (
+        <footer
+          data-testid={`strength-stat-goal-changes-${stat.exercise}`}
+          className="mt-4 border-t border-[#0a0a0a]/10 pt-3"
+        >
+          <p className="font-mono text-[10px] font-bold uppercase tracking-[0.22em] text-[#0a0a0a]/65">
+            goal changes
+          </p>
+          {/* Streaks and heatmap cells above are scored against the target
+              that was live each day, so this line is what explains a step in
+              those numbers rather than leaving it looking like a data glitch. */}
+          <ul className="mt-1.5 flex flex-wrap gap-x-4 gap-y-1">
+            {stat.targetChanges.map((change) => (
+              <li
+                key={change.effective_from}
+                className="font-mono text-[11px] tabular-nums text-[#0a0a0a]/70"
+              >
+                {describeGoalTargetChange(change)}
+              </li>
+            ))}
+          </ul>
+        </footer>
+      ) : null}
     </article>
   )
 }

--- a/lib/data/weight-room-shared.ts
+++ b/lib/data/weight-room-shared.ts
@@ -4,6 +4,7 @@ import { z } from 'zod'
 import {
   WeightRoomAchievementRowSchema,
   WeightRoomGoalRowSchema,
+  WeightRoomGoalTargetRowSchema,
   WeightRoomMonthlyFocusRowSchema,
   WeightRoomSetRowSchema,
   achievementRowToAchievement,
@@ -11,7 +12,11 @@ import {
   goalRowToExerciseGoal,
   setRowToStrengthSet,
 } from '@/lib/schemas/weight-room'
-import type { WeightRoomAchievement, WeightRoomData } from '@/types/weight-room'
+import type {
+  GoalTargetPoint,
+  WeightRoomAchievement,
+  WeightRoomData,
+} from '@/types/weight-room'
 
 import { fetchAllRows } from './paged-read'
 
@@ -29,16 +34,20 @@ import { fetchAllRows } from './paged-read'
 const SETS_TABLE = 'weight_room_sets'
 const GOALS_TABLE = 'weight_room_goals'
 const FOCUS_TABLE = 'weight_room_monthly_focus'
+/** Effective-dated daily-target history backing per-day goal resolution (#362). */
+const GOAL_TARGETS_TABLE = 'weight_room_goal_targets'
 
 /** Whitelisted column lists for each table; `updated_at` rides along for `imported_at` computation. */
 const SETS_COLUMNS = 'id, logged_at, exercise, reps, weight_lbs, variant, updated_at'
 const GOALS_COLUMNS = 'exercise, daily_target, color, kind, load_multiplier, updated_at'
 const FOCUS_COLUMNS =
   'id, exercise, daily_target, target_kind, color, category, start_date, end_date, updated_at'
+const GOAL_TARGETS_COLUMNS = 'id, exercise, daily_target, effective_from, updated_at'
 
 const WeightRoomSetRowsSchema = z.array(WeightRoomSetRowSchema)
 const WeightRoomGoalRowsSchema = z.array(WeightRoomGoalRowSchema)
 const WeightRoomMonthlyFocusRowsSchema = z.array(WeightRoomMonthlyFocusRowSchema)
+const WeightRoomGoalTargetRowsSchema = z.array(WeightRoomGoalTargetRowSchema)
 
 /** Supabase table backing the Trophy Room achievement ladder (#336). */
 const ACHIEVEMENTS_TABLE = 'weight_room_achievements'
@@ -147,7 +156,7 @@ export async function assembleWeightRoomData(
   // relative order unstable between fetches. `updated_at` resolves ties
   // by insertion order (sets have no update path), and `id` backstops
   // same-transaction inserts whose `updated_at` also collides.
-  const [setsRaw, goalsRes, focusRes] = await Promise.all([
+  const [setsRaw, goalsRes, focusRes, goalTargetsRes] = await Promise.all([
     // Paged — the set log is the one table here that grows without bound, and
     // it crossed PostgREST's response cap in July 2026, silently dropping the
     // *newest* sets (this query sorts ascending). The multi-key order above is
@@ -166,6 +175,13 @@ export async function assembleWeightRoomData(
     // Newest window first so the "Upcoming"/roadmap UI can slice from
     // the head without re-sorting.
     supabase.from(FOCUS_TABLE).select(FOCUS_COLUMNS).order('start_date', { ascending: false }),
+    // Oldest window first: `targetForDay` wants ascending order, and sorting
+    // here means the resolver's defensive re-sort is a no-op on live data.
+    supabase
+      .from(GOAL_TARGETS_TABLE)
+      .select(GOAL_TARGETS_COLUMNS)
+      .order('exercise', { ascending: true })
+      .order('effective_from', { ascending: true }),
   ])
 
   if (goalsRes.error) {
@@ -174,14 +190,18 @@ export async function assembleWeightRoomData(
   if (focusRes.error) {
     throw new Error(`Failed to load weight room monthly focus: ${focusRes.error.message}`)
   }
+  if (goalTargetsRes.error) {
+    throw new Error(`Failed to load weight room goal targets: ${goalTargetsRes.error.message}`)
+  }
 
   const goalsRaw = (goalsRes.data ?? []) as unknown as Array<Record<string, unknown>>
   const focusRaw = (focusRes.data ?? []) as unknown as Array<Record<string, unknown>>
+  const goalTargetsRaw = (goalTargetsRes.data ?? []) as unknown as Array<Record<string, unknown>>
 
   // Compute imported_at before stripping `updated_at` — that column lives
   // on every row but isn't part of the row-shape schema (`.strict()`
   // would reject it).
-  const importedAt = computeImportedAt([setsRaw, goalsRaw, focusRaw])
+  const importedAt = computeImportedAt([setsRaw, goalsRaw, focusRaw, goalTargetsRaw])
 
   // A monthly focus can't exist without its `kind: 'focus'` goal anchor
   // (FK), so sets+goals empty still means "no data" — focus is implied
@@ -205,13 +225,67 @@ export async function assembleWeightRoomData(
       `weight_room_monthly_focus failed schema validation: ${focusParsed.error.message}`,
     )
   }
+  const goalTargetsParsed = WeightRoomGoalTargetRowsSchema.safeParse(
+    goalTargetsRaw.map(stripUpdatedAt),
+  )
+  if (!goalTargetsParsed.success) {
+    throw new Error(
+      `weight_room_goal_targets failed schema validation: ${goalTargetsParsed.error.message}`,
+    )
+  }
+
+  const historyByExercise = groupTargetHistory(goalTargetsParsed.data)
 
   return {
     imported_at: importedAt,
     sets: setsParsed.data.map(setRowToStrengthSet),
-    goals: goalsParsed.data.map(goalRowToExerciseGoal),
+    goals: goalsParsed.data.map((row) => {
+      const goal = goalRowToExerciseGoal(row)
+      const history = historyByExercise.get(goal.exercise)
+      // Omit rather than attach `[]` so "no recorded history" is a single
+      // shape everywhere — `targetForDay` treats absent and empty the same,
+      // but keeping one of them off the wire makes fixtures and snapshots
+      // easier to read.
+      return history === undefined ? goal : { ...goal, target_history: history }
+    }),
     monthly_focus: focusParsed.data.map(focusRowToMonthlyFocus),
   }
+}
+
+/**
+ * Group validated `weight_room_goal_targets` rows into per-exercise history
+ * arrays, oldest entry first.
+ *
+ * Exercises with no rows are simply absent from the map, so the caller omits
+ * `target_history` entirely for them and every consumer falls back to the
+ * goal's current `daily_target` — the pre-#362 behavior.
+ *
+ * @param rows Validated target rows, in any order.
+ */
+function groupTargetHistory(
+  rows: readonly { exercise: string; daily_target: number; effective_from: string }[],
+): Map<string, GoalTargetPoint[]> {
+  const byExercise = new Map<string, GoalTargetPoint[]>()
+  for (const row of rows) {
+    const entry = byExercise.get(row.exercise)
+    const point: GoalTargetPoint = {
+      daily_target: row.daily_target,
+      effective_from: row.effective_from,
+    }
+    if (entry === undefined) {
+      byExercise.set(row.exercise, [point])
+    } else {
+      entry.push(point)
+    }
+  }
+  // The query orders by effective_from, but sort defensively so a fixture or
+  // a future query change can't hand the resolver unordered history.
+  for (const history of byExercise.values()) {
+    history.sort((a, b) =>
+      a.effective_from < b.effective_from ? -1 : a.effective_from > b.effective_from ? 1 : 0,
+    )
+  }
+  return byExercise
 }
 
 /**

--- a/lib/schemas/weight-room.ts
+++ b/lib/schemas/weight-room.ts
@@ -158,16 +158,48 @@ export const WeightRoomGoalRowSchema = z
 export type WeightRoomGoalRow = z.infer<typeof WeightRoomGoalRowSchema>
 
 /**
+ * Zod schema for one row of `public.weight_room_goal_targets` (#362).
+ * Mirrors the table in
+ * `supabase/migrations/20260730120000_weight_room_goal_targets.sql`.
+ *
+ * `effective_from` is a bare `YYYY-MM-DD` string (PostgREST's rendering of a
+ * Postgres `date`), validated by shape rather than parsed to a `Date` — the
+ * resolution helpers compare these keys lexicographically, so parsing would
+ * only introduce the UTC-midnight shift they exist to avoid.
+ */
+export const WeightRoomGoalTargetRowSchema = z
+  .object({
+    id: z.string().uuid(),
+    exercise: z.string().min(1),
+    daily_target: positiveInt(),
+    effective_from: z.string().regex(DATE_REGEX, 'effective_from must be YYYY-MM-DD'),
+  })
+  .strict()
+
+/** Validated `weight_room_goal_targets` row inferred from {@link WeightRoomGoalTargetRowSchema}. */
+export type WeightRoomGoalTargetRow = z.infer<typeof WeightRoomGoalTargetRowSchema>
+
+/**
  * Request-body schema for `POST /api/admin/weight-room/goals`. Same
  * shape as {@link WeightRoomGoalRowSchema} but lowercases `exercise` on
  * parse so direct API consumers can't create case-divergent duplicates
  * of an existing row.
+ *
+ * `effective_from` (#362) declares the day the supplied `daily_target` takes
+ * effect. Optional — omitted means "from today" — and backdatable, so a
+ * target change can be recorded after the fact against the day it really
+ * started. It only matters when `daily_target` actually changes; a
+ * colour-only edit appends no history row.
  */
 export const WeightRoomGoalUpsertSchema = z
   .object({
     exercise: exerciseWriteField(),
     daily_target: positiveInt(),
     color: z.string().regex(HEX_COLOR_REGEX, 'color must be a hex string like #EA580C'),
+    effective_from: z
+      .string()
+      .regex(DATE_REGEX, 'effective_from must be YYYY-MM-DD')
+      .optional(),
   })
   .strict()
 

--- a/lib/training-facility/achievements.test.ts
+++ b/lib/training-facility/achievements.test.ts
@@ -679,3 +679,73 @@ describe('formatEarnedOn', () => {
     expect(formatEarnedOn('nonsense', 'day')).toBe('')
   })
 })
+
+/**
+ * Effective-dated targets (#362). Badges are recomputed from the full log on
+ * every render, so a `'streak'` tier that read the *current* target would
+ * un-light the moment a goal was raised — retroactively taking away a badge
+ * that was genuinely earned.
+ */
+describe('streak scope with effective-dated targets (#362)', () => {
+  /** Pullups seeded at 30, raised to 50 on 2026-08-01. */
+  const PULLUPS_RAISED: ExerciseGoal = {
+    exercise: 'pullups',
+    daily_target: 50,
+    color: '#0EA5A1',
+    target_history: [
+      { daily_target: 30, effective_from: '2026-05-01' },
+      { daily_target: 50, effective_from: '2026-08-01' },
+    ],
+  }
+
+  /** Three consecutive 30-rep July days — a 3-day streak against the 30 goal. */
+  const JULY_STREAK: StrengthSet[] = [
+    set('2026-07-15', 'pullups', 30),
+    set('2026-07-16', 'pullups', 30),
+    set('2026-07-17', 'pullups', 30),
+  ]
+
+  it('keeps a streak badge earned after the goal is raised', () => {
+    const result = resolveOne(JULY_STREAK, tier('pullups', 'streak', 3), [PULLUPS_RAISED])
+    expect(result.earned).toBe(true)
+    expect(result.best).toBe(3)
+  })
+
+  it('un-lights nothing that was never earned — a post-change miss still misses', () => {
+    const augustShort = [
+      set('2026-08-15', 'pullups', 30),
+      set('2026-08-16', 'pullups', 30),
+      set('2026-08-17', 'pullups', 30),
+    ]
+    // 30 reps no longer clears the 50 bar in force in August.
+    const result = resolveOne(augustShort, tier('pullups', 'streak', 3), [PULLUPS_RAISED])
+    expect(result.earned).toBe(false)
+    expect(result.best).toBe(0)
+  })
+
+  it('counts a streak spanning the change against each day’s own target', () => {
+    const spanning = [
+      set('2026-07-30', 'pullups', 30),
+      set('2026-07-31', 'pullups', 30),
+      set('2026-08-01', 'pullups', 50),
+      set('2026-08-02', 'pullups', 50),
+    ]
+    const result = resolveOne(spanning, tier('pullups', 'streak', 4), [PULLUPS_RAISED])
+    expect(result.earned).toBe(true)
+    expect(result.best).toBe(4)
+  })
+
+  it('leaves a goal with no target history scored exactly as before', () => {
+    const result = resolveOne(
+      [
+        set('2026-07-15', 'pushups', 100),
+        set('2026-07-16', 'pushups', 100),
+        set('2026-07-17', 'pushups', 100),
+      ],
+      tier('pushups', 'streak', 3),
+      GOALS,
+    )
+    expect(result.earned).toBe(true)
+    expect(result.best).toBe(3)
+  })
+})

--- a/lib/training-facility/achievements.ts
+++ b/lib/training-facility/achievements.ts
@@ -6,6 +6,7 @@ import type {
   WeightRoomAchievement,
 } from '@/types/weight-room'
 
+import { targetResolverFor } from './goal-targets'
 import { pacificDayKey } from './load-management'
 
 /**
@@ -273,12 +274,18 @@ function emptyMetrics(): MovementMetrics {
  * per tier.
  *
  * @param sets All logged sets, usually `WeightRoomData.sets`.
- * @param goals Configured exercises — supplies each `daily_target`, which is
- *   what makes a day count toward a `'streak'`, and each `load_multiplier`,
- *   which converts a per-implement `weight_lbs` into the effective load. An
- *   exercise with no goal still gets volume metrics (at multiplier 1); its
- *   streak is simply always `0` (there's no bar to clear). Non-positive
- *   targets are treated the same way.
+ * @param goals Configured exercises — supplies each effective-dated daily
+ *   target, which is what makes a day count toward a `'streak'`, and each
+ *   `load_multiplier`, which converts a per-implement `weight_lbs` into the
+ *   effective load. An exercise with no goal still gets volume metrics (at
+ *   multiplier 1); its streak is simply always `0` (there's no bar to clear).
+ *   Non-positive targets are treated the same way.
+ *
+ *   Each day is tested against the target in effect *that day* (#362).
+ *   Because badges are recomputed from the full log on every render, reading
+ *   the current target here would un-light earned streak badges the moment a
+ *   goal was raised — the exact retroactive rewrite this module's "earned
+ *   state is never stored" design otherwise avoids.
  */
 function buildMetrics(
   sets: readonly StrengthSet[],
@@ -342,8 +349,10 @@ function buildMetrics(
   for (const goal of goals) {
     const m = metrics.get(goal.exercise)
     if (!m || goal.daily_target <= 0) continue
+    // Per-day bar (#362), bound once per goal rather than per logged day.
+    const targetFor = targetResolverFor(goal)
     for (const [day, reps] of m.byDay) {
-      if (reps < goal.daily_target) continue
+      if (reps < targetFor(day)) continue
       m.hitDays.push(day)
       pooledHits.add(day)
     }

--- a/lib/training-facility/achievements.ts
+++ b/lib/training-facility/achievements.ts
@@ -115,9 +115,9 @@ interface MovementMetrics {
   sets: { day: string; reps: number; load: number; tonnage: number }[]
   /**
    * Day keys that met the daily target, ascending — the `'streak'` scope's
-   * source. For a single exercise that's `reps >= its goal.daily_target`; for
-   * the pooled ladder it's any day where *at least one* exercise hit its own
-   * target.
+   * source. For a single exercise that's `reps >=` the target in effect *on
+   * that day* (#362), not the goal's current one; for the pooled ladder it's
+   * any day where *at least one* exercise hit its own target for that day.
    */
   hitDays: string[]
 }

--- a/lib/training-facility/goal-targets.test.ts
+++ b/lib/training-facility/goal-targets.test.ts
@@ -3,7 +3,9 @@ import { describe, expect, it } from 'vitest'
 import type { ExerciseGoal } from '@/types/weight-room'
 
 import {
+  describeGoalTargetChange,
   formatGoalTargetChange,
+  formatGoalTargetDate,
   goalTargetChanges,
   targetForDay,
   targetResolverFor,
@@ -193,6 +195,32 @@ describe('formatGoalTargetChange', () => {
   it('renders a compact arrow label without the date', () => {
     expect(formatGoalTargetChange({ from: 30, to: 50, effective_from: '2026-08-01' })).toBe(
       '30 → 50',
+    )
+  })
+})
+
+describe('formatGoalTargetDate', () => {
+  it('renders a short month/day label', () => {
+    expect(formatGoalTargetDate({ from: 30, to: 50, effective_from: '2026-08-01' })).toBe('Aug 1')
+  })
+
+  it('does not shift the day for viewers behind UTC', () => {
+    // Parsed at local noon, so a negative UTC offset can't roll the label
+    // back to Jul 31.
+    expect(formatGoalTargetDate({ from: 30, to: 50, effective_from: '2026-01-01' })).toBe('Jan 1')
+  })
+
+  it('falls back to the raw key when the date will not parse', () => {
+    expect(formatGoalTargetDate({ from: 30, to: 50, effective_from: 'not-a-date' })).toBe(
+      'not-a-date',
+    )
+  })
+})
+
+describe('describeGoalTargetChange', () => {
+  it('combines the arrow label and the effective date', () => {
+    expect(describeGoalTargetChange({ from: 30, to: 50, effective_from: '2026-08-01' })).toBe(
+      '30 → 50 on Aug 1',
     )
   })
 })

--- a/lib/training-facility/goal-targets.test.ts
+++ b/lib/training-facility/goal-targets.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it } from 'vitest'
+
+import type { ExerciseGoal } from '@/types/weight-room'
+
+import {
+  formatGoalTargetChange,
+  goalTargetChanges,
+  targetForDay,
+  targetResolverFor,
+} from './goal-targets'
+
+/**
+ * Unit tests for effective-dated goal targets (#362). The scenario driving
+ * most cases is the one from the issue: pullups at 30, raised to 50 effective
+ * Aug 1. July days must keep scoring against 30 and August days against 50.
+ */
+
+/** Pullups with no recorded history — the pre-#362 shape. */
+const NO_HISTORY: ExerciseGoal = {
+  exercise: 'pullups',
+  daily_target: 30,
+  color: '#0EA5A1',
+}
+
+/** Pullups seeded at 30, raised to 50 on Aug 1. */
+const RAISED: ExerciseGoal = {
+  exercise: 'pullups',
+  daily_target: 50,
+  color: '#0EA5A1',
+  target_history: [
+    { daily_target: 30, effective_from: '2026-05-01' },
+    { daily_target: 50, effective_from: '2026-08-01' },
+  ],
+}
+
+/** Pullups lowered 50 -> 30 on Aug 1 — the symmetric case. */
+const LOWERED: ExerciseGoal = {
+  exercise: 'pullups',
+  daily_target: 30,
+  color: '#0EA5A1',
+  target_history: [
+    { daily_target: 50, effective_from: '2026-05-01' },
+    { daily_target: 30, effective_from: '2026-08-01' },
+  ],
+}
+
+/** Three changes, supplied out of order to exercise the internal sort. */
+const MULTI_CHANGE: ExerciseGoal = {
+  exercise: 'pushups',
+  daily_target: 200,
+  color: '#EA580C',
+  target_history: [
+    { daily_target: 150, effective_from: '2026-06-01' },
+    { daily_target: 200, effective_from: '2026-09-01' },
+    { daily_target: 100, effective_from: '2026-03-01' },
+  ],
+}
+
+describe('targetForDay', () => {
+  it('falls back to daily_target for every day when there is no history', () => {
+    expect(targetForDay(NO_HISTORY, '2020-01-01')).toBe(30)
+    expect(targetForDay(NO_HISTORY, '2026-07-15')).toBe(30)
+    expect(targetForDay(NO_HISTORY, '2099-12-31')).toBe(30)
+  })
+
+  it('treats an empty history array the same as no history', () => {
+    const goal: ExerciseGoal = { ...NO_HISTORY, target_history: [] }
+    expect(targetForDay(goal, '2026-07-15')).toBe(30)
+  })
+
+  it('scores a day before the change against the old target', () => {
+    expect(targetForDay(RAISED, '2026-07-15')).toBe(30)
+    expect(targetForDay(RAISED, '2026-07-31')).toBe(30)
+  })
+
+  it('scores the boundary day itself against the new target (effective_from is inclusive)', () => {
+    expect(targetForDay(RAISED, '2026-08-01')).toBe(50)
+  })
+
+  it('scores days after the change against the new target', () => {
+    expect(targetForDay(RAISED, '2026-08-02')).toBe(50)
+    expect(targetForDay(RAISED, '2027-01-01')).toBe(50)
+  })
+
+  it('returns the earliest known target for a day before the first entry', () => {
+    // Backdated set / manually inserted future goal. Scoring against the
+    // oldest known bar beats dividing by zero.
+    expect(targetForDay(RAISED, '2026-04-30')).toBe(30)
+    expect(targetForDay(RAISED, '1999-01-01')).toBe(30)
+  })
+
+  it('returns the current target for an empty day key rather than the ancient one', () => {
+    // '' sorts before every real date, so a naive scan would take the
+    // before-earliest branch and score "today" against the oldest target.
+    expect(targetForDay(RAISED, '')).toBe(50)
+  })
+
+  it('is symmetric when a target is lowered — past days are not retroactively credited', () => {
+    expect(targetForDay(LOWERED, '2026-07-15')).toBe(50)
+    expect(targetForDay(LOWERED, '2026-08-01')).toBe(30)
+  })
+
+  it('resolves across multiple changes regardless of input order', () => {
+    expect(targetForDay(MULTI_CHANGE, '2026-02-01')).toBe(100) // before first
+    expect(targetForDay(MULTI_CHANGE, '2026-03-01')).toBe(100) // on first
+    expect(targetForDay(MULTI_CHANGE, '2026-05-31')).toBe(100)
+    expect(targetForDay(MULTI_CHANGE, '2026-06-01')).toBe(150)
+    expect(targetForDay(MULTI_CHANGE, '2026-08-31')).toBe(150)
+    expect(targetForDay(MULTI_CHANGE, '2026-09-01')).toBe(200)
+    expect(targetForDay(MULTI_CHANGE, '2027-06-01')).toBe(200)
+  })
+
+  it('clamps a non-positive stored target to 1 so callers never divide by zero', () => {
+    const broken: ExerciseGoal = {
+      exercise: 'pullups',
+      daily_target: 0,
+      color: '#0EA5A1',
+      target_history: [{ daily_target: 0, effective_from: '2026-05-01' }],
+    }
+    expect(targetForDay(broken, '2026-07-15')).toBe(1)
+    expect(targetForDay(broken, '')).toBe(1)
+  })
+
+  it('does not mutate the caller-supplied history array', () => {
+    const history = [...MULTI_CHANGE.target_history!]
+    targetForDay(MULTI_CHANGE, '2026-07-15')
+    expect(MULTI_CHANGE.target_history).toEqual(history)
+  })
+})
+
+describe('targetResolverFor', () => {
+  it('resolves identically to targetForDay across a change', () => {
+    const resolve = targetResolverFor(RAISED)
+    for (const day of ['2026-04-30', '2026-07-31', '2026-08-01', '2026-08-02', '']) {
+      expect(resolve(day)).toBe(targetForDay(RAISED, day))
+    }
+  })
+
+  it('returns the current target for every day when there is no history', () => {
+    const resolve = targetResolverFor(NO_HISTORY)
+    expect(resolve('2020-01-01')).toBe(30)
+    expect(resolve('2026-08-01')).toBe(30)
+  })
+
+  it('clamps a non-positive current target when there is no history', () => {
+    const resolve = targetResolverFor({ ...NO_HISTORY, daily_target: 0 })
+    expect(resolve('2026-07-15')).toBe(1)
+  })
+})
+
+describe('goalTargetChanges', () => {
+  it('returns nothing for a goal with no history', () => {
+    expect(goalTargetChanges(NO_HISTORY)).toEqual([])
+  })
+
+  it('returns nothing for a goal that has only its seed entry', () => {
+    const seeded: ExerciseGoal = {
+      ...NO_HISTORY,
+      target_history: [{ daily_target: 30, effective_from: '2026-05-01' }],
+    }
+    expect(goalTargetChanges(seeded)).toEqual([])
+  })
+
+  it('emits one change per move, with the old and new targets', () => {
+    expect(goalTargetChanges(RAISED)).toEqual([
+      { from: 30, to: 50, effective_from: '2026-08-01' },
+    ])
+  })
+
+  it('emits changes oldest-first regardless of input order', () => {
+    expect(goalTargetChanges(MULTI_CHANGE)).toEqual([
+      { from: 100, to: 150, effective_from: '2026-06-01' },
+      { from: 150, to: 200, effective_from: '2026-09-01' },
+    ])
+  })
+
+  it('skips a same-value re-save so no "30 -> 30" marker is drawn', () => {
+    const noop: ExerciseGoal = {
+      ...NO_HISTORY,
+      target_history: [
+        { daily_target: 30, effective_from: '2026-05-01' },
+        { daily_target: 30, effective_from: '2026-06-01' },
+        { daily_target: 50, effective_from: '2026-07-01' },
+      ],
+    }
+    expect(goalTargetChanges(noop)).toEqual([
+      { from: 30, to: 50, effective_from: '2026-07-01' },
+    ])
+  })
+})
+
+describe('formatGoalTargetChange', () => {
+  it('renders a compact arrow label without the date', () => {
+    expect(formatGoalTargetChange({ from: 30, to: 50, effective_from: '2026-08-01' })).toBe(
+      '30 → 50',
+    )
+  })
+})

--- a/lib/training-facility/goal-targets.ts
+++ b/lib/training-facility/goal-targets.ts
@@ -190,12 +190,17 @@ export function formatGoalTargetChange(change: GoalTargetChange): string {
  * be shifted backwards by the viewer's UTC offset — the same guard
  * `formatFocusWindow` uses. Falls back to the raw key if it won't parse.
  *
+ * Pinned to `en-US` rather than the ambient locale: this label sits beside
+ * `describeCell`'s already-`en-US` tooltip on the same chart, so an ambient
+ * locale would let the two disagree on the same date — and it would make the
+ * rendered string depend on the test runner's locale.
+ *
  * @param change The change whose effective date to label.
  */
 export function formatGoalTargetDate(change: GoalTargetChange): string {
   const d = new Date(change.effective_from + 'T12:00:00')
   if (!Number.isFinite(d.getTime())) return change.effective_from
-  return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
 }
 
 /**

--- a/lib/training-facility/goal-targets.ts
+++ b/lib/training-facility/goal-targets.ts
@@ -1,0 +1,210 @@
+import type { ExerciseGoal, GoalTargetPoint } from '@/types/weight-room'
+
+/**
+ * Effective-dated daily-target resolution for Weight Room goals (#362).
+ *
+ * `weight_room_goals.daily_target` is a single mutable scalar, so every
+ * historical rollup that divided by it was really dividing by *today's*
+ * target. Raising the pullups goal from 30 to 50 silently re-scored the
+ * entire past: days that closed the ring at 30 stopped counting as hits,
+ * streaks collapsed, and full-intensity heatmap cells dropped to half.
+ * This module resolves the target that was actually live on a given day so
+ * old reps keep the score they earned.
+ *
+ * All comparisons are lexicographic on bare `YYYY-MM-DD` strings. PostgREST
+ * renders a Postgres `date` in that canonical zero-padded form, and every
+ * day-key helper in this directory produces it, so string ordering *is*
+ * chronological ordering — no `Date` parsing, and none of the UTC-midnight
+ * hazards that come with it. Same reasoning as the module docblock in
+ * `monthly-focus.ts`.
+ *
+ * Deliberately agnostic about *which* day-key convention the caller uses
+ * (local vs Pacific — the two disagree across this directory, tracked in
+ * #319). Callers pass the key they already compute; this module only orders
+ * strings.
+ */
+
+/**
+ * A target change worth surfacing on a chart — the moment the bar moved.
+ * Produced by {@link goalTargetChanges}; rendered as a boundary marker on the
+ * History view so a step in adherence is explained rather than mysterious.
+ */
+export interface GoalTargetChange {
+  /** Target in effect immediately *before* {@link effective_from}. */
+  from: number
+  /** Target that took effect on {@link effective_from}. */
+  to: number
+  /** `YYYY-MM-DD` day the new target took effect (inclusive). */
+  effective_from: string
+}
+
+/**
+ * Sort target-history entries oldest-first without mutating the input.
+ *
+ * The data layer already orders by `effective_from`, but this module is the
+ * one place that depends on the ordering being correct, so it re-establishes
+ * it rather than trusting every future caller (a hand-built fixture, a
+ * reordered query) to have done so.
+ */
+function sortedByEffectiveFrom(history: readonly GoalTargetPoint[]): GoalTargetPoint[] {
+  return [...history].sort((a, b) =>
+    a.effective_from < b.effective_from ? -1 : a.effective_from > b.effective_from ? 1 : 0,
+  )
+}
+
+/**
+ * Clamp a target to a usable denominator. The DB CHECK and
+ * `WeightRoomGoalRowSchema` both enforce `> 0`, but a 0 or negative slipping
+ * through would divide-by-zero the heatmap `pct` and invert every hit-test —
+ * so every read path floors at 1. Mirrors the belt-and-suspenders clamp the
+ * rollups applied before this module existed.
+ */
+function clampTarget(target: number): number {
+  return Math.max(1, target)
+}
+
+/**
+ * The daily target that was in effect for `goal` on `dayKey`.
+ *
+ * Resolution is "the most recent entry whose `effective_from <= dayKey`".
+ * Three fallbacks, all of which resolve to something usable rather than
+ * throwing:
+ *
+ * - **No history** (absent or empty) — returns {@link ExerciseGoal.daily_target}
+ *   for every day. This is exactly the pre-#362 behavior, so a goal the
+ *   backfill missed degrades to the old semantics instead of breaking.
+ * - **Day before the earliest entry** — returns the *earliest* known target
+ *   rather than 0. Shouldn't happen after the backfill (which dates the seed
+ *   entry at or before the earliest logged set), but a backdated set or a
+ *   manually inserted future-dated goal could produce one, and scoring such a
+ *   day against the oldest known bar beats dividing by nothing.
+ * - **Empty `dayKey`** (an unparseable clock, which the day-key helpers signal
+ *   with `''`) — returns the current target. `''` sorts before every real
+ *   date, so without this it would take the before-earliest branch and score
+ *   today against an ancient target.
+ *
+ * @param goal The goal whose target to resolve; reads `target_history` and
+ *   falls back to `daily_target`.
+ * @param dayKey `YYYY-MM-DD` key for the day being scored, in whatever
+ *   convention the call site already uses.
+ */
+export function targetForDay(goal: ExerciseGoal, dayKey: string): number {
+  const history = goal.target_history
+  if (history === undefined || history.length === 0) {
+    return clampTarget(goal.daily_target)
+  }
+  if (dayKey === '') {
+    return clampTarget(goal.daily_target)
+  }
+
+  const sorted = sortedByEffectiveFrom(history)
+
+  // Walk backward to the newest entry at or before `dayKey`. The history is
+  // a handful of entries per exercise (a target changes a few times a year),
+  // so a linear scan is cheaper than the binary search it would take to beat
+  // it — and this runs once per heatmap cell, where the constant matters more
+  // than the asymptote.
+  for (let i = sorted.length - 1; i >= 0; i--) {
+    if (sorted[i].effective_from <= dayKey) {
+      return clampTarget(sorted[i].daily_target)
+    }
+  }
+
+  return clampTarget(sorted[0].daily_target)
+}
+
+/**
+ * Bind {@link targetForDay} to one goal, yielding a `dayKey -> target`
+ * function with the history resolved and sorted once.
+ *
+ * The rollups call this per goal and then invoke the returned resolver once
+ * per day (every heatmap cell, every logged day in a streak scan). Hoisting
+ * the sort out of that inner loop is the difference between sorting once and
+ * sorting ~365 times per exercise per render.
+ *
+ * @param goal The goal whose target history to bind.
+ */
+export function targetResolverFor(goal: ExerciseGoal): (dayKey: string) => number {
+  const history = goal.target_history
+  const current = clampTarget(goal.daily_target)
+  if (history === undefined || history.length === 0) {
+    return () => current
+  }
+
+  const sorted = sortedByEffectiveFrom(history)
+  const earliest = clampTarget(sorted[0].daily_target)
+
+  return (dayKey: string): number => {
+    if (dayKey === '') return current
+    for (let i = sorted.length - 1; i >= 0; i--) {
+      if (sorted[i].effective_from <= dayKey) {
+        return clampTarget(sorted[i].daily_target)
+      }
+    }
+    return earliest
+  }
+}
+
+/**
+ * The points at which a goal's target actually moved, oldest first — the
+ * data behind the History view's "goal 30 → 50, Aug 1" boundary markers.
+ *
+ * The oldest entry is the baseline, not a change, so it's never emitted:
+ * a goal that has never been edited yields `[]` and renders no markers.
+ * Consecutive entries with the same target (a same-value re-save, which the
+ * write path avoids but a manual insert could create) are also skipped, so a
+ * no-op edit doesn't draw a "30 → 30" marker.
+ *
+ * @param goal The goal whose history to summarize.
+ */
+export function goalTargetChanges(goal: ExerciseGoal): GoalTargetChange[] {
+  const history = goal.target_history
+  if (history === undefined || history.length < 2) return []
+
+  const sorted = sortedByEffectiveFrom(history)
+  const changes: GoalTargetChange[] = []
+  for (let i = 1; i < sorted.length; i++) {
+    const from = sorted[i - 1].daily_target
+    const to = sorted[i].daily_target
+    if (from === to) continue
+    changes.push({ from, to, effective_from: sorted[i].effective_from })
+  }
+  return changes
+}
+
+/**
+ * Format a change as a compact chart label, e.g. `30 → 50`. The effective
+ * date is rendered separately by the marker (it's already positioned on that
+ * column), so it isn't repeated here.
+ *
+ * @param change The change to label.
+ */
+export function formatGoalTargetChange(change: GoalTargetChange): string {
+  return `${change.from} → ${change.to}`
+}
+
+/**
+ * Format a change's effective date as a short `Aug 1` label.
+ *
+ * The bare `YYYY-MM-DD` is parsed at *local noon* so the rendered day can't
+ * be shifted backwards by the viewer's UTC offset — the same guard
+ * `formatFocusWindow` uses. Falls back to the raw key if it won't parse.
+ *
+ * @param change The change whose effective date to label.
+ */
+export function formatGoalTargetDate(change: GoalTargetChange): string {
+  const d = new Date(change.effective_from + 'T12:00:00')
+  if (!Number.isFinite(d.getTime())) return change.effective_from
+  return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
+}
+
+/**
+ * Full one-line description of a change — `30 → 50 on Aug 1`. Used by the
+ * stats panel, where there's no column position to imply the date, and as
+ * the accessible label for the heatmap's boundary marker.
+ *
+ * @param change The change to describe.
+ */
+export function describeGoalTargetChange(change: GoalTargetChange): string {
+  return `${formatGoalTargetChange(change)} on ${formatGoalTargetDate(change)}`
+}

--- a/lib/training-facility/strength-streaks.test.ts
+++ b/lib/training-facility/strength-streaks.test.ts
@@ -158,3 +158,65 @@ describe('computeStrengthStreaks', () => {
     })
   })
 })
+
+/**
+ * Effective-dated target coverage (#362) for the multi-goal streak path.
+ * Mirrors the single-goal cases in `weight-room-history.test.ts` — the two
+ * implementations must agree on what counts as a hit day.
+ */
+describe('computeStrengthStreaks with effective-dated targets (#362)', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  /** Pullups seeded at 30, raised to 50 on Aug 1. */
+  const PULLUPS_RAISED: ExerciseGoal = {
+    exercise: 'pullups',
+    daily_target: 50,
+    color: '#0EA5A1',
+    target_history: [
+      { daily_target: 30, effective_from: '2026-05-01' },
+      { daily_target: 50, effective_from: '2026-08-01' },
+    ],
+  }
+
+  it('counts a pre-change day against the old target', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-16T12:00:00'))
+    const result = computeStrengthStreaks([s('pullups', '2026-07-15', 30)], [PULLUPS_RAISED])
+    // 30 reps cleared the 30 goal live that day, so it stays a hit even
+    // though the goal is now 50.
+    expect(result.pullups).toEqual({ current: 1, longest: 1 })
+  })
+
+  it('does not count a post-change day that only clears the old target', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-08-16T12:00:00'))
+    const result = computeStrengthStreaks([s('pullups', '2026-08-15', 30)], [PULLUPS_RAISED])
+    expect(result.pullups).toEqual({ current: 0, longest: 0 })
+  })
+
+  it('runs a streak across the boundary without a false break', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-08-02T12:00:00'))
+    const result = computeStrengthStreaks(
+      [
+        s('pullups', '2026-07-31', 30),
+        s('pullups', '2026-08-01', 50),
+        s('pullups', '2026-08-02', 50),
+      ],
+      [PULLUPS_RAISED],
+    )
+    expect(result.pullups).toEqual({ current: 3, longest: 3 })
+  })
+
+  it('leaves a goal with no history scored exactly as before', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-16T12:00:00'))
+    const result = computeStrengthStreaks(
+      [s('pushups', '2026-07-15', 100), s('pushups', '2026-07-16', 100)],
+      [PUSHUPS],
+    )
+    expect(result.pushups).toEqual({ current: 2, longest: 2 })
+  })
+})

--- a/lib/training-facility/strength-streaks.ts
+++ b/lib/training-facility/strength-streaks.ts
@@ -1,16 +1,16 @@
 import type { ExerciseGoal, StrengthSet } from '@/types/weight-room'
 
+import { targetResolverFor } from './goal-targets'
 import { toLocalDateKey } from './strength-today'
 
 /**
  * Per-exercise streak result, mirrored on
  * {@link import('./streaks').StreakResult} so the UI surfaces can stay
  * shape-compatible across cardio and weight-room. "Goal hit" here means
- * the exercise's total reps for the day reached
- * {@link ExerciseGoal.daily_target} — note that historical changes to
- * the target aren't tracked, so the streak is computed against today's
- * configured target across the entire history (best we can do without
- * a target-history table).
+ * the exercise's total reps for the day reached the target that was in
+ * effect *on that day*, resolved from the goal's effective-dated history
+ * (#362) — so raising or lowering a target never re-scores days already
+ * completed.
  */
 export interface StrengthStreakResult {
   /**
@@ -43,8 +43,8 @@ function addDays(dateKey: string, n: number): string {
  * full row of `StreakBadge`s without juggling fallbacks.
  *
  * "Hit the goal" means the exercise's total reps for that calendar
- * day reach {@link ExerciseGoal.daily_target}. Multiple sets on the
- * same day sum together; the goal applies to the day, not per-set.
+ * day reach the target in effect on that day (#362). Multiple sets on
+ * the same day sum together; the goal applies to the day, not per-set.
  *
  * The "current" streak counts back from today (or yesterday if no
  * goal-hit set has been logged today yet) and is `0` when the most
@@ -54,8 +54,9 @@ function addDays(dateKey: string, n: number): string {
  *
  * @param sets All logged sets, usually `WeightRoomData.sets`.
  * @param goals All configured exercises, usually `WeightRoomData.goals`.
- *   Streaks are only computed for goals whose `daily_target > 0`;
+ *   Streaks are only computed for goals whose current `daily_target > 0`;
  *   non-positive targets short-circuit to `{ current: 0, longest: 0 }`.
+ *   Each day's bar comes from the goal's `target_history` when present.
  * @param now The clock used to derive "today" / "yesterday." Defaults
  *   to `new Date()`. Pass an explicit value from the viewer's clock
  *   when calling from a server-rendered surface so server-side UTC
@@ -93,10 +94,14 @@ export function computeStrengthStreaks(
     }
     const dayMap = repsByExerciseAndDay.get(goal.exercise) ?? new Map<string, number>()
 
+    // Per-day target resolution (#362) — bound once per goal so the history
+    // is sorted a single time rather than once per logged day.
+    const targetFor = targetResolverFor(goal)
+
     // "Goal-hit" calendar days, in chronological order.
     const hitDays: string[] = []
     for (const [day, total] of dayMap) {
-      if (total >= goal.daily_target) hitDays.push(day)
+      if (total >= targetFor(day)) hitDays.push(day)
     }
     hitDays.sort()
 

--- a/lib/training-facility/strength-today.ts
+++ b/lib/training-facility/strength-today.ts
@@ -1,5 +1,7 @@
 import type { ExerciseGoal, StrengthSet } from '@/types/weight-room'
 
+import { targetForDay } from './goal-targets'
+
 /**
  * Pure helpers for the Weight Room Today View (#80) — date bucketing,
  * per-exercise totals, and ring-percent computation. Lives separate
@@ -156,25 +158,32 @@ export function variantBreakdown(sets: readonly StrengthSet[]): VariantSlice[] {
 }
 
 /**
- * Fraction of `goal.daily_target` that today's reps cover. Returned
+ * Fraction of the day's target that a day's reps cover. Returned
  * unclamped — callers that animate a ring usually `Math.min(1, …)` the
  * stroke offset, but the center-text "75 / 100" surface keeps the raw
  * value so a 110-rep day reads as "110 / 100" not "100 / 100".
  *
- * Returns `0` when `goal.daily_target` is non-positive (defensive
+ * Returns `0` when the resolved target is non-positive (defensive
  * against a future settings UI accepting 0 — the schema currently
  * enforces `> 0`, but the helper shouldn't `Infinity` if that changes).
  *
- * @param totalReps Total reps logged for the exercise today, usually
- *   sourced from {@link totalsByExercise}.
+ * @param totalReps Total reps logged for the exercise on the day in
+ *   question, usually sourced from {@link totalsByExercise}.
  * @param goal The exercise's configured goal.
+ * @param dayKey Optional `YYYY-MM-DD` key for the day being scored. When
+ *   supplied, the denominator is the target that was in effect that day
+ *   (#362) rather than the goal's current one — so rendering a past day
+ *   shows the ring as it was actually earned. Omitted keeps the current
+ *   target, which is what the Today View wants.
  */
 export function computeRingPercent(
   totalReps: number,
   goal: ExerciseGoal,
+  dayKey?: string,
 ): number {
-  if (goal.daily_target <= 0) return 0
-  return totalReps / goal.daily_target
+  const target = dayKey === undefined ? goal.daily_target : targetForDay(goal, dayKey)
+  if (target <= 0) return 0
+  return totalReps / target
 }
 
 /**

--- a/lib/training-facility/weight-room-history.test.ts
+++ b/lib/training-facility/weight-room-history.test.ts
@@ -361,3 +361,149 @@ describe('computeStrengthStats', () => {
     expect(stats.longestStreak).toBe(2)
   })
 })
+
+/**
+ * Effective-dated target coverage (#362). The scenario throughout is the
+ * issue's: pullups at 30, raised to 50 effective Aug 1. Everything before
+ * that boundary must stay scored against 30.
+ */
+describe('effective-dated targets (#362)', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  /** Pullups seeded at 30, raised to 50 on Aug 1. */
+  const PULLUPS_RAISED: ExerciseGoal = {
+    exercise: 'pullups',
+    daily_target: 50,
+    color: '#0EA5A1',
+    target_history: [
+      { daily_target: 30, effective_from: '2026-05-01' },
+      { daily_target: 50, effective_from: '2026-08-01' },
+    ],
+  }
+
+  /** Pullups lowered 50 -> 30 on Aug 1 — the symmetric case. */
+  const PULLUPS_LOWERED: ExerciseGoal = {
+    exercise: 'pullups',
+    daily_target: 30,
+    color: '#0EA5A1',
+    target_history: [
+      { daily_target: 50, effective_from: '2026-05-01' },
+      { daily_target: 30, effective_from: '2026-08-01' },
+    ],
+  }
+
+  /** Find the heatmap cell for a given local date key. */
+  function cellFor(
+    grid: ReturnType<typeof buildStrengthHeatmap>,
+    dateKey: string,
+  ): { reps: number; pct: number; dailyTarget: number } | undefined {
+    for (const row of grid.grid) {
+      for (const cell of row) {
+        const key = `${cell.date.getFullYear()}-${String(cell.date.getMonth() + 1).padStart(2, '0')}-${String(cell.date.getDate()).padStart(2, '0')}`
+        if (key === dateKey) return cell
+      }
+    }
+    return undefined
+  }
+
+  it('scores a pre-change heatmap cell against the old target', () => {
+    // 30 reps on Jul 15 was a full day against a 30 goal. After raising the
+    // goal to 50 it must still read as 100%, not 60%.
+    const sets = [set('2026-07-15', 'pullups', 30)]
+    const grid = buildStrengthHeatmap(
+      sets,
+      PULLUPS_RAISED,
+      new Date('2026-07-01T12:00:00'),
+      new Date('2026-08-31T12:00:00'),
+    )
+    const cell = cellFor(grid, '2026-07-15')
+    expect(cell?.reps).toBe(30)
+    expect(cell?.dailyTarget).toBe(30)
+    expect(cell?.pct).toBe(1)
+    expect(intensityFromPct(cell!.pct)).toBe(3)
+  })
+
+  it('scores a post-change heatmap cell against the new target', () => {
+    const sets = [set('2026-08-15', 'pullups', 40)]
+    const grid = buildStrengthHeatmap(
+      sets,
+      PULLUPS_RAISED,
+      new Date('2026-07-01T12:00:00'),
+      new Date('2026-08-31T12:00:00'),
+    )
+    const cell = cellFor(grid, '2026-08-15')
+    expect(cell?.dailyTarget).toBe(50)
+    expect(cell?.pct).toBe(0.8)
+    expect(intensityFromPct(cell!.pct)).toBe(2)
+  })
+
+  it('computes a streak across the boundary with no false break', () => {
+    // 30 reps/day Jul 30-31 (hits the 30 goal), 50 reps/day Aug 1-2 (hits
+    // the raised 50 goal). All four days are hits, so the streak is 4.
+    const sets = [
+      set('2026-07-30', 'pullups', 30),
+      set('2026-07-31', 'pullups', 30),
+      set('2026-08-01', 'pullups', 50),
+      set('2026-08-02', 'pullups', 50),
+    ]
+    const streak = computeStrengthStreaks(sets, PULLUPS_RAISED, new Date('2026-08-02T12:00:00'))
+    expect(streak.current).toBe(4)
+    expect(streak.longest).toBe(4)
+  })
+
+  it('breaks the streak on a post-change day that misses the raised target', () => {
+    // Aug 1 has 30 reps — enough for the old goal, short of the new one, so
+    // it must not count as a hit. Anchoring "now" at Aug 2 puts the last hit
+    // (Jul 31) outside the today/yesterday grace window, so the break shows
+    // up in `current` rather than being masked by it.
+    const sets = [
+      set('2026-07-30', 'pullups', 30),
+      set('2026-07-31', 'pullups', 30),
+      set('2026-08-01', 'pullups', 30),
+    ]
+    const streak = computeStrengthStreaks(sets, PULLUPS_RAISED, new Date('2026-08-02T12:00:00'))
+    expect(streak.current).toBe(0)
+    expect(streak.longest).toBe(2)
+  })
+
+  it('keeps the streak alive under the grace period when today has not yet cleared the new bar', () => {
+    // Same data, anchored at Aug 1: Jul 31 is "yesterday" and still a hit, so
+    // the streak is legitimately alive at 2 even though today falls short.
+    const sets = [
+      set('2026-07-30', 'pullups', 30),
+      set('2026-07-31', 'pullups', 30),
+      set('2026-08-01', 'pullups', 30),
+    ]
+    const streak = computeStrengthStreaks(sets, PULLUPS_RAISED, new Date('2026-08-01T12:00:00'))
+    expect(streak.current).toBe(2)
+    expect(streak.longest).toBe(2)
+  })
+
+  it('does not retroactively credit past days when a target is lowered', () => {
+    // 40 reps on Jul 15 missed the 50 goal in force at the time. Lowering
+    // the goal to 30 in August must not turn it into a hit.
+    const sets = [set('2026-07-15', 'pullups', 40), set('2026-08-15', 'pullups', 40)]
+    const streak = computeStrengthStreaks(sets, PULLUPS_LOWERED, new Date('2026-08-15T12:00:00'))
+    expect(streak.current).toBe(1)
+    expect(streak.longest).toBe(1)
+  })
+
+  it('surfaces the change on the stats payload and keeps dailyTarget current', () => {
+    const sets = [set('2026-07-15', 'pullups', 30)]
+    const [stats] = computeStrengthStats(sets, [PULLUPS_RAISED], new Date('2026-08-15T12:00:00'))
+    expect(stats.dailyTarget).toBe(50)
+    expect(stats.targetChanges).toEqual([
+      { from: 30, to: 50, effective_from: '2026-08-01' },
+    ])
+  })
+
+  it('leaves a goal with no history scored exactly as before', () => {
+    const sets = [set('2026-04-15', 'pushups', 100), set('2026-04-16', 'pushups', 100)]
+    const streak = computeStrengthStreaks(sets, PUSHUPS, new Date('2026-04-16T12:00:00'))
+    expect(streak).toEqual({ current: 2, longest: 2 })
+    const [stats] = computeStrengthStats(sets, [PUSHUPS], new Date('2026-04-16T12:00:00'))
+    expect(stats.targetChanges).toEqual([])
+  })
+})

--- a/lib/training-facility/weight-room-history.ts
+++ b/lib/training-facility/weight-room-history.ts
@@ -1,5 +1,7 @@
 import type { ExerciseGoal, StrengthSet } from '@/types/weight-room'
 
+import { type GoalTargetChange, goalTargetChanges, targetResolverFor } from './goal-targets'
+
 /**
  * Pure helpers for the Weight Room History View (#81). Mirrors the
  * cardio-side `heatmap-grid.ts` + `streaks.ts` split: this module owns
@@ -11,6 +13,12 @@ import type { ExerciseGoal, StrengthSet } from '@/types/weight-room'
  * Strength sets carry an ISO `logged_at` timestamp; heatmap and stats
  * both bucket by *local* calendar day so a set logged at 11pm doesn't
  * silently roll into the next day.
+ *
+ * Every goal-relative number here resolves the target **per day** via
+ * {@link targetResolverFor} rather than reading `goal.daily_target` (#362).
+ * Dividing the whole history by the current target meant raising a goal
+ * retroactively re-scored days already completed — closed rings re-opened,
+ * streaks collapsed, full-intensity cells dropped to half.
  */
 
 /** A single cell in the strength heatmap grid for one exercise. */
@@ -24,8 +32,18 @@ export interface StrengthHeatmapCell {
   /**
    * `reps / dailyTarget` — un-clamped, so 100% means "exactly hit the
    * goal" and 1.5 means "150% of goal". Empty days are `0`.
+   *
+   * The denominator is the target that was in effect on {@link date}, not
+   * the goal's current target (#362), so a cell keeps the intensity it
+   * earned when the goal later moves.
    */
   pct: number
+  /**
+   * The daily target in effect on {@link date} — the denominator behind
+   * {@link pct}. Surfaced so a tooltip can say "32 of 30" using the bar that
+   * actually applied rather than today's.
+   */
+  dailyTarget: number
 }
 
 /** Result of {@link buildStrengthHeatmap}. */
@@ -61,11 +79,22 @@ export interface StrengthExerciseStats {
   exercise: string
   /** Hex color from the matching {@link ExerciseGoal.color}. */
   color: string
-  /** Daily target reps from the matching goal. */
+  /**
+   * The goal's *current* daily target — what the panel labels the exercise
+   * with today. Historical rollups on this same object (the streaks) resolve
+   * their own per-day targets and do NOT divide by this (#362); read
+   * {@link targetChanges} for where the bar moved.
+   */
   dailyTarget: number
-  /** Consecutive days (ending today or yesterday) hitting the daily target. */
+  /**
+   * Consecutive days (ending today or yesterday) hitting the daily target,
+   * each day tested against the target in effect that day.
+   */
   currentStreak: number
-  /** Longest run of consecutive days hitting the daily target, all-time. */
+  /**
+   * Longest run of consecutive days hitting the daily target, all-time, each
+   * day tested against the target in effect that day.
+   */
   longestStreak: number
   /** Total reps logged this ISO week (Mon–Sun, current). */
   thisWeekReps: number
@@ -85,6 +114,13 @@ export interface StrengthExerciseStats {
   avgSetsPerActiveDay: number
   /** All-time total reps for this exercise. */
   allTimeReps: number
+  /**
+   * Every point at which this goal's target moved, oldest first (#362) —
+   * empty for a goal that has never been edited. The stats panel renders
+   * these as "30 → 50 on Aug 1" so a step in adherence is explained rather
+   * than mysterious.
+   */
+  targetChanges: GoalTargetChange[]
 }
 
 const DAY_MS = 86_400_000
@@ -153,7 +189,9 @@ export function intensityFromPct(pct: number): 0 | 1 | 2 | 3 {
  * Each cell carries the day's rep total, set count, and `pct = reps /
  * dailyTarget` so the renderer can pick a color via
  * {@link intensityFromPct} and a tooltip can read "32 reps (3 sets,
- * 32% of goal)".
+ * 32% of goal)". The denominator is resolved per cell from the goal's
+ * effective-dated history (#362), so cells on either side of a goal change
+ * are each scored against the bar that was live that day.
  *
  * Sets whose `exercise` doesn't match `goal.exercise` are silently
  * ignored — call once per exercise.
@@ -161,7 +199,8 @@ export function intensityFromPct(pct: number): 0 | 1 | 2 | 3 {
  * @param sets every logged set from {@link import('@/types/weight-room').WeightRoomData.sets};
  *   the helper filters to the matching exercise.
  * @param goal the {@link ExerciseGoal} for the target exercise; supplies
- *   the `daily_target` denominator for `pct`.
+ *   the per-day `daily_target` denominator for `pct` via its
+ *   `target_history` (falling back to `daily_target` when absent).
  * @param dateFrom optional inclusive start of the range; clamped to ~2
  *   years before `dateTo` if longer.
  * @param dateTo optional inclusive end; defaults to today.
@@ -202,10 +241,10 @@ export function buildStrengthHeatmap(
     lookup.set(key, entry)
   }
 
-  // Belt-and-suspenders: the schema (`WeightRoomGoalRowSchema`) already
-  // enforces a positive integer, but a 0/negative target slipping
-  // through would divide-by-zero or invert the intensity bucket.
-  const target = Math.max(1, goal.daily_target)
+  // Per-day target resolution (#362). Bound once so the history is sorted
+  // a single time rather than per cell; the resolver also owns the
+  // non-positive clamp that used to live here inline.
+  const targetFor = targetResolverFor(goal)
   const startMs = startMonday.getTime()
   const totalCols = Math.floor((endDate.getTime() - startMs) / WEEK_MS) + 1
   const grid: StrengthHeatmapCell[][] = Array.from({ length: 7 }, () => [])
@@ -218,11 +257,13 @@ export function buildStrengthHeatmap(
       const key = toDateKey(date)
       const entry = lookup.get(key)
       const reps = entry?.reps ?? 0
+      const dailyTarget = targetFor(key)
       grid[row].push({
         date,
         reps,
         setCount: entry?.setCount ?? 0,
-        pct: reps / target,
+        pct: reps / dailyTarget,
+        dailyTarget,
       })
 
       if (date.getMonth() !== lastMonth) {
@@ -246,9 +287,14 @@ export function buildStrengthHeatmap(
  * crossed the target yet) and is `0` when the most recent goal-hit day
  * is older than yesterday. `longest` is the all-time best.
  *
+ * Each day is tested against the target that was in effect *that day*
+ * (#362), so a streak spanning a goal change is neither falsely broken (old
+ * days re-tested against a raised bar) nor falsely continued (old days
+ * credited against a lowered one).
+ *
  * @param sets every logged set; filtered to `goal.exercise` internally.
- * @param goal the {@link ExerciseGoal} whose `daily_target` defines the
- *   bar to clear.
+ * @param goal the {@link ExerciseGoal} whose effective-dated target defines
+ *   the bar to clear on each day.
  * @param now optional override for the "today" anchor used to decide
  *   whether `current` includes the most recent hit-day. Defaults to
  *   `new Date()`. Threaded through from {@link computeStrengthStats}
@@ -267,7 +313,7 @@ export function computeStrengthStreaks(
     const key = toDateKey(d)
     dailyReps.set(key, (dailyReps.get(key) ?? 0) + s.reps)
   }
-  return streakFromDailyReps(dailyReps, goal.daily_target, now)
+  return streakFromDailyReps(dailyReps, targetResolverFor(goal), now)
 }
 
 /**
@@ -278,23 +324,21 @@ export function computeStrengthStreaks(
  * the stats path avoid a second traversal of `sets` per goal.
  *
  * @param dailyReps Reps summed per local-date key.
- * @param dailyTarget The exercise's `daily_target`. Clamped to a
- *   minimum of `1` so a 0/negative slip-through (the schema enforces
- *   `> 0` so it shouldn't happen) doesn't invert the hit-day predicate.
+ * @param targetFor Resolves the target in effect on a given day key, from
+ *   {@link targetResolverFor}. Taking a resolver rather than a scalar is
+ *   what makes the hit-test effective-dated (#362); it already clamps
+ *   non-positive targets to `1` so the predicate can't invert.
  * @param now Anchor for the current/yesterday rolling-day grace
  *   period.
  */
 function streakFromDailyReps(
   dailyReps: ReadonlyMap<string, number>,
-  dailyTarget: number,
+  targetFor: (dayKey: string) => number,
   now: Date
 ): { current: number; longest: number } {
-  // Belt-and-suspenders — same reason as in `buildStrengthHeatmap`.
-  const target = Math.max(1, dailyTarget)
-
   const hitDays: string[] = []
   for (const [key, reps] of dailyReps) {
-    if (reps >= target) hitDays.push(key)
+    if (reps >= targetFor(key)) hitDays.push(key)
   }
   if (hitDays.length === 0) return { current: 0, longest: 0 }
   hitDays.sort()
@@ -401,7 +445,7 @@ export function computeStrengthStats(
     }
 
     const avgSetsPerActiveDay = dailyReps.size === 0 ? 0 : validSetCount / dailyReps.size
-    const streak = streakFromDailyReps(dailyReps, goal.daily_target, now)
+    const streak = streakFromDailyReps(dailyReps, targetResolverFor(goal), now)
 
     return {
       exercise: goal.exercise,
@@ -415,6 +459,7 @@ export function computeStrengthStats(
       lastMonthReps,
       avgSetsPerActiveDay,
       allTimeReps,
+      targetChanges: goalTargetChanges(goal),
     }
   })
 }

--- a/supabase/migrations/20260730120000_weight_room_goal_targets.sql
+++ b/supabase/migrations/20260730120000_weight_room_goal_targets.sql
@@ -1,0 +1,104 @@
+-- Effective-dated Weight Room goal targets (#362). Extends the strength
+-- model (#79, `20260507120000_weight_room_tables.sql`) with a *history* of
+-- each exercise's daily target.
+--
+-- The problem: `weight_room_goals.daily_target` is a single mutable scalar,
+-- so every historical rollup (heatmap `pct`, streak hit-test, stats panel,
+-- Today View rings, achievement `'streak'` scope) divides by whatever the
+-- target is *right now*. Raising the pullups goal from 30 to 50 silently
+-- re-scores the entire past: days that closed the ring at 30 stop counting
+-- as hits, the longest streak collapses, and full-intensity heatmap cells
+-- drop to half — retroactively rewriting history that was actually
+-- completed. Lowering a target is the same bug in reverse, retroactively
+-- crediting days that didn't clear the bar at the time.
+--
+-- The fix: a goal's target becomes a series of (daily_target,
+-- effective_from) rows. The value in effect on day D is the most recent row
+-- with effective_from <= D. `weight_room_goals.daily_target` stays as a
+-- denormalized mirror of the newest row so the cheap "what's the target
+-- now" read doesn't need a join; the admin write path
+-- (`app/api/admin/weight-room/goals`) updates both in the same request, and
+-- the backfill below seeds the two consistently.
+--
+-- RLS mirrors weight_room_goals / weight_room_sets: anon + authenticated
+-- SELECT only; writes go through the service-role key via admin-gated API
+-- routes. All DDL is idempotent so re-applying on a fresh dev project (or
+-- after a branch reset) is a safe no-op.
+
+-- 1. The history table.
+create table if not exists public.weight_room_goal_targets (
+  id uuid primary key default gen_random_uuid(),
+  exercise text not null references public.weight_room_goals(exercise) on delete cascade,
+  daily_target integer not null check (daily_target > 0),
+  effective_from date not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  -- One target per exercise per day. Re-saving the same effective date is an
+  -- update of that day's value, not a second competing row — which is what
+  -- lets the write path upsert on (exercise, effective_from) when a target
+  -- change is corrected before it ships.
+  unique (exercise, effective_from)
+);
+
+comment on table public.weight_room_goal_targets is
+  'Effective-dated daily targets for Weight Room goals (#362). One row per (exercise, effective_from); the target in effect on day D is the most recent row with effective_from <= D. Historical rollups resolve per-day through this table so changing a goal never re-scores days already completed. weight_room_goals.daily_target mirrors the newest row for cheap current-value reads.';
+
+comment on column public.weight_room_goal_targets.effective_from is
+  'Inclusive first day this target applies to. Backdatable: setting it to a past date retroactively declares when a target change actually took effect, which is the point — the admin API accepts an explicit date rather than always stamping today.';
+
+-- Resolution always scans one exercise's rows newest-first, so the index
+-- order matches the lookup.
+create index if not exists weight_room_goal_targets_exercise_effective_idx
+  on public.weight_room_goal_targets (exercise, effective_from desc);
+
+alter table public.weight_room_goal_targets enable row level security;
+
+do $$
+begin
+  create policy "anon and authenticated can read weight room goal targets"
+    on public.weight_room_goal_targets
+    for select
+    to anon, authenticated
+    using (true);
+exception when duplicate_object then null;
+end $$;
+
+-- 2. Backfill — one seed row per existing goal, carrying that goal's current
+--    target. This is the step that must NOT re-score anything: seeding the
+--    *current* value means every existing chart, streak, and badge resolves
+--    to exactly the number it resolved to before this migration.
+--
+--    `effective_from` is dated at or before the earliest day the exercise
+--    could be scored on — the earlier of its first logged set and the goal's
+--    own created_at — so no logged day falls before the seed. Pacific is the
+--    anchor (same as load-management.ts / achievements.ts / monthly-focus.ts)
+--    because that's the timezone the app buckets days in; a set logged at
+--    10 pm Pacific must not land on the following UTC day and slip in front
+--    of its own seed row.
+--
+--    Belt-and-braces: `targetForDay` independently falls back to the
+--    earliest known target for any day preceding the first row, so even a
+--    backdated set inserted later still resolves to this same seed value
+--    rather than dividing by zero.
+--
+--    The `not exists` guard makes this idempotent and keeps it from
+--    re-stamping a goal whose history has since moved on — re-running after
+--    a real target change must not resurrect the original value.
+insert into public.weight_room_goal_targets (exercise, daily_target, effective_from)
+select
+  g.exercise,
+  g.daily_target,
+  least(
+    (
+      select min((s.logged_at at time zone 'America/Los_Angeles')::date)
+      from public.weight_room_sets s
+      where s.exercise = g.exercise
+    ),
+    (g.created_at at time zone 'America/Los_Angeles')::date
+  )
+from public.weight_room_goals g
+where not exists (
+  select 1
+  from public.weight_room_goal_targets t
+  where t.exercise = g.exercise
+);

--- a/types/weight-room.ts
+++ b/types/weight-room.ts
@@ -46,6 +46,32 @@ export interface StrengthSet {
 }
 
 /**
+ * One entry in an exercise's daily-target history (#362) — the target that
+ * took effect on {@link effective_from} and stayed in effect until the next
+ * entry (or forever, if it's the newest). Mirrors a row of
+ * `public.weight_room_goal_targets`.
+ *
+ * Resolve "what was the target on day D" with
+ * {@link import('@/lib/training-facility/goal-targets').targetForDay} rather
+ * than scanning this array by hand — it owns the before-first-entry fallback
+ * and the non-positive-target clamp.
+ */
+export interface GoalTargetPoint {
+  /**
+   * Target reps per day that took effect on {@link effective_from}. Positive
+   * (DB CHECK enforces), same units as {@link ExerciseGoal.daily_target}.
+   */
+  daily_target: number
+  /**
+   * Inclusive first day this target applies to, as a bare `YYYY-MM-DD` local
+   * date. PostgREST renders a Postgres `date` in this canonical form, so
+   * lexicographic string comparison against a day key is exactly
+   * chronological comparison — no `Date` parsing needed.
+   */
+  effective_from: string
+}
+
+/**
  * Per-exercise daily target + display color. Drives the Today View's
  * activity rings and the History View's heatmap intensity. Managed via
  * the Settings UI; the migration seeds `pushups` (rim-orange) and
@@ -57,6 +83,12 @@ export interface ExerciseGoal {
   /**
    * Target reps per day for the "grease the groove" goal. Activity
    * rings fill toward this number; the heatmap colors by % of target.
+   *
+   * This is the *current* target — a denormalized mirror of the newest
+   * {@link target_history} entry, kept for cheap reads. Historical rollups
+   * must NOT divide by it; they resolve the target in effect on each day via
+   * {@link import('@/lib/training-facility/goal-targets').targetForDay}, or a
+   * goal change would retroactively re-score days already completed (#362).
    */
   daily_target: number
   /**
@@ -90,6 +122,17 @@ export interface ExerciseGoal {
    * history at once.
    */
   load_multiplier?: number
+  /**
+   * Effective-dated history of this goal's {@link daily_target} (#362), oldest
+   * entry first. Attached by the data layer from
+   * `public.weight_room_goal_targets`.
+   *
+   * Absent or empty means "no recorded history" — every consumer then falls
+   * back to {@link daily_target} for all days, which is exactly the pre-#362
+   * behavior. The migration backfills one entry per goal dated at or before
+   * the earliest logged set, so in practice this is populated.
+   */
+  target_history?: GoalTargetPoint[]
 }
 
 /**


### PR DESCRIPTION
## What

`weight_room_goals.daily_target` was a **single mutable scalar**, so every historical rollup divided by whatever the target is *right now*. Raising the pullups goal 30 → 50 silently re-scored the entire past: July days that closed the ring at 30 stopped counting as hits, the longest streak collapsed, and full-intensity heatmap cells dropped to half. Lowering a target was the same bug in reverse — retroactively crediting days that never cleared the bar.

A goal's target is now a series of `(daily_target, effective_from)` rows. The value in effect on day D is the most recent row with `effective_from <= D`, and **every** goal-relative number resolves per-day rather than reading the current scalar.

## How

- **`lib/training-facility/goal-targets.ts`** (new) — `targetForDay`, `targetResolverFor` (binds once per goal so the history is sorted once, not once per heatmap cell), `goalTargetChanges`, and the label formatters. Pure, lexicographic `YYYY-MM-DD` comparison — no `Date` parsing, no UTC-midnight hazard, same reasoning as the `monthly-focus.ts` docblock.
- **Migration** `20260730120000_weight_room_goal_targets.sql` — history table + guarded backfill.
- **Rollups threaded**: `buildStrengthHeatmap` (`pct` + a new per-cell `dailyTarget`), *both* `computeStrengthStreaks` implementations, `streakFromDailyReps` (now takes a resolver, not a scalar), `computeStrengthStats`, `computeRingPercent`, and `achievements.ts` goal-hit days + pooled streak scope.
- **Writes append**: `POST /api/admin/weight-room/goals` upserts a history row on `(exercise, effective_from)` and re-derives the mirror from history. `effective_from` is optional (defaults to today) and **backdatable**.
- **Annotation**: a shared `GoalChangeMarker` (dashed boundary rule + `30 → 50` label) on the heatmap, plus a goal-changes footer on each stats card.

## The backfill provably does not re-score anything

Seeded with each goal's *current* target, dated at `least(earliest logged set, goal.created_at)` in Pacific. Verified against production before/after — hit-day counts are identical:

| exercise | target | active days | hit days before | hit days after |
|---|---|---|---|---|
| pullups | 30 | 40 | 31 | **31** |
| pushups | 100 | 52 | 36 | **36** |
| shrugs | 100 | 27 | 26 | **26** |
| squats | 100 | 19 | 18 | **18** |

Zero days resolved to a null target. `squats` is why `least()` matters — its first set (07-06) predates its goal's `created_at` (07-07), so a naive seed would have left a logged day uncovered.

Belt-and-braces: `targetForDay` independently falls back to the *earliest* known target for any day before the first row, so even a later backdated set resolves correctly instead of dividing by zero.

## Decisions worth a look

- **Future-dated `effective_from` is rejected (400).** The issue asks for backdating, not future-dating. Allowing it would leave the `daily_target` mirror stale from the moment that date arrived, with nothing to re-sync it — the exact failure mode the issue calls out. Easy to revisit if wanted, but it needs a resolve-on-read design.
- **History is written before the mirror.** If the history write fails, nothing changed and the request is cleanly retryable; if only the mirror update fails, historical scoring is still correct and the next save repairs the label. There's a test asserting this ordering.
- **`ExerciseGoal.daily_target` stays** as a current-value mirror (per the issue's "cheap reads"), re-derived from history on every write so a backdate landing *behind* a newer entry doesn't wrongly advance it.
- **Day-key convention left alone.** The resolver takes a `YYYY-MM-DD` string and only orders strings, so this doesn't quietly absorb #319's local-vs-Pacific unification.

## Also applied two unrelated migrations to staging

`migrations:check` against **staging** was already failing before this branch, on two committed-but-unapplied migrations from #345: `restrict_private_health_trends` and `scope_private_health_trends_to_owner`. Production had both; staging had drifted.

I applied them, because preview deploys read staging — so staging was still serving bodyweight and sleep to anon, which is precisely the exposure #345 set out to close. **Consequence for this preview:** the relative-strength chart on the history page self-hides (it guards on `bodyMass.length > 0`), same as anon on production. That is expected and unrelated to this PR.

Both projects now report `✓ migrations in sync — 25 committed, all applied.`

## Test plan

- [ ] `/training-facility/weight-room/history` — heatmap, weekly volume, and stats render unchanged (no goal has moved yet, so no markers should appear)
- [ ] Stats cards show **no** "goal changes" footer for pushups/pullups/squats/shrugs
- [ ] Hover a populated heatmap cell — tooltip now reads `… 100% of 100 pushups goal` (names the target that applied that day)
- [ ] `/training-facility/weight-room` — Today View rings and totals unchanged
- [ ] `/training-facility/weight-room/achievements` — Trophy Room badges unchanged, streak badges still lit
- [ ] **The real exercise:** in Settings, raise pullups 30 → 50. Then confirm on History that July days still read as full-intensity hits, the longest streak did not collapse, a dashed `30 → 50` marker appears at the boundary, and the stats card lists `30 → 50 on <date>`
- [ ] Lower it back to 30 and confirm past days are not retroactively credited

Verified locally: `tsc --noEmit` clean, `next build` compiles, **1632 unit tests pass (137 files)**, **43 Playwright e2e pass**, `eslint` clean, `migrations:check` clean against production *and* staging.

Closes #362.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added effective-dated exercise targets, allowing goal changes to apply from a specific date.
  * Added target-change history to exercise statistics and daily progress views.
  * Added heatmap markers and tooltips showing target changes and the target active on each day.

* **Bug Fixes**
  * Updated streaks, achievements, ring percentages, and historical scoring to use the correct daily target across goal changes.
  * Preserved existing behavior for exercises without target history.

* **Tests**
  * Expanded coverage for historical targets, date boundaries, streaks, scoring, and visual indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->