### PR TITLE
fix(weight-room): Focus Lane History renders legibly at short spans (#370)

### DIFF
--- a/app/training-facility/weight-room/history/page.tsx
+++ b/app/training-facility/weight-room/history/page.tsx
@@ -28,6 +28,7 @@ import {
   buildFocusLaneCells,
   computeFocusAdherence,
   computeFocusLoadStats,
+  type FocusDayCell,
 } from '@/lib/training-facility/monthly-focus'
 import { computeStrengthStats } from '@/lib/training-facility/weight-room-history'
 import type { ExerciseGoal } from '@/types/weight-room'
@@ -334,28 +335,55 @@ export default async function WeightRoomHistoryPage({
                   Focus Lane History
                 </h2>
                 <p className="mt-2 max-w-xl text-sm leading-7 text-[#e8d5be]">
-                  One stitched heatmap per body region, spanning the full rotation. Each day is
-                  colored by how close that day got to the active focus&rsquo;s daily target —
-                  so shrugs in July and a new exercise in August sit on the same timeline.
+                  A stitched heatmap for each body region that has a rotation on file. Each day
+                  is colored by how close it came to the active focus&rsquo;s daily target, and
+                  every rotation keeps its own color — so when the focus changes, the next
+                  exercise picks up on the same timeline. Faint cells are days between rotations.
                 </p>
-                {upperCells.length > 0 && (
-                  <div className="mt-4 rounded-[1.2rem] border border-white/10 bg-white/5 p-5">
-                    <div className="overflow-x-auto">
-                      <FocusLaneHeatmap cells={upperCells} label="Upper Focus Lane" />
-                    </div>
-                  </div>
-                )}
-                {lowerCells.length > 0 && (
-                  <div className="mt-4 rounded-[1.2rem] border border-white/10 bg-white/5 p-5">
-                    <div className="overflow-x-auto">
-                      <FocusLaneHeatmap cells={lowerCells} label="Lower Focus Lane" />
-                    </div>
-                  </div>
-                )}
+                <div className="mt-4 grid gap-4 md:grid-cols-2">
+                  {upperCells.length > 0 && (
+                    <FocusLaneCard cells={upperCells} title="Upper" />
+                  )}
+                  {lowerCells.length > 0 && (
+                    <FocusLaneCard cells={lowerCells} title="Lower" />
+                  )}
+                </div>
               </section>
             )}
           </>
         )}
+      </div>
+    </div>
+  )
+}
+
+/** Props for {@link FocusLaneCard}. */
+interface FocusLaneCardProps {
+  /** Ordered lane cells from `buildFocusLaneCells`, one body region's worth. */
+  cells: FocusDayCell[]
+  /** Body-region name shown as the card header, e.g. `"Upper"`. */
+  title: string
+}
+
+/**
+ * One body region's lane heatmap in its own card.
+ *
+ * Half-width from `md` up so a lane covering a few weeks sits in a
+ * container it can plausibly fill, rather than a full-width card it leaves
+ * ~87% empty (#370). The header is what tells the two lanes apart once
+ * both are configured — the region name previously lived only in the SVG's
+ * `aria-label`, invisible to sighted readers.
+ */
+function FocusLaneCard({ cells, title }: FocusLaneCardProps): JSX.Element {
+  return (
+    <div className="rounded-[1.2rem] border border-white/10 bg-white/5 p-5">
+      <h3 className="font-mono text-[10px] uppercase tracking-[0.28em] text-[#e8d5be]/70">
+        {title}
+      </h3>
+      {/* Scrolls rather than squashing once the rotation history outgrows
+          the card — the same treatment the per-exercise heatmaps get. */}
+      <div className="mt-3 overflow-x-auto">
+        <FocusLaneHeatmap cells={cells} label={`${title} Focus Lane`} />
       </div>
     </div>
   )

--- a/components/training-facility/weight-room/FocusLaneHeatmap.test.tsx
+++ b/components/training-facility/weight-room/FocusLaneHeatmap.test.tsx
@@ -1,0 +1,205 @@
+import { describe, expect, it } from 'vitest'
+import { render } from '@testing-library/react'
+
+import type { FocusDayCell } from '@/lib/training-facility/monthly-focus'
+import type { MonthlyFocus } from '@/types/weight-room'
+
+import { FocusLaneHeatmap } from './FocusLaneHeatmap'
+
+const SHRUGS: MonthlyFocus = {
+  id: 'focus-shrugs',
+  exercise: 'shrugs',
+  daily_target: 50,
+  target_kind: 'reps',
+  color: '#C9A268',
+  category: 'upper',
+  start_date: '2026-06-29',
+  end_date: '2026-08-02',
+}
+
+const DIPS: MonthlyFocus = {
+  ...SHRUGS,
+  id: 'focus-dips',
+  exercise: 'dips',
+  color: '#EA580C',
+  start_date: '2026-08-03',
+  end_date: '2026-09-06',
+}
+
+/** Build a contiguous run of cells starting at `from`, all on `focus`. */
+function lane(from: string, days: number, focus: MonthlyFocus | null): FocusDayCell[] {
+  const start = new Date(from + 'T12:00:00')
+  return Array.from({ length: days }, (_, i) => {
+    const d = new Date(start.getFullYear(), start.getMonth(), start.getDate() + i, 12)
+    const dayKey = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(
+      d.getDate(),
+    ).padStart(2, '0')}`
+    return { dayKey, focus, volume: focus === null ? 0 : 50, pct: focus === null ? 0 : 1 }
+  })
+}
+
+/** Parse the `viewBox` into `[width, height]`. */
+function viewBox(container: HTMLElement): [number, number] {
+  const raw = container.querySelector('svg')?.getAttribute('viewBox') ?? ''
+  const [, , w, h] = raw.split(' ').map(Number)
+  return [w, h]
+}
+
+/** Rendered month labels, in document order. */
+function monthLabels(container: HTMLElement): string[] {
+  const g = container.querySelector('svg > g')
+  return Array.from(g?.querySelectorAll('text') ?? []).map((t) => t.textContent ?? '')
+}
+
+/** X offsets of the rendered month labels, in document order. */
+function monthLabelXs(container: HTMLElement): number[] {
+  const g = container.querySelector('svg > g')
+  return Array.from(g?.querySelectorAll('text') ?? []).map((t) => Number(t.getAttribute('x')))
+}
+
+/**
+ * Advance width of a three-glyph month name at 11px — the distance two
+ * labels must clear to avoid rendering as one word.
+ */
+const GLYPH_WIDTH_3 = 3 * 11 * 0.6
+
+describe('FocusLaneHeatmap', () => {
+  it('renders nothing when the lane has no cells', () => {
+    const { container } = render(<FocusLaneHeatmap cells={[]} label="Upper Focus Lane" />)
+    expect(container.querySelector('svg')).toBeNull()
+  })
+
+  it('exposes the lane label on the SVG', () => {
+    const { getByRole } = render(
+      <FocusLaneHeatmap cells={lane('2026-06-29', 36, SHRUGS)} label="Upper Focus Lane" />,
+    )
+    expect(getByRole('img', { name: 'Upper Focus Lane' })).toBeInTheDocument()
+  })
+
+  // ---- #370: a short rotation must not render as a postage stamp ----------
+
+  it('scales a short rotation up rather than leaving a 116px chart', () => {
+    // One ~5-week rotation — the exact case that rendered 116px wide inside
+    // a 902px card at the fixed 14px stride.
+    const { container } = render(
+      <FocusLaneHeatmap cells={lane('2026-06-29', 36, SHRUGS)} label="Upper Focus Lane" />,
+    )
+    const [width] = viewBox(container)
+    expect(width).toBeGreaterThan(200)
+  })
+
+  it('caps the scale-up so cells stay cells', () => {
+    // Two weeks is the shortest plausible lane; without a cap the stride
+    // would balloon to fill the target width.
+    const { container } = render(
+      <FocusLaneHeatmap cells={lane('2026-06-29', 14, SHRUGS)} label="Upper Focus Lane" />,
+    )
+    const [, height] = viewBox(container)
+    // 7 rows at the 30px cap, plus the month row and legend strip.
+    expect(height).toBeLessThan(7 * 30 + 60)
+  })
+
+  it('leaves a long lane at the base stride, matching StrengthHeatmap', () => {
+    // A year of rotations is already wider than the target, so nothing is
+    // scaled and the lane renders exactly as it does today.
+    const cells = lane('2025-08-04', 364, SHRUGS)
+    const { container } = render(<FocusLaneHeatmap cells={cells} label="Upper Focus Lane" />)
+    const [width] = viewBox(container)
+    // 52 columns × 14px + the 32px day-label gutter, plus label overhang.
+    expect(width).toBeGreaterThanOrEqual(52 * 14 + 32)
+    expect(width).toBeLessThan(52 * 14 + 32 + 40)
+  })
+
+  it('honors an explicit cellSize as a floor', () => {
+    const cells = lane('2025-08-04', 364, SHRUGS)
+    const base = render(<FocusLaneHeatmap cells={cells} label="Upper" />)
+    const bigger = render(<FocusLaneHeatmap cells={cells} label="Upper" cellSize={20} />)
+    expect(viewBox(bigger.container)[0]).toBeGreaterThan(viewBox(base.container)[0])
+  })
+
+  // ---- #370: month labels must not collide or clip -----------------------
+
+  it('does not render two month labels on top of each other', () => {
+    // Jun 29 2026 is a Monday, so Jun owns exactly one column and Jul starts
+    // in the next one — the "JunJul" repro. On a lane this short the wider
+    // stride is what separates them; the thinning rule is the backstop.
+    const { container } = render(
+      <FocusLaneHeatmap cells={lane('2026-06-29', 36, SHRUGS)} label="Upper Focus Lane" />,
+    )
+    const xs = monthLabelXs(container)
+    expect(xs.length).toBeGreaterThan(1)
+    for (let i = 1; i < xs.length; i++) {
+      expect(xs[i] - xs[i - 1]).toBeGreaterThanOrEqual(GLYPH_WIDTH_3)
+    }
+  })
+
+  it('drops a leading month sliver once the lane is long enough to sit at base stride', () => {
+    // ~29 weeks renders at the 14px stride, so the same Jun/Jul adjacency
+    // can no longer be solved by scaling — the sliver label is dropped.
+    const { container } = render(
+      <FocusLaneHeatmap cells={lane('2026-06-29', 200, SHRUGS)} label="Upper Focus Lane" />,
+    )
+    const labels = monthLabels(container)
+    expect(labels).not.toContain('Jun')
+    expect(labels[0]).toBe('Jul')
+
+    const xs = monthLabelXs(container)
+    for (let i = 1; i < xs.length; i++) {
+      expect(xs[i] - xs[i - 1]).toBeGreaterThanOrEqual(GLYPH_WIDTH_3)
+    }
+  })
+
+  it('reserves width for a trailing month label so it is not clipped', () => {
+    // "Aug" lands in the final column; the SVG must extend past the grid.
+    const cells = lane('2026-06-29', 36, SHRUGS)
+    const { container } = render(<FocusLaneHeatmap cells={cells} label="Upper Focus Lane" />)
+    const [width] = viewBox(container)
+
+    const g = container.querySelectorAll('svg > g')[0]
+    const texts = Array.from(g.querySelectorAll('text'))
+    const lastX = Math.max(...texts.map((t) => Number(t.getAttribute('x'))))
+    // 32px gutter + the label's own x + room for three glyphs at 11px.
+    expect(width).toBeGreaterThanOrEqual(32 + lastX + 3 * 11 * 0.6)
+  })
+
+  // ---- #370: legend entries must not overlap -----------------------------
+
+  it('spaces legend entries so their labels cannot overlap', () => {
+    // Two rotations stitched into one lane: shrugs then dips.
+    const cells = [...lane('2026-06-29', 35, SHRUGS), ...lane('2026-08-03', 35, DIPS)]
+    const { container } = render(<FocusLaneHeatmap cells={cells} label="Upper Focus Lane" />)
+
+    const groups = container.querySelectorAll('svg > g')
+    const legend = groups[groups.length - 1]
+    const entries = Array.from(legend.querySelectorAll('g')).map((g) => {
+      const m = /translate\(([-\d.]+), ([-\d.]+)\)/.exec(g.getAttribute('transform') ?? '')
+      return { x: Number(m?.[1]), y: Number(m?.[2]) }
+    })
+
+    expect(entries).toHaveLength(2)
+    // Either stacked on separate rows, or far enough apart on the same row
+    // to clear the swatch plus the longest label.
+    const [a, b] = entries
+    const clears = a.y !== b.y || Math.abs(b.x - a.x) >= 12 + 4 + 'shrugs'.length * 10 * 0.6
+    expect(clears).toBe(true)
+  })
+
+  it('renders one legend swatch per rotation, not per day', () => {
+    const cells = [...lane('2026-06-29', 35, SHRUGS), ...lane('2026-08-03', 35, DIPS)]
+    const { getByText } = render(<FocusLaneHeatmap cells={cells} label="Upper Focus Lane" />)
+    expect(getByText('shrugs')).toBeInTheDocument()
+    expect(getByText('dips')).toBeInTheDocument()
+  })
+
+  it('keeps gap days visible as cells with no focus color', () => {
+    const cells = [
+      ...lane('2026-06-29', 7, SHRUGS),
+      ...lane('2026-07-06', 7, null),
+      ...lane('2026-07-13', 7, SHRUGS),
+    ]
+    const { container } = render(<FocusLaneHeatmap cells={cells} label="Upper Focus Lane" />)
+    const tinted = container.querySelectorAll(`rect[fill="${SHRUGS.color}"]`)
+    // 14 focus days plus one legend swatch.
+    expect(tinted.length).toBe(15)
+  })
+})

--- a/components/training-facility/weight-room/FocusLaneHeatmap.tsx
+++ b/components/training-facility/weight-room/FocusLaneHeatmap.tsx
@@ -1,5 +1,10 @@
 import type { JSX } from 'react'
 
+import {
+  estimateTextWidth,
+  monthLabelOverhang,
+  thinMonthLabels,
+} from '@/lib/training-facility/heatmap-labels'
 import { intensityFromPct } from '@/lib/training-facility/weight-room-history'
 import type { FocusDayCell } from '@/lib/training-facility/monthly-focus'
 import type { MonthlyFocus } from '@/types/weight-room'
@@ -24,6 +29,29 @@ const INTENSITY_OPACITY = [0, 0.28, 0.62, 1] as const
 const EMPTY_CELL_FILL = 'rgba(247, 234, 217, 0.07)'
 /** Soft cream label color for month and day-of-week labels. */
 const LABEL_FILL = 'rgba(247, 234, 217, 0.55)'
+/** Font size for the month labels along the top axis. */
+const MONTH_LABEL_FONT_SIZE = 11
+/** Font size for the day-of-week labels and the legend text. */
+const SMALL_LABEL_FONT_SIZE = 10
+/**
+ * Grid width, in pixels, that a short lane is scaled up toward by
+ * {@link cellSizeForCols}. Roughly a half-width card on desktop.
+ */
+const TARGET_GRID_WIDTH = 420
+/** Upper bound on the derived cell stride, so cells stay cells not tiles. */
+const MAX_CELL_SIZE = 30
+/** Legend swatch edge length, held at the base cell size regardless of stride. */
+const LEGEND_SWATCH = 12
+/** Vertical stride per legend row. */
+const LEGEND_ROW_HEIGHT = 16
+/** Gap between the grid's bottom edge and the legend's first baseline. */
+const LEGEND_TOP_PAD = 14
+/** Trailing space below the last legend row. */
+const LEGEND_BOTTOM_PAD = 8
+/** Gap between a legend swatch and its exercise name. */
+const LEGEND_TEXT_GAP = 4
+/** Gap between two legend columns. */
+const LEGEND_COL_GAP = 12
 const DAY_LABELS = ['Mon', '', 'Wed', '', 'Fri', '', ''] as const
 const MONTH_LABELS = [
   'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
@@ -158,6 +186,77 @@ function describeSlot(slot: GridSlot): string {
   return `${dateLabel}: ${cell.volume} ${unit} ${cell.focus.exercise} (${pctLabel})`
 }
 
+/**
+ * Pixel stride per column for a grid `cols` wide.
+ *
+ * Unlike the per-exercise heatmap — which always spans a trailing 52 weeks
+ * and so always fills its card — a lane spans only as much calendar as its
+ * rotation history covers. A freshly-started rotation is a handful of
+ * columns, which at the base stride renders as a postage stamp in a
+ * full-width card (#370). Short spans therefore scale up toward
+ * {@link TARGET_GRID_WIDTH}, capped at {@link MAX_CELL_SIZE}.
+ *
+ * Spans already wider than the target keep `base`, so once enough history
+ * accumulates the lane renders at exactly the size it does today.
+ */
+function cellSizeForCols(cols: number, base: number): number {
+  if (cols <= 0) return base
+  return Math.min(MAX_CELL_SIZE, Math.max(base, Math.floor(TARGET_GRID_WIDTH / cols)))
+}
+
+/** One positioned entry in the legend strip. */
+interface LegendEntry {
+  /** The rotation segment this swatch stands for. */
+  focus: MonthlyFocus
+  /** X offset within the legend group. */
+  x: number
+  /** Y offset within the legend group (baseline of the label). */
+  y: number
+}
+
+/** Legend geometry computed by {@link layoutLegend}. */
+interface LegendLayout {
+  /** Positioned entries, in first-appearance order. */
+  entries: LegendEntry[]
+  /** Total width consumed, so the SVG can widen to fit a long name. */
+  width: number
+  /** Total height consumed, including the pad above and below. */
+  height: number
+}
+
+/**
+ * Lay the rotation legend out in as many columns as `gridWidth` allows.
+ *
+ * Columns are uniform and sized to the **longest** exercise name, so a
+ * short name can't let its neighbour creep underneath. The previous fixed
+ * three-per-row split at `gridWidth / 3` put columns ~23px apart on a
+ * narrow lane, overlapping every label (#370); it only escaped notice
+ * because a single rotation renders a single swatch.
+ */
+function layoutLegend(focuses: readonly MonthlyFocus[], gridWidth: number): LegendLayout {
+  if (focuses.length === 0) return { entries: [], width: 0, height: 0 }
+
+  const widest = focuses.reduce(
+    (max, f) => Math.max(max, estimateTextWidth(f.exercise, SMALL_LABEL_FONT_SIZE)),
+    0,
+  )
+  const stride = LEGEND_SWATCH + LEGEND_TEXT_GAP + widest + LEGEND_COL_GAP
+  const perRow = Math.max(1, Math.floor(gridWidth / stride))
+
+  const entries = focuses.map((focus, i) => ({
+    focus,
+    x: (i % perRow) * stride,
+    y: Math.floor(i / perRow) * LEGEND_ROW_HEIGHT,
+  }))
+
+  const rows = Math.ceil(focuses.length / perRow)
+  return {
+    entries,
+    width: Math.min(focuses.length, perRow) * stride - LEGEND_COL_GAP,
+    height: LEGEND_TOP_PAD + (rows - 1) * LEGEND_ROW_HEIGHT + LEGEND_BOTTOM_PAD,
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Component
 // ---------------------------------------------------------------------------
@@ -173,12 +272,17 @@ export interface FocusLaneHeatmapProps {
   cells: FocusDayCell[]
   /**
    * Accessible label for the SVG `role="img"` wrapper, e.g.
-   * `"Upper Focus Lane"`. Also shown as the lane header.
+   * `"Upper Focus Lane"`. Not rendered visibly — the surrounding card
+   * owns the visible header.
    */
   label: string
   /**
-   * Pixel stride per cell (including the trailing inter-cell gap).
+   * Minimum pixel stride per cell (including the trailing inter-cell gap).
    * Defaults to `14` — same default as {@link import('./StrengthHeatmap').StrengthHeatmap}.
+   *
+   * A floor, not a fixed size: a lane covering few enough weeks to render
+   * as a postage stamp is scaled up from here, capped at 30px. A lane wide
+   * enough already renders at exactly this stride.
    */
   cellSize?: number
   /** Pixel gap between cells. Defaults to `2`. */
@@ -208,16 +312,31 @@ export function FocusLaneHeatmap({
   if (cells.length === 0) return null
 
   const { grid, monthLabels, uniqueFocuses, cols } = buildLaneGrid(cells)
-  const cellInner = cellSize - cellGap
-  const gridWidth = cols * cellSize
-  const gridHeight = 7 * cellSize
 
-  // Legend height: one row at 22 px, plus 16 px per additional row (up to
-  // ⌈uniqueFocuses.length / 3⌉ rows at 3 items per row).
-  const legendRows = Math.max(1, Math.ceil(uniqueFocuses.length / 3))
-  const legendHeight = 22 + (legendRows - 1) * 16
-  const totalWidth = DAY_LABEL_WIDTH + gridWidth
-  const totalHeight = MONTH_LABEL_HEIGHT + gridHeight + legendHeight
+  // Derived, not the raw prop: a short rotation would otherwise render a
+  // ~116px chart inside a ~900px card (#370). An explicit `cellSize` is
+  // still the floor, so callers can only ever scale a lane up.
+  const stride = cellSizeForCols(cols, cellSize)
+  const cellInner = stride - cellGap
+  const gridWidth = cols * stride
+  const gridHeight = 7 * stride
+
+  const visibleMonths = thinMonthLabels(monthLabels, { cellSize: stride, totalCols: cols })
+  const monthOverhang = monthLabelOverhang(
+    visibleMonths,
+    stride,
+    gridWidth,
+    MONTH_LABEL_FONT_SIZE,
+  )
+
+  const legend = layoutLegend(uniqueFocuses, gridWidth)
+
+  // Widen for whichever of the two overhangs the content actually has: a
+  // trailing month label hanging past the final column, or a legend row
+  // longer than the grid it sits under.
+  const contentWidth = Math.max(gridWidth + monthOverhang, legend.width)
+  const totalWidth = DAY_LABEL_WIDTH + contentWidth
+  const totalHeight = MONTH_LABEL_HEIGHT + gridHeight + legend.height
 
   return (
     <svg
@@ -226,15 +345,20 @@ export function FocusLaneHeatmap({
       height={totalHeight}
       role="img"
       aria-label={label}
+      // Centered so a lane narrower than its card reads as a deliberately
+      // compact chart rather than one pinned to the top-left corner. When
+      // the lane is wider, the card's `overflow-x-auto` scrolls it and the
+      // auto margins collapse to zero.
+      style={{ display: 'block', marginInline: 'auto' }}
     >
-      {/* Month labels along the top */}
+      {/* Month labels along the top, thinned so neighbours can't collide */}
       <g transform={`translate(${DAY_LABEL_WIDTH}, ${MONTH_LABEL_HEIGHT - 4})`}>
-        {monthLabels.map((m) => (
+        {visibleMonths.map((m) => (
           <text
             key={`month-${m.col}-${m.label}`}
-            x={m.col * cellSize}
+            x={m.col * stride}
             y={0}
-            fontSize={11}
+            fontSize={MONTH_LABEL_FONT_SIZE}
             fill={LABEL_FILL}
           >
             {m.label}
@@ -249,9 +373,9 @@ export function FocusLaneHeatmap({
             <text
               key={`day-${row}`}
               x={DAY_LABEL_WIDTH - 6}
-              y={row * cellSize + cellSize / 2 + 3}
+              y={row * stride + stride / 2 + 3}
               textAnchor="end"
-              fontSize={10}
+              fontSize={SMALL_LABEL_FONT_SIZE}
               fill={LABEL_FILL}
             >
               {dayLabel}
@@ -272,8 +396,8 @@ export function FocusLaneHeatmap({
             return (
               <rect
                 key={`cell-${colIdx}-${rowIdx}`}
-                x={colIdx * cellSize}
-                y={rowIdx * cellSize}
+                x={colIdx * stride}
+                y={rowIdx * stride}
                 width={cellInner}
                 height={cellInner}
                 rx={2}
@@ -289,30 +413,31 @@ export function FocusLaneHeatmap({
       </g>
 
       {/* Legend — one swatch + exercise label per rotation segment */}
-      <g transform={`translate(${DAY_LABEL_WIDTH}, ${MONTH_LABEL_HEIGHT + gridHeight + 14})`}>
-        {uniqueFocuses.map((focus, i) => {
-          const col = i % 3
-          const row = Math.floor(i / 3)
-          const x = col * Math.floor(gridWidth / 3)
-          const y = row * 16
-          return (
-            <g key={focus.id} transform={`translate(${x}, ${y})`}>
-              <rect
-                x={0}
-                y={-9}
-                width={cellInner}
-                height={cellInner}
-                rx={2}
-                ry={2}
-                fill={focus.color}
-                fillOpacity={1}
-              />
-              <text x={cellSize + 2} y={0} fontSize={10} fill={LABEL_FILL}>
-                {focus.exercise}
-              </text>
-            </g>
-          )
-        })}
+      <g
+        transform={`translate(${DAY_LABEL_WIDTH}, ${MONTH_LABEL_HEIGHT + gridHeight + LEGEND_TOP_PAD})`}
+      >
+        {legend.entries.map(({ focus, x, y }) => (
+          <g key={focus.id} transform={`translate(${x}, ${y})`}>
+            <rect
+              x={0}
+              y={-9}
+              width={LEGEND_SWATCH}
+              height={LEGEND_SWATCH}
+              rx={2}
+              ry={2}
+              fill={focus.color}
+              fillOpacity={1}
+            />
+            <text
+              x={LEGEND_SWATCH + LEGEND_TEXT_GAP}
+              y={0}
+              fontSize={SMALL_LABEL_FONT_SIZE}
+              fill={LABEL_FILL}
+            >
+              {focus.exercise}
+            </text>
+          </g>
+        ))}
       </g>
     </svg>
   )

--- a/components/training-facility/weight-room/StrengthHeatmap.tsx
+++ b/components/training-facility/weight-room/StrengthHeatmap.tsx
@@ -1,6 +1,7 @@
 import type { JSX } from 'react'
 
 import { type GoalTargetChange, goalTargetChanges } from '@/lib/training-facility/goal-targets'
+import { thinMonthLabels } from '@/lib/training-facility/heatmap-labels'
 import {
   buildStrengthHeatmap,
   intensityFromPct,
@@ -132,9 +133,12 @@ export function StrengthHeatmap({
       aria-label={label}
       style={{ fontFamily }}
     >
-      {/* Month labels along the top */}
+      {/* Month labels along the top, thinned so neighbours can't collide.
+          Over a full 52-week window months land ~4.3 columns apart and
+          nothing is dropped; a caller passing a narrow `dateFrom`/`dateTo`
+          is the case this protects (#370). */}
       <g transform={`translate(${DAY_LABEL_WIDTH}, ${MONTH_LABEL_HEIGHT - 4})`}>
-        {monthLabels.map((m) => (
+        {thinMonthLabels(monthLabels, { cellSize, totalCols: cols }).map((m) => (
           <text
             key={`month-${m.col}-${m.label}`}
             x={m.col * cellSize}

--- a/lib/training-facility/heatmap-labels.test.ts
+++ b/lib/training-facility/heatmap-labels.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  DEFAULT_MIN_MONTH_LABEL_GAP,
+  estimateTextWidth,
+  monthLabelOverhang,
+  thinMonthLabels,
+  type HeatmapMonthLabel,
+} from './heatmap-labels'
+
+/** Base grid stride used by both heatmaps. */
+const CELL = 14
+
+describe('thinMonthLabels', () => {
+  it('returns an empty array for no labels', () => {
+    expect(thinMonthLabels([], { cellSize: CELL, totalCols: 0 })).toEqual([])
+  })
+
+  it('keeps every label when months land far enough apart', () => {
+    // A 52-week window puts months ~4.3 columns (~60px) apart — comfortably
+    // clear of the 26px minimum, so the per-exercise heatmap is unaffected.
+    const labels: HeatmapMonthLabel[] = [
+      { col: 0, label: 'Jan' },
+      { col: 5, label: 'Feb' },
+      { col: 9, label: 'Mar' },
+      { col: 13, label: 'Apr' },
+    ]
+    expect(thinMonthLabels(labels, { cellSize: CELL, totalCols: 18 })).toEqual(labels)
+  })
+
+  it('drops a one-column sliver in favour of the month that fills the grid', () => {
+    // The #370 repro: a rotation starting Jun 28 renders Jun in column 0 and
+    // Jul in column 1 — 14px apart, so they overlapped into "JunJul".
+    const labels: HeatmapMonthLabel[] = [
+      { col: 0, label: 'Jun' },
+      { col: 1, label: 'Jul' },
+      { col: 6, label: 'Aug' },
+    ]
+    expect(thinMonthLabels(labels, { cellSize: CELL, totalCols: 7 })).toEqual([
+      { col: 1, label: 'Jul' },
+      { col: 6, label: 'Aug' },
+    ])
+  })
+
+  it('keeps the earlier label when it is the wider month', () => {
+    // The tie-break is span, not position. Jul owns 5 columns and Aug only
+    // the last one, so a collision resolves the other way. Forced with an
+    // oversized minimum gap — at the real 26px these two clear each other.
+    const labels: HeatmapMonthLabel[] = [
+      { col: 0, label: 'Jul' },
+      { col: 5, label: 'Aug' },
+    ]
+    expect(thinMonthLabels(labels, { cellSize: CELL, totalCols: 6, minGapPx: 100 })).toEqual([
+      { col: 0, label: 'Jul' },
+    ])
+  })
+
+  it('drops a leading sliver on a long grid, where the stride stays at base', () => {
+    // A rotation starting on the last day of a month puts a one-column
+    // sliver at col 0. Unlike the short-lane case this is not fixed by
+    // scaling the cells up — a 30-column lane renders at the base stride,
+    // so the two labels stay 14px apart and need thinning.
+    const labels: HeatmapMonthLabel[] = [
+      { col: 0, label: 'Jun' },
+      { col: 1, label: 'Jul' },
+      { col: 5, label: 'Aug' },
+      { col: 9, label: 'Sep' },
+    ]
+    expect(thinMonthLabels(labels, { cellSize: CELL, totalCols: 30 })).toEqual([
+      { col: 1, label: 'Jul' },
+      { col: 5, label: 'Aug' },
+      { col: 9, label: 'Sep' },
+    ])
+  })
+
+  it('measures the gap in pixels, so a wider stride keeps more labels', () => {
+    const labels: HeatmapMonthLabel[] = [
+      { col: 0, label: 'Jun' },
+      { col: 1, label: 'Jul' },
+    ]
+    // At 14px the two columns are 14px apart — a collision.
+    expect(thinMonthLabels(labels, { cellSize: 14, totalCols: 6 })).toHaveLength(1)
+    // Scaled up to 30px they clear the 26px minimum and both survive.
+    expect(thinMonthLabels(labels, { cellSize: 30, totalCols: 6 })).toEqual(labels)
+  })
+
+  it('honours an explicit minGapPx', () => {
+    const labels: HeatmapMonthLabel[] = [
+      { col: 0, label: 'Jan' },
+      { col: 5, label: 'Feb' },
+    ]
+    expect(thinMonthLabels(labels, { cellSize: CELL, totalCols: 10, minGapPx: 0 })).toEqual(labels)
+    expect(
+      thinMonthLabels(labels, { cellSize: CELL, totalCols: 10, minGapPx: 200 }),
+    ).toHaveLength(1)
+  })
+
+  it('never emits two labels closer than the minimum gap', () => {
+    // Every month boundary in adjacent columns — the pathological case.
+    const labels: HeatmapMonthLabel[] = Array.from({ length: 8 }, (_, i) => ({
+      col: i,
+      label: `M${i}`,
+    }))
+    const kept = thinMonthLabels(labels, { cellSize: CELL, totalCols: 8 })
+    for (let i = 1; i < kept.length; i++) {
+      expect((kept[i].col - kept[i - 1].col) * CELL).toBeGreaterThanOrEqual(
+        DEFAULT_MIN_MONTH_LABEL_GAP,
+      )
+    }
+  })
+
+  it('preserves ascending column order', () => {
+    const labels: HeatmapMonthLabel[] = [
+      { col: 0, label: 'Jun' },
+      { col: 1, label: 'Jul' },
+      { col: 2, label: 'Aug' },
+      { col: 9, label: 'Sep' },
+    ]
+    const kept = thinMonthLabels(labels, { cellSize: CELL, totalCols: 12 })
+    const cols = kept.map((k) => k.col)
+    expect([...cols].sort((a, b) => a - b)).toEqual(cols)
+  })
+})
+
+describe('monthLabelOverhang', () => {
+  it('is zero when no labels are rendered', () => {
+    expect(monthLabelOverhang([], CELL, 84, 11)).toBe(0)
+  })
+
+  it('is zero when the last label sits well inside the grid', () => {
+    const labels: HeatmapMonthLabel[] = [{ col: 0, label: 'Jan' }]
+    expect(monthLabelOverhang(labels, CELL, 52 * CELL, 11)).toBe(0)
+  })
+
+  it('reserves room for a label overhanging the final column', () => {
+    // The #370 repro: "Aug" in the last column of a 6-wide grid rendered as
+    // "Au" because totalWidth only accounted for cells.
+    const labels: HeatmapMonthLabel[] = [{ col: 5, label: 'Aug' }]
+    const overhang = monthLabelOverhang(labels, CELL, 6 * CELL, 11)
+    expect(overhang).toBeGreaterThan(0)
+    // 5×14 + width("Aug") − 84 = 70 + 19.8 − 84
+    expect(overhang).toBeCloseTo(5.8, 5)
+  })
+})
+
+describe('estimateTextWidth', () => {
+  it('scales with both character count and font size', () => {
+    expect(estimateTextWidth('Aug', 11)).toBeCloseTo(3 * 11 * 0.6, 5)
+    expect(estimateTextWidth('', 11)).toBe(0)
+    expect(estimateTextWidth('pullups', 10)).toBeGreaterThan(estimateTextWidth('dips', 10))
+  })
+})

--- a/lib/training-facility/heatmap-labels.ts
+++ b/lib/training-facility/heatmap-labels.ts
@@ -1,0 +1,129 @@
+/**
+ * Shared axis-label geometry for the Weight Room calendar heatmaps.
+ *
+ * Both {@link import('@/components/training-facility/weight-room/StrengthHeatmap').StrengthHeatmap}
+ * and {@link import('@/components/training-facility/weight-room/FocusLaneHeatmap').FocusLaneHeatmap}
+ * draw month names above a 7×N week grid at `col * cellSize`, with no
+ * spacing rule. That only stays legible while months land far apart — over
+ * a trailing 52 weeks they average ~4.3 columns, so the per-exercise
+ * heatmap gets away with it. A grid narrow enough to put two month
+ * boundaries in adjacent columns renders them on top of each other
+ * (`JunJul`), which is what the focus lanes do on a fresh rotation (#370).
+ */
+
+/** A month marker on a heatmap's top axis. */
+export interface HeatmapMonthLabel {
+  /** Zero-based grid column the label is drawn above. */
+  col: number
+  /** Short month name, e.g. `"Jul"`. */
+  label: string
+}
+
+/** Options for {@link thinMonthLabels}. */
+export interface ThinMonthLabelsOptions {
+  /** Pixel stride per grid column — the cell size including its gap. */
+  cellSize: number
+  /**
+   * Total columns in the grid. Bounds the span of the final label, which
+   * has no following marker to measure against.
+   */
+  totalCols: number
+  /**
+   * Minimum pixel gap to leave between two rendered labels. Defaults to
+   * {@link DEFAULT_MIN_MONTH_LABEL_GAP}.
+   */
+  minGapPx?: number
+}
+
+/**
+ * Default minimum spacing between month labels, in pixels. Sized for a
+ * three-glyph month name at 11px (~20px of advance width) plus a little
+ * air, so adjacent labels read as two words rather than one.
+ */
+export const DEFAULT_MIN_MONTH_LABEL_GAP = 26
+
+/**
+ * Per-character advance width as a fraction of font size, used by
+ * {@link estimateTextWidth}.
+ *
+ * Deliberately generous for the site's sans stack: over-reserving leaves a
+ * few px of whitespace, under-reserving clips a glyph.
+ */
+const AVG_CHAR_WIDTH_EM = 0.6
+
+/**
+ * Approximate rendered width of `text` at `fontSize`, in pixels.
+ *
+ * SVG text cannot be measured during a server render, so any layout that
+ * has to reserve room for a label — right-edge padding so the last month
+ * isn't clipped, legend column stride — estimates it instead.
+ */
+export function estimateTextWidth(text: string, fontSize: number): number {
+  return text.length * fontSize * AVG_CHAR_WIDTH_EM
+}
+
+/**
+ * Drop month labels that would overlap their left-hand neighbour.
+ *
+ * Walks the markers left to right and keeps one only when it clears the
+ * last kept label by `minGapPx`. On a collision the month covering **more
+ * columns** wins, so a one-column sliver at the start of the range yields
+ * to the month that actually fills the grid — labelling a Jun 28 → Aug 3
+ * rotation `Jul`, not `Jun`. Keeping the earlier marker unconditionally
+ * would name the whole chart after its first three days.
+ *
+ * @param labels Month markers in ascending column order.
+ * @returns The subset to render, in the same order.
+ */
+export function thinMonthLabels(
+  labels: readonly HeatmapMonthLabel[],
+  { cellSize, totalCols, minGapPx = DEFAULT_MIN_MONTH_LABEL_GAP }: ThinMonthLabelsOptions,
+): HeatmapMonthLabel[] {
+  if (labels.length === 0) return []
+
+  /** Columns this marker owns, up to the next marker or the grid's end. */
+  const spanOf = (i: number): number =>
+    (i === labels.length - 1 ? totalCols : labels[i + 1].col) - labels[i].col
+
+  const kept: { label: HeatmapMonthLabel; span: number }[] = []
+  for (let i = 0; i < labels.length; i++) {
+    const entry = { label: labels[i], span: spanOf(i) }
+    const prev = kept[kept.length - 1]
+
+    if (prev === undefined || (entry.label.col - prev.label.col) * cellSize >= minGapPx) {
+      kept.push(entry)
+      continue
+    }
+
+    // Colliding: swap in the wider month, or drop this one. A replacement
+    // only ever moves the label right, and `prev` already cleared the entry
+    // before it, so the swap cannot re-collide further left.
+    if (entry.span > prev.span) kept[kept.length - 1] = entry
+  }
+
+  return kept.map((k) => k.label)
+}
+
+/**
+ * Extra width, in pixels, a grid must reserve to the right of its last
+ * column so the final month label isn't clipped mid-glyph.
+ *
+ * The label is anchored at its column's left edge and overhangs the grid
+ * whenever it sits in one of the last columns — which is exactly where a
+ * short span puts it, rendering `Aug` as `Au` (#370).
+ *
+ * @param labels The labels actually being rendered (post-{@link thinMonthLabels}).
+ * @param cellSize Pixel stride per grid column.
+ * @param gridWidth Pixel width of the cell grid itself, excluding labels.
+ * @param fontSize Font size the labels are drawn at.
+ */
+export function monthLabelOverhang(
+  labels: readonly HeatmapMonthLabel[],
+  cellSize: number,
+  gridWidth: number,
+  fontSize: number,
+): number {
+  const last = labels[labels.length - 1]
+  if (last === undefined) return 0
+  return Math.max(0, last.col * cellSize + estimateTextWidth(last.label, fontSize) - gridWidth)
+}


### PR DESCRIPTION
Fixes #370.

`FocusLaneHeatmap` sizes its `<svg>` to the extent of the rotation history, so with a single ~5-week rotation on file it rendered **116 px wide inside a 902 px card**. `StrengthHeatmap` never shows this because it always spans 52 weeks — the lane heatmap is the only one whose width is a function of how much history exists, so it looked broken precisely when there was the least data.

## The four defects

**1. Tiny chart, huge card.** The cell stride is now derived from the column count instead of fixed at 14 px: short spans scale up toward a 420 px target, capped at 30 px so cells stay cells rather than tiles. A span already wider than the target keeps the base stride, so a long history renders *exactly* as it does today — no regression once rotations accumulate. The `cellSize` prop becomes a floor rather than a fixed size.

The lanes also move into the same two-column grid the Stats section right above them uses, so a lane sits in a container it can plausibly fill, with a visible region header (`Upper` / `Lower`) — the region name previously lived only in the SVG's `aria-label`, invisible to sighted readers.

| | before | after |
|---|---|---|
| svg width | 116 px | **212 px** |
| container width | 902 px | **464 px** |
| dead space | ~87% | ~54% |

**2. Month labels collided.** Placed at `col * cellSize` with no spacing rule, so `Jun` and `Jul` one column apart rendered as `JunJul`. New `thinMonthLabels` drops a label that can't clear its neighbour by 26 px.

On a collision **the month covering more columns wins**, which is the part worth reviewing: a one-column sliver at the start of the range yields to the month that actually fills the grid, so a Jun 29 → Aug 3 rotation is labelled `Jul`, not `Jun`. Keeping the earlier marker unconditionally — the obvious implementation — would name the whole chart after its first three days.

**3. Last month label was clipped.** `totalWidth` counted cells but not label text overhanging the final column, so `Aug` rendered as `Au`. `monthLabelOverhang` reserves the difference; it returns 0 when the last label sits well inside the grid, so no width is wasted.

**4. Intro copy over-promised.** It described "shrugs in July and a new exercise in August" sitting on the same timeline — but only the Upper lane exists and there's no August exercise. The copy now describes what's actually rendered.

## Also fixed

The legend carried a latent version of defect 2: swatches at `col * floor(gridWidth / 3)` are ~23 px apart on a narrow grid. Invisible today because one rotation renders one swatch, but it would overlap the moment a second rotation existed. It now lays out in as many uniform columns as the grid width allows, sized to the **longest** exercise name so a short name can't let its neighbour creep underneath.

`StrengthHeatmap` adopts the label thinning too. It dodges the collision only by accident — over 52 weeks months land ~4.3 columns (~60 px) apart — but a caller passing a narrow `dateFrom`/`dateTo` would hit it.

The helpers live in a **new `lib/training-facility/heatmap-labels.ts`** rather than in `weight-room-history.ts`, deliberately: #319 and #373 are both in flight against that file.

## Note on the two fixes overlapping

Scaling and thinning solve the repro at different sizes, and both are needed:

- On a **short** lane the wider stride (30 px) is already past the 26 px minimum, so `Jun`/`Jul` separate without dropping anything.
- On a **long** lane the stride stays at 14 px, so the same leading-sliver adjacency can't be solved by scaling and the label is dropped instead.

Both paths have their own test.

## Verification

Measured on a flag-enabled dev server against the real production rotation, at the card widths the layout actually produces:

- Month labels: `Jun` / `Jul` / `Aug` all render, 12.3 px clear of each other after glyph widths.
- `Aug` right edge at 202.2 px inside a 212 px viewBox — not clipped.
- Centering: 105 px inset on both sides.
- Fits and centers down to a 260 px container; below that it falls back to horizontal scroll with nothing clipped off the left edge.

The estimated glyph width used for layout checks out against the browser: `Aug` estimates 19.8 px, measures 20.2 px.

`FocusLaneHeatmap` had no test file — this adds one (12 cases) plus 13 unit tests for the label helpers. Full suite green: 141 files / 1724 tests, `tsc --noEmit` and `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned focus heatmaps into responsive cards with clear body-region headings and horizontal scrolling.
  * Improved heatmap responsiveness across short and wide date ranges.
  * Added adaptive legends and improved month-label spacing to prevent overlap or clipping.
* **Bug Fixes**
  * Prevented missing or obscured labels, including calendar gaps and final month labels.
  * Improved heatmap centering and sizing on smaller displays.
* **Tests**
  * Added comprehensive coverage for responsive layouts, labels, legends, empty states, and accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->