### PR TITLE
feat(weight-room): exercise catalog — split the movement roster from daily goals (#373)

### DIFF
--- a/.claude/skills/log-workout/SKILL.md
+++ b/.claude/skills/log-workout/SKILL.md
@@ -27,16 +27,23 @@ and out of scope here.
 
 ## Data model
 
-Two Supabase tables back the Weight Room (see
-`supabase/migrations/20260507120000_weight_room_tables.sql`):
+Three Supabase tables back the Weight Room (see
+`supabase/migrations/20260507120000_weight_room_tables.sql` and
+`20260731120000_weight_room_exercises_catalog.sql`):
 
-- **`weight_room_goals`** — `(exercise PK, daily_target, color, kind)`. One row
-  per exercise. Seeded with `pushups` (target 100) and `pullups` (target 30);
-  `kind` is `permanent` or `focus` (the monthly "grease the groove" anchor —
-  e.g. `shrugs`, seeded by #255). You don't write this table when logging sets.
+- **`weight_room_exercises`** — `(slug PK, display_name, equipment,
+  muscle_group, load_multiplier, is_unilateral, archived)`. **The movement
+  roster**, added by #373, and the FK target for every set. A movement must
+  exist here to be loggable — and that is *all* it needs. Gym lifts (bench,
+  squat, rows) live here with no daily goal at all.
+- **`weight_room_goals`** — `(exercise PK, daily_target, color, kind)`. An
+  **overlay** on the roster: only the grease-the-groove movements that also have
+  a daily ring. `exercise` FKs the catalog. `kind` is `permanent` or `focus`
+  (the monthly anchor — e.g. `shrugs`, #255). You don't write this table when
+  logging sets, and **a movement does not need a row here to be logged.**
 - **`weight_room_sets`** — `(id, logged_at, exercise, reps, weight_lbs)`. One row
-  per set. `exercise` is a FK to `weight_room_goals(exercise)` — inserting a set
-  for an exercise that isn't configured fails with a `23503` FK violation.
+  per set. `exercise` is a FK to `weight_room_exercises(slug)` — inserting a set
+  for a movement that isn't in the catalog fails with a `23503` FK violation.
   `weight_lbs` (added by #255, migration
   `20260628120100_weight_room_monthly_focus.sql`) is an **optional** load in
   pounds: set it for weighted movements (shrugs, carries), leave it **null** for
@@ -74,30 +81,36 @@ goal): if one set's reps exceed `daily_target`, confirm with the user before
 inserting. (The goals fetched for canonicalization below already give you each
 exercise's `daily_target`.)
 
-**Canonicalize the exercise name against the existing goals — don't trust the
-prose alone.** Writing directly via the MCP bypasses the admin API's Zod
+**Canonicalize the movement name against the catalog — don't trust the prose
+alone.** Writing directly via the MCP bypasses the admin API's Zod
 `exerciseWriteField` transform (`.toLowerCase()` in `lib/schemas/weight-room.ts`),
 and there is no DB-level case-folding, so a stray `Pushups` would insert as a
 *distinct* exercise and surface as a separate ring (the case-divergent-duplicate
-bug #181 fixed). To stay safe, first read the configured keys and match the
-parsed name case-insensitively to one of them:
+bug #181 fixed). To stay safe, first read the roster and match the parsed name
+case-insensitively against both the slug and the display name:
 
 ```sql
-select exercise from public.weight_room_goals order by exercise;
+select slug, display_name, daily_target
+from public.weight_room_exercises e
+left join public.weight_room_goals g on g.exercise = e.slug
+where not e.archived
+order by e.slug;
 ```
 
-Use the **exact stored key** for the insert (e.g. parsed `Pull-ups` → stored
-`pullups`). If nothing matches, treat it as a new exercise — see step 6; do not
-invent a near-duplicate key.
+Use the **exact stored slug** for the insert (e.g. parsed `Pull-ups` → stored
+`pullups`, `Barbell Bench Press` → `barbell-bench-press`). If nothing matches,
+treat it as a new movement — see step 6; do not invent a near-duplicate key.
 
-**The exercise roster is a moving target — read it live every time; never work
-from a remembered or hardcoded list.** Permanent rings get added over time (e.g.
-`squats`, a bodyweight lower-body goal), and the monthly focus rotates a
-different accessory in each month (`shrugs` in July). Because logging keys purely
-off the `exercise` column in `weight_room_goals`, the skill stays correct across
-new exercises and focus rotations with no change here — *provided* you
-canonicalize against the live table each run rather than assuming only
-pushups/pullups/shrugs exist.
+`daily_target` comes back **null for movements with no daily goal** — that's the
+normal state for every gym lift, not a problem. It's only used for the
+implausible-rep sanity check above, which simply doesn't apply when it's null.
+
+**Read the roster live every time; never work from a remembered or hardcoded
+list.** It grows (gym movements get added in settings, permanent rings like
+`squats` appear) and the monthly focus rotates a different accessory each month.
+Because logging keys purely off `weight_room_exercises.slug`, the skill stays
+correct across new movements and focus rotations with no change here — *provided*
+you canonicalize against the live table each run.
 
 ### 1b. Parse the load (optional)
 
@@ -199,41 +212,67 @@ returning id, exercise, reps, weight_lbs;
 -- <OFFSET> = the offset from step 2, e.g. -07:00 (PDT) or -08:00 (PST).
 -- top_set_lbs / tonnage_lbs come back null for bodyweight exercises (every
 -- weight_lbs is null), so they self-hide — only weighted lanes get numbers.
-select s.exercise, sum(s.reps) as total, g.daily_target,
+-- LEFT join the goals overlay: a gym lift has no goal row (#373), and an inner
+-- join would silently drop it from the readback entirely.
+select s.exercise, sum(s.reps) as total, g.daily_target, g.color,
        max(s.weight_lbs)          as top_set_lbs,
        sum(s.reps * s.weight_lbs) as tonnage_lbs
 from public.weight_room_sets s
-join public.weight_room_goals g on g.exercise = s.exercise
+left join public.weight_room_goals g on g.exercise = s.exercise
 where s.logged_at >= '2026-05-28T00:00:00<OFFSET>'
   and s.logged_at <  '2026-05-29T00:00:00<OFFSET>'
-group by s.exercise, g.daily_target
+group by s.exercise, g.daily_target, g.color
 order by s.exercise;
 ```
 
 Then report each exercise as `total / daily_target` (e.g. "Pushups: 60 / 100").
+When `daily_target` is null the movement has no daily ring — report the bare
+total ("Bench press: 5 sets, 25 reps") rather than inventing a denominator.
 For a **weighted** exercise, also surface its load from the readback — e.g.
 "Shrugs: 30 / 100 · 100 lb top set · 3,000 lb tonnage" — but only when
 `top_set_lbs`/`tonnage_lbs` are non-null (bodyweight lanes omit them).
 Match the site's voice — basketball-flavored, lightly celebratory. Use each
-exercise's configured `color` from `weight_room_goals` for its emoji lane,
-mapping the hex to the nearest emoji rather than hardcoding a fixed list — the
-two seeded exercises are pushups (`#EA580C` rim-orange, 🟠) and pullups
-(`#0EA5A1` teal, 🟢), but an exercise added via step 6 brings its own color, so
-read it from the row rather than assuming only these two exist.
+exercise's configured `color` from the readback for its emoji lane, mapping the
+hex to the nearest emoji rather than hardcoding a fixed list — the two seeded
+exercises are pushups (`#EA580C` rim-orange, 🟠) and pullups (`#0EA5A1` teal,
+🟢), but a movement with a goal added later brings its own color, so read it
+from the row rather than assuming only these two exist. `color` is null for a
+catalog-only movement (no daily goal) — use a neutral ⚪ lane for those.
 
-### 6. Unconfigured exercise (FK violation)
+### 6. Movement not in the catalog (FK violation)
 
-If the insert fails with Postgres code `23503`, the exercise has no row in
-`weight_room_goals`. Don't silently drop it — tell the user it's not configured
-and offer to add it (ask for a sensible `daily_target` and a hex `color`):
+If the insert fails with Postgres code `23503`, the movement has no row in
+`weight_room_exercises`. Don't silently drop it — tell the user it isn't in the
+catalog and offer to add it.
+
+**Add a catalog row, not a daily goal.** These are two different things as of
+#373, and conflating them is the trap: a `weight_room_goals` row creates a
+*daily ring* on the Today view with a target the movement has to hit every day.
+That's right for a grease-the-groove movement and wrong for every gym lift —
+a phantom "0 / 50 bench press" ring would show up on the dashboard forever.
+
+Ask for `equipment` and `muscle_group` (both are constrained — see the values in
+the migration), confirm the generated slug, then:
+
+```sql
+insert into public.weight_room_exercises
+  (slug, display_name, equipment, muscle_group, load_multiplier)
+values ('dumbbell-bench-press', 'Dumbbell Bench Press', 'dumbbell', 'chest', 2)
+on conflict (slug) do nothing;
+```
+
+`load_multiplier` is **2 for anything carried as a pair of dumbbells** and 1
+otherwise — `weight_lbs` is per implement, so this is what makes tonnage count
+both. Then retry the set insert.
+
+Only add a `weight_room_goals` row if the user explicitly wants a **daily
+target** for the movement, and ask for the target and hex color separately:
 
 ```sql
 insert into public.weight_room_goals (exercise, daily_target, color)
 values ('dips', 50, '#F59E0B')
 on conflict (exercise) do nothing;
 ```
-
-Then retry the set insert.
 
 ## Notes
 

--- a/app/api/admin/weight-room/exercises/[slug]/route.ts
+++ b/app/api/admin/weight-room/exercises/[slug]/route.ts
@@ -1,0 +1,189 @@
+/**
+ * Admin-only item endpoints for the Weight Room movement roster (#373) —
+ * partial edit and delete. Sibling of the collection POST: same admin gate,
+ * same service-role client.
+ *
+ * DELETE is deliberately the *narrow* path. `weight_room_sets.exercise` is
+ * `on delete restrict` into this table, so a movement with any logged history
+ * cannot be removed — the editor archives it instead. That restriction is the
+ * point of the catalog: before #373 the roster lived on `weight_room_goals`
+ * with `on delete cascade`, and removing a movement silently destroyed every
+ * set ever logged for it.
+ */
+
+import { NextResponse, type NextRequest } from 'next/server'
+import { ZodError } from 'zod'
+
+import { requireAdmin } from '@/lib/auth/require-admin'
+import { WeightRoomExerciseUpdateSchema } from '@/lib/schemas/weight-room'
+import { createAdminSupabaseClient } from '@/lib/supabase/admin'
+import { withTelemetry } from '@/lib/telemetry/with-telemetry'
+
+interface Context {
+  params: Promise<{ slug: string }>
+}
+
+/**
+ * Read and normalize the `slug` route segment.
+ *
+ * Next.js decodes dynamic segments before the handler sees them, so there's no
+ * `decodeURIComponent` here — matching the `goals/[exercise]` precedent and
+ * avoiding the URIError a malformed `%` sequence would otherwise throw.
+ * Lowercased to match {@link WeightRoomExerciseUpsertSchema}'s write-side
+ * canonicalization, so `/exercises/Bench-Press` addresses the same row as
+ * `/exercises/bench-press`.
+ *
+ * @param ctx Next.js route context.
+ */
+async function resolveSlug(ctx: Context): Promise<string> {
+  const { slug } = await ctx.params
+  return slug.trim().toLowerCase()
+}
+
+/**
+ * Partially update a catalog movement. Body must conform to
+ * {@link WeightRoomExerciseUpdateSchema} — every field optional, at least one
+ * required. This is what the editor uses to flip `archived` or fix a label
+ * without restating the whole row.
+ *
+ * `slug` is not patchable: it's the value stored on every logged set, and the
+ * editor treats movements as immutable identities. (The FK is `on update
+ * cascade`, so the database would propagate a rename — the restriction is
+ * product, not schema.)
+ *
+ * Status codes:
+ * - 200 — updated (response echoes the row)
+ * - 400 — empty slug segment, invalid JSON, or failed Zod validation
+ * - 401 — not signed in
+ * - 403 — not on the allowlist
+ * - 404 — no catalog row for `slug`
+ * - 500 — unexpected Supabase error
+ *
+ * @param request Incoming JSON request whose body matches
+ *   {@link WeightRoomExerciseUpdateSchema}.
+ * @param ctx Next.js route context; `ctx.params.slug` is the primary key.
+ * @throws when Supabase env vars are missing (misconfigured deploy).
+ */
+async function handlePATCH(request: NextRequest, ctx: Context): Promise<NextResponse> {
+  const auth = await requireAdmin()
+  if (!auth.ok) return auth.response
+
+  const slug = await resolveSlug(ctx)
+  if (slug.length === 0) {
+    return NextResponse.json({ error: 'slug must be non-empty.' }, { status: 400 })
+  }
+
+  let payload: unknown
+  try {
+    payload = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Body must be valid JSON.' }, { status: 400 })
+  }
+
+  let patch
+  try {
+    patch = WeightRoomExerciseUpdateSchema.parse(payload)
+  } catch (err) {
+    if (err instanceof ZodError) {
+      return NextResponse.json(
+        { error: 'Validation failed.', issues: err.flatten() },
+        { status: 400 }
+      )
+    }
+    throw err
+  }
+
+  const supabase = createAdminSupabaseClient()
+  const { data, error } = await supabase
+    .from('weight_room_exercises')
+    .update({ ...patch, updated_at: new Date().toISOString() })
+    .eq('slug', slug)
+    .select()
+    .maybeSingle()
+
+  if (error) {
+    return NextResponse.json(
+      { error: `Failed to update exercise: ${error.message}` },
+      { status: 500 }
+    )
+  }
+  if (!data) {
+    return NextResponse.json({ error: `No exercise for '${slug}'.` }, { status: 404 })
+  }
+  return NextResponse.json(data, { status: 200 })
+}
+
+/**
+ * Delete a catalog movement. Only succeeds for a movement with no logged sets,
+ * no daily goal, and no monthly focus — all three FK into this table with
+ * `on delete restrict`.
+ *
+ * A 409 here is the expected outcome for anything you've actually trained, not
+ * an error state: archive it instead (`PATCH { archived: true }`), which keeps
+ * the history intact and drops the movement out of pickers.
+ *
+ * Status codes:
+ * - 200 — deleted (response echoes the removed row)
+ * - 400 — empty `slug` segment
+ * - 401 — not signed in
+ * - 403 — not on the allowlist
+ * - 404 — no catalog row for `slug`
+ * - 409 — the movement is referenced by sets, a goal, or a focus
+ * - 500 — unexpected Supabase error
+ *
+ * @param _request Unused — DELETE has no body. Required by the Next.js handler
+ *   signature.
+ * @param ctx Next.js route context; `ctx.params.slug` is the primary key.
+ * @throws when Supabase env vars are missing (misconfigured deploy).
+ */
+async function handleDELETE(_request: NextRequest, ctx: Context): Promise<NextResponse> {
+  const auth = await requireAdmin()
+  if (!auth.ok) return auth.response
+
+  const slug = await resolveSlug(ctx)
+  if (slug.length === 0) {
+    return NextResponse.json({ error: 'slug must be non-empty.' }, { status: 400 })
+  }
+
+  const supabase = createAdminSupabaseClient()
+  const { data, error } = await supabase
+    .from('weight_room_exercises')
+    .delete()
+    .eq('slug', slug)
+    .select()
+    .maybeSingle()
+
+  if (error) {
+    // Postgres FK violation — something still references this movement. Answer
+    // with the remedy rather than the raw constraint name; a 409 here is the
+    // normal outcome for any movement with history, not a failure.
+    if (error.code === '23503') {
+      return NextResponse.json(
+        {
+          error: `'${slug}' has logged sets, a daily goal, or a monthly focus, so it can't be deleted. Archive it instead — that hides it from pickers and keeps its history.`,
+        },
+        { status: 409 }
+      )
+    }
+    return NextResponse.json(
+      { error: `Failed to delete exercise: ${error.message}` },
+      { status: 500 }
+    )
+  }
+  if (!data) {
+    return NextResponse.json({ error: `No exercise for '${slug}'.` }, { status: 404 })
+  }
+  return NextResponse.json(data, { status: 200 })
+}
+
+/** `handlePATCH` wrapped with one-event-per-request telemetry (#220). */
+export const PATCH = withTelemetry(
+  'PATCH /api/admin/weight-room/exercises/[slug]',
+  handlePATCH
+)
+
+/** `handleDELETE` wrapped with one-event-per-request telemetry (#220). */
+export const DELETE = withTelemetry(
+  'DELETE /api/admin/weight-room/exercises/[slug]',
+  handleDELETE
+)

--- a/app/api/admin/weight-room/exercises/route.ts
+++ b/app/api/admin/weight-room/exercises/route.ts
@@ -1,0 +1,88 @@
+/**
+ * Admin-only collection endpoint for the Weight Room movement roster (#373).
+ *
+ * The Settings catalog editor hits this both to add a movement and to correct
+ * an existing one's metadata. `slug` is the primary key, so a single POST with
+ * `onConflict: 'slug'` covers create and replace — same shape as the goals
+ * route, and for the same reason (no separate PUT).
+ *
+ * Pair with `[slug]/route.ts` for the partial edit (PATCH) and delete.
+ */
+
+import { NextResponse, type NextRequest } from 'next/server'
+import { ZodError } from 'zod'
+
+import { requireAdmin } from '@/lib/auth/require-admin'
+import { WeightRoomExerciseUpsertSchema } from '@/lib/schemas/weight-room'
+import { createAdminSupabaseClient } from '@/lib/supabase/admin'
+import { withTelemetry } from '@/lib/telemetry/with-telemetry'
+
+/**
+ * Upsert a catalog movement — create-or-replace by `slug`. Body must conform to
+ * {@link WeightRoomExerciseUpsertSchema}, which lowercases `slug` so `Bench-Press`
+ * and `bench-press` collapse onto one roster entry instead of splitting a
+ * movement's history across two.
+ *
+ * This is a full replace: every field the schema defaults (`load_multiplier`,
+ * `is_unilateral`, `archived`) is written even when the caller omitted it. Use
+ * `PATCH [slug]` to change one field without restating the rest.
+ *
+ * Status codes:
+ * - 200 — upserted (response echoes the row)
+ * - 400 — payload failed Zod validation or wasn't valid JSON
+ * - 401 — not signed in
+ * - 403 — signed in but email not on the allowlist
+ * - 500 — unexpected Supabase error
+ *
+ * @param request Incoming JSON request whose body matches
+ *   {@link WeightRoomExerciseUpsertSchema}.
+ * @throws when Supabase env vars are missing (misconfigured deploy).
+ *   Domain failures are returned as JSON responses, not thrown.
+ */
+async function handlePOST(request: NextRequest): Promise<NextResponse> {
+  const auth = await requireAdmin()
+  if (!auth.ok) return auth.response
+
+  let payload: unknown
+  try {
+    payload = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Body must be valid JSON.' }, { status: 400 })
+  }
+
+  let exercise
+  try {
+    exercise = WeightRoomExerciseUpsertSchema.parse(payload)
+  } catch (err) {
+    if (err instanceof ZodError) {
+      return NextResponse.json(
+        { error: 'Validation failed.', issues: err.flatten() },
+        { status: 400 }
+      )
+    }
+    throw err
+  }
+
+  const supabase = createAdminSupabaseClient()
+  // Stamp `updated_at` explicitly so an edit advances the audit timestamp —
+  // without it the existing-row branch keeps the original insert time and the
+  // data layer's `MAX(updated_at)` freshness never reflects catalog edits.
+  // Same reasoning as the goals upsert.
+  const { data, error } = await supabase
+    .from('weight_room_exercises')
+    .upsert({ ...exercise, updated_at: new Date().toISOString() }, { onConflict: 'slug' })
+    .select()
+    .single()
+
+  if (error) {
+    return NextResponse.json(
+      { error: `Failed to upsert exercise: ${error.message}` },
+      { status: 500 }
+    )
+  }
+
+  return NextResponse.json(data, { status: 200 })
+}
+
+/** `handlePOST` wrapped with one-event-per-request telemetry (#220). */
+export const POST = withTelemetry('POST /api/admin/weight-room/exercises', handlePOST)

--- a/app/api/admin/weight-room/goals/[exercise]/route.ts
+++ b/app/api/admin/weight-room/goals/[exercise]/route.ts
@@ -1,12 +1,16 @@
 /**
  * Admin-only item endpoint for Weight Room goal deletion (#79). Sibling
  * of the collection POST — same admin gate, same service-role client.
- * Used by the Settings UI's "remove exercise" affordance.
+ * Used by the Settings UI's "remove daily goal" affordance.
  *
- * Deletes are FK-cascaded: removing a goal also drops every set logged
- * for that exercise (per the migration's `on delete cascade`). The
- * Settings UI surfaces a confirmation prompt before calling DELETE so
- * the cascade isn't silent.
+ * As of #373 this removes the *daily ring only*. Sets FK into
+ * `weight_room_exercises` (the roster), not into this table, so the movement
+ * and its entire logged history survive — deleting a goal now means "stop
+ * ringing this movement", not "erase it". Before #373 the FK cascaded from
+ * here and this endpoint destroyed every set for the exercise.
+ *
+ * The one thing still cascaded is `weight_room_goal_targets`, which is
+ * daily-target history and therefore goal-scoped by definition.
  */
 
 import { NextResponse, type NextRequest } from 'next/server'
@@ -20,7 +24,8 @@ interface Context {
 }
 
 /**
- * Delete a goal (and, via FK cascade, every set for that exercise).
+ * Delete a goal — the daily ring and its target history. Logged sets are
+ * untouched (#373); the movement stays in `weight_room_exercises`.
  *
  * Status codes:
  * - 200 — deleted (response body echoes the removed row)

--- a/app/api/admin/weight-room/goals/route.test.ts
+++ b/app/api/admin/weight-room/goals/route.test.ts
@@ -21,7 +21,14 @@ vi.mock('@/lib/auth/require-admin', () => ({
  * naming each step lets a test program exactly the one it cares about and
  * leave the rest on sensible defaults.
  */
-type QueryKind = 'existingGoal' | 'insertGoal' | 'upsertGoal' | 'historyRead' | 'historyUpsert'
+type QueryKind =
+  | 'existingGoal'
+  | 'insertGoal'
+  | 'upsertGoal'
+  | 'historyRead'
+  | 'historyUpsert'
+  /** Catalog provisioning for a brand-new goal's movement (#373). */
+  | 'catalogUpsert'
 
 /** A Supabase-shaped result. */
 interface QueryResult {
@@ -40,6 +47,7 @@ const DEFAULTS: Record<QueryKind, QueryResult> = {
   upsertGoal: { data: null, error: null },
   historyRead: { data: [], error: null },
   historyUpsert: { data: null, error: null },
+  catalogUpsert: { data: null, error: null },
 }
 
 /**
@@ -75,7 +83,12 @@ function makeChain(table: string) {
       return chain
     }),
     upsert: vi.fn((payload: unknown, options?: unknown) => {
-      kind = table === 'weight_room_goals' ? 'upsertGoal' : 'historyUpsert'
+      kind =
+        table === 'weight_room_goals'
+          ? 'upsertGoal'
+          : table === 'weight_room_exercises'
+            ? 'catalogUpsert'
+            : 'historyUpsert'
       record.kind = kind
       record.payload = payload
       record.options = options

--- a/app/api/admin/weight-room/goals/route.ts
+++ b/app/api/admin/weight-room/goals/route.ts
@@ -20,6 +20,7 @@ import { NextResponse, type NextRequest } from 'next/server'
 import { ZodError } from 'zod'
 
 import { requireAdmin } from '@/lib/auth/require-admin'
+import { ensureWeightRoomExercise } from '@/lib/data/ensure-weight-room-exercise'
 import { WeightRoomGoalUpsertSchema } from '@/lib/schemas/weight-room'
 import { createAdminSupabaseClient } from '@/lib/supabase/admin'
 import { withTelemetry } from '@/lib/telemetry/with-telemetry'
@@ -202,6 +203,16 @@ async function handlePOST(request: NextRequest): Promise<NextResponse> {
   // The history table is FK'd to weight_room_goals, so a brand-new goal's row
   // has to exist before its seed entry can be written.
   if (existing === null) {
+    // ...and as of #373 the goal itself FKs the movement catalog, so the roster
+    // entry has to exist before the goal. Adding a daily target for a movement
+    // that isn't in the catalog yet is the normal case for this form — it was
+    // the *only* way to register an exercise before the catalog existed — so
+    // provision it rather than making the admin visit two editors.
+    const catalogError = await ensureWeightRoomExercise(supabase, goalFields.exercise)
+    if (catalogError !== null) {
+      return NextResponse.json({ error: catalogError }, { status: 500 })
+    }
+
     const { error: insertError } = await supabase
       .from('weight_room_goals')
       .insert({ ...goalFields, updated_at: nowIso })

--- a/app/api/admin/weight-room/monthly-focus/route.test.ts
+++ b/app/api/admin/weight-room/monthly-focus/route.test.ts
@@ -17,10 +17,23 @@ vi.mock('@/lib/auth/require-admin', () => ({
 }))
 
 const upsertResultMock = vi.fn()
+const catalogUpsertResultMock = vi.fn()
 const singleMock = vi.fn()
+/**
+ * Table the most recent `.from()` targeted, so `.upsert()` can route to the
+ * right result. The route upserts twice — first the movement catalog (#373),
+ * then the goal anchor — and a single shared result would make "the anchor
+ * upsert fails" actually fail the catalog write instead.
+ */
+let lastTable = ''
 const supabaseChain = {
-  from: vi.fn(() => supabaseChain),
-  upsert: vi.fn(() => upsertResultMock()),
+  from: vi.fn((table: string) => {
+    lastTable = table
+    return supabaseChain
+  }),
+  upsert: vi.fn(() =>
+    lastTable === 'weight_room_exercises' ? catalogUpsertResultMock() : upsertResultMock(),
+  ),
   insert: vi.fn(() => supabaseChain),
   select: vi.fn(() => supabaseChain),
   single: vi.fn(() => singleMock()),
@@ -41,19 +54,27 @@ const validFocus = {
 beforeEach(() => {
   requireAdminMock.mockReset()
   upsertResultMock.mockReset()
+  catalogUpsertResultMock.mockReset()
   singleMock.mockReset()
+  lastTable = ''
   supabaseChain.from.mockClear()
   supabaseChain.upsert.mockClear()
   supabaseChain.insert.mockClear()
   supabaseChain.select.mockClear()
   supabaseChain.single.mockClear()
-  supabaseChain.from.mockReturnValue(supabaseChain)
-  supabaseChain.upsert.mockImplementation(() => upsertResultMock())
+  supabaseChain.from.mockImplementation((table: string) => {
+    lastTable = table
+    return supabaseChain
+  })
+  supabaseChain.upsert.mockImplementation(() =>
+    lastTable === 'weight_room_exercises' ? catalogUpsertResultMock() : upsertResultMock(),
+  )
   supabaseChain.insert.mockReturnValue(supabaseChain)
   supabaseChain.select.mockReturnValue(supabaseChain)
   supabaseChain.single.mockImplementation(() => singleMock())
   // Happy-path defaults; individual tests override.
   upsertResultMock.mockResolvedValue({ error: null })
+  catalogUpsertResultMock.mockResolvedValue({ error: null })
   singleMock.mockResolvedValue({ data: { id: 'f1', ...validFocus, target_kind: 'reps' }, error: null })
 })
 
@@ -115,6 +136,28 @@ describe('POST /api/admin/weight-room/monthly-focus', () => {
     expect(res.status).toBe(500)
     const body = await res.json()
     expect(body.error).toMatch(/anchor focus goal/i)
+  })
+
+  it('provisions the movement catalog before the goal anchor (#373)', async () => {
+    requireAdminMock.mockResolvedValue({ ok: true, email: 'a@b.com' })
+    await POST(makeRequest(validFocus) as never)
+    // Both the anchor and the focus row FK the catalog, so the roster entry
+    // has to land first or a brand-new focus exercise 23503s.
+    const tables = supabaseChain.from.mock.calls.map(([table]) => table)
+    expect(tables.indexOf('weight_room_exercises')).toBeLessThan(
+      tables.indexOf('weight_room_goals'),
+    )
+  })
+
+  it('returns 500 when the catalog provisioning fails (#373)', async () => {
+    requireAdminMock.mockResolvedValue({ ok: true, email: 'a@b.com' })
+    catalogUpsertResultMock.mockResolvedValueOnce({
+      error: { code: 'XX001', message: 'boom' },
+    })
+    const res = await POST(makeRequest(validFocus) as never)
+    expect(res.status).toBe(500)
+    const body = await res.json()
+    expect(body.error).toMatch(/movement catalog/i)
   })
 
   it('returns 500 when the focus insert fails', async () => {

--- a/app/api/admin/weight-room/monthly-focus/route.ts
+++ b/app/api/admin/weight-room/monthly-focus/route.ts
@@ -20,6 +20,7 @@ import { NextResponse, type NextRequest } from 'next/server'
 import { ZodError } from 'zod'
 
 import { requireAdmin } from '@/lib/auth/require-admin'
+import { ensureWeightRoomExercise } from '@/lib/data/ensure-weight-room-exercise'
 import { WeightRoomMonthlyFocusCreateSchema } from '@/lib/schemas/weight-room'
 import { createAdminSupabaseClient } from '@/lib/supabase/admin'
 import { withTelemetry } from '@/lib/telemetry/with-telemetry'
@@ -67,6 +68,14 @@ async function handlePOST(request: NextRequest): Promise<NextResponse> {
   }
 
   const supabase = createAdminSupabaseClient()
+
+  // 0. Ensure the movement is in the catalog. Both the goal anchor below and
+  //    the focus row itself FK it as of #373, so a brand-new focus exercise
+  //    would fail with a raw 23503 without this.
+  const catalogError = await ensureWeightRoomExercise(supabase, focus.exercise)
+  if (catalogError !== null) {
+    return NextResponse.json({ error: catalogError }, { status: 500 })
+  }
 
   // 1. Ensure the goal anchor exists. ignoreDuplicates leaves an existing
   //    goal untouched so we never flip a permanent exercise to 'focus'.

--- a/app/api/admin/weight-room/sets/route.ts
+++ b/app/api/admin/weight-room/sets/route.ts
@@ -27,8 +27,8 @@ import { withTelemetry } from '@/lib/telemetry/with-telemetry'
  * - 400 — payload failed Zod validation or wasn't valid JSON
  * - 401 — not signed in
  * - 403 — signed in but email not on the allowlist
- * - 409 — `exercise` doesn't exist in `weight_room_goals` (FK violation;
- *   add it via the settings UI first)
+ * - 409 — `exercise` isn't in the `weight_room_exercises` roster (FK
+ *   violation; add it via the settings catalog first)
  * - 500 — unexpected Supabase error
  *
  * @param request Incoming JSON request whose body matches
@@ -79,11 +79,13 @@ async function handlePOST(request: NextRequest): Promise<NextResponse> {
     .single()
 
   if (error) {
-    // Postgres FK violation — exercise isn't in weight_room_goals.
+    // Postgres FK violation — exercise isn't in the weight_room_exercises
+    // roster (#373). Note the movement does NOT need a daily goal to be
+    // loggable any more; it only needs a catalog row.
     if (error.code === '23503') {
       return NextResponse.json(
         {
-          error: `Exercise '${entry.exercise}' is not configured. Add it via the settings UI before logging sets.`,
+          error: `Exercise '${entry.exercise}' is not in the movement catalog. Add it in settings before logging sets.`,
         },
         { status: 409 }
       )

--- a/app/training-facility/weight-room/settings/page.tsx
+++ b/app/training-facility/weight-room/settings/page.tsx
@@ -5,12 +5,14 @@ import { notFound } from 'next/navigation'
 import { BackToCourtButton } from '@/components/common/BackToCourtButton'
 import { FacilityBackLink } from '@/components/training-facility/FacilityBackLink'
 import { AchievementSettings } from '@/components/training-facility/weight-room/AchievementSettings'
+import { ExerciseCatalogSettings } from '@/components/training-facility/weight-room/ExerciseCatalogSettings'
 import { StrengthSettings } from '@/components/training-facility/weight-room/StrengthSettings'
 import { WeightRoomSubNav } from '@/components/training-facility/weight-room/WeightRoomSubNav'
 import { requireAdminPage } from '@/lib/auth/require-admin-page'
 import {
   getWeightRoomAchievementsServer,
   getWeightRoomDataServer,
+  getWeightRoomExercisesServer,
 } from '@/lib/data/weight-room-server'
 import { isWeightRoomEnabled } from '@/lib/feature-flags'
 
@@ -38,9 +40,10 @@ export default async function WeightRoomSettingsPage(): Promise<JSX.Element> {
   // UI handles `goals: []` gracefully (renders the add-exercise form
   // without an existing-goal table). The achievement ladder read (#336)
   // degrades independently — a failed fetch just empties that editor.
-  const [data, achievements] = await Promise.all([
+  const [data, achievements, exercises] = await Promise.all([
     getWeightRoomDataServer().catch(() => null),
     getWeightRoomAchievementsServer().catch(() => []),
+    getWeightRoomExercisesServer().catch(() => []),
   ])
   const goals = data?.goals ?? []
 
@@ -74,6 +77,24 @@ export default async function WeightRoomSettingsPage(): Promise<JSX.Element> {
 
         <section className="mt-10">
           <StrengthSettings initialGoals={goals} />
+        </section>
+
+        <section className="mt-14 border-t border-white/10 pt-10">
+          <h2 className="font-mono text-[11px] uppercase tracking-[0.32em] text-amber-300/80">
+            Movement catalog
+          </h2>
+          <p className="mt-2 max-w-xl text-sm leading-7 text-[#e8d5be]">
+            Every movement you can log a set against. A daily goal above is an{' '}
+            <em>overlay</em> on this list — a gym lift only needs a row here, no
+            ring and no target. Movements with logged sets can&rsquo;t be deleted,
+            only archived.
+          </p>
+          <div className="mt-6">
+            <ExerciseCatalogSettings
+              initialExercises={exercises}
+              goalSlugs={goals.map((goal) => goal.exercise)}
+            />
+          </div>
         </section>
 
         <section className="mt-14 border-t border-white/10 pt-10">

--- a/components/training-facility/weight-room/ExerciseCatalogSettings.tsx
+++ b/components/training-facility/weight-room/ExerciseCatalogSettings.tsx
@@ -1,0 +1,564 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import { useMemo, useState, useTransition, type FormEvent, type JSX } from 'react'
+
+import type {
+  ExerciseEquipment,
+  ExerciseMuscleGroup,
+  WeightRoomExercise,
+} from '@/types/weight-room'
+
+/** Props for {@link ExerciseCatalogSettings}. */
+export interface ExerciseCatalogSettingsProps {
+  /**
+   * The full roster as read by the server component on first paint, archived
+   * rows included. The editor hydrates from this list; mutations refresh via
+   * `router.refresh()` so the next render comes from a fresh server fetch.
+   */
+  initialExercises: readonly WeightRoomExercise[]
+  /**
+   * Slugs that currently have a grease-the-groove daily goal. Rendered as a
+   * badge so it's obvious which roster entries drive a Today-view ring — and
+   * why those can't be deleted even before their sets are considered.
+   */
+  goalSlugs: readonly string[]
+}
+
+/** Selectable equipment kinds, matching the DB check constraint. */
+const EQUIPMENT_OPTIONS: readonly ExerciseEquipment[] = [
+  'barbell',
+  'dumbbell',
+  'kettlebell',
+  'machine',
+  'cable',
+  'band',
+  'bodyweight',
+  'other',
+]
+
+/** Selectable muscle groups, matching the DB check constraint. */
+const MUSCLE_OPTIONS: readonly ExerciseMuscleGroup[] = [
+  'chest',
+  'back',
+  'shoulders',
+  'arms',
+  'legs',
+  'core',
+  'full-body',
+]
+
+/**
+ * The editable half of a catalog row — everything except the immutable slug.
+ * Shared by the row editor and the add form so the two can't drift on what a
+ * movement carries.
+ */
+interface ExerciseDraft {
+  display_name: string
+  equipment: ExerciseEquipment
+  muscle_group: ExerciseMuscleGroup
+  load_multiplier: number
+  is_unilateral: boolean
+}
+
+/**
+ * Admin-only Weight Room movement-catalog editor (#373).
+ *
+ * The catalog is the roster every logged set foreign-keys into, so this is
+ * where a movement starts existing — a gym lift needs a row here and nothing
+ * else, while the separate goal editor above adds a daily ring for the handful
+ * of grease-the-groove movements.
+ *
+ * Deleting is intentionally the narrow path: the FK is `on delete restrict`, so
+ * anything with logged history returns 409 and the UI steers to archiving
+ * instead. Archived movements stay in the list (dimmed, behind a toggle) so
+ * they can be brought back.
+ *
+ * Mobile-first like its siblings — rows collapse to a summary line and expand
+ * into the edit form, which keeps a 30+ movement roster scannable on a phone.
+ */
+export function ExerciseCatalogSettings({
+  initialExercises,
+  goalSlugs,
+}: ExerciseCatalogSettingsProps): JSX.Element {
+  const router = useRouter()
+  const [error, setError] = useState<string | null>(null)
+  const [query, setQuery] = useState('')
+  const [showArchived, setShowArchived] = useState(false)
+  const [isPending, startTransition] = useTransition()
+
+  const goalSet = useMemo(() => new Set(goalSlugs), [goalSlugs])
+
+  const visible = useMemo(() => {
+    const needle = query.trim().toLowerCase()
+    return initialExercises.filter((exercise) => {
+      if (!showArchived && exercise.archived === true) return false
+      if (needle.length === 0) return true
+      return (
+        exercise.slug.includes(needle) ||
+        exercise.display_name.toLowerCase().includes(needle) ||
+        exercise.equipment.includes(needle) ||
+        exercise.muscle_group.includes(needle)
+      )
+    })
+  }, [initialExercises, query, showArchived])
+
+  const archivedCount = useMemo(
+    () => initialExercises.filter((exercise) => exercise.archived === true).length,
+    [initialExercises],
+  )
+
+  function refresh(): void {
+    startTransition(() => {
+      router.refresh()
+    })
+  }
+
+  /** Read `{ error }` off a failed response, falling back to the status code. */
+  async function messageFor(res: Response, fallback: string): Promise<string> {
+    const body = (await res.json().catch(() => ({}))) as { error?: string }
+    return body.error ?? `${fallback} (${res.status})`
+  }
+
+  async function createExercise(slug: string, draft: ExerciseDraft): Promise<boolean> {
+    setError(null)
+    const res = await fetch('/api/admin/weight-room/exercises', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ slug, ...draft }),
+    })
+    if (!res.ok) {
+      setError(await messageFor(res, 'Save failed'))
+      return false
+    }
+    refresh()
+    return true
+  }
+
+  async function patchExercise(
+    slug: string,
+    patch: Partial<ExerciseDraft> & { archived?: boolean },
+  ): Promise<void> {
+    setError(null)
+    const res = await fetch(`/api/admin/weight-room/exercises/${encodeURIComponent(slug)}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(patch),
+    })
+    if (!res.ok) {
+      setError(await messageFor(res, 'Save failed'))
+      return
+    }
+    refresh()
+  }
+
+  async function deleteExercise(slug: string): Promise<void> {
+    setError(null)
+    const ok = window.confirm(
+      `Delete "${slug}" from the catalog? This only works if it has no logged sets, no daily goal, and no monthly focus — otherwise archive it instead.`,
+    )
+    if (!ok) return
+    const res = await fetch(`/api/admin/weight-room/exercises/${encodeURIComponent(slug)}`, {
+      method: 'DELETE',
+    })
+    if (!res.ok) {
+      // 409 is the expected answer for anything with history — surface the
+      // route's remedy copy rather than treating it as a failure.
+      setError(await messageFor(res, 'Delete failed'))
+      return
+    }
+    refresh()
+  }
+
+  return (
+    <div className="space-y-6">
+      {error ? (
+        <p
+          role="alert"
+          className="rounded border border-rose-400/30 bg-rose-950/40 px-3 py-2 font-mono text-[12px] text-rose-200"
+        >
+          {error}
+        </p>
+      ) : null}
+
+      <div className="flex flex-wrap items-center gap-3">
+        <label className="flex flex-1 items-center gap-2 text-xs text-white/70">
+          <span className="sr-only">Filter movements</span>
+          <input
+            type="search"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Filter by name, equipment, or muscle…"
+            autoCapitalize="none"
+            className="w-full rounded border border-white/15 bg-black/40 px-3 py-2 font-mono text-sm text-white focus:border-amber-300/60 focus:outline-none"
+          />
+        </label>
+        {archivedCount > 0 ? (
+          <label className="flex items-center gap-2 font-mono text-[11px] uppercase tracking-[0.18em] text-white/60">
+            <input
+              type="checkbox"
+              checked={showArchived}
+              onChange={(e) => setShowArchived(e.target.checked)}
+              className="h-4 w-4 accent-amber-300"
+            />
+            Show archived ({archivedCount})
+          </label>
+        ) : null}
+      </div>
+
+      <section aria-label="Movement catalog">
+        {visible.length === 0 ? (
+          <p className="text-sm text-[#e8d5be]/70">
+            {initialExercises.length === 0
+              ? 'No movements yet — add one below to start logging sets.'
+              : 'No movements match that filter.'}
+          </p>
+        ) : (
+          <ul className="space-y-2">
+            {visible.map((exercise) => (
+              <ExerciseRow
+                key={exercise.slug}
+                exercise={exercise}
+                hasGoal={goalSet.has(exercise.slug)}
+                disabled={isPending}
+                onPatch={patchExercise}
+                onDelete={deleteExercise}
+              />
+            ))}
+          </ul>
+        )}
+        <p className="mt-3 font-mono text-[11px] text-white/40">
+          {visible.length} of {initialExercises.length} movements
+        </p>
+      </section>
+
+      <section aria-label="Add a movement">
+        <h3 className="font-mono text-[11px] uppercase tracking-[0.32em] text-amber-300/80">
+          Add movement
+        </h3>
+        <AddExerciseForm disabled={isPending} onAdd={createExercise} />
+      </section>
+    </div>
+  )
+}
+
+interface ExerciseRowProps {
+  exercise: WeightRoomExercise
+  hasGoal: boolean
+  disabled: boolean
+  onPatch: (
+    slug: string,
+    patch: Partial<ExerciseDraft> & { archived?: boolean },
+  ) => Promise<void>
+  onDelete: (slug: string) => Promise<void>
+}
+
+function ExerciseRow({
+  exercise,
+  hasGoal,
+  disabled,
+  onPatch,
+  onDelete,
+}: ExerciseRowProps): JSX.Element {
+  const archived = exercise.archived === true
+  const [draft, setDraft] = useState<ExerciseDraft>({
+    display_name: exercise.display_name,
+    equipment: exercise.equipment,
+    muscle_group: exercise.muscle_group,
+    load_multiplier: exercise.load_multiplier ?? 1,
+    is_unilateral: exercise.is_unilateral === true,
+  })
+
+  const dirty =
+    draft.display_name !== exercise.display_name ||
+    draft.equipment !== exercise.equipment ||
+    draft.muscle_group !== exercise.muscle_group ||
+    draft.load_multiplier !== (exercise.load_multiplier ?? 1) ||
+    draft.is_unilateral !== (exercise.is_unilateral === true)
+
+  async function handleSubmit(e: FormEvent<HTMLFormElement>): Promise<void> {
+    e.preventDefault()
+    if (!dirty) return
+    await onPatch(exercise.slug, draft)
+  }
+
+  return (
+    <li
+      className={`rounded-[1.1rem] border border-white/10 bg-white/5 ${archived ? 'opacity-50' : ''}`}
+    >
+      <details>
+        <summary className="cursor-pointer list-none px-4 py-3">
+          <span className="flex flex-wrap items-center gap-x-3 gap-y-1">
+            <span className="text-sm font-semibold text-white">{exercise.display_name}</span>
+            <span className="font-mono text-[11px] text-white/40">{exercise.slug}</span>
+            <span className="ml-auto flex flex-wrap items-center gap-1.5">
+              <Chip>{exercise.equipment}</Chip>
+              <Chip>{exercise.muscle_group}</Chip>
+              {(exercise.load_multiplier ?? 1) > 1 ? (
+                <Chip>×{exercise.load_multiplier}</Chip>
+              ) : null}
+              {exercise.is_unilateral === true ? <Chip>unilateral</Chip> : null}
+              {hasGoal ? <Chip accent>daily goal</Chip> : null}
+              {archived ? <Chip>archived</Chip> : null}
+            </span>
+          </span>
+        </summary>
+
+        <form onSubmit={handleSubmit} className="grid gap-3 border-t border-white/10 p-4">
+          <label className="flex flex-col gap-1 text-xs text-white/70">
+            <span className="font-mono uppercase tracking-[0.18em]">display name</span>
+            <input
+              type="text"
+              required
+              maxLength={60}
+              value={draft.display_name}
+              onChange={(e) => setDraft({ ...draft, display_name: e.target.value })}
+              className="rounded border border-white/15 bg-black/40 px-2 py-1.5 text-sm text-white focus:border-amber-300/60 focus:outline-none"
+            />
+          </label>
+
+          <div className="grid gap-3 sm:grid-cols-2">
+            <label className="flex flex-col gap-1 text-xs text-white/70">
+              <span className="font-mono uppercase tracking-[0.18em]">equipment</span>
+              <select
+                value={draft.equipment}
+                onChange={(e) =>
+                  setDraft({ ...draft, equipment: e.target.value as ExerciseEquipment })
+                }
+                className="rounded border border-white/15 bg-black/40 px-2 py-1.5 font-mono text-sm text-white focus:border-amber-300/60 focus:outline-none"
+              >
+                {EQUIPMENT_OPTIONS.map((option) => (
+                  <option key={option} value={option} className="bg-[#120d0a]">
+                    {option}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="flex flex-col gap-1 text-xs text-white/70">
+              <span className="font-mono uppercase tracking-[0.18em]">muscle group</span>
+              <select
+                value={draft.muscle_group}
+                onChange={(e) =>
+                  setDraft({ ...draft, muscle_group: e.target.value as ExerciseMuscleGroup })
+                }
+                className="rounded border border-white/15 bg-black/40 px-2 py-1.5 font-mono text-sm text-white focus:border-amber-300/60 focus:outline-none"
+              >
+                {MUSCLE_OPTIONS.map((option) => (
+                  <option key={option} value={option} className="bg-[#120d0a]">
+                    {option}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
+
+          <div className="flex flex-wrap items-end gap-4">
+            <label className="flex flex-col gap-1 text-xs text-white/70">
+              <span className="font-mono uppercase tracking-[0.18em]">implements / set</span>
+              <input
+                type="number"
+                min={1}
+                inputMode="numeric"
+                value={draft.load_multiplier}
+                onChange={(e) =>
+                  setDraft({ ...draft, load_multiplier: Number(e.target.value) })
+                }
+                className="w-20 rounded border border-white/15 bg-black/40 px-2 py-1.5 text-right font-mono text-sm text-white focus:border-amber-300/60 focus:outline-none"
+              />
+            </label>
+            <label className="flex items-center gap-2 pb-1.5 text-xs text-white/70">
+              <input
+                type="checkbox"
+                checked={draft.is_unilateral}
+                onChange={(e) => setDraft({ ...draft, is_unilateral: e.target.checked })}
+                className="h-4 w-4 accent-amber-300"
+              />
+              <span className="font-mono uppercase tracking-[0.18em]">unilateral</span>
+            </label>
+          </div>
+          <p className="text-[11px] leading-5 text-white/40">
+            Weight is recorded <strong>per implement</strong> — a 60 lb dumbbell shrug is 60
+            per hand. Set implements&nbsp;/&nbsp;set to 2 for anything carried as a pair, so
+            tonnage counts both.
+          </p>
+
+          <div className="flex flex-wrap gap-2">
+            <button
+              type="submit"
+              disabled={disabled || !dirty}
+              className="rounded-full border border-amber-200/30 bg-amber-200/10 px-4 py-1.5 font-mono text-[11px] uppercase tracking-[0.22em] text-amber-100 transition hover:bg-amber-200/20 disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              Save
+            </button>
+            <button
+              type="button"
+              disabled={disabled}
+              onClick={() => onPatch(exercise.slug, { archived: !archived })}
+              className="rounded-full border border-white/20 bg-white/5 px-4 py-1.5 font-mono text-[11px] uppercase tracking-[0.22em] text-white/80 transition hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              {archived ? 'Unarchive' : 'Archive'}
+            </button>
+            <button
+              type="button"
+              disabled={disabled}
+              onClick={() => onDelete(exercise.slug)}
+              className="ml-auto rounded-full border border-rose-300/25 bg-rose-300/5 px-4 py-1.5 font-mono text-[11px] uppercase tracking-[0.22em] text-rose-200 transition hover:bg-rose-300/15 disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              Delete
+            </button>
+          </div>
+        </form>
+      </details>
+    </li>
+  )
+}
+
+/** Small pill used for the equipment / muscle / status tokens on a row summary. */
+function Chip({
+  children,
+  accent = false,
+}: {
+  children: React.ReactNode
+  accent?: boolean
+}): JSX.Element {
+  return (
+    <span
+      className={`rounded-full px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.14em] ${
+        accent
+          ? 'border border-amber-200/30 bg-amber-200/10 text-amber-100'
+          : 'border border-white/10 bg-white/5 text-white/50'
+      }`}
+    >
+      {children}
+    </span>
+  )
+}
+
+interface AddExerciseFormProps {
+  disabled: boolean
+  onAdd: (slug: string, draft: ExerciseDraft) => Promise<boolean>
+}
+
+/**
+ * Derive a URL-safe slug from a typed display name — lowercase, non-alphanumeric
+ * runs collapsed to single hyphens, ends trimmed. `Farmer's Carry` →
+ * `farmers-carry`. The API lowercases too, but generating it here means the
+ * field can be previewed before saving.
+ */
+function slugify(displayName: string): string {
+  return displayName
+    .toLowerCase()
+    .replace(/['’]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}
+
+function AddExerciseForm({ disabled, onAdd }: AddExerciseFormProps): JSX.Element {
+  const [displayName, setDisplayName] = useState('')
+  const [equipment, setEquipment] = useState<ExerciseEquipment>('barbell')
+  const [muscleGroup, setMuscleGroup] = useState<ExerciseMuscleGroup>('chest')
+  const [loadMultiplier, setLoadMultiplier] = useState(1)
+  const [isUnilateral, setIsUnilateral] = useState(false)
+
+  const slug = slugify(displayName)
+
+  async function handleSubmit(e: FormEvent<HTMLFormElement>): Promise<void> {
+    e.preventDefault()
+    if (slug.length === 0) return
+    const created = await onAdd(slug, {
+      display_name: displayName.trim(),
+      equipment,
+      muscle_group: muscleGroup,
+      load_multiplier: loadMultiplier,
+      is_unilateral: isUnilateral,
+    })
+    if (!created) return
+    setDisplayName('')
+    setLoadMultiplier(1)
+    setIsUnilateral(false)
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="mt-3 grid gap-3 rounded-[1.1rem] border border-white/10 bg-white/5 p-4"
+    >
+      <label className="flex flex-col gap-1 text-xs text-white/70">
+        <span className="font-mono uppercase tracking-[0.18em]">movement</span>
+        <input
+          type="text"
+          required
+          maxLength={60}
+          value={displayName}
+          onChange={(e) => setDisplayName(e.target.value)}
+          placeholder="Barbell Bench Press"
+          className="rounded border border-white/15 bg-black/40 px-2 py-1.5 text-sm text-white focus:border-amber-300/60 focus:outline-none"
+        />
+        <span className="font-mono text-[11px] text-white/40">
+          {slug.length > 0 ? `slug: ${slug}` : 'slug generated from the name'}
+        </span>
+      </label>
+
+      <div className="grid gap-3 sm:grid-cols-2">
+        <label className="flex flex-col gap-1 text-xs text-white/70">
+          <span className="font-mono uppercase tracking-[0.18em]">equipment</span>
+          <select
+            value={equipment}
+            onChange={(e) => setEquipment(e.target.value as ExerciseEquipment)}
+            className="rounded border border-white/15 bg-black/40 px-2 py-1.5 font-mono text-sm text-white focus:border-amber-300/60 focus:outline-none"
+          >
+            {EQUIPMENT_OPTIONS.map((option) => (
+              <option key={option} value={option} className="bg-[#120d0a]">
+                {option}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="flex flex-col gap-1 text-xs text-white/70">
+          <span className="font-mono uppercase tracking-[0.18em]">muscle group</span>
+          <select
+            value={muscleGroup}
+            onChange={(e) => setMuscleGroup(e.target.value as ExerciseMuscleGroup)}
+            className="rounded border border-white/15 bg-black/40 px-2 py-1.5 font-mono text-sm text-white focus:border-amber-300/60 focus:outline-none"
+          >
+            {MUSCLE_OPTIONS.map((option) => (
+              <option key={option} value={option} className="bg-[#120d0a]">
+                {option}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+
+      <div className="flex flex-wrap items-end gap-4">
+        <label className="flex flex-col gap-1 text-xs text-white/70">
+          <span className="font-mono uppercase tracking-[0.18em]">implements / set</span>
+          <input
+            type="number"
+            min={1}
+            inputMode="numeric"
+            value={loadMultiplier}
+            onChange={(e) => setLoadMultiplier(Number(e.target.value))}
+            className="w-20 rounded border border-white/15 bg-black/40 px-2 py-1.5 text-right font-mono text-sm text-white focus:border-amber-300/60 focus:outline-none"
+          />
+        </label>
+        <label className="flex items-center gap-2 pb-1.5 text-xs text-white/70">
+          <input
+            type="checkbox"
+            checked={isUnilateral}
+            onChange={(e) => setIsUnilateral(e.target.checked)}
+            className="h-4 w-4 accent-amber-300"
+          />
+          <span className="font-mono uppercase tracking-[0.18em]">unilateral</span>
+        </label>
+        <button
+          type="submit"
+          disabled={disabled || slug.length === 0}
+          className="ml-auto rounded-full border border-amber-200/30 bg-amber-200/10 px-5 py-2 font-mono text-[11px] uppercase tracking-[0.22em] text-amber-100 transition hover:bg-amber-200/20 disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          Add
+        </button>
+      </div>
+    </form>
+  )
+}

--- a/components/training-facility/weight-room/ExerciseCatalogSettings.tsx
+++ b/components/training-facility/weight-room/ExerciseCatalogSettings.tsx
@@ -83,6 +83,10 @@ export function ExerciseCatalogSettings({
 }: ExerciseCatalogSettingsProps): JSX.Element {
   const router = useRouter()
   const [error, setError] = useState<string | null>(null)
+  // Slug the current error belongs to, so a row-scoped failure (the 409 you get
+  // trying to delete a movement with history) renders *in that row* rather than
+  // in a banner that's scrolled off the top of a 37-movement list.
+  const [errorSlug, setErrorSlug] = useState<string | null>(null)
   const [query, setQuery] = useState('')
   const [showArchived, setShowArchived] = useState(false)
   const [isPending, startTransition] = useTransition()
@@ -114,6 +118,11 @@ export function ExerciseCatalogSettings({
     })
   }
 
+  function clearError(): void {
+    setError(null)
+    setErrorSlug(null)
+  }
+
   /** Read `{ error }` off a failed response, falling back to the status code. */
   async function messageFor(res: Response, fallback: string): Promise<string> {
     const body = (await res.json().catch(() => ({}))) as { error?: string }
@@ -121,7 +130,7 @@ export function ExerciseCatalogSettings({
   }
 
   async function createExercise(slug: string, draft: ExerciseDraft): Promise<boolean> {
-    setError(null)
+    clearError()
     const res = await fetch('/api/admin/weight-room/exercises', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -139,7 +148,7 @@ export function ExerciseCatalogSettings({
     slug: string,
     patch: Partial<ExerciseDraft> & { archived?: boolean },
   ): Promise<void> {
-    setError(null)
+    clearError()
     const res = await fetch(`/api/admin/weight-room/exercises/${encodeURIComponent(slug)}`, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
@@ -147,13 +156,14 @@ export function ExerciseCatalogSettings({
     })
     if (!res.ok) {
       setError(await messageFor(res, 'Save failed'))
+      setErrorSlug(slug)
       return
     }
     refresh()
   }
 
   async function deleteExercise(slug: string): Promise<void> {
-    setError(null)
+    clearError()
     const ok = window.confirm(
       `Delete "${slug}" from the catalog? This only works if it has no logged sets, no daily goal, and no monthly focus — otherwise archive it instead.`,
     )
@@ -163,8 +173,10 @@ export function ExerciseCatalogSettings({
     })
     if (!res.ok) {
       // 409 is the expected answer for anything with history — surface the
-      // route's remedy copy rather than treating it as a failure.
+      // route's remedy copy on the row itself, since the Archive button it
+      // points at is right there and a top-of-page banner would be off screen.
       setError(await messageFor(res, 'Delete failed'))
+      setErrorSlug(slug)
       return
     }
     refresh()
@@ -172,7 +184,7 @@ export function ExerciseCatalogSettings({
 
   return (
     <div className="space-y-6">
-      {error ? (
+      {error !== null && errorSlug === null ? (
         <p
           role="alert"
           className="rounded border border-rose-400/30 bg-rose-950/40 px-3 py-2 font-mono text-[12px] text-rose-200"
@@ -221,6 +233,7 @@ export function ExerciseCatalogSettings({
                 exercise={exercise}
                 hasGoal={goalSet.has(exercise.slug)}
                 disabled={isPending}
+                error={errorSlug === exercise.slug ? error : null}
                 onPatch={patchExercise}
                 onDelete={deleteExercise}
               />
@@ -236,7 +249,11 @@ export function ExerciseCatalogSettings({
         <h3 className="font-mono text-[11px] uppercase tracking-[0.32em] text-amber-300/80">
           Add movement
         </h3>
-        <AddExerciseForm disabled={isPending} onAdd={createExercise} />
+        <AddExerciseForm
+          disabled={isPending}
+          existingSlugs={initialExercises.map((exercise) => exercise.slug)}
+          onAdd={createExercise}
+        />
       </section>
     </div>
   )
@@ -246,6 +263,8 @@ interface ExerciseRowProps {
   exercise: WeightRoomExercise
   hasGoal: boolean
   disabled: boolean
+  /** Failure from this row's last save/archive/delete, or null. */
+  error: string | null
   onPatch: (
     slug: string,
     patch: Partial<ExerciseDraft> & { archived?: boolean },
@@ -257,6 +276,7 @@ function ExerciseRow({
   exercise,
   hasGoal,
   disabled,
+  error,
   onPatch,
   onDelete,
 }: ExerciseRowProps): JSX.Element {
@@ -286,7 +306,7 @@ function ExerciseRow({
     <li
       className={`rounded-[1.1rem] border border-white/10 bg-white/5 ${archived ? 'opacity-50' : ''}`}
     >
-      <details>
+      <details open={error !== null}>
         <summary className="cursor-pointer list-none px-4 py-3">
           <span className="flex flex-wrap items-center gap-x-3 gap-y-1">
             <span className="text-sm font-semibold text-white">{exercise.display_name}</span>
@@ -305,6 +325,15 @@ function ExerciseRow({
         </summary>
 
         <form onSubmit={handleSubmit} className="grid gap-3 border-t border-white/10 p-4">
+          {error !== null ? (
+            <p
+              role="alert"
+              className="rounded border border-rose-400/30 bg-rose-950/40 px-3 py-2 text-[12px] leading-5 text-rose-200"
+            >
+              {error}
+            </p>
+          ) : null}
+
           <label className="flex flex-col gap-1 text-xs text-white/70">
             <span className="font-mono uppercase tracking-[0.18em]">display name</span>
             <input
@@ -436,6 +465,14 @@ function Chip({
 
 interface AddExerciseFormProps {
   disabled: boolean
+  /**
+   * Slugs already in the roster. The collection POST is an **upsert** on
+   * `slug`, so submitting a name that slugifies to an existing movement would
+   * silently overwrite that movement's metadata — resetting its
+   * `load_multiplier` and un-archiving it — rather than reporting a conflict.
+   * The form blocks that case instead of relying on the user to notice.
+   */
+  existingSlugs: readonly string[]
   onAdd: (slug: string, draft: ExerciseDraft) => Promise<boolean>
 }
 
@@ -453,7 +490,11 @@ function slugify(displayName: string): string {
     .replace(/^-+|-+$/g, '')
 }
 
-function AddExerciseForm({ disabled, onAdd }: AddExerciseFormProps): JSX.Element {
+function AddExerciseForm({
+  disabled,
+  existingSlugs,
+  onAdd,
+}: AddExerciseFormProps): JSX.Element {
   const [displayName, setDisplayName] = useState('')
   const [equipment, setEquipment] = useState<ExerciseEquipment>('barbell')
   const [muscleGroup, setMuscleGroup] = useState<ExerciseMuscleGroup>('chest')
@@ -461,10 +502,11 @@ function AddExerciseForm({ disabled, onAdd }: AddExerciseFormProps): JSX.Element
   const [isUnilateral, setIsUnilateral] = useState(false)
 
   const slug = slugify(displayName)
+  const taken = slug.length > 0 && existingSlugs.includes(slug)
 
   async function handleSubmit(e: FormEvent<HTMLFormElement>): Promise<void> {
     e.preventDefault()
-    if (slug.length === 0) return
+    if (slug.length === 0 || taken) return
     const created = await onAdd(slug, {
       display_name: displayName.trim(),
       equipment,
@@ -494,8 +536,15 @@ function AddExerciseForm({ disabled, onAdd }: AddExerciseFormProps): JSX.Element
           placeholder="Barbell Bench Press"
           className="rounded border border-white/15 bg-black/40 px-2 py-1.5 text-sm text-white focus:border-amber-300/60 focus:outline-none"
         />
-        <span className="font-mono text-[11px] text-white/40">
-          {slug.length > 0 ? `slug: ${slug}` : 'slug generated from the name'}
+        <span
+          className={`font-mono text-[11px] ${taken ? 'text-rose-300' : 'text-white/40'}`}
+          {...(taken ? { role: 'alert' as const } : {})}
+        >
+          {slug.length === 0
+            ? 'slug generated from the name'
+            : taken
+              ? `"${slug}" is already in the catalog — edit that row instead of re-adding it.`
+              : `slug: ${slug}`}
         </span>
       </label>
 
@@ -553,7 +602,7 @@ function AddExerciseForm({ disabled, onAdd }: AddExerciseFormProps): JSX.Element
         </label>
         <button
           type="submit"
-          disabled={disabled || slug.length === 0}
+          disabled={disabled || slug.length === 0 || taken}
           className="ml-auto rounded-full border border-amber-200/30 bg-amber-200/10 px-5 py-2 font-mono text-[11px] uppercase tracking-[0.22em] text-amber-100 transition hover:bg-amber-200/20 disabled:cursor-not-allowed disabled:opacity-40"
         >
           Add

--- a/components/training-facility/weight-room/StrengthSettings.tsx
+++ b/components/training-facility/weight-room/StrengthSettings.tsx
@@ -58,8 +58,10 @@ export function StrengthSettings({ initialGoals }: StrengthSettingsProps): JSX.E
 
   async function deleteGoal(exercise: string): Promise<void> {
     setError(null)
+    // Sets FK into the movement catalog, not into goals (#373), so this drops
+    // the daily ring and its target history and leaves the training log alone.
     const ok = window.confirm(
-      `Delete "${exercise}"? This also removes every set logged for it.`,
+      `Remove the daily goal for "${exercise}"? Its logged sets are kept — this only stops the daily ring and clears its target history.`,
     )
     if (!ok) return
     const res = await fetch(

--- a/lib/data/ensure-weight-room-exercise.test.ts
+++ b/lib/data/ensure-weight-room-exercise.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { ensureWeightRoomExercise, titleCaseSlug } from './ensure-weight-room-exercise'
+
+/**
+ * Coverage for the catalog write-side guard (#373).
+ *
+ * `weight_room_goals` and `weight_room_monthly_focus` both FK
+ * `weight_room_exercises`, so the routes that create them have to provision a
+ * roster entry first or fail with a raw `23503`. These assert the two
+ * properties that matter: a movement always gets provisioned, and an existing
+ * one is never overwritten.
+ */
+
+/** Minimal Supabase stub capturing the upsert payload and options. */
+function stubClient(error: { message: string } | null = null) {
+  const upsert = vi.fn().mockResolvedValue({ error })
+  const from = vi.fn().mockReturnValue({ upsert })
+  return { client: { from } as never, from, upsert }
+}
+
+describe('titleCaseSlug', () => {
+  it('turns a kebab slug into a display label', () => {
+    expect(titleCaseSlug('barbell-bench-press')).toBe('Barbell Bench Press')
+    expect(titleCaseSlug('pushups')).toBe('Pushups')
+  })
+
+  it('tolerates doubled and trailing separators', () => {
+    expect(titleCaseSlug('leg--press-')).toBe('Leg Press')
+  })
+})
+
+describe('ensureWeightRoomExercise', () => {
+  it('provisions the movement with the neutral fallback classification', async () => {
+    const { client, from, upsert } = stubClient()
+
+    await expect(ensureWeightRoomExercise(client, 'barbell-row')).resolves.toBeNull()
+
+    expect(from).toHaveBeenCalledWith('weight_room_exercises')
+    expect(upsert.mock.calls[0][0]).toMatchObject({
+      slug: 'barbell-row',
+      display_name: 'Barbell Row',
+      equipment: 'other',
+      muscle_group: 'full-body',
+    })
+  })
+
+  it('never overwrites an existing row', async () => {
+    const { client, upsert } = stubClient()
+
+    await ensureWeightRoomExercise(client, 'shrugs')
+
+    // Without ignoreDuplicates this would reset a curated movement's
+    // equipment/muscle_group/load_multiplier every time its goal is re-saved —
+    // shrugs would silently lose load_multiplier: 2 and halve its tonnage.
+    expect(upsert.mock.calls[0][1]).toMatchObject({
+      onConflict: 'slug',
+      ignoreDuplicates: true,
+    })
+  })
+
+  it('reports a failure as a message rather than throwing', async () => {
+    const { client } = stubClient({ message: 'permission denied' })
+
+    await expect(ensureWeightRoomExercise(client, 'dips')).resolves.toMatch(
+      /permission denied/,
+    )
+  })
+})

--- a/lib/data/ensure-weight-room-exercise.ts
+++ b/lib/data/ensure-weight-room-exercise.ts
@@ -1,0 +1,62 @@
+import 'server-only'
+
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+/**
+ * Write-side helper that guarantees a movement exists in the
+ * `weight_room_exercises` roster before something foreign-keys to it (#373).
+ *
+ * Both `weight_room_goals` and `weight_room_monthly_focus` FK the catalog, so
+ * the two admin routes that create them — the Settings "Add exercise" goal form
+ * and the monthly-focus anchor — would otherwise fail with a raw `23503` for
+ * any movement that isn't already in the roster. Before #373 those routes
+ * *were* the thing that made an exercise loggable, so preserving that one-step
+ * flow means provisioning the catalog row on their behalf.
+ */
+
+/**
+ * Title-case a slug for use as a display label: `barbell-bench-press` →
+ * `Barbell Bench Press`. Mirrors the `initcap(replace(slug, '-', ' '))` the
+ * catalog migration uses to backfill labels, so a movement provisioned here and
+ * one backfilled there read identically.
+ *
+ * @param slug Lowercase kebab-case exercise slug.
+ */
+export function titleCaseSlug(slug: string): string {
+  return slug
+    .split('-')
+    .filter((part) => part.length > 0)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ')
+}
+
+/**
+ * Insert a catalog row for `slug` if the roster doesn't already have one.
+ *
+ * Uses `ignoreDuplicates` so an existing movement is left completely alone —
+ * this must never overwrite a curated `equipment` / `muscle_group` /
+ * `load_multiplier` just because a goal was re-saved. A provisioned row lands
+ * on the deliberately neutral `other` / `full-body`, the same fallback the
+ * migration uses for a movement it can't classify; the admin refines it in the
+ * Settings catalog editor, where it shows up immediately.
+ *
+ * @param supabase Service-role client — RLS on the catalog is SELECT-only.
+ * @param slug Lowercase slug, already canonicalized by the caller's Zod schema.
+ * @returns `null` on success, or a human-readable message on failure.
+ */
+export async function ensureWeightRoomExercise(
+  supabase: SupabaseClient,
+  slug: string,
+): Promise<string | null> {
+  const { error } = await supabase.from('weight_room_exercises').upsert(
+    {
+      slug,
+      display_name: titleCaseSlug(slug),
+      equipment: 'other',
+      muscle_group: 'full-body',
+      updated_at: new Date().toISOString(),
+    },
+    { onConflict: 'slug', ignoreDuplicates: true },
+  )
+  return error === null ? null : `Failed to add '${slug}' to the movement catalog: ${error.message}`
+}

--- a/lib/data/weight-room-server.ts
+++ b/lib/data/weight-room-server.ts
@@ -1,11 +1,16 @@
 import 'server-only'
 
 import { createServerSupabaseClient } from '@/lib/supabase/server'
-import type { WeightRoomAchievement, WeightRoomData } from '@/types/weight-room'
+import type {
+  WeightRoomAchievement,
+  WeightRoomData,
+  WeightRoomExercise,
+} from '@/types/weight-room'
 
 import {
   assembleWeightRoomAchievements,
   assembleWeightRoomData,
+  assembleWeightRoomExercises,
 } from './weight-room-shared'
 
 /**
@@ -47,4 +52,20 @@ export async function getWeightRoomDataServer(): Promise<WeightRoomData | null> 
 export async function getWeightRoomAchievementsServer(): Promise<WeightRoomAchievement[]> {
   const supabase = await createServerSupabaseClient()
   return assembleWeightRoomAchievements(supabase)
+}
+
+/**
+ * Server-side reader for the movement roster (#373) — used by the Settings
+ * page's catalog editor. Wraps {@link assembleWeightRoomExercises} with the
+ * per-request SSR client.
+ *
+ * Returns an empty array (never `null`) when the roster is empty, and includes
+ * archived movements so the editor can un-archive them.
+ *
+ * @throws See {@link assembleWeightRoomExercises}. The Settings page downgrades
+ *   this to an empty roster rather than failing the page.
+ */
+export async function getWeightRoomExercisesServer(): Promise<WeightRoomExercise[]> {
+  const supabase = await createServerSupabaseClient()
+  return assembleWeightRoomExercises(supabase)
 }

--- a/lib/data/weight-room-shared.ts
+++ b/lib/data/weight-room-shared.ts
@@ -3,19 +3,23 @@ import { z } from 'zod'
 
 import {
   WeightRoomAchievementRowSchema,
+  WeightRoomExerciseRowSchema,
   WeightRoomGoalRowSchema,
   WeightRoomGoalTargetRowSchema,
   WeightRoomMonthlyFocusRowSchema,
   WeightRoomSetRowSchema,
   achievementRowToAchievement,
+  exerciseRowToWeightRoomExercise,
   focusRowToMonthlyFocus,
   goalRowToExerciseGoal,
   setRowToStrengthSet,
 } from '@/lib/schemas/weight-room'
 import type {
+  ExerciseGoal,
   GoalTargetPoint,
   WeightRoomAchievement,
   WeightRoomData,
+  WeightRoomExercise,
 } from '@/types/weight-room'
 
 import { fetchAllRows } from './paged-read'
@@ -36,18 +40,106 @@ const GOALS_TABLE = 'weight_room_goals'
 const FOCUS_TABLE = 'weight_room_monthly_focus'
 /** Effective-dated daily-target history backing per-day goal resolution (#362). */
 const GOAL_TARGETS_TABLE = 'weight_room_goal_targets'
+/** Movement roster — FK target for sets, and the owner of `load_multiplier` (#373). */
+const EXERCISES_TABLE = 'weight_room_exercises'
 
 /** Whitelisted column lists for each table; `updated_at` rides along for `imported_at` computation. */
 const SETS_COLUMNS = 'id, logged_at, exercise, reps, weight_lbs, variant, updated_at'
-const GOALS_COLUMNS = 'exercise, daily_target, color, kind, load_multiplier, updated_at'
+// `load_multiplier` deliberately absent (#373) — it moved to the catalog and is
+// joined on below. The goals column still exists (dropping it while the
+// deployed build still selected it would break the live read) but is dead.
+const GOALS_COLUMNS = 'exercise, daily_target, color, kind, updated_at'
 const FOCUS_COLUMNS =
   'id, exercise, daily_target, target_kind, color, category, start_date, end_date, updated_at'
 const GOAL_TARGETS_COLUMNS = 'id, exercise, daily_target, effective_from, updated_at'
+const EXERCISES_COLUMNS =
+  'slug, display_name, equipment, muscle_group, load_multiplier, is_unilateral, archived, updated_at'
 
 const WeightRoomSetRowsSchema = z.array(WeightRoomSetRowSchema)
 const WeightRoomGoalRowsSchema = z.array(WeightRoomGoalRowSchema)
 const WeightRoomMonthlyFocusRowsSchema = z.array(WeightRoomMonthlyFocusRowSchema)
 const WeightRoomGoalTargetRowsSchema = z.array(WeightRoomGoalTargetRowSchema)
+const WeightRoomExerciseRowsSchema = z.array(WeightRoomExerciseRowSchema)
+
+/**
+ * Fetch the movement roster (#373) using the supplied client.
+ *
+ * Shared between the browser and server entries, and used directly by the
+ * Settings catalog editor. Ordered by slug so the editor renders a stable list
+ * without re-sorting. Includes archived rows — the editor needs to show them to
+ * un-archive them; pickers filter.
+ *
+ * Returns an empty array (not `null`) when the table is empty, matching
+ * {@link assembleWeightRoomAchievements}: an empty roster is a valid state that
+ * the editor renders as "add your first movement", not a "no data yet" branch.
+ *
+ * @param supabase Browser or server SSR client (both anon role; the table's RLS
+ *   allows anon SELECT).
+ * @throws when the Supabase query fails or row-shape validation fails.
+ */
+export async function assembleWeightRoomExercises(
+  supabase: SupabaseClient,
+): Promise<WeightRoomExercise[]> {
+  const res = await supabase
+    .from(EXERCISES_TABLE)
+    .select(EXERCISES_COLUMNS)
+    .order('slug', { ascending: true })
+
+  if (res.error) {
+    throw new Error(`Failed to load weight room exercises: ${res.error.message}`)
+  }
+
+  return parseExerciseRows((res.data ?? []) as unknown as Array<Record<string, unknown>>)
+}
+
+/**
+ * Validate raw catalog rows and convert them to {@link WeightRoomExercise}.
+ * Factored out so {@link assembleWeightRoomData} and
+ * {@link assembleWeightRoomExercises} can't drift on how the roster is parsed.
+ *
+ * @param raw Rows straight from PostgREST, still carrying `updated_at`.
+ * @throws when row-shape validation fails.
+ */
+function parseExerciseRows(
+  raw: Array<Record<string, unknown>>,
+): WeightRoomExercise[] {
+  const parsed = WeightRoomExerciseRowsSchema.safeParse(raw.map(stripUpdatedAt))
+  if (!parsed.success) {
+    throw new Error(`weight_room_exercises failed schema validation: ${parsed.error.message}`)
+  }
+  return parsed.data.map(exerciseRowToWeightRoomExercise)
+}
+
+/**
+ * Attach each goal's `load_multiplier` from the catalog (#373).
+ *
+ * The column moved to `weight_room_exercises` so movements without a daily goal
+ * could carry it, but the tonnage math in `achievements.ts`, `monthly-focus.ts`,
+ * and `LogDataIsland` all read it off {@link ExerciseGoal} — joining it here
+ * keeps every one of those call sites unchanged.
+ *
+ * A multiplier of 1 is omitted rather than attached: it's the documented
+ * default at every read site, so leaving it off keeps the pre-#373 shape for
+ * the movements where nothing changed.
+ *
+ * @param goals Converted goals, in read order.
+ * @param exercises The full roster, used to build the lookup.
+ */
+function attachLoadMultipliers(
+  goals: readonly ExerciseGoal[],
+  exercises: readonly WeightRoomExercise[],
+): ExerciseGoal[] {
+  const multiplierBySlug = new Map(
+    exercises.map((exercise) => [exercise.slug, exercise.load_multiplier ?? 1]),
+  )
+  return goals.map((goal) => {
+    // A goal with no catalog row is impossible — the FK guarantees one — but
+    // defaulting rather than asserting keeps a partially-migrated project
+    // rendering instead of throwing.
+    const multiplier = multiplierBySlug.get(goal.exercise) ?? 1
+    return multiplier === 1 ? goal : { ...goal, load_multiplier: multiplier }
+  })
+}
 
 /** Supabase table backing the Trophy Room achievement ladder (#336). */
 const ACHIEVEMENTS_TABLE = 'weight_room_achievements'
@@ -156,7 +248,7 @@ export async function assembleWeightRoomData(
   // relative order unstable between fetches. `updated_at` resolves ties
   // by insertion order (sets have no update path), and `id` backstops
   // same-transaction inserts whose `updated_at` also collides.
-  const [setsRaw, goalsRes, focusRes, goalTargetsRes] = await Promise.all([
+  const [setsRaw, goalsRes, focusRes, goalTargetsRes, exercisesRes] = await Promise.all([
     // Paged — the set log is the one table here that grows without bound, and
     // it crossed PostgREST's response cap in July 2026, silently dropping the
     // *newest* sets (this query sorts ascending). The multi-key order above is
@@ -182,6 +274,9 @@ export async function assembleWeightRoomData(
       .select(GOAL_TARGETS_COLUMNS)
       .order('exercise', { ascending: true })
       .order('effective_from', { ascending: true }),
+    // The roster (#373). Read here rather than in a second round trip because
+    // the goals below need its `load_multiplier` joined on regardless.
+    supabase.from(EXERCISES_TABLE).select(EXERCISES_COLUMNS).order('slug', { ascending: true }),
   ])
 
   if (goalsRes.error) {
@@ -193,15 +288,25 @@ export async function assembleWeightRoomData(
   if (goalTargetsRes.error) {
     throw new Error(`Failed to load weight room goal targets: ${goalTargetsRes.error.message}`)
   }
+  if (exercisesRes.error) {
+    throw new Error(`Failed to load weight room exercises: ${exercisesRes.error.message}`)
+  }
 
   const goalsRaw = (goalsRes.data ?? []) as unknown as Array<Record<string, unknown>>
   const focusRaw = (focusRes.data ?? []) as unknown as Array<Record<string, unknown>>
   const goalTargetsRaw = (goalTargetsRes.data ?? []) as unknown as Array<Record<string, unknown>>
+  const exercisesRaw = (exercisesRes.data ?? []) as unknown as Array<Record<string, unknown>>
 
   // Compute imported_at before stripping `updated_at` — that column lives
   // on every row but isn't part of the row-shape schema (`.strict()`
   // would reject it).
-  const importedAt = computeImportedAt([setsRaw, goalsRaw, focusRaw, goalTargetsRaw])
+  const importedAt = computeImportedAt([
+    setsRaw,
+    goalsRaw,
+    focusRaw,
+    goalTargetsRaw,
+    exercisesRaw,
+  ])
 
   // A monthly focus can't exist without its `kind: 'focus'` goal anchor
   // (FK), so sets+goals empty still means "no data" — focus is implied
@@ -235,20 +340,24 @@ export async function assembleWeightRoomData(
   }
 
   const historyByExercise = groupTargetHistory(goalTargetsParsed.data)
+  const exercises = parseExerciseRows(exercisesRaw)
+
+  const goals = goalsParsed.data.map((row) => {
+    const goal = goalRowToExerciseGoal(row)
+    const history = historyByExercise.get(goal.exercise)
+    // Omit rather than attach `[]` so "no recorded history" is a single
+    // shape everywhere — `targetForDay` treats absent and empty the same,
+    // but keeping one of them off the wire makes fixtures and snapshots
+    // easier to read.
+    return history === undefined ? goal : { ...goal, target_history: history }
+  })
 
   return {
     imported_at: importedAt,
     sets: setsParsed.data.map(setRowToStrengthSet),
-    goals: goalsParsed.data.map((row) => {
-      const goal = goalRowToExerciseGoal(row)
-      const history = historyByExercise.get(goal.exercise)
-      // Omit rather than attach `[]` so "no recorded history" is a single
-      // shape everywhere — `targetForDay` treats absent and empty the same,
-      // but keeping one of them off the wire makes fixtures and snapshots
-      // easier to read.
-      return history === undefined ? goal : { ...goal, target_history: history }
-    }),
+    goals: attachLoadMultipliers(goals, exercises),
     monthly_focus: focusParsed.data.map(focusRowToMonthlyFocus),
+    exercises,
   }
 }
 

--- a/lib/data/weight-room.test.ts
+++ b/lib/data/weight-room.test.ts
@@ -167,6 +167,7 @@ describe('getWeightRoomData', () => {
         { exercise: 'pullups', daily_target: 30, color: '#0EA5A1' },
       ],
       monthly_focus: [],
+      exercises: [],
     })
   })
 
@@ -308,6 +309,129 @@ describe('getWeightRoomData', () => {
     )
     await expect(getWeightRoomData()).rejects.toThrow(
       /weight_room_sets failed schema validation/,
+    )
+  })
+})
+
+describe('getWeightRoomData — exercise catalog (#373)', () => {
+  /** One catalog row, with the not-null columns PostgREST always returns. */
+  function catalogRow(
+    slug: string,
+    overrides: Record<string, unknown> = {},
+  ): Record<string, unknown> {
+    return {
+      slug,
+      display_name: slug,
+      equipment: 'bodyweight',
+      muscle_group: 'full-body',
+      load_multiplier: 1,
+      is_unilateral: false,
+      archived: false,
+      updated_at: '2026-07-31T08:00:00Z',
+      ...overrides,
+    }
+  }
+
+  /** A goal row as read after #373 — no `load_multiplier` column. */
+  function goalRow(exercise: string): Record<string, unknown> {
+    return {
+      exercise,
+      daily_target: 100,
+      color: '#EA580C',
+      updated_at: '2026-07-31T08:00:00Z',
+    }
+  }
+
+  it('joins load_multiplier from the catalog onto the goal', async () => {
+    stubTable('weight_room_sets', [])
+    stubTable('weight_room_goals', [goalRow('shrugs')])
+    stubTable('weight_room_exercises', [
+      catalogRow('shrugs', { equipment: 'dumbbell', load_multiplier: 2 }),
+    ])
+
+    const data = await getWeightRoomData()
+
+    // The tonnage math in achievements.ts / monthly-focus.ts reads this off
+    // the goal, so the join is what keeps those call sites working unchanged.
+    expect(data?.goals[0]).toMatchObject({ exercise: 'shrugs', load_multiplier: 2 })
+  })
+
+  it('omits load_multiplier when the movement moves a single implement', async () => {
+    stubTable('weight_room_sets', [])
+    stubTable('weight_room_goals', [goalRow('pushups')])
+    stubTable('weight_room_exercises', [catalogRow('pushups', { load_multiplier: 1 })])
+
+    const data = await getWeightRoomData()
+
+    // Absent rather than `1` — every read site defaults it, and omitting keeps
+    // the pre-#373 shape for movements where nothing actually changed.
+    expect(data?.goals[0]).not.toHaveProperty('load_multiplier')
+  })
+
+  it('defaults to a single implement when a goal has no catalog row', async () => {
+    stubTable('weight_room_sets', [])
+    stubTable('weight_room_goals', [goalRow('orphaned')])
+    stubTable('weight_room_exercises', [])
+
+    // The FK makes this unreachable in practice; the point is that a
+    // partially-migrated project still renders instead of throwing.
+    const data = await getWeightRoomData()
+    expect(data?.goals[0]).not.toHaveProperty('load_multiplier')
+  })
+
+  it('surfaces the roster on the assembled shape, archived rows included', async () => {
+    stubTable('weight_room_sets', [])
+    stubTable('weight_room_goals', [goalRow('pushups')])
+    stubTable('weight_room_exercises', [
+      catalogRow('pushups', { display_name: 'Pushups', muscle_group: 'chest' }),
+      catalogRow('leg-press', {
+        display_name: 'Leg Press',
+        equipment: 'machine',
+        muscle_group: 'legs',
+        archived: true,
+      }),
+    ])
+
+    const data = await getWeightRoomData()
+
+    // The live columns are all NOT NULL DEFAULT, so PostgREST always returns
+    // them and the converter carries them through — only a `null` (a fixture
+    // or a pre-default row) collapses to absent.
+    expect(data?.exercises).toEqual([
+      {
+        slug: 'pushups',
+        display_name: 'Pushups',
+        equipment: 'bodyweight',
+        muscle_group: 'chest',
+        load_multiplier: 1,
+        is_unilateral: false,
+        archived: false,
+      },
+      {
+        slug: 'leg-press',
+        display_name: 'Leg Press',
+        equipment: 'machine',
+        muscle_group: 'legs',
+        load_multiplier: 1,
+        is_unilateral: false,
+        archived: true,
+      },
+    ])
+  })
+
+  it('throws a descriptive error when the catalog query fails', async () => {
+    stubTable('weight_room_sets', [])
+    stubTable('weight_room_goals', [goalRow('pushups')])
+    stubTable('weight_room_exercises', null, { message: 'relation does not exist' })
+    await expect(getWeightRoomData()).rejects.toThrow(/relation does not exist/)
+  })
+
+  it('throws when a catalog row carries an equipment value outside the enum', async () => {
+    stubTable('weight_room_sets', [])
+    stubTable('weight_room_goals', [goalRow('pushups')])
+    stubTable('weight_room_exercises', [catalogRow('pushups', { equipment: 'trebuchet' })])
+    await expect(getWeightRoomData()).rejects.toThrow(
+      /weight_room_exercises failed schema validation/,
     )
   })
 })

--- a/lib/data/weight-room.ts
+++ b/lib/data/weight-room.ts
@@ -1,9 +1,14 @@
 import { getBrowserSupabaseClient } from '@/lib/supabase/browser'
-import type { WeightRoomAchievement, WeightRoomData } from '@/types/weight-room'
+import type {
+  WeightRoomAchievement,
+  WeightRoomData,
+  WeightRoomExercise,
+} from '@/types/weight-room'
 
 import {
   assembleWeightRoomAchievements,
   assembleWeightRoomData,
+  assembleWeightRoomExercises,
 } from './weight-room-shared'
 
 /**
@@ -39,4 +44,17 @@ export async function getWeightRoomData(): Promise<WeightRoomData | null> {
  */
 export async function getWeightRoomAchievements(): Promise<WeightRoomAchievement[]> {
   return assembleWeightRoomAchievements(getBrowserSupabaseClient())
+}
+
+/**
+ * Browser-side reader for the movement roster (#373). Wraps
+ * {@link assembleWeightRoomExercises} with the cached browser client.
+ *
+ * Returns an empty array (never `null`) when the roster is empty, and includes
+ * archived movements — callers that render a picker should filter them out.
+ *
+ * @throws See {@link assembleWeightRoomExercises}.
+ */
+export async function getWeightRoomExercises(): Promise<WeightRoomExercise[]> {
+  return assembleWeightRoomExercises(getBrowserSupabaseClient())
 }

--- a/lib/schemas/weight-room.test.ts
+++ b/lib/schemas/weight-room.test.ts
@@ -3,12 +3,16 @@ import { describe, expect, it } from 'vitest'
 import {
   WeightRoomAchievementCreateSchema,
   WeightRoomAchievementUpdateSchema,
+  WeightRoomExerciseRowSchema,
+  WeightRoomExerciseUpdateSchema,
+  WeightRoomExerciseUpsertSchema,
   WeightRoomGoalRowSchema,
   WeightRoomGoalUpsertSchema,
   WeightRoomMonthlyFocusCreateSchema,
   WeightRoomMonthlyFocusRowSchema,
   WeightRoomSetCreateSchema,
   WeightRoomSetRowSchema,
+  exerciseRowToWeightRoomExercise,
   setRowToStrengthSet,
 } from './weight-room'
 
@@ -44,6 +48,156 @@ describe('WeightRoomGoalRowSchema (read)', () => {
 
   it('rejects a non-hex color', () => {
     expect(() => WeightRoomGoalRowSchema.parse({ ...base, color: 'orange' })).toThrow()
+  })
+
+  it('rejects load_multiplier, which moved to the exercise catalog (#373)', () => {
+    // `.strict()` turns the moved column into a loud failure rather than a
+    // silently-ignored key, which is what would let the two sides drift.
+    expect(() =>
+      WeightRoomGoalRowSchema.parse({ ...base, load_multiplier: 2 }),
+    ).toThrow()
+  })
+})
+
+describe('WeightRoomExerciseRowSchema (read, #373)', () => {
+  const base = {
+    slug: 'barbell-bench-press',
+    display_name: 'Barbell Bench Press',
+    equipment: 'barbell',
+    muscle_group: 'chest',
+  }
+
+  it('accepts a row carrying only the not-null columns', () => {
+    expect(WeightRoomExerciseRowSchema.parse(base)).toEqual(base)
+  })
+
+  it('preserves DB casing on read, matching every sibling row schema', () => {
+    const parsed = WeightRoomExerciseRowSchema.parse({ ...base, slug: 'Barbell-Bench-Press' })
+    expect(parsed.slug).toBe('Barbell-Bench-Press')
+  })
+
+  it('accepts null optionals (a fixture or a pre-default row)', () => {
+    expect(() =>
+      WeightRoomExerciseRowSchema.parse({
+        ...base,
+        load_multiplier: null,
+        is_unilateral: null,
+        archived: null,
+      }),
+    ).not.toThrow()
+  })
+
+  it('rejects an equipment or muscle_group outside the check constraint', () => {
+    expect(() =>
+      WeightRoomExerciseRowSchema.parse({ ...base, equipment: 'trebuchet' }),
+    ).toThrow()
+    expect(() =>
+      WeightRoomExerciseRowSchema.parse({ ...base, muscle_group: 'lats' }),
+    ).toThrow()
+  })
+
+  it('rejects a non-positive load_multiplier', () => {
+    expect(() =>
+      WeightRoomExerciseRowSchema.parse({ ...base, load_multiplier: 0 }),
+    ).toThrow()
+  })
+})
+
+describe('exerciseRowToWeightRoomExercise (row → public shape)', () => {
+  const base = {
+    slug: 'dips',
+    display_name: 'Dips',
+    equipment: 'bodyweight' as const,
+    muscle_group: 'chest' as const,
+  }
+
+  it('omits null optionals so read sites apply their documented defaults', () => {
+    const converted = exerciseRowToWeightRoomExercise({
+      ...base,
+      load_multiplier: null,
+      is_unilateral: null,
+      archived: null,
+    })
+    expect(converted).toEqual(base)
+  })
+
+  it('carries through the values that are actually set', () => {
+    const converted = exerciseRowToWeightRoomExercise({
+      ...base,
+      load_multiplier: 2,
+      is_unilateral: true,
+      archived: true,
+    })
+    expect(converted).toMatchObject({
+      load_multiplier: 2,
+      is_unilateral: true,
+      archived: true,
+    })
+  })
+})
+
+describe('WeightRoomExerciseUpsertSchema (write body, #373)', () => {
+  const base = {
+    slug: 'barbell-bench-press',
+    display_name: 'Barbell Bench Press',
+    equipment: 'barbell',
+    muscle_group: 'chest',
+  }
+
+  it('lowercases the slug so the roster cannot grow case-divergent duplicates', () => {
+    // Two rows for one movement would split its history across both — the
+    // same anti-duplicate reasoning as the goals upsert.
+    const parsed = WeightRoomExerciseUpsertSchema.parse({ ...base, slug: 'Barbell-Bench-Press' })
+    expect(parsed.slug).toBe('barbell-bench-press')
+  })
+
+  it('defaults load_multiplier to 1 and both flags to false', () => {
+    const parsed = WeightRoomExerciseUpsertSchema.parse(base)
+    expect(parsed).toMatchObject({
+      load_multiplier: 1,
+      is_unilateral: false,
+      archived: false,
+    })
+  })
+
+  it('trims the display name and rejects an empty one', () => {
+    expect(WeightRoomExerciseUpsertSchema.parse({ ...base, display_name: '  Dips  ' })
+      .display_name).toBe('Dips')
+    expect(() =>
+      WeightRoomExerciseUpsertSchema.parse({ ...base, display_name: '   ' }),
+    ).toThrow()
+  })
+
+  it('rejects an unknown key', () => {
+    expect(() =>
+      WeightRoomExerciseUpsertSchema.parse({ ...base, muscle: 'chest' }),
+    ).toThrow()
+  })
+})
+
+describe('WeightRoomExerciseUpdateSchema (patch body, #373)', () => {
+  it('accepts a single-field patch — archiving without restating the row', () => {
+    expect(WeightRoomExerciseUpdateSchema.parse({ archived: true })).toEqual({
+      archived: true,
+    })
+  })
+
+  it('injects no defaults for omitted keys', () => {
+    // Zod 4 applies `.default()` to a missing key even inside `.partial()`,
+    // so a patch schema derived from a defaulted create schema would reset
+    // load_multiplier to 1 and un-archive the row on every label edit.
+    const parsed = WeightRoomExerciseUpdateSchema.parse({ display_name: 'Dips' })
+    expect(Object.keys(parsed)).toEqual(['display_name'])
+  })
+
+  it('rejects an empty patch', () => {
+    expect(() => WeightRoomExerciseUpdateSchema.parse({})).toThrow()
+  })
+
+  it('rejects a slug change — the value is stored on every logged set', () => {
+    expect(() =>
+      WeightRoomExerciseUpdateSchema.parse({ slug: 'renamed' }),
+    ).toThrow()
   })
 })
 

--- a/lib/schemas/weight-room.ts
+++ b/lib/schemas/weight-room.ts
@@ -15,10 +15,13 @@ import { z } from 'zod'
 import type {
   AchievementMeasure,
   AchievementScope,
+  ExerciseEquipment,
   ExerciseGoal,
+  ExerciseMuscleGroup,
   MonthlyFocus,
   StrengthSet,
   WeightRoomAchievement,
+  WeightRoomExercise,
 } from '@/types/weight-room'
 
 /**
@@ -136,6 +139,10 @@ export type WeightRoomSetRow = z.infer<typeof WeightRoomSetRowSchema>
  * Zod schema for one row of `public.weight_room_goals` as read from
  * Supabase. Preserves DB casing exactly — see {@link exerciseWriteField}
  * for why the lowercase transform is write-side only.
+ *
+ * No `load_multiplier` as of #373: it moved to `weight_room_exercises`, and the
+ * data layer joins it onto {@link ExerciseGoal} after conversion. The goals
+ * column is no longer selected (a follow-up drops it once this deploys).
  */
 export const WeightRoomGoalRowSchema = z
   .object({
@@ -147,10 +154,6 @@ export const WeightRoomGoalRowSchema = z
     // 'permanent', so live rows always carry it. Absent → treated as
     // 'permanent' by the row converter.
     kind: z.enum(['permanent', 'focus']).nullable().optional(),
-    // Optional + nullable so pre-load-ladder rows (and fixtures) without the
-    // column still validate; the DB column is NOT NULL DEFAULT 1, so live rows
-    // always carry it. Absent → treated as 1 by the row converter.
-    load_multiplier: positiveInt().nullable().optional(),
   })
   .strict()
 
@@ -253,6 +256,11 @@ export function setRowToStrengthSet(row: WeightRoomSetRow): StrengthSet {
  * Translate a validated `weight_room_goals` row into the public
  * {@link ExerciseGoal} shape. Pass-through; same reasoning as
  * {@link setRowToStrengthSet}.
+ *
+ * `load_multiplier` is deliberately *not* set here — it lives on the catalog as
+ * of #373, and the data layer attaches it from `weight_room_exercises` after
+ * this conversion. A goal converted in isolation therefore has it absent, which
+ * every read site already treats as `1`.
  */
 export function goalRowToExerciseGoal(row: WeightRoomGoalRow): ExerciseGoal {
   return {
@@ -262,10 +270,137 @@ export function goalRowToExerciseGoal(row: WeightRoomGoalRow): ExerciseGoal {
     // Absent/null → omit so it defaults to 'permanent' at read sites
     // (pre-#255 goals and fixtures never carry kind).
     ...(row.kind != null ? { kind: row.kind } : {}),
-    // Same treatment: absent/null → omit so read sites default it to 1.
-    ...(row.load_multiplier != null ? { load_multiplier: row.load_multiplier } : {}),
   }
 }
+
+/** The eight equipment kinds, as a Zod enum reused by the row + write schemas. */
+const exerciseEquipment = (): z.ZodType<ExerciseEquipment> =>
+  z.enum([
+    'barbell',
+    'dumbbell',
+    'kettlebell',
+    'machine',
+    'cable',
+    'band',
+    'bodyweight',
+    'other',
+  ])
+
+/** The seven coarse muscle groups, as a Zod enum reused by the row + write schemas. */
+const exerciseMuscleGroup = (): z.ZodType<ExerciseMuscleGroup> =>
+  z.enum(['chest', 'back', 'shoulders', 'arms', 'legs', 'core', 'full-body'])
+
+/**
+ * Zod schema for one row of `public.weight_room_exercises` (#373) — the
+ * movement roster. Mirrors the table in
+ * `supabase/migrations/20260731120000_weight_room_exercises_catalog.sql`.
+ *
+ * `slug` preserves DB casing on read for the same reason every sibling row
+ * schema does (see {@link exerciseWriteField}); writes lowercase it.
+ * `load_multiplier` / `is_unilateral` / `archived` are `.nullable().optional()`
+ * so a fixture omitting them still validates, even though the live columns are
+ * all `NOT NULL DEFAULT`.
+ */
+export const WeightRoomExerciseRowSchema = z
+  .object({
+    slug: z.string().min(1),
+    display_name: z.string().min(1),
+    equipment: exerciseEquipment(),
+    muscle_group: exerciseMuscleGroup(),
+    load_multiplier: positiveInt().nullable().optional(),
+    is_unilateral: z.boolean().nullable().optional(),
+    archived: z.boolean().nullable().optional(),
+  })
+  .strict()
+
+/** Validated `weight_room_exercises` row inferred from {@link WeightRoomExerciseRowSchema}. */
+export type WeightRoomExerciseRow = z.infer<typeof WeightRoomExerciseRowSchema>
+
+/**
+ * Translate a validated `weight_room_exercises` row into the public
+ * {@link WeightRoomExercise} shape. Null/absent optionals are omitted so the
+ * consumed type stays `number | undefined` / `boolean | undefined` and read
+ * sites can apply their documented defaults (1 / false / false).
+ */
+export function exerciseRowToWeightRoomExercise(
+  row: WeightRoomExerciseRow,
+): WeightRoomExercise {
+  return {
+    slug: row.slug,
+    display_name: row.display_name,
+    equipment: row.equipment,
+    muscle_group: row.muscle_group,
+    ...(row.load_multiplier != null ? { load_multiplier: row.load_multiplier } : {}),
+    ...(row.is_unilateral != null ? { is_unilateral: row.is_unilateral } : {}),
+    ...(row.archived != null ? { archived: row.archived } : {}),
+  }
+}
+
+/**
+ * The catalog write fields, without any `.default()`.
+ *
+ * Kept default-free so {@link WeightRoomExerciseUpdateSchema} can be derived
+ * from it safely — Zod 4 applies `.default()` to a missing key even inside
+ * `.partial()`, so a PATCH built from a defaulted create schema would silently
+ * reset `load_multiplier` to 1 and un-archive a row on every edit. Same trap
+ * documented on {@link achievementWriteFields}.
+ */
+const exerciseWriteFields = {
+  display_name: z
+    .string()
+    .trim()
+    .min(1, 'display_name is required')
+    .max(60, 'display_name is too long'),
+  equipment: exerciseEquipment(),
+  muscle_group: exerciseMuscleGroup(),
+  load_multiplier: positiveInt(),
+  is_unilateral: z.boolean(),
+  archived: z.boolean(),
+}
+
+/**
+ * Request-body schema for `POST /api/admin/weight-room/exercises` (#373).
+ *
+ * `slug` is lowercased via {@link exerciseWriteField} so the roster can't grow
+ * case-divergent duplicates — a set logged against `Bench-Press` must FK to the
+ * same row as one logged against `bench-press`. `load_multiplier` defaults to
+ * 1 and the two booleans to `false`, matching the DB column defaults, so the
+ * common case (a plain barbell movement) needs neither.
+ */
+export const WeightRoomExerciseUpsertSchema = z
+  .object({
+    ...exerciseWriteFields,
+    slug: exerciseWriteField(),
+    load_multiplier: exerciseWriteFields.load_multiplier.default(1),
+    is_unilateral: exerciseWriteFields.is_unilateral.default(false),
+    archived: exerciseWriteFields.archived.default(false),
+  })
+  .strict()
+
+/** Validated body of `POST /api/admin/weight-room/exercises`. */
+export type WeightRoomExerciseUpsert = z.infer<typeof WeightRoomExerciseUpsertSchema>
+
+/**
+ * Request-body schema for `PATCH /api/admin/weight-room/exercises/[slug]`.
+ * Every field optional so the editor can flip `archived` alone, but the body
+ * must carry at least one field — an empty patch is a client bug, not a no-op.
+ *
+ * `slug` is absent by design: it's the primary key and the value stored on
+ * every logged set. The FK is `on update cascade` so the database *would*
+ * propagate a rename, but exposing it through the editor invites renaming a
+ * movement mid-history by accident; retiring one is what `archived` is for.
+ */
+export const WeightRoomExerciseUpdateSchema = z
+  .object(exerciseWriteFields)
+  .strict()
+  .partial()
+  .refine((patch) => Object.keys(patch).length > 0, {
+    message:
+      'At least one field (display_name, equipment, muscle_group, load_multiplier, is_unilateral, or archived) is required.',
+  })
+
+/** Validated body of `PATCH /api/admin/weight-room/exercises/[slug]`. */
+export type WeightRoomExerciseUpdate = z.infer<typeof WeightRoomExerciseUpdateSchema>
 
 /**
  * Zod schema for one row of `public.weight_room_monthly_focus` (#255).

--- a/supabase/migrations/20260731120000_weight_room_exercises_catalog.sql
+++ b/supabase/migrations/20260731120000_weight_room_exercises_catalog.sql
@@ -1,0 +1,236 @@
+-- Weight Room exercise catalog (#373) — split the movement roster out of
+-- `weight_room_goals` so a movement can exist without a daily rep target.
+--
+-- Before this migration `weight_room_goals` did two jobs: it was the FK target
+-- for every set (the roster) *and* the grease-the-groove daily-target config
+-- (`daily_target integer not null check (daily_target > 0)`). That conflation
+-- was free while every tracked movement had a daily ring, but it makes a gym
+-- lift unloggable — bench press has no honest `daily_target`, and inventing one
+-- would put a phantom ring on the Today view and a phantom streak in the stats.
+--
+-- After this migration:
+--
+--   * weight_room_exercises — the roster. One row per movement, with the
+--     display label and the equipment/muscle metadata a template builder needs.
+--     FK target for sets, goals, and monthly focus.
+--   * weight_room_goals     — an *overlay* on the roster: the handful of
+--     movements that also have a daily ring. Still keyed by exercise name.
+--
+-- Two deliberate behavior changes ride along:
+--
+--   * Sets now `on delete restrict` into the catalog instead of
+--     `on delete cascade` into goals. Deleting a goal used to destroy every set
+--     ever logged for that movement; removing a daily goal now means "stop
+--     ringing this movement", not "erase its history". Retiring a movement from
+--     the roster is `archived = true`, which is why the catalog carries it.
+--   * `on update cascade` on every repointed FK, so renaming a slug propagates
+--     instead of erroring. The settings UI keeps slugs immutable, but the
+--     database no longer forbids a rename.
+--
+-- NOT done here, on purpose: dropping `weight_room_goals.load_multiplier`.
+-- The catalog is its source of truth from this migration on and the app stops
+-- reading the goals column, but production applies migrations *ahead* of the
+-- code that lands with them (see CLAUDE.md), so dropping it now would break the
+-- deployed read — `GOALS_COLUMNS` still names it — for the window between apply
+-- and promote. The drop is a follow-up applied after this deploys.
+--
+-- RLS mirrors every sibling table: anon + authenticated SELECT only; writes go
+-- through the service-role key via `app/api/admin/weight-room/*`.
+--
+-- All DDL is idempotent — re-applying on a fresh project or after a branch
+-- reset is a safe no-op.
+
+-- ---------------------------------------------------------------------------
+-- 1. The catalog
+-- ---------------------------------------------------------------------------
+
+create table if not exists public.weight_room_exercises (
+  slug text primary key,
+  display_name text not null check (btrim(display_name) <> ''),
+  equipment text not null check (
+    equipment in (
+      'barbell', 'dumbbell', 'kettlebell', 'machine',
+      'cable', 'band', 'bodyweight', 'other'
+    )
+  ),
+  muscle_group text not null check (
+    muscle_group in (
+      'chest', 'back', 'shoulders', 'arms', 'legs', 'core', 'full-body'
+    )
+  ),
+  load_multiplier integer not null default 1 check (load_multiplier > 0),
+  is_unilateral boolean not null default false,
+  archived boolean not null default false,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+comment on table public.weight_room_exercises is
+  'Movement roster for the Weight Room (#373). One row per exercise, keyed by slug. FK target for weight_room_sets, weight_room_goals, and weight_room_monthly_focus — a movement must exist here before it can be logged. Carries the display label and the equipment/muscle metadata; weight_room_goals is a separate overlay holding only the movements that also have a grease-the-groove daily target.';
+
+comment on column public.weight_room_exercises.load_multiplier is
+  'How many loaded implements this movement moves per set. weight_room_sets.weight_lbs records the load on ONE implement (a "60 lb dumbbell shrug" is 60 per hand), so effective load is weight_lbs x load_multiplier. Two-dumbbell movements set 2; barbell, vest, dip belt, and bodyweight stay 1. Moved here from weight_room_goals so a movement with no daily ring can still carry it.';
+
+comment on column public.weight_room_exercises.is_unilateral is
+  'True when the movement trains one side at a time (single-arm dumbbell row). Distinct from load_multiplier, which counts implements moved simultaneously: a single-arm row is unilateral with multiplier 1, a two-dumbbell press is bilateral with multiplier 2.';
+
+comment on column public.weight_room_exercises.archived is
+  'Soft-retire flag. Sets FK into this table with on delete restrict, so a movement with history can never be deleted — archiving hides it from pickers while leaving every logged set intact.';
+
+create index if not exists weight_room_exercises_active_idx
+  on public.weight_room_exercises (muscle_group, slug)
+  where archived = false;
+
+alter table public.weight_room_exercises enable row level security;
+
+do $$
+begin
+  create policy "anon and authenticated can read weight room exercises"
+    on public.weight_room_exercises
+    for select
+    to anon, authenticated
+    using (true);
+exception when duplicate_object then null;
+end $$;
+
+-- ---------------------------------------------------------------------------
+-- 2. Backfill the roster from what already exists
+-- ---------------------------------------------------------------------------
+-- Every currently-configured goal becomes a catalog row, carrying its
+-- load_multiplier across. The four live movements get explicit equipment and
+-- muscle groups; anything else (a goal added between this file being written
+-- and it being applied) lands on 'other'/'full-body' rather than blocking the
+-- migration, and can be corrected in the settings UI.
+--
+-- `on conflict do nothing` makes this re-runnable, and means a re-apply never
+-- re-stamps a row whose metadata was since edited by hand.
+
+insert into public.weight_room_exercises (slug, display_name, equipment, muscle_group, load_multiplier)
+select
+  g.exercise,
+  initcap(replace(g.exercise, '-', ' ')),
+  case g.exercise
+    when 'pushups' then 'bodyweight'
+    when 'pullups' then 'bodyweight'
+    when 'squats'  then 'bodyweight'
+    when 'shrugs'  then 'dumbbell'
+    else 'other'
+  end,
+  case g.exercise
+    when 'pushups' then 'chest'
+    when 'pullups' then 'back'
+    when 'squats'  then 'legs'
+    when 'shrugs'  then 'shoulders'
+    else 'full-body'
+  end,
+  coalesce(g.load_multiplier, 1)
+from public.weight_room_goals g
+on conflict (slug) do nothing;
+
+-- Defensive: the FK repoint below fails if any set or focus names a movement
+-- the catalog doesn't hold. Today's FKs make that impossible (both point at
+-- goals), but a project where a goal was removed under the old cascade — or a
+-- staging copy mid-restore — would otherwise hit a constraint error mid-apply
+-- with the roster half-built. Cheap to guarantee, expensive to debug.
+
+insert into public.weight_room_exercises (slug, display_name, equipment, muscle_group)
+select distinct s.exercise, initcap(replace(s.exercise, '-', ' ')), 'other', 'full-body'
+from public.weight_room_sets s
+on conflict (slug) do nothing;
+
+insert into public.weight_room_exercises (slug, display_name, equipment, muscle_group)
+select distinct f.exercise, initcap(replace(f.exercise, '-', ' ')), 'other', 'full-body'
+from public.weight_room_monthly_focus f
+on conflict (slug) do nothing;
+
+-- ---------------------------------------------------------------------------
+-- 3. Repoint the foreign keys at the catalog
+-- ---------------------------------------------------------------------------
+-- Drop-then-add rather than `add constraint if not exists` (which Postgres
+-- doesn't support). The drop is guarded, so the pair is idempotent: a re-apply
+-- drops the constraint this migration created and recreates it identically.
+
+alter table public.weight_room_sets
+  drop constraint if exists weight_room_sets_exercise_fkey;
+
+alter table public.weight_room_sets
+  add constraint weight_room_sets_exercise_fkey
+  foreign key (exercise) references public.weight_room_exercises(slug)
+  on delete restrict on update cascade;
+
+comment on table public.weight_room_sets is
+  'Logged strength sets for the Weight Room sub-area (PRD §7.6 / #79). One row per set. FK on `exercise` points at weight_room_exercises with ON DELETE RESTRICT (#373) — a movement with logged history cannot be deleted, only archived. It previously cascaded from weight_room_goals, which meant removing a daily goal silently destroyed that movement''s entire training log.';
+
+alter table public.weight_room_goals
+  drop constraint if exists weight_room_goals_exercise_fkey;
+
+alter table public.weight_room_goals
+  add constraint weight_room_goals_exercise_fkey
+  foreign key (exercise) references public.weight_room_exercises(slug)
+  on delete restrict on update cascade;
+
+comment on table public.weight_room_goals is
+  'Grease-the-groove daily targets (#79), an overlay on the weight_room_exercises roster (#373). Only movements with a daily ring have a row here; a gym lift lives in the catalog with no goal. Deleting a row stops the ring and drops its target history — it no longer touches logged sets.';
+
+alter table public.weight_room_monthly_focus
+  drop constraint if exists weight_room_monthly_focus_exercise_fkey;
+
+alter table public.weight_room_monthly_focus
+  add constraint weight_room_monthly_focus_exercise_fkey
+  foreign key (exercise) references public.weight_room_exercises(slug)
+  on delete restrict on update cascade;
+
+-- weight_room_goal_targets.exercise deliberately keeps its FK into
+-- weight_room_goals with ON DELETE CASCADE: it is daily-target history, which
+-- is goal-scoped by definition. Removing a goal should take its target history
+-- with it, and a catalog-only movement has no target history to hold.
+
+-- ---------------------------------------------------------------------------
+-- 4. Seed a starting gym roster
+-- ---------------------------------------------------------------------------
+-- Enough to build the first templates against; refine in the settings UI.
+-- load_multiplier is 2 for movements carried as a pair of dumbbells (see the
+-- column comment) and 1 for barbell / machine / cable / bodyweight work.
+-- is_unilateral marks movements trained one side at a time.
+
+insert into public.weight_room_exercises
+  (slug, display_name, equipment, muscle_group, load_multiplier, is_unilateral)
+values
+  -- barbell
+  ('barbell-bench-press',      'Barbell Bench Press',      'barbell',    'chest',     1, false),
+  ('barbell-incline-press',    'Barbell Incline Press',    'barbell',    'chest',     1, false),
+  ('barbell-overhead-press',   'Barbell Overhead Press',   'barbell',    'shoulders', 1, false),
+  ('barbell-back-squat',       'Barbell Back Squat',       'barbell',    'legs',      1, false),
+  ('barbell-front-squat',      'Barbell Front Squat',      'barbell',    'legs',      1, false),
+  ('barbell-deadlift',         'Barbell Deadlift',         'barbell',    'back',      1, false),
+  ('barbell-romanian-deadlift','Barbell Romanian Deadlift','barbell',    'legs',      1, false),
+  ('barbell-row',              'Barbell Row',              'barbell',    'back',      1, false),
+  ('barbell-hip-thrust',       'Barbell Hip Thrust',       'barbell',    'legs',      1, false),
+  ('barbell-curl',             'Barbell Curl',             'barbell',    'arms',      1, false),
+  -- dumbbell (pairs carry two implements — load_multiplier 2)
+  ('dumbbell-bench-press',     'Dumbbell Bench Press',     'dumbbell',   'chest',     2, false),
+  ('dumbbell-incline-press',   'Dumbbell Incline Press',   'dumbbell',   'chest',     2, false),
+  ('dumbbell-shoulder-press',  'Dumbbell Shoulder Press',  'dumbbell',   'shoulders', 2, false),
+  ('dumbbell-lateral-raise',   'Dumbbell Lateral Raise',   'dumbbell',   'shoulders', 2, false),
+  ('dumbbell-curl',            'Dumbbell Curl',            'dumbbell',   'arms',      2, false),
+  ('dumbbell-row',             'Dumbbell Row',             'dumbbell',   'back',      1, true),
+  ('dumbbell-lunge',           'Dumbbell Lunge',           'dumbbell',   'legs',      2, false),
+  ('dumbbell-romanian-deadlift','Dumbbell Romanian Deadlift','dumbbell', 'legs',      2, false),
+  ('farmers-carry',            'Farmer''s Carry',          'dumbbell',   'full-body', 2, false),
+  -- machine / cable
+  ('lat-pulldown',             'Lat Pulldown',             'cable',      'back',      1, false),
+  ('seated-cable-row',         'Seated Cable Row',         'cable',      'back',      1, false),
+  ('cable-tricep-pushdown',    'Cable Tricep Pushdown',    'cable',      'arms',      1, false),
+  ('cable-face-pull',          'Cable Face Pull',          'cable',      'shoulders', 1, false),
+  ('chest-press-machine',      'Chest Press Machine',      'machine',    'chest',     1, false),
+  ('pec-deck',                 'Pec Deck',                 'machine',    'chest',     1, false),
+  ('leg-press',                'Leg Press',                'machine',    'legs',      1, false),
+  ('leg-curl',                 'Leg Curl',                 'machine',    'legs',      1, false),
+  ('leg-extension',            'Leg Extension',            'machine',    'legs',      1, false),
+  ('calf-raise',               'Calf Raise',               'machine',    'legs',      1, false),
+  -- bodyweight
+  ('dips',                     'Dips',                     'bodyweight', 'chest',     1, false),
+  ('chinups',                  'Chinups',                  'bodyweight', 'back',      1, false),
+  ('hanging-leg-raise',        'Hanging Leg Raise',        'bodyweight', 'core',      1, false),
+  ('plank',                    'Plank',                    'bodyweight', 'core',      1, false)
+on conflict (slug) do nothing;

--- a/types/weight-room.ts
+++ b/types/weight-room.ts
@@ -19,8 +19,14 @@ export interface StrengthSet {
   /** ISO 8601 timestamp the set was logged at (matches `logged_at` column). */
   logged_at: string
   /**
-   * Exercise name (`pushups`, `pullups`, …). Foreign-keyed to
-   * {@link ExerciseGoal.exercise}; deleting a goal cascades sets.
+   * Exercise slug (`pushups`, `barbell-bench-press`, …). Foreign-keyed to
+   * {@link WeightRoomExercise.slug} — the movement roster, *not* the daily-goal
+   * overlay (#373), so a gym lift with no daily target is still loggable.
+   *
+   * The FK is `on delete restrict`: a movement with logged sets can't be
+   * deleted, only {@link WeightRoomExercise.archived}. Before #373 it cascaded
+   * from `weight_room_goals`, so removing a daily goal destroyed that
+   * movement's entire history.
    */
   exercise: string
   /** Rep count for this single set. Always positive (DB CHECK enforces). */
@@ -43,6 +49,102 @@ export interface StrengthSet {
    * *slice* volume by variant in the History View, never to split it.
    */
   variant?: string
+}
+
+/**
+ * How a movement is loaded (#373). Drives the catalog's equipment filter and,
+ * once templates land, "what can I swap this for when the rack is taken".
+ *
+ * `'bodyweight'` is the explicit marker for movements that carry no external
+ * load — previously this was *inferred* from `weight_lbs IS NULL` plus a
+ * share-of-weighted-sets threshold in `load-management.ts`.
+ */
+export type ExerciseEquipment =
+  | 'barbell'
+  | 'dumbbell'
+  | 'kettlebell'
+  | 'machine'
+  | 'cable'
+  | 'band'
+  | 'bodyweight'
+  | 'other'
+
+/**
+ * Coarse body region a movement trains (#373). Deliberately seven buckets
+ * rather than a per-muscle taxonomy: enough to organize a catalog of ~30 lifts
+ * and a template builder, and it lines up with the existing upper/lower
+ * {@link FocusCategory} lanes. Splitting finer later is a check-constraint
+ * change, not a redesign.
+ */
+export type ExerciseMuscleGroup =
+  | 'chest'
+  | 'back'
+  | 'shoulders'
+  | 'arms'
+  | 'legs'
+  | 'core'
+  | 'full-body'
+
+/**
+ * One movement in the Weight Room roster (#373) — mirrors a row of
+ * `public.weight_room_exercises`.
+ *
+ * This is the FK target for every logged set, so a movement must exist here
+ * before it can be logged. It is deliberately *separate* from
+ * {@link ExerciseGoal}: the catalog says "this movement exists and here's how
+ * it's loaded", while a goal says "and I want N reps of it every day". Gym
+ * lifts have the former and not the latter — which is the whole point, since
+ * `weight_room_goals.daily_target` is `not null check (> 0)` and there is no
+ * honest daily rep target for a bench press.
+ */
+export interface WeightRoomExercise {
+  /**
+   * Primary key and the value stored in {@link StrengthSet.exercise}. Lowercase
+   * kebab-case (`barbell-bench-press`); lowercased on write by the API so
+   * `Pushups` and `pushups` can't diverge into two roster entries.
+   */
+  slug: string
+  /**
+   * Human-readable label (`Barbell Bench Press`). Exists because {@link slug}
+   * doubles as the primary key and reads badly in UI. Stored and editable as of
+   * #373; the Today / History / Trophy Room surfaces still render the slug
+   * until the label rollout follow-up.
+   */
+  display_name: string
+  /** How the movement is loaded. */
+  equipment: ExerciseEquipment
+  /** Coarse body region this movement trains. */
+  muscle_group: ExerciseMuscleGroup
+  /**
+   * How many loaded implements this movement moves per set. Absent is treated
+   * as `1`.
+   *
+   * {@link StrengthSet.weight_lbs} records the load on *one* implement, since
+   * that's how it's read off the equipment — a "60 lb dumbbell shrug" is 60 per
+   * hand, not 60 total. Movements carried two at a time (shrugs, dumbbell
+   * press) set this to `2`, so effective load is `weight_lbs × load_multiplier`.
+   * Barbell, machine, vest, dip belt, and bodyweight work all stay at `1`.
+   *
+   * Moved here from `weight_room_goals` in #373 — it describes how a movement
+   * is performed, so it has to be available for movements that have no daily
+   * goal at all.
+   */
+  load_multiplier?: number
+  /**
+   * Whether the movement trains one side at a time (single-arm dumbbell row).
+   *
+   * Orthogonal to {@link load_multiplier}, which counts implements moved
+   * *simultaneously*: a single-arm row is unilateral with multiplier 1, a
+   * two-dumbbell press is bilateral with multiplier 2. Absent is treated as
+   * `false`.
+   */
+  is_unilateral?: boolean
+  /**
+   * Soft-retire flag. Archived movements stay in the roster (their sets are
+   * FK'd to it and the FK is `on delete restrict`, so they can never be
+   * deleted) but drop out of pickers. Absent is treated as `false`.
+   */
+  archived?: boolean
 }
 
 /**
@@ -111,15 +213,11 @@ export interface ExerciseGoal {
    * How many loaded implements this movement moves per set. Absent is treated
    * as `1`.
    *
-   * {@link StrengthSet.weight_lbs} records the load on *one* implement, since
-   * that's how it's read off the equipment — a "60 lb dumbbell shrug" is 60 per
-   * hand, not 60 total. Shrugs are carried two at a time, so they set this to
-   * `2` and their effective load is `weight_lbs × 2`. Every single-implement
-   * movement (barbell, vest, dip belt, bodyweight) leaves it at `1`.
-   *
-   * Lives on the goal rather than the set because it describes how the movement
-   * is performed, not one logged instance — so setting it corrects the entire
-   * history at once.
+   * **Joined from {@link WeightRoomExercise.load_multiplier}**, which owns it as
+   * of #373 — the column moved to the catalog so movements without a daily goal
+   * could carry it too. The data layer attaches it here on read so the tonnage
+   * math in `achievements.ts` / `monthly-focus.ts` / `LogDataIsland` keeps
+   * reading it off the goal unchanged. Editing it means editing the catalog.
    */
   load_multiplier?: number
   /**
@@ -285,6 +383,18 @@ export interface WeightRoomData {
   sets: StrengthSet[]
   /** Every configured exercise goal, ordered by exercise name. */
   goals: ExerciseGoal[]
+  /**
+   * The full movement roster (#373), ordered by slug — including archived
+   * entries and movements with no daily goal, so callers can filter for
+   * themselves.
+   *
+   * Optional because it postdates the fixtures: the demo fixture and the
+   * component tests build a {@link WeightRoomData} without it, and every
+   * consumer that predates the catalog ignores it. The live assembler always
+   * populates it — it reads the table anyway to join
+   * {@link ExerciseGoal.load_multiplier}, so surfacing it costs nothing.
+   */
+  exercises?: WeightRoomExercise[]
   /**
    * "Grease the groove" monthly focuses (#255), ordered newest window
    * first. Empty when none are configured. Includes past, active, and


### PR DESCRIPTION
Foundation for #372. Splits the movement roster out of `weight_room_goals` into a `weight_room_exercises` catalog, so a movement can exist — and be logged against — without a daily rep target.

## Why

`weight_room_goals` was doing two jobs: the FK target for every set (the roster) **and** the grease-the-groove daily-target config, whose `daily_target` is `not null check (> 0)`. That was free while every tracked movement had a daily ring, but it makes a gym lift unloggable — there's no honest daily rep target for a bench press, and inventing one would put a phantom ring on Today, a phantom lane on History, and a phantom streak in the stats.

After this, `weight_room_exercises` is the roster and `weight_room_goals` is an **overlay** on it: only the movements that also want a daily ring. A gym lift needs a catalog row and nothing else.

## Two behavior changes worth reading

**Deleting a goal no longer destroys training history.** Sets used to FK into `weight_room_goals` with `on delete cascade`, so `DELETE /api/admin/weight-room/goals/{exercise}` silently dropped every set ever logged for that movement. Sets now FK into the catalog with `on delete restrict` — removing a daily goal means "stop ringing this movement", not "erase it". Retiring a movement from the roster is `archived`, and the catalog DELETE returns a 409 with the remedy rather than a raw constraint error.

**`load_multiplier` moved to the catalog.** It describes how a movement is performed, so it has to be available for movements with no goal. The data layer joins it back onto `ExerciseGoal.load_multiplier`, which leaves the tonnage math in `achievements.ts`, `monthly-focus.ts`, and `LogDataIsland` completely untouched.

## Migration

`20260731120000_weight_room_exercises_catalog.sql` — applied to **both** projects; `migrations:check` clean on production, and staging's ledger matches (26 committed, 26 applied on each).

Rehearsed on staging first, inside a transaction that rolled back, which is what confirmed the two behavior changes above:

```
REHEARSAL OK: 170 squats sets survived the goal delete; catalog delete refused.
```

Backfills the 4 live movements (`shrugs` keeps `load_multiplier = 2`) and seeds 33 gym movements. All DDL is idempotent; the FK repoints are `drop if exists` + `add` so a re-apply is a no-op.

**Deliberately deferred: dropping `weight_room_goals.load_multiplier`.** Production applies migrations *ahead* of the code that lands with them, and the deployed build still names that column in `GOALS_COLUMNS` — dropping it now would break the live read for the window between apply and promote. The column is dead as of this PR (nothing selects it); a follow-up drops it after this deploys. Filed as a follow-up rather than done here.

## Also in scope

- **Settings catalog editor** — add/edit/archive movements, filter by name/equipment/muscle, archived hidden behind a toggle. Rows collapse to a summary and expand to edit, which keeps a 37-movement roster usable on a phone.
- **`log-workout` skill guard.** The skill canonicalized against `weight_room_goals` and, on a `23503`, offered to create a *goal* row — which after this migration would mint a phantom daily ring for every gym lift. It now reads the catalog and offers a catalog row. Its day-readback join also became a `LEFT` join; an inner join would have silently dropped catalog-only movements from the report.
- `display_name` is stored and editable but **not yet rendered** on Today / History / Trophy Room — deliberate scope boundary, since the label rollout touches ~10 components plus e2e text assertions. Follow-up.

## Test plan

- [ ] `/training-facility/weight-room` — rings, streaks, and totals unchanged. Shrugs tonnage still counts both dumbbells (the `load_multiplier` join).
- [ ] `/training-facility/weight-room/history` — heatmaps, weekly volume, per-exercise stats unchanged; no lane appears for the 33 seeded gym movements (they have no goal).
- [ ] `/training-facility/weight-room/achievements` — Trophy Room unchanged; no tier retroactively unlocks.
- [ ] `/training-facility/weight-room/settings` → **Movement catalog** — filter, expand a row, edit a display name, archive/unarchive, add a new movement (check the generated slug), and try deleting one with history → expect the 409 copy steering to archive.
- [ ] Same page → **Exercises** (goals) — the delete confirm now says sets are kept. Removing a goal and re-adding it should leave the set history intact.
- [ ] `/training-facility/weight-room/log` — logging a set still works.
- [ ] Non-admin still gets a 404 on `/settings`.

Verified locally: `tsc --noEmit` clean, `next build` compiles, 1783 unit tests pass, 43/43 Playwright pass.

Closes #373.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
