### PR TITLE
fix(weight-room): bucket every day in Pacific, on one shared day-key toolkit (#319)

### DIFF
--- a/app/api/admin/weight-room/goals/route.ts
+++ b/app/api/admin/weight-room/goals/route.ts
@@ -24,7 +24,7 @@ import { WeightRoomGoalUpsertSchema } from '@/lib/schemas/weight-room'
 import { createAdminSupabaseClient } from '@/lib/supabase/admin'
 import { withTelemetry } from '@/lib/telemetry/with-telemetry'
 import { targetForDay } from '@/lib/training-facility/goal-targets'
-import { pacificDayKey } from '@/lib/training-facility/load-management'
+import { pacificDayKey } from '@/lib/training-facility/day-keys'
 import type { GoalTargetPoint } from '@/types/weight-room'
 
 /**

--- a/app/training-facility/weight-room/history/page.tsx
+++ b/app/training-facility/weight-room/history/page.tsx
@@ -22,7 +22,8 @@ import {
   EXERCISE_FILTER_PARAM,
   parseExerciseSelection,
 } from '@/lib/training-facility/exercise-filter'
-import { buildMovementLoads, pacificDayKey } from '@/lib/training-facility/load-management'
+import { pacificDayKey } from '@/lib/training-facility/day-keys'
+import { buildMovementLoads } from '@/lib/training-facility/load-management'
 import { TRAINING_FACILITY_PREVIEW_PARAM } from '@/lib/training-facility/preview-param'
 import {
   buildFocusLaneCells,

--- a/components/training-facility/weight-room/StrengthHeatmap.tsx
+++ b/components/training-facility/weight-room/StrengthHeatmap.tsx
@@ -1,5 +1,6 @@
 import type { JSX } from 'react'
 
+import { formatDayKey } from '@/lib/training-facility/day-keys'
 import { type GoalTargetChange, goalTargetChanges } from '@/lib/training-facility/goal-targets'
 import {
   buildStrengthHeatmap,
@@ -243,13 +244,18 @@ export function StrengthHeatmap({
  *
  * The percentage is against the target in effect *that* day, so a cell on
  * the far side of a goal change explains its own colour (#362).
+ *
+ * Formatted from the cell's day key through {@link formatDayKey}, which pins
+ * the Pacific zone (#319). Formatting `cell.date` in viewer-local time would
+ * name the *following* day for anyone at UTC+5 or east of it, so the tooltip
+ * would contradict the square it's attached to.
  */
 function describeCell(cell: StrengthHeatmapCell, goal: ExerciseGoal): string {
-  const dateLabel = cell.date.toLocaleDateString('en-US', {
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-  })
+  const dateLabel = formatDayKey(
+    cell.dayKey,
+    { month: 'short', day: 'numeric', year: 'numeric' },
+    'en-US',
+  )
   if (cell.reps === 0) return dateLabel
   const setNoun = cell.setCount === 1 ? 'set' : 'sets'
   const pctLabel = `${Math.round(cell.pct * 100)}%`
@@ -262,8 +268,11 @@ function describeCell(cell: StrengthHeatmapCell, goal: ExerciseGoal): string {
  *
  * Scans the Monday row and returns the last column that starts on or before
  * the target day — the grid's columns are contiguous weeks, so that column is
- * the one containing it. Comparing `YYYY-MM-DD` keys keeps this consistent
- * with the rest of the day math (no `Date` arithmetic, no DST edge).
+ * the one containing it.
+ *
+ * Compares each cell's own `dayKey` (#319). This used to re-derive a key from
+ * `cell.date` in the *viewer's* timezone, which could name a different day
+ * than the cell was built for and drop a marker onto the neighbouring column.
  *
  * @param heatmap The built grid to locate the day within.
  * @param dayKey `YYYY-MM-DD` day to find.
@@ -272,15 +281,12 @@ function columnForDayKey(heatmap: StrengthHeatmapGrid, dayKey: string): number |
   const mondays = heatmap.grid[0]
   if (mondays === undefined || mondays.length === 0) return null
 
-  const keyOf = (d: Date): string =>
-    `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
-
   // Before the first rendered week — the change predates the window.
-  if (dayKey < keyOf(mondays[0].date)) return null
+  if (dayKey < mondays[0].dayKey) return null
 
   let found = -1
   for (let col = 0; col < mondays.length; col++) {
-    if (keyOf(mondays[col].date) <= dayKey) found = col
+    if (mondays[col].dayKey <= dayKey) found = col
     else break
   }
   if (found === -1) return null
@@ -289,7 +295,7 @@ function columnForDayKey(heatmap: StrengthHeatmapGrid, dayKey: string): number |
   const lastRow = heatmap.grid[6]
   if (lastRow !== undefined && found === mondays.length - 1) {
     const sunday = lastRow[found]
-    if (sunday !== undefined && dayKey > keyOf(sunday.date)) return null
+    if (sunday !== undefined && dayKey > sunday.dayKey) return null
   }
   return found
 }

--- a/lib/training-facility/achievements.ts
+++ b/lib/training-facility/achievements.ts
@@ -7,7 +7,7 @@ import type {
 } from '@/types/weight-room'
 
 import { targetResolverFor } from './goal-targets'
-import { pacificDayKey } from './load-management'
+import { mondayOfDayKey, safePacificDayKey, shiftDayKey } from './day-keys'
 
 /**
  * Pure resolver for the Weight Room Trophy Room (#336) — "grease the groove"
@@ -208,47 +208,6 @@ export interface TrophyRoomView {
   nextUp: ResolvedAchievement[]
 }
 
-/** Two-digit zero-pad for assembling a `YYYY-MM-DD` key. */
-function pad2(n: number): string {
-  return String(n).padStart(2, '0')
-}
-
-/**
- * Pacific day key for a set's `logged_at`, or `''` when the timestamp is
- * unparseable. {@link pacificDayKey} would throw a `RangeError` on an Invalid
- * Date; callers here treat `''` as "skip this set", so a single malformed row
- * can't take down the whole wall.
- */
-function safePacificDayKey(loggedAt: string): string {
-  const d = new Date(loggedAt)
-  return Number.isFinite(d.getTime()) ? pacificDayKey(d) : ''
-}
-
-/**
- * Add `n` days to a `YYYY-MM-DD` key.
- *
- * Arithmetic runs in UTC on a bare calendar date, which makes it exact: the
- * key is already a *Pacific* day (see {@link pacificDayKey}), so re-entering a
- * timezone here — even via a local-noon `Date` — would only reintroduce a zone
- * the caller has already resolved. UTC has no DST, so "+1 day" is always
- * exactly 86,400,000 ms.
- */
-function addDays(dayKey: string, n: number): string {
-  const [y, m, d] = dayKey.split('-').map(Number)
-  const dt = new Date(Date.UTC(y, m - 1, d) + n * 86_400_000)
-  return `${dt.getUTCFullYear()}-${pad2(dt.getUTCMonth() + 1)}-${pad2(dt.getUTCDate())}`
-}
-
-/**
- * ISO-week (Monday) key for a `YYYY-MM-DD` day key — the Monday at or before
- * it. Same zone-free arithmetic as {@link addDays}.
- */
-function weekKeyOf(dayKey: string): string {
-  const [y, m, d] = dayKey.split('-').map(Number)
-  const dow = new Date(Date.UTC(y, m - 1, d)).getUTCDay()
-  return addDays(dayKey, -(dow === 0 ? 6 : dow - 1))
-}
-
 /** Increment a `key → number` tally, treating a missing key as `0`. */
 function bump(map: Map<string, number>, key: string, by: number): void {
   map.set(key, (map.get(key) ?? 0) + by)
@@ -323,7 +282,7 @@ function buildMetrics(
     .sort((a, b) => (a.day < b.day ? -1 : a.day > b.day ? 1 : 0))
 
   for (const { set, day } of ordered) {
-    const week = weekKeyOf(day)
+    const week = mondayOfDayKey(day)
     const month = day.slice(0, 7)
     // Effective load: what's actually being moved, not what's stamped on one
     // dumbbell. Bodyweight sets carry no `weight_lbs` and contribute 0.
@@ -460,7 +419,7 @@ function resolveStreak(metrics: MovementMetrics, threshold: number): MetricOutco
   let previous: string | null = null
 
   for (const day of metrics.hitDays) {
-    run = previous !== null && addDays(previous, 1) === day ? run + 1 : 1
+    run = previous !== null && shiftDayKey(previous, 1) === day ? run + 1 : 1
     previous = day
     if (run > best) best = run
     if (run === threshold) earnedOn.push(day)

--- a/lib/training-facility/day-keys.test.ts
+++ b/lib/training-facility/day-keys.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  dayKeyToPacificNoon,
+  dayKeyToPacificNoonIso,
+  firstDayOfMonth,
+  inclusiveDaySpan,
+  isDayKey,
+  isoWeekdayOfDayKey,
+  lastDayOfMonth,
+  mondayOfDayKey,
+  monthIndexOfDayKey,
+  pacificDayKey,
+  safePacificDayKey,
+  shiftDayKey,
+  todayDayKey,
+} from './day-keys'
+
+/**
+ * Unit tests for the shared Pacific day-key toolkit (#319).
+ *
+ * The cases that matter are the ones the old server-local implementation got
+ * wrong: an evening Pacific timestamp that is already tomorrow in UTC, and day
+ * arithmetic across a DST transition.
+ */
+
+describe('pacificDayKey', () => {
+  it('buckets an evening Pacific timestamp to that Pacific day, not the UTC one', () => {
+    // 05:00Z on the 12th is 10pm PDT on the 11th. The server-local reading
+    // this replaces would have said 2026-07-12 — the whole bug in one case.
+    expect(pacificDayKey(new Date('2026-07-12T05:00:00Z'))).toBe('2026-07-11')
+  })
+
+  it('buckets a midday Pacific timestamp to the same day in both zones', () => {
+    expect(pacificDayKey(new Date('2026-07-11T19:00:00Z'))).toBe('2026-07-11')
+  })
+
+  it('handles the PST side of the year', () => {
+    // 07:00Z on Jan 2 is 11pm PST on Jan 1.
+    expect(pacificDayKey(new Date('2026-01-02T07:00:00Z'))).toBe('2026-01-01')
+  })
+
+  it('zero-pads so keys sort lexicographically', () => {
+    expect(pacificDayKey(new Date('2026-03-05T20:00:00Z'))).toBe('2026-03-05')
+    expect('2026-03-05' < '2026-03-12').toBe(true)
+  })
+})
+
+describe('safePacificDayKey', () => {
+  it('accepts an ISO string', () => {
+    expect(safePacificDayKey('2026-07-12T05:00:00Z')).toBe('2026-07-11')
+  })
+
+  it('accepts a Date', () => {
+    expect(safePacificDayKey(new Date('2026-07-12T05:00:00Z'))).toBe('2026-07-11')
+  })
+
+  it('returns an empty string for an unparseable timestamp', () => {
+    expect(safePacificDayKey('not-a-timestamp')).toBe('')
+    expect(safePacificDayKey(new Date(NaN))).toBe('')
+  })
+
+  it('returns a key that sorts before every real one, so bad rows drop out', () => {
+    expect('' < '1970-01-01').toBe(true)
+  })
+})
+
+describe('isDayKey', () => {
+  it('accepts a bare YYYY-MM-DD', () => {
+    expect(isDayKey('2026-07-11')).toBe(true)
+  })
+
+  it('rejects a timestamp or a partial date', () => {
+    expect(isDayKey('2026-07-11T05:00:00Z')).toBe(false)
+    expect(isDayKey('2026-7-11')).toBe(false)
+    expect(isDayKey('2026-07')).toBe(false)
+    expect(isDayKey('')).toBe(false)
+  })
+})
+
+describe('shiftDayKey', () => {
+  it('adds and subtracts days', () => {
+    expect(shiftDayKey('2026-07-11', 1)).toBe('2026-07-12')
+    expect(shiftDayKey('2026-07-11', -1)).toBe('2026-07-10')
+    expect(shiftDayKey('2026-07-11', 0)).toBe('2026-07-11')
+  })
+
+  it('crosses month and year boundaries', () => {
+    expect(shiftDayKey('2026-07-31', 1)).toBe('2026-08-01')
+    expect(shiftDayKey('2026-01-01', -1)).toBe('2025-12-31')
+  })
+
+  it('handles a leap day', () => {
+    expect(shiftDayKey('2028-02-28', 1)).toBe('2028-02-29')
+    expect(shiftDayKey('2028-03-01', -1)).toBe('2028-02-29')
+  })
+
+  it('is unaffected by the spring-forward DST transition', () => {
+    // 2026-03-08 is a 23-hour day in Pacific. Millisecond arithmetic on a
+    // zoned Date lands on the wrong side of it; calendar arithmetic doesn't.
+    expect(shiftDayKey('2026-03-07', 1)).toBe('2026-03-08')
+    expect(shiftDayKey('2026-03-08', 1)).toBe('2026-03-09')
+  })
+
+  it('is unaffected by the fall-back DST transition', () => {
+    // 2026-11-01 is a 25-hour day in Pacific.
+    expect(shiftDayKey('2026-10-31', 1)).toBe('2026-11-01')
+    expect(shiftDayKey('2026-11-01', 1)).toBe('2026-11-02')
+  })
+})
+
+describe('isoWeekdayOfDayKey', () => {
+  it('numbers Monday as 1 through Sunday as 7', () => {
+    expect(isoWeekdayOfDayKey('2026-07-06')).toBe(1) // Monday
+    expect(isoWeekdayOfDayKey('2026-07-11')).toBe(6) // Saturday
+    expect(isoWeekdayOfDayKey('2026-07-12')).toBe(7) // Sunday
+  })
+})
+
+describe('mondayOfDayKey', () => {
+  it('returns the same day for a Monday', () => {
+    expect(mondayOfDayKey('2026-07-06')).toBe('2026-07-06')
+  })
+
+  it('walks back to Monday from mid-week', () => {
+    expect(mondayOfDayKey('2026-07-09')).toBe('2026-07-06')
+  })
+
+  it('treats Sunday as the end of its week, not the start', () => {
+    expect(mondayOfDayKey('2026-07-12')).toBe('2026-07-06')
+  })
+
+  it('crosses a month boundary', () => {
+    expect(mondayOfDayKey('2026-08-01')).toBe('2026-07-27')
+  })
+})
+
+describe('inclusiveDaySpan', () => {
+  it('counts a single day as 1', () => {
+    expect(inclusiveDaySpan('2026-07-11', '2026-07-11')).toBe(1)
+  })
+
+  it('counts both endpoints', () => {
+    expect(inclusiveDaySpan('2026-07-01', '2026-07-31')).toBe(31)
+  })
+
+  it('returns 0 when the range is inverted', () => {
+    expect(inclusiveDaySpan('2026-07-31', '2026-07-01')).toBe(0)
+  })
+
+  it('is exact across a DST transition', () => {
+    // March 2026 has both a 23-hour day and 31 calendar days.
+    expect(inclusiveDaySpan('2026-03-01', '2026-03-31')).toBe(31)
+    expect(inclusiveDaySpan('2026-11-01', '2026-11-30')).toBe(30)
+  })
+})
+
+describe('month helpers', () => {
+  it('finds the first and last day of a month', () => {
+    expect(firstDayOfMonth('2026-07-15')).toBe('2026-07-01')
+    expect(lastDayOfMonth('2026-07-15')).toBe('2026-07-31')
+  })
+
+  it('handles a 30-day month and February', () => {
+    expect(lastDayOfMonth('2026-06-10')).toBe('2026-06-30')
+    expect(lastDayOfMonth('2026-02-10')).toBe('2026-02-28')
+    expect(lastDayOfMonth('2028-02-10')).toBe('2028-02-29')
+  })
+
+  it('reports a zero-based month index', () => {
+    expect(monthIndexOfDayKey('2026-01-15')).toBe(0)
+    expect(monthIndexOfDayKey('2026-12-15')).toBe(11)
+  })
+})
+
+describe('dayKeyToPacificNoon', () => {
+  it('round-trips back to the same key', () => {
+    for (const key of ['2026-01-01', '2026-03-08', '2026-07-11', '2026-11-01', '2026-12-31']) {
+      expect(pacificDayKey(dayKeyToPacificNoon(key)!)).toBe(key)
+    }
+  })
+
+  it('lands midday so a viewer in another zone still reads the right day', () => {
+    const d = dayKeyToPacificNoon('2026-07-11')!
+    // 19:00Z = noon PDT. Far enough from either midnight that no real UTC
+    // offset renders it as an adjacent day.
+    expect(d.toISOString()).toBe('2026-07-11T19:00:00.000Z')
+  })
+
+  it('rejects a malformed key', () => {
+    expect(dayKeyToPacificNoon('2026-7-11')).toBeNull()
+    expect(dayKeyToPacificNoon('')).toBeNull()
+  })
+
+  it('rejects a calendar-invalid date rather than rolling it forward', () => {
+    // `new Date('2026-02-31…')` silently becomes March 3.
+    expect(dayKeyToPacificNoon('2026-02-31')).toBeNull()
+  })
+})
+
+describe('dayKeyToPacificNoonIso', () => {
+  it('stamps a backdated set at Pacific noon on the chosen day', () => {
+    const iso = dayKeyToPacificNoonIso('2026-07-11')
+    expect(safePacificDayKey(iso)).toBe('2026-07-11')
+  })
+
+  it('returns an empty string for an invalid key', () => {
+    expect(dayKeyToPacificNoonIso('nope')).toBe('')
+  })
+})
+
+describe('todayDayKey', () => {
+  it('uses the supplied clock', () => {
+    expect(todayDayKey(new Date('2026-07-12T05:00:00Z'))).toBe('2026-07-11')
+  })
+})

--- a/lib/training-facility/day-keys.test.ts
+++ b/lib/training-facility/day-keys.test.ts
@@ -4,6 +4,7 @@ import {
   dayKeyToPacificNoon,
   dayKeyToPacificNoonIso,
   firstDayOfMonth,
+  formatDayKey,
   inclusiveDaySpan,
   isDayKey,
   isoWeekdayOfDayKey,
@@ -212,5 +213,35 @@ describe('dayKeyToPacificNoonIso', () => {
 describe('todayDayKey', () => {
   it('uses the supplied clock', () => {
     expect(todayDayKey(new Date('2026-07-12T05:00:00Z'))).toBe('2026-07-11')
+  })
+})
+
+describe('formatDayKey', () => {
+  it('names the Pacific day regardless of the viewer timezone', () => {
+    // The underlying instant is 19:00Z, which is already the *next* local day
+    // in Asia/Tokyo (UTC+9). Formatting it viewer-local would render "Jul 12"
+    // for a 2026-07-11 key and contradict the key it came from.
+    expect(formatDayKey('2026-07-11', { month: 'short', day: 'numeric' }, 'en-US')).toBe('Jul 11')
+  })
+
+  it('ignores a caller-supplied timeZone', () => {
+    const label = formatDayKey(
+      '2026-07-11',
+      { month: 'short', day: 'numeric', timeZone: 'Asia/Tokyo' },
+      'en-US',
+    )
+    expect(label).toBe('Jul 11')
+  })
+
+  it('formats a weekday label', () => {
+    // 2026-05-25 is a Monday.
+    expect(
+      formatDayKey('2026-05-25', { weekday: 'short', month: 'short', day: 'numeric' }, 'en-US'),
+    ).toBe('Mon, May 25')
+  })
+
+  it('returns an empty string for an invalid key', () => {
+    expect(formatDayKey('nope', { month: 'short' }, 'en-US')).toBe('')
+    expect(formatDayKey('2026-02-31', { month: 'short' }, 'en-US')).toBe('')
   })
 })

--- a/lib/training-facility/day-keys.ts
+++ b/lib/training-facility/day-keys.ts
@@ -197,3 +197,33 @@ export function dayKeyToPacificNoonIso(key: string): string {
 export function todayDayKey(now: Date = new Date()): string {
   return pacificDayKey(now)
 }
+
+/**
+ * Human-format a day key, rendering the **Pacific** calendar day.
+ *
+ * Use this rather than `dayKeyToPacificNoon(key).toLocaleDateString(...)`.
+ * That instant is 19:00Z, which is *already the next local day* for any viewer
+ * at UTC+5 or further east — so in Tokyo a `2026-07-11` key would render as
+ * "Jul 12", contradicting the key it came from. Pinning `timeZone` makes the
+ * label agree with the key everywhere.
+ *
+ * The locale is left to the viewer (`undefined`) unless a caller pins one;
+ * only the *zone* has to be fixed, because only the zone can change which day
+ * is named.
+ *
+ * @param key `YYYY-MM-DD`.
+ * @param options `Intl.DateTimeFormat` options — e.g.
+ *   `{ weekday: 'short', month: 'short', day: 'numeric' }`. A caller-supplied
+ *   `timeZone` is ignored; that's the whole point.
+ * @param locale BCP-47 tag, or `undefined` for the viewer's.
+ * @returns The formatted label, or `''` when `key` isn't a valid calendar day.
+ */
+export function formatDayKey(
+  key: string,
+  options: Intl.DateTimeFormatOptions,
+  locale?: string,
+): string {
+  const d = dayKeyToPacificNoon(key)
+  if (d === null) return ''
+  return d.toLocaleDateString(locale, { ...options, timeZone: PACIFIC_TZ })
+}

--- a/lib/training-facility/day-keys.ts
+++ b/lib/training-facility/day-keys.ts
@@ -1,0 +1,199 @@
+/**
+ * The one place the Training Facility turns a timestamp into a calendar day
+ * (#319).
+ *
+ * **Everything buckets in Pacific.** Before this module there were three
+ * parallel conventions: `pacificDayKey` (load-management), a server-local
+ * `toDateKey` (weight-room-history), and a browser-local `toLocalDateKey`
+ * (strength-today). The server-local one was a live bug — the History page is
+ * a Server Component, so on Vercel "local" is UTC, and an evening Pacific
+ * session straddles UTC midnight. Split across two UTC days, neither half
+ * reaches the daily target, so the heatmap and streaks under-counted goal-hit
+ * days while the Pacific-bucketed Load Management panel and Trophy Room on the
+ * same page counted them correctly.
+ *
+ * A single home timezone is the right model here: the log is anchored to where
+ * the training happens, not to where the reader happens to be. Logging while
+ * travelling still lands on the Pacific day, which is what keeps a streak from
+ * breaking because of a flight.
+ *
+ * **Keys are bare `YYYY-MM-DD` strings, and that's load-bearing.** PostgREST
+ * renders a Postgres `date` in exactly that canonical zero-padded form, so
+ * lexicographic string comparison *is* chronological comparison. Every window
+ * test, sort, and boundary check in this directory relies on it — which is why
+ * the arithmetic below stays on the calendar numbers rather than round-tripping
+ * through a zoned `Date`.
+ */
+
+/** IANA zone every Training Facility day bucket is anchored to. */
+export const PACIFIC_TZ = 'America/Los_Angeles'
+
+/** Reused formatter — constructing an `Intl.DateTimeFormat` per call is expensive. */
+const PACIFIC_DATE_FORMAT = new Intl.DateTimeFormat('en-CA', {
+  timeZone: PACIFIC_TZ,
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+})
+
+/** Matches a bare `YYYY-MM-DD` key. */
+const DAY_KEY_PATTERN = /^\d{4}-\d{2}-\d{2}$/
+
+/**
+ * The `YYYY-MM-DD` **Pacific** calendar day a timestamp falls on. A set logged
+ * at `2026-07-12T05:00:00Z` (10pm PT on the 11th) buckets to `2026-07-11`.
+ *
+ * Assembled from `formatToParts` rather than string-parsing the formatter's
+ * output, so a locale or ICU quirk can't reorder the fields.
+ *
+ * @param d Any `Date`; callers usually pass `new Date(set.logged_at)`.
+ */
+export function pacificDayKey(d: Date): string {
+  const parts = PACIFIC_DATE_FORMAT.formatToParts(d)
+  let year = ''
+  let month = ''
+  let day = ''
+  for (const part of parts) {
+    if (part.type === 'year') year = part.value
+    else if (part.type === 'month') month = part.value
+    else if (part.type === 'day') day = part.value
+  }
+  return `${year}-${month}-${day}`
+}
+
+/**
+ * {@link pacificDayKey} that tolerates bad input, returning `''` instead of
+ * throwing or emitting `NaN-NaN-NaN`.
+ *
+ * Callers treat `''` as "skip this row" — it sorts before every real key and
+ * matches no window, so a corrupt timestamp drops out of a rollup rather than
+ * poisoning it.
+ *
+ * @param input ISO 8601 timestamp string, or a `Date` the caller already built.
+ */
+export function safePacificDayKey(input: string | Date): string {
+  const d = typeof input === 'string' ? new Date(input) : input
+  return Number.isFinite(d.getTime()) ? pacificDayKey(d) : ''
+}
+
+/** Whether `value` has the exact `YYYY-MM-DD` shape this module works in. */
+export function isDayKey(value: string): boolean {
+  return DAY_KEY_PATTERN.test(value)
+}
+
+/**
+ * Shift a `YYYY-MM-DD` key by `delta` days.
+ *
+ * Arithmetic runs in UTC on the bare calendar numbers — no zone, no DST — so
+ * the result is always a clean calendar date. Doing this with millisecond math
+ * on a zoned `Date` lands on the wrong day twice a year, when a "day" is 23 or
+ * 25 hours long.
+ *
+ * @param key `YYYY-MM-DD` to shift.
+ * @param delta Days to add; negative goes back.
+ */
+export function shiftDayKey(key: string, delta: number): string {
+  const [y, m, d] = key.split('-').map(Number)
+  const dt = new Date(Date.UTC(y, m - 1, d + delta))
+  const yy = dt.getUTCFullYear()
+  const mm = String(dt.getUTCMonth() + 1).padStart(2, '0')
+  const dd = String(dt.getUTCDate()).padStart(2, '0')
+  return `${yy}-${mm}-${dd}`
+}
+
+/**
+ * ISO weekday for a day key: 1 = Monday … 7 = Sunday.
+ *
+ * @param key `YYYY-MM-DD`.
+ */
+export function isoWeekdayOfDayKey(key: string): number {
+  const [y, m, d] = key.split('-').map(Number)
+  const dow = new Date(Date.UTC(y, m - 1, d)).getUTCDay()
+  return dow === 0 ? 7 : dow
+}
+
+/**
+ * The Monday of the ISO week containing `key`. Weeks run Mon–Sun to match the
+ * heatmap's row layout and the stats panel's week rollups.
+ *
+ * @param key `YYYY-MM-DD` anywhere in the week.
+ */
+export function mondayOfDayKey(key: string): string {
+  return shiftDayKey(key, -(isoWeekdayOfDayKey(key) - 1))
+}
+
+/**
+ * Inclusive count of calendar days from `startKey` through `endKey`. `1` when
+ * they're the same day; `0` when `endKey` precedes `startKey`.
+ *
+ * @param startKey `YYYY-MM-DD` first day.
+ * @param endKey `YYYY-MM-DD` last day.
+ */
+export function inclusiveDaySpan(startKey: string, endKey: string): number {
+  if (endKey < startKey) return 0
+  const toUtcMs = (key: string): number => {
+    const [y, m, d] = key.split('-').map(Number)
+    return Date.UTC(y, m - 1, d)
+  }
+  return Math.round((toUtcMs(endKey) - toUtcMs(startKey)) / 86_400_000) + 1
+}
+
+/** First day of the calendar month containing `key`. */
+export function firstDayOfMonth(key: string): string {
+  return `${key.slice(0, 7)}-01`
+}
+
+/** Last day of the calendar month containing `key`. */
+export function lastDayOfMonth(key: string): string {
+  const [y, m] = key.split('-').map(Number)
+  // Day 0 of the following month is the last day of this one.
+  const dt = new Date(Date.UTC(y, m, 0))
+  return `${dt.getUTCFullYear()}-${String(dt.getUTCMonth() + 1).padStart(2, '0')}-${String(dt.getUTCDate()).padStart(2, '0')}`
+}
+
+/** Zero-based month index (0 = January) for a day key. */
+export function monthIndexOfDayKey(key: string): number {
+  return Number(key.slice(5, 7)) - 1
+}
+
+/**
+ * A `Date` positioned at **noon Pacific** on `key`.
+ *
+ * Noon, not midnight, is the point: midnight in one zone is the previous or
+ * next day in another, so a midnight-anchored `Date` renders as the wrong day
+ * for any viewer east or west of the anchor. Noon has ~12 hours of slack in
+ * both directions, which no real offset crosses.
+ *
+ * Used where an API wants a `Date` rather than a key — chart axis labels,
+ * `toLocaleDateString`, and the `logged_at` stamp for a backdated set.
+ *
+ * @param key `YYYY-MM-DD`.
+ * @returns The `Date`, or `null` when `key` isn't a valid calendar day.
+ */
+export function dayKeyToPacificNoon(key: string): Date | null {
+  if (!isDayKey(key)) return null
+  // Pacific is UTC-8 (PST) or UTC-7 (PDT); 19:00Z is noon in the first and
+  // 12:00 PDT in the second. Either way it's the middle of the target day, so
+  // one fixed offset works year-round without a DST lookup.
+  const d = new Date(`${key}T19:00:00Z`)
+  if (!Number.isFinite(d.getTime())) return null
+  // Guard against calendar-invalid input the shape check can't catch, e.g.
+  // `2026-02-31`, which `Date` would silently roll into March.
+  return pacificDayKey(d) === key ? d : null
+}
+
+/**
+ * ISO timestamp at noon Pacific on `key` — what a backdated set is stamped
+ * with so it buckets onto the day the user picked.
+ *
+ * @param key `YYYY-MM-DD`.
+ * @returns The ISO string, or `''` when `key` isn't a valid calendar day.
+ */
+export function dayKeyToPacificNoonIso(key: string): string {
+  return dayKeyToPacificNoon(key)?.toISOString() ?? ''
+}
+
+/** Today's Pacific day key. @param now Clock override; defaults to `new Date()`. */
+export function todayDayKey(now: Date = new Date()): string {
+  return pacificDayKey(now)
+}

--- a/lib/training-facility/hit-day-streaks.test.ts
+++ b/lib/training-facility/hit-day-streaks.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest'
+
+import { streakFromDailyReps, streakFromHitDays } from './hit-day-streaks'
+
+/**
+ * Unit tests for the consolidated streak algorithm (#366).
+ *
+ * This replaced two independent implementations, so it's worth pinning
+ * directly rather than only through its callers: the grace period, the
+ * longest-vs-current split, and the DST-safe day arithmetic are exactly the
+ * behaviours that would drift if the two copies had been merged carelessly.
+ */
+
+describe('streakFromHitDays', () => {
+  it('returns zeroes for no hit days', () => {
+    expect(streakFromHitDays([], '2026-07-15')).toEqual({ current: 0, longest: 0 })
+  })
+
+  it('counts a single hit day as a streak of 1', () => {
+    expect(streakFromHitDays(['2026-07-15'], '2026-07-15')).toEqual({ current: 1, longest: 1 })
+  })
+
+  it('counts consecutive days', () => {
+    const days = ['2026-07-13', '2026-07-14', '2026-07-15']
+    expect(streakFromHitDays(days, '2026-07-15')).toEqual({ current: 3, longest: 3 })
+  })
+
+  it('sorts unordered input rather than trusting the caller', () => {
+    const days = ['2026-07-15', '2026-07-13', '2026-07-14']
+    expect(streakFromHitDays(days, '2026-07-15')).toEqual({ current: 3, longest: 3 })
+  })
+
+  it('does not mutate the caller-supplied array', () => {
+    const days = ['2026-07-15', '2026-07-13']
+    streakFromHitDays(days, '2026-07-15')
+    expect(days).toEqual(['2026-07-15', '2026-07-13'])
+  })
+
+  it('breaks the run on a gap, keeping the longest', () => {
+    // 3 days, gap, 2 days ending today.
+    const days = [
+      '2026-07-06',
+      '2026-07-07',
+      '2026-07-08',
+      '2026-07-14',
+      '2026-07-15',
+    ]
+    expect(streakFromHitDays(days, '2026-07-15')).toEqual({ current: 2, longest: 3 })
+  })
+
+  it('keeps the streak alive when the last hit was yesterday', () => {
+    // The grace period: without it a streak would read as broken every
+    // morning until that day's first set landed.
+    expect(streakFromHitDays(['2026-07-14', '2026-07-15'], '2026-07-16')).toEqual({
+      current: 2,
+      longest: 2,
+    })
+  })
+
+  it('drops current to 0 once the last hit is older than yesterday', () => {
+    const result = streakFromHitDays(['2026-07-14', '2026-07-15'], '2026-07-17')
+    expect(result.current).toBe(0)
+    expect(result.longest).toBe(2)
+  })
+
+  it('reports longest from the current run when it is the best', () => {
+    const days = ['2026-07-01', '2026-07-13', '2026-07-14', '2026-07-15']
+    expect(streakFromHitDays(days, '2026-07-15')).toEqual({ current: 3, longest: 3 })
+  })
+
+  it('counts across a month boundary', () => {
+    const days = ['2026-07-30', '2026-07-31', '2026-08-01']
+    expect(streakFromHitDays(days, '2026-08-01')).toEqual({ current: 3, longest: 3 })
+  })
+
+  it('counts across the spring-forward DST transition', () => {
+    // 2026-03-08 is a 23-hour Pacific day; millisecond arithmetic would
+    // mis-step here, calendar arithmetic doesn't.
+    const days = ['2026-03-07', '2026-03-08', '2026-03-09']
+    expect(streakFromHitDays(days, '2026-03-09')).toEqual({ current: 3, longest: 3 })
+  })
+
+  it('counts across the fall-back DST transition', () => {
+    const days = ['2026-10-31', '2026-11-01', '2026-11-02']
+    expect(streakFromHitDays(days, '2026-11-02')).toEqual({ current: 3, longest: 3 })
+  })
+
+  it('yields current 0 but a real longest for an unparseable clock', () => {
+    // `todayKey === ''` means "today is unknown" — better to report no active
+    // streak than to invent one against a key that matches nothing.
+    const result = streakFromHitDays(['2026-07-14', '2026-07-15'], '')
+    expect(result.current).toBe(0)
+    expect(result.longest).toBe(2)
+  })
+})
+
+describe('streakFromDailyReps', () => {
+  /** Every day scored against a flat target, the common case. */
+  const flat = (n: number) => () => n
+
+  it('counts only days that clear the target', () => {
+    const reps = new Map([
+      ['2026-07-13', 100],
+      ['2026-07-14', 40], // short
+      ['2026-07-15', 100],
+    ])
+    expect(streakFromDailyReps(reps, flat(100), '2026-07-15')).toEqual({
+      current: 1,
+      longest: 1,
+    })
+  })
+
+  it('treats exactly hitting the target as a hit', () => {
+    const reps = new Map([['2026-07-15', 100]])
+    expect(streakFromDailyReps(reps, flat(100), '2026-07-15').current).toBe(1)
+  })
+
+  it('applies the per-day target rather than one scalar (#362)', () => {
+    // 30 clears the old 30 bar on Jul 15 but not the 50 in force from Aug 1.
+    const targetFor = (day: string): number => (day < '2026-08-01' ? 30 : 50)
+    const reps = new Map([
+      ['2026-07-15', 30],
+      ['2026-08-15', 30],
+    ])
+    const result = streakFromDailyReps(reps, targetFor, '2026-08-15')
+    expect(result.longest).toBe(1)
+    expect(result.current).toBe(0)
+  })
+
+  it('returns zeroes when nothing clears the bar', () => {
+    const reps = new Map([['2026-07-15', 10]])
+    expect(streakFromDailyReps(reps, flat(100), '2026-07-15')).toEqual({
+      current: 0,
+      longest: 0,
+    })
+  })
+
+  it('returns zeroes for an empty map', () => {
+    expect(streakFromDailyReps(new Map(), flat(100), '2026-07-15')).toEqual({
+      current: 0,
+      longest: 0,
+    })
+  })
+})

--- a/lib/training-facility/hit-day-streaks.ts
+++ b/lib/training-facility/hit-day-streaks.ts
@@ -1,0 +1,94 @@
+import { shiftDayKey } from './day-keys'
+
+/**
+ * The one implementation of "consecutive days that cleared the daily target"
+ * (#366).
+ *
+ * This lived in two places — `weight-room-history.ts` (one goal, returns
+ * `{ current, longest }`) and `strength-streaks.ts` (all goals, returns a
+ * record) — with identical logic and different day-key conventions. #362 had
+ * to make the same effective-dated edit in both copies, which is the usual
+ * sign the logic should be shared. Consolidating was blocked until #319 gave
+ * both call sites one day-key convention: with the arithmetic no longer
+ * varying, the only thing left to inject is the per-day target.
+ */
+
+/** Consecutive-day counts for one exercise. */
+export interface StreakCounts {
+  /**
+   * Length of the active run ending today, or yesterday when today hasn't
+   * cleared the bar yet. `0` when the most recent qualifying day is older
+   * than yesterday.
+   *
+   * The one-day grace matters: without it a streak would appear broken every
+   * morning until that day's first set landed.
+   */
+  current: number
+  /** Longest run of consecutive qualifying days, ever. Independent of {@link current}. */
+  longest: number
+}
+
+/**
+ * Count streaks from an ascending-sortable set of qualifying day keys.
+ *
+ * @param hitDays Day keys that cleared the bar, any order — sorted internally.
+ * @param todayKey `YYYY-MM-DD` anchor for the today/yesterday grace period.
+ *   Pass `''` (an unparseable clock) to get `current: 0` with `longest` still
+ *   computed, rather than a spurious streak.
+ */
+export function streakFromHitDays(
+  hitDays: readonly string[],
+  todayKey: string,
+): StreakCounts {
+  if (hitDays.length === 0) return { current: 0, longest: 0 }
+
+  const days = [...hitDays].sort()
+
+  let longest = 1
+  let run = 1
+  for (let i = 1; i < days.length; i++) {
+    if (shiftDayKey(days[i - 1], 1) === days[i]) {
+      run++
+      if (run > longest) longest = run
+    } else {
+      run = 1
+    }
+  }
+
+  const last = days[days.length - 1]
+  const yesterdayKey = todayKey === '' ? '' : shiftDayKey(todayKey, -1)
+  if (todayKey === '' || (last !== todayKey && last !== yesterdayKey)) {
+    return { current: 0, longest }
+  }
+
+  let current = 1
+  for (let i = days.length - 2; i >= 0; i--) {
+    if (shiftDayKey(days[i], 1) === days[i + 1]) current++
+    else break
+  }
+
+  return { current, longest: Math.max(longest, current) }
+}
+
+/**
+ * Count streaks from a `day key → reps` map, testing each day against the
+ * target that was in effect *that* day.
+ *
+ * @param dailyReps Reps summed per day key.
+ * @param targetFor Resolves the target in effect on a day key — from
+ *   `targetResolverFor`. Taking a resolver rather than a scalar is what makes
+ *   the hit-test effective-dated (#362); it already clamps non-positive
+ *   targets to `1`, so the predicate can't invert.
+ * @param todayKey `YYYY-MM-DD` anchor for the grace period.
+ */
+export function streakFromDailyReps(
+  dailyReps: ReadonlyMap<string, number>,
+  targetFor: (dayKey: string) => number,
+  todayKey: string,
+): StreakCounts {
+  const hitDays: string[] = []
+  for (const [key, reps] of dailyReps) {
+    if (reps >= targetFor(key)) hitDays.push(key)
+  }
+  return streakFromHitDays(hitDays, todayKey)
+}

--- a/lib/training-facility/load-management.test.ts
+++ b/lib/training-facility/load-management.test.ts
@@ -2,7 +2,8 @@ import { describe, it, expect } from 'vitest'
 
 import type { StrengthSet } from '@/types/weight-room'
 
-import { buildMovementLoads, pacificDayKey } from './load-management'
+import { pacificDayKey } from './day-keys'
+import { buildMovementLoads } from './load-management'
 
 /**
  * Minimal {@link StrengthSet} stamped at noon Pacific on `dayKey` (noon so

--- a/lib/training-facility/load-management.ts
+++ b/lib/training-facility/load-management.ts
@@ -14,7 +14,8 @@ import { pacificDayKey, shiftDayKey } from './day-keys'
  *
  * Turns raw {@link StrengthSet} rows into a per-movement view of how fast
  * volume is climbing relative to the tendon's recent baseline. All
- * calendar bucketing is anchored to **Pacific time** ({@link PACIFIC_TZ}),
+ * calendar bucketing is anchored to **Pacific time**
+ * ({@link import('./day-keys').PACIFIC_TZ}),
  * not the server's local zone — on Vercel the server runs in UTC, so
  * bucketing in local time would silently shift every day boundary. The
  * thresholds that turn these numbers into flags live in
@@ -23,9 +24,6 @@ import { pacificDayKey, shiftDayKey } from './day-keys'
  * Windows are **calendar-day** windows (not "last N sets"), so a rest day
  * contributes a real zero and correctly drags the acute load down.
  */
-
-/** IANA zone every day/week bucket is anchored to. Never bucket on raw UTC. */
-export const PACIFIC_TZ = 'America/Los_Angeles'
 
 /** Trailing days in the acute window. */
 const ACUTE_DAYS = 7

--- a/lib/training-facility/load-management.ts
+++ b/lib/training-facility/load-management.ts
@@ -7,6 +7,8 @@ import {
 } from '@/constants/ramp-rate'
 import type { ExerciseGoal, StrengthSet } from '@/types/weight-room'
 
+import { pacificDayKey, shiftDayKey } from './day-keys'
+
 /**
  * Ramp-rate aggregation for the Weight Room Load Management panel (#316).
  *
@@ -46,50 +48,6 @@ const LOADED_SET_FRACTION = 0.5
 
 /** Movement color when no matching {@link ExerciseGoal} supplies one. Rim-orange. */
 const DEFAULT_MOVEMENT_COLOR = '#EA580C'
-
-/** Reused Pacific date formatter — constructing one per call is expensive. */
-const PACIFIC_DATE_FORMAT = new Intl.DateTimeFormat('en-CA', {
-  timeZone: PACIFIC_TZ,
-  year: 'numeric',
-  month: '2-digit',
-  day: '2-digit',
-})
-
-/**
- * The `YYYY-MM-DD` **Pacific** calendar day a timestamp falls on. A set
- * logged at `2026-07-12T05:00:00Z` (10pm PT on the 11th) buckets to
- * `2026-07-11`. Assembled from `formatToParts` rather than string-parsing
- * the formatter output so a locale/ICU quirk can't reorder the fields.
- *
- * @param d any `Date`; callers pass `new Date(set.logged_at)`.
- */
-export function pacificDayKey(d: Date): string {
-  const parts = PACIFIC_DATE_FORMAT.formatToParts(d)
-  let year = ''
-  let month = ''
-  let day = ''
-  for (const part of parts) {
-    if (part.type === 'year') year = part.value
-    else if (part.type === 'month') month = part.value
-    else if (part.type === 'day') day = part.value
-  }
-  return `${year}-${month}-${day}`
-}
-
-/**
- * Shift a `YYYY-MM-DD` calendar key by `delta` days. Arithmetic runs in
- * UTC on the bare calendar numbers (no zone, no DST), so the returned key
- * is always a clean calendar date — never off-by-an-hour onto the wrong
- * day the way raw millisecond math can be across a DST transition.
- */
-function shiftDayKey(key: string, delta: number): string {
-  const [y, m, d] = key.split('-').map(Number)
-  const dt = new Date(Date.UTC(y, m - 1, d + delta))
-  const yy = dt.getUTCFullYear()
-  const mm = String(dt.getUTCMonth() + 1).padStart(2, '0')
-  const dd = String(dt.getUTCDate()).padStart(2, '0')
-  return `${yy}-${mm}-${dd}`
-}
 
 /** One point in a movement's trailing daily-volume sparkline. */
 export interface DailyVolumePoint {

--- a/lib/training-facility/monthly-focus.ts
+++ b/lib/training-facility/monthly-focus.ts
@@ -1,5 +1,5 @@
 import type { FocusCategory, MonthlyFocus, StrengthSet } from '@/types/weight-room'
-import { pacificDayKey } from './load-management'
+import { inclusiveDaySpan, pacificDayKey, safePacificDayKey, shiftDayKey } from './day-keys'
 
 export type { FocusCategory }
 
@@ -20,15 +20,6 @@ export type { FocusCategory }
  * this module runs inside a Vercel Server Component.
  */
 
-/**
- * Convert an ISO timestamp string to a Pacific `YYYY-MM-DD` key, or `''`
- * when the string doesn't parse. Mirrors `safePacificDayKey` in
- * `achievements.ts`.
- */
-function safePacificDayKey(ts: string): string {
-  const d = new Date(ts)
-  return Number.isFinite(d.getTime()) ? pacificDayKey(d) : ''
-}
 
 /**
  * Whether a focus window covers `dayKey` (inclusive on both ends).
@@ -116,35 +107,6 @@ export function formatFocusWindow(focus: MonthlyFocus): string {
 }
 
 /**
- * Add `n` days to a `YYYY-MM-DD` key, returning a new key. UTC-noon base
- * time anchors the arithmetic so DST transitions don't shift the calendar
- * day — the input key is already a resolved Pacific day, and pure date
- * arithmetic doesn't re-introduce a zone. Same helper shape as
- * `strength-streaks.addDays` / `achievements.addDays`.
- */
-function addDays(dateKey: string, n: number): string {
-  const d = new Date(dateKey + 'T12:00:00Z')
-  d.setUTCDate(d.getUTCDate() + n)
-  return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}-${String(d.getUTCDate()).padStart(2, '0')}`
-}
-
-/**
- * Inclusive day count between two `YYYY-MM-DD` keys (`end - start + 1`),
- * or `0` when `end` precedes `start`. Walks the calendar via
- * {@link addDays} so month boundaries and DST are handled correctly.
- */
-function inclusiveDaySpan(startKey: string, endKey: string): number {
-  if (endKey < startKey) return 0
-  let count = 1
-  let cursor = startKey
-  while (cursor < endKey) {
-    cursor = addDays(cursor, 1)
-    count++
-  }
-  return count
-}
-
-/**
  * Per-day target attainment for one focus, restricted to its window up
  * to "today". A day counts as hit when the day's logged volume reaches
  * {@link MonthlyFocus.daily_target} — interpreted as total reps for
@@ -227,7 +189,7 @@ export function computeFocusAdherence(
   let cursor = lastElapsed
   while (cursor >= focus.start_date && hit(cursor)) {
     currentStreak++
-    cursor = addDays(cursor, -1)
+    cursor = shiftDayKey(cursor, -1)
   }
 
   return {
@@ -430,7 +392,7 @@ export function buildFocusLaneCells(
       cells.push({ dayKey: cursor, focus, volume, pct })
     }
 
-    cursor = addDays(cursor, 1)
+    cursor = shiftDayKey(cursor, 1)
   }
 
   return cells

--- a/lib/training-facility/strength-streaks.ts
+++ b/lib/training-facility/strength-streaks.ts
@@ -1,7 +1,8 @@
 import type { ExerciseGoal, StrengthSet } from '@/types/weight-room'
 
+import { pacificDayKey, safePacificDayKey } from './day-keys'
 import { targetResolverFor } from './goal-targets'
-import { toLocalDateKey } from './strength-today'
+import { type StreakCounts, streakFromDailyReps } from './hit-day-streaks'
 
 /**
  * Per-exercise streak result, mirrored on
@@ -11,30 +12,12 @@ import { toLocalDateKey } from './strength-today'
  * effect *on that day*, resolved from the goal's effective-dated history
  * (#362) — so raising or lowering a target never re-scores days already
  * completed.
+ *
+ * Structurally identical to {@link StreakCounts}, which is what the shared
+ * computation returns; kept as its own name because the cardio-side
+ * `StreakResult` pairing is what makes the two UI surfaces interchangeable.
  */
-export interface StrengthStreakResult {
-  /**
-   * Length in days of the active goal-hit streak ending at today, or
-   * yesterday if today's target hasn't been hit yet. `0` when the most
-   * recent goal-hit day is older than yesterday.
-   */
-  current: number
-  /**
-   * Longest run of consecutive calendar days that hit the goal, ever.
-   * Independent of {@link current}.
-   */
-  longest: number
-}
-
-/**
- * Add `n` days to a `YYYY-MM-DD` key, returning a new key. Local-noon
- * base time so DST transitions don't shift the calendar day.
- */
-function addDays(dateKey: string, n: number): string {
-  const d = new Date(dateKey + 'T12:00:00')
-  d.setDate(d.getDate() + n)
-  return toLocalDateKey(d)
-}
+export type StrengthStreakResult = StreakCounts
 
 /**
  * Compute streaks for every configured exercise. Returns a record
@@ -69,12 +52,12 @@ export function computeStrengthStreaks(
 ): Record<string, StrengthStreakResult> {
   const result: Record<string, StrengthStreakResult> = {}
 
-  // Bucket reps by exercise → day → running total. Uses Maps to keep
-  // the inner structure ordered insertion-wise; the streak loop sorts
-  // keys explicitly so the input order doesn't matter.
+  // Bucket reps by exercise -> day -> running total. Uses Maps to keep
+  // the inner structure ordered insertion-wise; the shared streak helper
+  // sorts keys explicitly so the input order doesn't matter.
   const repsByExerciseAndDay = new Map<string, Map<string, number>>()
   for (const s of sets) {
-    const day = toLocalDateKey(s.logged_at)
+    const day = safePacificDayKey(s.logged_at)
     if (day === '') continue
     let dayMap = repsByExerciseAndDay.get(s.exercise)
     if (!dayMap) {
@@ -84,8 +67,7 @@ export function computeStrengthStreaks(
     dayMap.set(day, (dayMap.get(day) ?? 0) + s.reps)
   }
 
-  const today = toLocalDateKey(now)
-  const yesterday = today === '' ? '' : addDays(today, -1)
+  const todayKey = pacificDayKey(now)
 
   for (const goal of goals) {
     if (goal.daily_target <= 0) {
@@ -93,55 +75,9 @@ export function computeStrengthStreaks(
       continue
     }
     const dayMap = repsByExerciseAndDay.get(goal.exercise) ?? new Map<string, number>()
-
     // Per-day target resolution (#362) — bound once per goal so the history
     // is sorted a single time rather than once per logged day.
-    const targetFor = targetResolverFor(goal)
-
-    // "Goal-hit" calendar days, in chronological order.
-    const hitDays: string[] = []
-    for (const [day, total] of dayMap) {
-      if (total >= targetFor(day)) hitDays.push(day)
-    }
-    hitDays.sort()
-
-    if (hitDays.length === 0) {
-      result[goal.exercise] = { current: 0, longest: 0 }
-      continue
-    }
-
-    // Longest run of consecutive goal-hit days, ever.
-    let longest = 1
-    let run = 1
-    for (let i = 1; i < hitDays.length; i++) {
-      if (addDays(hitDays[i - 1], 1) === hitDays[i]) {
-        run++
-        if (run > longest) longest = run
-      } else {
-        run = 1
-      }
-    }
-
-    // Current streak: walk backward from the latest goal-hit day if
-    // it's today or yesterday (matches `computeStreaks`'s rolling-day
-    // grace period).
-    const last = hitDays[hitDays.length - 1]
-    let current = 0
-    if (last === today || last === yesterday) {
-      current = 1
-      for (let i = hitDays.length - 2; i >= 0; i--) {
-        if (addDays(hitDays[i], 1) === hitDays[i + 1]) {
-          current++
-        } else {
-          break
-        }
-      }
-    }
-
-    result[goal.exercise] = {
-      current,
-      longest: Math.max(longest, current),
-    }
+    result[goal.exercise] = streakFromDailyReps(dayMap, targetResolverFor(goal), todayKey)
   }
 
   return result

--- a/lib/training-facility/strength-today.test.ts
+++ b/lib/training-facility/strength-today.test.ts
@@ -174,16 +174,21 @@ describe('computeRingPercent', () => {
 })
 
 describe('localNoonIsoForDay', () => {
-  it('round-trips back to the same local day key', () => {
-    // The exact UTC string depends on the test runner's timezone; the
-    // contract is "this instant buckets onto the requested day."
+  it('round-trips back to the same day key', () => {
+    // The contract is "this instant buckets onto the requested day" — the
+    // only assertion that holds regardless of the runner's timezone.
     expect(toLocalDateKey(localNoonIsoForDay('2026-05-25'))).toBe('2026-05-25')
   })
 
-  it('stamps local noon, not midnight', () => {
-    const d = new Date(localNoonIsoForDay('2026-05-25'))
-    expect(d.getHours()).toBe(12)
-    expect(d.getMinutes()).toBe(0)
+  it('round-trips for a day on the PST side of the year too', () => {
+    expect(toLocalDateKey(localNoonIsoForDay('2026-01-15'))).toBe('2026-01-15')
+  })
+
+  it('stamps Pacific midday, not midnight', () => {
+    // Asserted in UTC rather than via getHours(): the stamp is Pacific noon
+    // (#319), so a local-hours assertion would read 12 only on a Pacific
+    // runner and 19 on the UTC one CI uses.
+    expect(localNoonIsoForDay('2026-05-25')).toBe('2026-05-25T19:00:00.000Z')
   })
 
   it('returns "" for a non-day-key string', () => {

--- a/lib/training-facility/strength-today.ts
+++ b/lib/training-facility/strength-today.ts
@@ -1,5 +1,10 @@
 import type { ExerciseGoal, StrengthSet } from '@/types/weight-room'
 
+import {
+  dayKeyToPacificNoon,
+  dayKeyToPacificNoonIso,
+  safePacificDayKey,
+} from './day-keys'
 import { targetForDay } from './goal-targets'
 
 /**
@@ -7,34 +12,34 @@ import { targetForDay } from './goal-targets'
  * per-exercise totals, and ring-percent computation. Lives separate
  * from the React components so the math has unit-test coverage without
  * any DOM mounted, and so {@link computeRingPercent} can be reused by
- * the future History View (#81) when it shows "today" alongside the
- * heatmap.
+ * the History View (#81) when it shows "today" alongside the heatmap.
  *
- * All date math runs in the *caller's* local timezone. The Today View
- * is by definition "what happened on this calendar day" — the user
- * looking at a phone in Pacific time wants their local midnight
- * boundary, not UTC's.
+ * Date math runs in **Pacific**, via the shared toolkit in `day-keys.ts`
+ * (#319). This module previously bucketed in the *caller's* local zone on the
+ * reasoning that "today" should mean the viewer's calendar day — but the log
+ * is anchored to where the training happens, and viewer-local left the Today
+ * View's streaks able to disagree with the Trophy Room's (already Pacific) for
+ * the same day. One anchor also means a trip abroad can't silently re-bucket
+ * the history or break a streak.
  */
 
 /**
- * Local-date key (`YYYY-MM-DD`) for an ISO timestamp string or a Date.
+ * Pacific day key (`YYYY-MM-DD`) for an ISO timestamp string or a Date.
  * Strips off the time-of-day so two sets logged at 06:00 and 23:00 of
  * the same day collapse to the same key.
+ *
+ * Thin alias over {@link safePacificDayKey}, kept because this is the name
+ * the Today View surfaces import. New code should reach for `day-keys.ts`
+ * directly.
  *
  * @param input ISO 8601 timestamp string from
  *   {@link StrengthSet.logged_at}, or a Date already constructed by
  *   the caller.
- * @returns `YYYY-MM-DD` in the caller's local timezone, or `''` when
- *   `input` is unparseable (so callers can use `key === ''` as a skip
- *   condition without throwing).
+ * @returns `YYYY-MM-DD` Pacific, or `''` when `input` is unparseable (so
+ *   callers can use `key === ''` as a skip condition without throwing).
  */
 export function toLocalDateKey(input: string | Date): string {
-  const d = typeof input === 'string' ? new Date(input) : input
-  if (!Number.isFinite(d.getTime())) return ''
-  const yyyy = d.getFullYear().toString().padStart(4, '0')
-  const mm = (d.getMonth() + 1).toString().padStart(2, '0')
-  const dd = d.getDate().toString().padStart(2, '0')
-  return `${yyyy}-${mm}-${dd}`
+  return safePacificDayKey(input)
 }
 
 /**
@@ -187,47 +192,25 @@ export function computeRingPercent(
 }
 
 /**
- * Strict `YYYY-MM-DD` shape produced by {@link toLocalDateKey} and the
- * native `<input type="date">` value. Anchored so a stray timestamp
- * (`2026-05-25T08:00`) doesn't silently parse as a day key.
- */
-const DAY_KEY_REGEX = /^(\d{4})-(\d{2})-(\d{2})$/
-
-/**
- * Parse a `YYYY-MM-DD` day key into a Date at *local noon* of that day.
- * Component-wise rather than `new Date(dayKey)` — the Date constructor
- * treats a bare date string as UTC midnight, which lands on the
- * *previous* local day in negative-offset timezones.
- *
- * @returns The local-noon Date, or `null` when `dayKey` isn't a valid
- *   calendar day (bad shape, or component overflow like `2026-02-31`
- *   that would silently roll into March).
- */
-function parseDayKeyToLocalNoon(dayKey: string): Date | null {
-  const match = DAY_KEY_REGEX.exec(dayKey)
-  if (!match) return null
-  const [, yyyy, mm, dd] = match
-  const d = new Date(Number(yyyy), Number(mm) - 1, Number(dd), 12, 0, 0)
-  if (!Number.isFinite(d.getTime()) || toLocalDateKey(d) !== dayKey) return null
-  return d
-}
-
-/**
- * ISO timestamp for *local noon* of a `YYYY-MM-DD` day key. Used when
+ * ISO timestamp for **noon Pacific** of a `YYYY-MM-DD` day key. Used when
  * backdating a QuickLog set (#202): stamping the set at the middle of
- * the day keeps it inside the intended calendar day for any plausible
- * timezone the data is later viewed in, instead of straddling a
+ * the day keeps it inside the intended calendar day instead of straddling a
  * midnight boundary the way a 00:00 stamp would.
+ *
+ * Pacific noon rather than local noon (#319) so the write round-trips through
+ * the read path: the set is bucketed back out with {@link toLocalDateKey},
+ * which is now Pacific. Stamping local noon from a non-Pacific browser could
+ * land the set on the adjacent Pacific day — a backdated set appearing on the
+ * wrong square.
  *
  * @param dayKey `YYYY-MM-DD` key as produced by {@link toLocalDateKey}
  *   or an `<input type="date">` value.
- * @returns ISO 8601 UTC timestamp of the day's local noon, or `''` when
+ * @returns ISO 8601 UTC timestamp of the day's Pacific noon, or `''` when
  *   `dayKey` isn't a valid day key (so callers can fall back to the
  *   server-side `now()` default instead of throwing).
  */
 export function localNoonIsoForDay(dayKey: string): string {
-  const d = parseDayKeyToLocalNoon(dayKey)
-  return d ? d.toISOString() : ''
+  return dayKeyToPacificNoonIso(dayKey)
 }
 
 /**
@@ -242,7 +225,7 @@ export function localNoonIsoForDay(dayKey: string): string {
  *   unparseable.
  */
 export function formatDayLabel(dayKey: string): string {
-  const d = parseDayKeyToLocalNoon(dayKey)
+  const d = dayKeyToPacificNoon(dayKey)
   if (!d) return ''
   return d.toLocaleDateString(undefined, {
     weekday: 'short',

--- a/lib/training-facility/strength-today.ts
+++ b/lib/training-facility/strength-today.ts
@@ -1,10 +1,6 @@
 import type { ExerciseGoal, StrengthSet } from '@/types/weight-room'
 
-import {
-  dayKeyToPacificNoon,
-  dayKeyToPacificNoonIso,
-  safePacificDayKey,
-} from './day-keys'
+import { dayKeyToPacificNoonIso, formatDayKey, safePacificDayKey } from './day-keys'
 import { targetForDay } from './goal-targets'
 
 /**
@@ -225,11 +221,5 @@ export function localNoonIsoForDay(dayKey: string): string {
  *   unparseable.
  */
 export function formatDayLabel(dayKey: string): string {
-  const d = dayKeyToPacificNoon(dayKey)
-  if (!d) return ''
-  return d.toLocaleDateString(undefined, {
-    weekday: 'short',
-    month: 'short',
-    day: 'numeric',
-  })
+  return formatDayKey(dayKey, { weekday: 'short', month: 'short', day: 'numeric' })
 }

--- a/lib/training-facility/weight-room-history.test.ts
+++ b/lib/training-facility/weight-room-history.test.ts
@@ -646,3 +646,76 @@ describe('computeStrengthStats — focus dailyTarget label (#367 review)', () =>
     expect(stats.dailyTarget).toBe(100)
   })
 })
+
+/**
+ * Pacific bucketing (#319). These are the cases the old server-local
+ * `toDateKey` got wrong: on Vercel "local" is UTC, so an evening Pacific set
+ * landed on the following calendar day. They assert against explicit `Z`
+ * timestamps so the result is identical on a Pacific dev machine and a UTC CI
+ * runner — the timezone-independence is the point.
+ */
+describe('Pacific day bucketing (#319)', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  /** A set at an explicit UTC instant, so the test doesn't depend on the runner's zone. */
+  function utcSet(iso: string, exercise: string, reps: number): StrengthSet {
+    return { id: `${exercise}-${iso}-${reps}`, logged_at: iso, exercise, reps }
+  }
+
+  it('buckets an evening Pacific set onto that Pacific day, not the next UTC one', () => {
+    // 2026-07-16T05:00:00Z is 10pm PDT on the 15th.
+    const sets = [utcSet('2026-07-16T05:00:00Z', 'pushups', 100)]
+    const grid = buildStrengthHeatmap(
+      sets,
+      PUSHUPS,
+      new Date('2026-07-13T19:00:00Z'),
+      new Date('2026-07-19T19:00:00Z'),
+    )
+    const cells = grid.grid.flat().filter((c) => c.reps > 0)
+    expect(cells).toHaveLength(1)
+    expect(cells[0].dayKey).toBe('2026-07-15')
+  })
+
+  it('keeps a split evening session on one day so it can reach the target', () => {
+    // Two halves of the same Pacific evening that straddle UTC midnight.
+    // Bucketed by UTC they are 50 + 50 on separate days — neither a hit.
+    const sets = [
+      utcSet('2026-07-16T02:00:00Z', 'pushups', 50), // 7pm PDT Jul 15
+      utcSet('2026-07-16T05:00:00Z', 'pushups', 50), // 10pm PDT Jul 15
+    ]
+    const streak = computeStrengthStreaks(sets, PUSHUPS, new Date('2026-07-16T19:00:00Z'))
+    expect(streak.longest).toBe(1)
+  })
+
+  it('rolls an evening set into the Pacific week, not the next one', () => {
+    // 2026-07-13T05:00:00Z is 10pm PDT Sunday Jul 12 — the *end* of the
+    // Jul 6 week. In UTC it is Monday Jul 13, opening the next week.
+    const sets = [utcSet('2026-07-13T05:00:00Z', 'pushups', 60)]
+    const points = buildWeeklyVolume(sets, PUSHUPS, 3, new Date('2026-07-15T19:00:00Z'))
+    const withReps = points.filter((p) => p.reps > 0)
+    expect(withReps).toHaveLength(1)
+    expect(withReps[0].weekKey).toBe('2026-07-06')
+  })
+
+  it('counts an evening set in the Pacific month it belongs to', () => {
+    // 2026-08-01T05:00:00Z is 10pm PDT on Jul 31.
+    const sets = [utcSet('2026-08-01T05:00:00Z', 'pushups', 120)]
+    const [stats] = computeStrengthStats(sets, [PUSHUPS], new Date('2026-08-15T19:00:00Z'))
+    expect(stats.lastMonthReps).toBe(120)
+    expect(stats.thisMonthReps).toBe(0)
+  })
+
+  it('exposes a Pacific dayKey on every cell', () => {
+    const grid = buildStrengthHeatmap(
+      [],
+      PUSHUPS,
+      new Date('2026-07-13T19:00:00Z'),
+      new Date('2026-07-19T19:00:00Z'),
+    )
+    // Row 0 is Monday, so the first cell of the first column is a Monday.
+    expect(grid.grid[0][0].dayKey).toBe('2026-07-13')
+    expect(grid.grid[6][0].dayKey).toBe('2026-07-19')
+  })
+})

--- a/lib/training-facility/weight-room-history.test.ts
+++ b/lib/training-facility/weight-room-history.test.ts
@@ -399,10 +399,13 @@ describe('effective-dated targets (#362)', () => {
     grid: ReturnType<typeof buildStrengthHeatmap>,
     dateKey: string,
   ): { reps: number; pct: number; dailyTarget: number } | undefined {
+    // Match on the cell's own `dayKey`, not a key re-derived from `cell.date`
+    // (#319). That Date is a fixed 19:00Z instant, so reading its local
+    // components would name the following day on a runner east of UTC+5 — the
+    // exact hazard `StrengthHeatmapCell.dayKey` exists to remove.
     for (const row of grid.grid) {
       for (const cell of row) {
-        const key = `${cell.date.getFullYear()}-${String(cell.date.getMonth() + 1).padStart(2, '0')}-${String(cell.date.getDate()).padStart(2, '0')}`
-        if (key === dateKey) return cell
+        if (cell.dayKey === dateKey) return cell
       }
     }
     return undefined

--- a/lib/training-facility/weight-room-history.ts
+++ b/lib/training-facility/weight-room-history.ts
@@ -173,7 +173,7 @@ export interface StrengthExerciseStats {
 
 /** Cap at ~2 years to limit DOM node count when a wide range is requested. */
 const MAX_COLS = 104
-/** Days per heatmap column. */
+/** Days in a calendar week — heatmap column height, and the week-key stride. */
 const DAYS_PER_WEEK = 7
 
 const MONTH_LABELS = [
@@ -238,11 +238,18 @@ export function buildStrengthHeatmap(
 ): StrengthHeatmapGrid {
   // Column boundaries walk day keys, not milliseconds (#319): a DST week is
   // 23 or 25 hours long, so `+ 7 * DAY_MS` drifts off the Monday twice a year.
-  const endMondayKey = mondayOfDayKey(pacificDayKey(dateTo ?? new Date()))
+  //
+  // Both bounds go through `safePacificDayKey` because they arrive as props
+  // from user-derived state: `pacificDayKey` throws `RangeError` on an Invalid
+  // Date, which would take the whole page down rather than degrading. An
+  // unusable bound falls back to the same default as omitting it.
+  const endKey = safePacificDayKey(dateTo ?? new Date())
+  const endMondayKey = mondayOfDayKey(endKey === '' ? pacificDayKey(new Date()) : endKey)
 
+  const startKey = dateFrom ? safePacificDayKey(dateFrom) : ''
   let startMondayKey: string
-  if (dateFrom) {
-    startMondayKey = mondayOfDayKey(pacificDayKey(dateFrom))
+  if (startKey !== '') {
+    startMondayKey = mondayOfDayKey(startKey)
     const maxStartKey = shiftDayKey(endMondayKey, -MAX_COLS * DAYS_PER_WEEK)
     if (startMondayKey < maxStartKey) startMondayKey = maxStartKey
   } else {

--- a/lib/training-facility/weight-room-history.ts
+++ b/lib/training-facility/weight-room-history.ts
@@ -1,11 +1,23 @@
 import type { ExerciseGoal, MonthlyFocus, StrengthSet } from '@/types/weight-room'
 
 import {
+  dayKeyToPacificNoon,
+  firstDayOfMonth,
+  inclusiveDaySpan,
+  lastDayOfMonth,
+  mondayOfDayKey,
+  monthIndexOfDayKey,
+  pacificDayKey,
+  safePacificDayKey,
+  shiftDayKey,
+} from './day-keys'
+import {
   type GoalTargetChange,
   goalTargetChanges,
   targetForDay,
   targetResolverFor,
 } from './goal-targets'
+import { type StreakCounts, streakFromDailyReps } from './hit-day-streaks'
 import {
   type FocusCampaignSummary,
   focusTargetHistory,
@@ -33,8 +45,18 @@ import {
 
 /** A single cell in the strength heatmap grid for one exercise. */
 export interface StrengthHeatmapCell {
-  /** Local-time date this cell represents. */
+  /**
+   * The day this cell represents, positioned at **noon Pacific** (#319) so a
+   * renderer calling `toLocaleDateString` can't display the adjacent day.
+   * Prefer {@link dayKey} for comparisons; this is for formatting.
+   */
   date: Date
+  /**
+   * `YYYY-MM-DD` Pacific key for this cell — the canonical identity, and what
+   * every window/boundary comparison should use. Saves callers re-deriving a
+   * key from {@link date} and getting a different timezone's answer.
+   */
+  dayKey: string
   /** Sum of reps logged for this exercise on {@link date}. `0` for empty days. */
   reps: number
   /** Number of distinct sets logged on {@link date}. */
@@ -149,10 +171,10 @@ export interface StrengthExerciseStats {
   focus?: FocusCampaignSummary
 }
 
-const DAY_MS = 86_400_000
-const WEEK_MS = 7 * DAY_MS
 /** Cap at ~2 years to limit DOM node count when a wide range is requested. */
 const MAX_COLS = 104
+/** Days per heatmap column. */
+const DAYS_PER_WEEK = 7
 
 const MONTH_LABELS = [
   'Jan',
@@ -168,29 +190,6 @@ const MONTH_LABELS = [
   'Nov',
   'Dec',
 ] as const
-
-/** Get the Monday at or before a given local date (00:00 local). */
-function getMondayOf(d: Date): Date {
-  const m = new Date(d.getFullYear(), d.getMonth(), d.getDate())
-  const dow = m.getDay()
-  m.setDate(m.getDate() - (dow === 0 ? 6 : dow - 1))
-  return m
-}
-
-/** Get a `YYYY-MM-DD` local-date key from a Date. */
-function toDateKey(d: Date): string {
-  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
-}
-
-/**
- * Add `n` days to a `YYYY-MM-DD` key, returning a new key. Uses
- * local-noon as the base so DST transitions don't shift the date.
- */
-function addDays(dateKey: string, n: number): string {
-  const d = new Date(dateKey + 'T12:00:00')
-  d.setDate(d.getDate() + n)
-  return toDateKey(d)
-}
 
 /**
  * Bucket reps-as-percent-of-goal into one of four intensity levels for
@@ -237,30 +236,28 @@ export function buildStrengthHeatmap(
   dateFrom?: Date | null,
   dateTo?: Date | null
 ): StrengthHeatmapGrid {
-  const endMonday = getMondayOf(dateTo ?? new Date())
-  const endDate = new Date(endMonday.getTime() + 6 * DAY_MS)
+  // Column boundaries walk day keys, not milliseconds (#319): a DST week is
+  // 23 or 25 hours long, so `+ 7 * DAY_MS` drifts off the Monday twice a year.
+  const endMondayKey = mondayOfDayKey(pacificDayKey(dateTo ?? new Date()))
 
-  let startMonday: Date
+  let startMondayKey: string
   if (dateFrom) {
-    startMonday = getMondayOf(dateFrom)
-    const maxStart = new Date(endMonday.getTime() - MAX_COLS * WEEK_MS)
-    if (startMonday.getTime() < maxStart.getTime()) {
-      startMonday = maxStart
-    }
+    startMondayKey = mondayOfDayKey(pacificDayKey(dateFrom))
+    const maxStartKey = shiftDayKey(endMondayKey, -MAX_COLS * DAYS_PER_WEEK)
+    if (startMondayKey < maxStartKey) startMondayKey = maxStartKey
   } else {
-    startMonday = new Date(endMonday.getTime() - 52 * WEEK_MS)
+    startMondayKey = shiftDayKey(endMondayKey, -52 * DAYS_PER_WEEK)
   }
 
-  // Lookup: local-date key → { reps, setCount } for the matching exercise.
+  // Lookup: Pacific day key → { reps, setCount } for the matching exercise.
   // Read-modify-write the same shape regardless of hit/miss so the
   // accumulation reads symmetrically; the trailing `lookup.set` is a
   // no-op on a hit because we mutate the same object reference.
   const lookup = new Map<string, { reps: number; setCount: number }>()
   for (const s of sets) {
     if (s.exercise !== goal.exercise) continue
-    const d = new Date(s.logged_at)
-    if (!Number.isFinite(d.getTime())) continue
-    const key = toDateKey(d)
+    const key = safePacificDayKey(s.logged_at)
+    if (key === '') continue
     const entry = lookup.get(key) ?? { reps: 0, setCount: 0 }
     entry.reps += s.reps
     entry.setCount += 1
@@ -271,30 +268,36 @@ export function buildStrengthHeatmap(
   // a single time rather than per cell; the resolver also owns the
   // non-positive clamp that used to live here inline.
   const targetFor = targetResolverFor(goal)
-  const startMs = startMonday.getTime()
-  const totalCols = Math.floor((endDate.getTime() - startMs) / WEEK_MS) + 1
+  const totalCols =
+    Math.floor(
+      (inclusiveDaySpan(startMondayKey, shiftDayKey(endMondayKey, 6)) - 1) / DAYS_PER_WEEK
+    ) + 1
   const grid: StrengthHeatmapCell[][] = Array.from({ length: 7 }, () => [])
   const monthLabels: { col: number; label: string }[] = []
   let lastMonth = -1
 
   for (let col = 0; col < totalCols; col++) {
     for (let row = 0; row < 7; row++) {
-      const date = new Date(startMs + (col * 7 + row) * DAY_MS)
-      const key = toDateKey(date)
+      const key = shiftDayKey(startMondayKey, col * DAYS_PER_WEEK + row)
       const entry = lookup.get(key)
       const reps = entry?.reps ?? 0
       const dailyTarget = targetFor(key)
+      // Pacific noon, so a renderer calling `toLocaleDateString` shows the
+      // day the cell actually represents rather than the one before it.
+      const date = dayKeyToPacificNoon(key) ?? new Date(NaN)
       grid[row].push({
         date,
+        dayKey: key,
         reps,
         setCount: entry?.setCount ?? 0,
         pct: reps / dailyTarget,
         dailyTarget,
       })
 
-      if (date.getMonth() !== lastMonth) {
-        lastMonth = date.getMonth()
-        monthLabels.push({ col, label: MONTH_LABELS[date.getMonth()] })
+      const month = monthIndexOfDayKey(key)
+      if (month !== lastMonth) {
+        lastMonth = month
+        monthLabels.push({ col, label: MONTH_LABELS[month] })
       }
     }
   }
@@ -330,73 +333,15 @@ export function computeStrengthStreaks(
   sets: readonly StrengthSet[],
   goal: ExerciseGoal,
   now: Date = new Date()
-): { current: number; longest: number } {
+): StreakCounts {
   const dailyReps = new Map<string, number>()
   for (const s of sets) {
     if (s.exercise !== goal.exercise) continue
-    const d = new Date(s.logged_at)
-    if (!Number.isFinite(d.getTime())) continue
-    const key = toDateKey(d)
+    const key = safePacificDayKey(s.logged_at)
+    if (key === '') continue
     dailyReps.set(key, (dailyReps.get(key) ?? 0) + s.reps)
   }
-  return streakFromDailyReps(dailyReps, targetResolverFor(goal), now)
-}
-
-/**
- * Streak computation off an already-built `day-key → reps` map. Shared
- * between {@link computeStrengthStreaks} (which builds the map from
- * `sets`) and {@link computeStrengthStats} (which builds it inline as
- * part of its single-pass aggregation). Pulling this out is what lets
- * the stats path avoid a second traversal of `sets` per goal.
- *
- * @param dailyReps Reps summed per local-date key.
- * @param targetFor Resolves the target in effect on a given day key, from
- *   {@link targetResolverFor}. Taking a resolver rather than a scalar is
- *   what makes the hit-test effective-dated (#362); it already clamps
- *   non-positive targets to `1` so the predicate can't invert.
- * @param now Anchor for the current/yesterday rolling-day grace
- *   period.
- */
-function streakFromDailyReps(
-  dailyReps: ReadonlyMap<string, number>,
-  targetFor: (dayKey: string) => number,
-  now: Date
-): { current: number; longest: number } {
-  const hitDays: string[] = []
-  for (const [key, reps] of dailyReps) {
-    if (reps >= targetFor(key)) hitDays.push(key)
-  }
-  if (hitDays.length === 0) return { current: 0, longest: 0 }
-  hitDays.sort()
-
-  let longest = 1
-  let run = 1
-  for (let i = 1; i < hitDays.length; i++) {
-    if (addDays(hitDays[i - 1], 1) === hitDays[i]) {
-      run++
-      if (run > longest) longest = run
-    } else {
-      run = 1
-    }
-  }
-
-  const today = toDateKey(now)
-  const yesterday = addDays(today, -1)
-  const lastDay = hitDays[hitDays.length - 1]
-  if (lastDay !== today && lastDay !== yesterday) {
-    return { current: 0, longest }
-  }
-
-  let current = 1
-  for (let i = hitDays.length - 2; i >= 0; i--) {
-    if (addDays(hitDays[i], 1) === hitDays[i + 1]) {
-      current++
-    } else {
-      break
-    }
-  }
-
-  return { current, longest: Math.max(longest, current) }
+  return streakFromDailyReps(dailyReps, targetResolverFor(goal), pacificDayKey(now))
 }
 
 /**
@@ -435,16 +380,20 @@ export function computeStrengthStats(
   now: Date = new Date(),
   focuses: readonly MonthlyFocus[] = []
 ): StrengthExerciseStats[] {
-  const todayMonday = getMondayOf(now)
-  const thisWeekStart = toDateKey(todayMonday)
-  const thisWeekEnd = toDateKey(new Date(todayMonday.getTime() + 6 * DAY_MS))
-  const lastWeekStart = toDateKey(new Date(todayMonday.getTime() - 7 * DAY_MS))
-  const lastWeekEnd = toDateKey(new Date(todayMonday.getTime() - DAY_MS))
+  // Every boundary is a Pacific day key (#319), so the week and month a set
+  // falls into matches the day its heatmap cell lands on. Derived by calendar
+  // arithmetic rather than `Date` offsets — a DST week is 23 or 25 hours, and
+  // millisecond math drifts off the Monday twice a year.
+  const todayKey = pacificDayKey(now)
+  const thisWeekStart = mondayOfDayKey(todayKey)
+  const thisWeekEnd = shiftDayKey(thisWeekStart, 6)
+  const lastWeekStart = shiftDayKey(thisWeekStart, -7)
+  const lastWeekEnd = shiftDayKey(thisWeekStart, -1)
 
-  const thisMonthStart = toDateKey(new Date(now.getFullYear(), now.getMonth(), 1))
-  const thisMonthEnd = toDateKey(new Date(now.getFullYear(), now.getMonth() + 1, 0))
-  const lastMonthStart = toDateKey(new Date(now.getFullYear(), now.getMonth() - 1, 1))
-  const lastMonthEnd = toDateKey(new Date(now.getFullYear(), now.getMonth(), 0))
+  const thisMonthStart = firstDayOfMonth(todayKey)
+  const thisMonthEnd = lastDayOfMonth(todayKey)
+  const lastMonthEnd = shiftDayKey(thisMonthStart, -1)
+  const lastMonthStart = firstDayOfMonth(lastMonthEnd)
 
   return goals.map(goal => {
     // A focus anchor's real bar is its rotation's target, not the anchor's
@@ -466,9 +415,8 @@ export function computeStrengthStats(
 
     for (const s of sets) {
       if (s.exercise !== goal.exercise) continue
-      const d = new Date(s.logged_at)
-      if (!Number.isFinite(d.getTime())) continue
-      const key = toDateKey(d)
+      const key = safePacificDayKey(s.logged_at)
+      if (key === '') continue
 
       // All-time + active-day rollups.
       dailyReps.set(key, (dailyReps.get(key) ?? 0) + s.reps)
@@ -487,7 +435,7 @@ export function computeStrengthStats(
     }
 
     const avgSetsPerActiveDay = dailyReps.size === 0 ? 0 : validSetCount / dailyReps.size
-    const streak = streakFromDailyReps(dailyReps, targetResolverFor(scoringGoal), now)
+    const streak = streakFromDailyReps(dailyReps, targetResolverFor(scoringGoal), todayKey)
 
     return {
       exercise: goal.exercise,
@@ -495,7 +443,7 @@ export function computeStrengthStats(
       // Resolved through `scoringGoal` so the label and the streak agree. For
       // a permanent goal this is just today's target; for a focus it's the
       // rotation's, falling back to the anchor scalar when no window applies.
-      dailyTarget: targetForDay(scoringGoal, toDateKey(now)),
+      dailyTarget: targetForDay(scoringGoal, todayKey),
       currentStreak: streak.current,
       longestStreak: streak.longest,
       thisWeekReps,
@@ -541,16 +489,16 @@ export function buildWeeklyVolume(
   now: Date = new Date()
 ): WeeklyVolumePoint[] {
   const span = Math.max(1, Math.floor(weeks))
-  const currentMonday = getMondayOf(now)
-  const startMs = currentMonday.getTime() - (span - 1) * WEEK_MS
+  const currentMondayKey = mondayOfDayKey(pacificDayKey(now))
+  const startMondayKey = shiftDayKey(currentMondayKey, -(span - 1) * DAYS_PER_WEEK)
 
-  // weekKey (Monday YYYY-MM-DD) → reps + set tallies for this exercise.
+  // weekKey (Monday YYYY-MM-DD, Pacific) → reps + set tallies for this exercise.
   const lookup = new Map<string, { reps: number; setCount: number }>()
   for (const s of sets) {
     if (s.exercise !== goal.exercise) continue
-    const d = new Date(s.logged_at)
-    if (!Number.isFinite(d.getTime())) continue
-    const key = toDateKey(getMondayOf(d))
+    const dayKey = safePacificDayKey(s.logged_at)
+    if (dayKey === '') continue
+    const key = mondayOfDayKey(dayKey)
     const entry = lookup.get(key) ?? { reps: 0, setCount: 0 }
     entry.reps += s.reps
     entry.setCount += 1
@@ -559,15 +507,16 @@ export function buildWeeklyVolume(
 
   const points: WeeklyVolumePoint[] = []
   for (let i = 0; i < span; i++) {
-    // Snap each generated week back through getMondayOf so a DST hour
-    // shift in the raw ms arithmetic can't land the key on a Sunday.
-    const weekStart = getMondayOf(new Date(startMs + i * WEEK_MS))
-    const weekKey = toDateKey(weekStart)
+    // Calendar arithmetic, so a DST week can't land the key on a Sunday —
+    // the snap-back through `getMondayOf` this replaces existed only to undo
+    // that millisecond drift.
+    const weekKey = shiftDayKey(startMondayKey, i * DAYS_PER_WEEK)
+    const weekStart = dayKeyToPacificNoon(weekKey) ?? new Date(NaN)
     const entry = lookup.get(weekKey)
     points.push({
       weekStart,
       weekKey,
-      label: `${weekStart.getMonth() + 1}/${weekStart.getDate()}`,
+      label: `${monthIndexOfDayKey(weekKey) + 1}/${Number(weekKey.slice(8, 10))}`,
       reps: entry?.reps ?? 0,
       setCount: entry?.setCount ?? 0,
     })


### PR DESCRIPTION
## This is a live bug, not a latent one

#319 filed the server-local bucketing as "the latent off-by-a-day #316 called out". It isn't latent — it's been mis-counting the History page since it shipped.

`buildStrengthHeatmap`, `computeStrengthStats` and `buildWeeklyVolume` bucketed on `toDateKey`, a **server-local** day key. The History page is a Server Component, so on Vercel that's **UTC**. Measured against production:

- **721 of 1187 sets (61%)** fall on a different calendar day in UTC than in Pacific — an evening session is already tomorrow in UTC.
- Worse, a session split either side of UTC midnight becomes two part-days, and **neither reaches the target**.

The visible cost, goal-hit days:

| exercise | UTC (what the page shows) | Pacific (correct) | |
|---|---|---|---|
| pushups | 30 | **37** | +7 |
| shrugs | 22 | **27** | +5 |
| squats | 15 | **19** | +4 |
| pullups | 29 | **31** | +2 |

**18 hit days under-counted**, with the Load Management panel and Trophy Room — already Pacific — showing the correct higher numbers on the same page.

## What changed

**`lib/training-facility/day-keys.ts` (new)** is now the only place a timestamp becomes a calendar day. It replaces three parallel conventions:

| was | where | anchor |
|---|---|---|
| `toDateKey` / `getMondayOf` / `addDays` | weight-room-history | server-local → **UTC on Vercel** |
| `toLocalDateKey` / `parseDayKeyToLocalNoon` | strength-today | browser-local |
| `pacificDayKey` / `shiftDayKey` | load-management | Pacific |

Plus private `safePacificDayKey` / `addDays` / `weekKeyOf` / `inclusiveDaySpan` copies in `achievements.ts` and `monthly-focus.ts`, now deleted.

Picking one anchor also settles a live disagreement I hadn't expected: **Today View streaks (local) and Trophy Room streaks (Pacific) could report different numbers for the same day.**

Two details worth a look:

- **Arithmetic stays on the bare calendar numbers**, never millisecond offsets. A DST day is 23 or 25 hours, so `+ 7 * DAY_MS` drifts off the Monday twice a year — `buildWeeklyVolume` had a "snap back through `getMondayOf`" specifically to undo that drift, and it's gone now because the drift can't happen.
- **Backdated sets stamp Pacific noon**, not local noon. The write has to round-trip through a read path that's now Pacific; stamping local noon from a non-Pacific browser could land a backdated set on the adjacent Pacific day.

## Also closes #366 item 1

The streak algorithm was implemented twice — `weight-room-history.streakFromDailyReps` and `strength-streaks.computeStrengthStreaks` — and #362 had to make the same effective-dated edit in both. Consolidating was blocked on exactly this issue, because a shared helper would have needed the day-key arithmetic injected. With one convention there's nothing left to inject, so both now call `hit-day-streaks.ts`.

## Verification

The old suite passed on a Pacific dev machine and would have kept passing while the deployed page was wrong — the fixtures used midday timestamps that bucket the same either way. So the meaningful check is timezone independence:

```
TZ=UTC              npm test  → 1739 passed
TZ=America/New_York npm test  → 1739 passed
(machine local)     npm test  → 1739 passed
```

Running under UTC caught exactly one stale assertion — `stamps local noon` asserted `getHours() === 12`, true only on a Pacific runner. It now asserts the actual invariant (the stamp buckets back onto the requested day) plus an explicit UTC instant.

New tests pin the cases that were broken, all against explicit `Z` timestamps so they can't drift with the runner: an evening set landing on its Pacific day, a split evening session still reaching the target, an evening set staying in its Pacific week and month, and both DST transitions.

## Out of scope

`heatmap-grid.ts` and `streaks.ts` (cardio) still have their own local-time helpers. **They don't have this bug** — their only consumers (`AllCardioOverview`, `WorkoutHeatmap`) are `'use client'`, so "local" there is the viewer's zone, not UTC. They're a remaining inconsistency rather than a defect; noted for a follow-up.

## Test plan

- [ ] `/training-facility/weight-room/history` — heatmap cells and stats should now **agree** with the Load Management panel above them
- [ ] **Goal-hit days go up**: pushups ~37 (was 30), shrugs ~27, squats ~19, pullups ~31. Streaks may lengthen accordingly — this is the fix, not a regression
- [ ] Hover a heatmap cell logged in the evening — it should sit on the day you trained, not the day after
- [ ] Weekly volume bars: a Sunday-evening set belongs to that week, not the next
- [ ] `/training-facility/weight-room` — Today View rings/totals unchanged for today
- [ ] Today View streak and Trophy Room streak for the same exercise should now **match**
- [ ] Day picker → backdate a set to a past day → it appears on that day, and still does after a reload
- [ ] `/training-facility/weight-room/achievements` — badges unchanged (already Pacific)

Verified locally: `tsc --noEmit` clean, `next build` compiles, **1739 unit tests pass under three timezones**, **43 Playwright e2e pass**, `eslint` clean.

Closes #319. Closes #366 item 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Training Facility date and time handling across history, goals, streaks, load management, and monthly views.
  * Prevented daylight-saving and timezone-related errors when grouping activity by day, week, or month.
  * Kept Pacific calendar days, streaks, statistics, heatmap labels, and goal markers accurate across date boundaries.
  * Improved current and longest streak calculations, including gaps and activity near today or yesterday.

* **Tests**
  * Added comprehensive coverage for timezone boundaries, daylight-saving transitions, invalid dates, streaks, and calendar calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->