### PR TITLE
test(e2e): mobile-WebKit project + specs for the two bug classes that escaped (#359)

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -35,8 +35,14 @@ jobs:
       - name: Set up Node.js and install dependencies
         uses: ./.github/actions/node-setup
 
-      - name: Install Playwright Chromium
-        run: npx playwright install --with-deps chromium
+      # WebKit as well as Chromium (#359): the `mobile-webkit` project runs the
+      # rendering specs on an iPhone 14 profile, which is the only place the
+      # suite exercises a non-Chromium engine or a phone viewport — the two
+      # gaps that let #353 and #355/#356 ship. `--with-deps` pulls WebKit's
+      # system libraries, which is the bulk of the added setup time; the run
+      # itself reuses the dev servers the other projects already start.
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium webkit
 
       - name: Run Playwright smoke suite
         run: npm run test:e2e

--- a/app/training-facility/weight-room/history/page.tsx
+++ b/app/training-facility/weight-room/history/page.tsx
@@ -14,6 +14,7 @@ import { StrengthVsBodyweightChart } from '@/components/training-facility/weight
 import { VariantBreakdown } from '@/components/training-facility/weight-room/VariantBreakdown'
 import { WeeklyVolumeChart } from '@/components/training-facility/weight-room/WeeklyVolumeChart'
 import { WeightRoomSubNav } from '@/components/training-facility/weight-room/WeightRoomSubNav'
+import { buildWeightRoomDemoData } from '@/constants/weight-room-demo-fixture'
 import { isAdminRequest } from '@/lib/auth/admin-session'
 import { getCardioDataServer } from '@/lib/data/cardio-server'
 import { getWeightRoomDataServer } from '@/lib/data/weight-room-server'
@@ -24,7 +25,10 @@ import {
 } from '@/lib/training-facility/exercise-filter'
 import { pacificDayKey } from '@/lib/training-facility/day-keys'
 import { buildMovementLoads } from '@/lib/training-facility/load-management'
-import { TRAINING_FACILITY_PREVIEW_PARAM } from '@/lib/training-facility/preview-param'
+import {
+  TRAINING_FACILITY_PREVIEW_PARAM,
+  isPreviewDemoActive,
+} from '@/lib/training-facility/preview-param'
 import {
   buildFocusLaneCells,
   computeFocusAdherence,
@@ -80,11 +84,26 @@ export default async function WeightRoomHistoryPage({
   // failed/empty cardio fetch just drops the relative-strength section.
   // `isAdmin` is resolved here rather than by the sub-nav so this page ships
   // no browser Supabase client — see WeightRoomSubNavProps.isAdmin (#345).
-  const [data, cardio, isAdmin] = await Promise.all([
+  const [realData, cardio, isAdmin] = await Promise.all([
     getWeightRoomDataServer().catch(() => null),
     getCardioDataServer().catch(() => null),
     isAdminRequest().catch(() => false),
   ])
+
+  // `?preview=demo` substitutes the sample dataset when there's nothing real
+  // to show — same opt-in the Gym and Weight Room scenes already honour
+  // (#162 / #171), extended here so the charts have something to draw (#359).
+  //
+  // It is what makes this page's rendering testable in CI: the e2e job has no
+  // Supabase credentials, so without a fixture every chart renders empty and a
+  // browser-level assertion about chart layout would pass by finding nothing.
+  // Gated on the real data being empty, so a populated deploy ignores the
+  // param entirely.
+  const realIsEmpty = realData === null || realData.sets.length === 0
+  const data = realIsEmpty && isPreviewDemoActive(params[TRAINING_FACILITY_PREVIEW_PARAM])
+    ? buildWeightRoomDemoData()
+    : realData
+
   const goals: readonly ExerciseGoal[] = data?.goals ?? []
   const sets = data?.sets ?? []
   const focuses = data?.monthly_focus ?? []

--- a/app/training-facility/weight-room/history/page.tsx
+++ b/app/training-facility/weight-room/history/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from 'next/navigation'
 
 import { BackToCourtButton } from '@/components/common/BackToCourtButton'
 import { FacilityBackLink } from '@/components/training-facility/FacilityBackLink'
+import { PreviewModeBadge } from '@/components/training-facility/shared/PreviewModeBadge'
 import { ExerciseFilterChips } from '@/components/training-facility/weight-room/ExerciseFilterChips'
 import { FocusLaneHeatmap } from '@/components/training-facility/weight-room/FocusLaneHeatmap'
 import { LoadManagementPanel } from '@/components/training-facility/weight-room/LoadManagementPanel'
@@ -100,9 +101,9 @@ export default async function WeightRoomHistoryPage({
   // Gated on the real data being empty, so a populated deploy ignores the
   // param entirely.
   const realIsEmpty = realData === null || realData.sets.length === 0
-  const data = realIsEmpty && isPreviewDemoActive(params[TRAINING_FACILITY_PREVIEW_PARAM])
-    ? buildWeightRoomDemoData()
-    : realData
+  const isPreviewMode =
+    realIsEmpty && isPreviewDemoActive(params[TRAINING_FACILITY_PREVIEW_PARAM])
+  const data = isPreviewMode ? buildWeightRoomDemoData() : realData
 
   const goals: readonly ExerciseGoal[] = data?.goals ?? []
   const sets = data?.sets ?? []
@@ -186,6 +187,16 @@ export default async function WeightRoomHistoryPage({
           </p>
           <WeightRoomSubNav active="history" className="mt-5" isAdmin={isAdmin} />
         </header>
+
+        {/* Sample data must never read as a real log. Same treatment the
+            Combine and cardio surfaces already use for their preview branch
+            (#160 / #162) — a visible chip plus an exit affordance, rather than
+            demo heatmaps and stats that look exactly like populated ones. */}
+        {isPreviewMode ? (
+          <div className="mt-6">
+            <PreviewModeBadge description="These heatmaps and stats are illustrative — not Lucas’s real training log." />
+          </div>
+        ) : null}
 
         {permanentGoals.length === 0 && focuses.length === 0 ? (
           <section

--- a/e2e/chart-overflow.spec.ts
+++ b/e2e/chart-overflow.spec.ts
@@ -1,0 +1,76 @@
+import { expect, test } from '@playwright/test'
+
+/**
+ * Pins the #355 / #356 class of bug: a chart that sizes itself from its data
+ * must **overflow** its card at phone width so `overflow-x-auto` has something
+ * to scroll, and must **not** overflow at desktop width, where a floor above
+ * the column width would clip every chart behind a scrollbar instead.
+ *
+ * Both ends matter, because fixing one end is what broke the other — #355 gave
+ * the charts a width floor so they'd scroll on a phone, and #356 had to make
+ * that floor breakpoint-aware after it started clipping desktop.
+ *
+ * Runs in two projects: `training-facility-enabled` (Chromium, 1280) asserts
+ * the desktop end, `mobile-webkit` (iPhone 14, 390) the mobile end. The
+ * assertions branch on the measured viewport rather than the project name, so
+ * adding a third width doesn't need a new branch here.
+ *
+ * `?preview=demo` supplies the dataset. The e2e job has no Supabase
+ * credentials, so without it every chart renders empty and this spec would
+ * pass by measuring nothing — hence the explicit "found some charts" guard
+ * before any width assertion.
+ */
+
+/** Below Tailwind's `lg`, where the chart grid is stacked and cards span the viewport. */
+const LG_BREAKPOINT = 1024
+
+test.describe('chart overflow behaviour', () => {
+  test('data-sized charts scroll on a phone and fit on desktop', async ({ page }) => {
+    await page.goto('/training-facility/weight-room/history?preview=demo')
+
+    const heatmaps = page.getByTestId('weight-room-heatmaps')
+    await expect(heatmaps).toBeVisible()
+
+    const measured = await heatmaps.evaluate((section) => {
+      const boxes = [...section.querySelectorAll<HTMLElement>('.overflow-x-auto')]
+      return {
+        viewport: window.innerWidth,
+        count: boxes.length,
+        // A chart "overflows" when its content is wider than the scroll
+        // container — the precondition for `overflow-x-auto` to do anything.
+        overflowing: boxes.filter((el) => el.scrollWidth > el.clientWidth).length,
+        widest: boxes.reduce((max, el) => Math.max(max, el.scrollWidth - el.clientWidth), 0),
+      }
+    })
+
+    // Guard: if the fixture ever stops producing charts, fail loudly rather
+    // than silently asserting over an empty list.
+    expect(measured.count).toBeGreaterThan(0)
+
+    if (measured.viewport < LG_BREAKPOINT) {
+      // #355: at phone width the chart must be wider than its card, or there
+      // is nothing to drag and a season of data is crushed into ~330px.
+      expect(measured.overflowing).toBeGreaterThan(0)
+    } else {
+      // #356: at desktop the chart fills its column and must not force a
+      // horizontal scrollbar, which would clip its right edge.
+      expect(measured.overflowing).toBe(0)
+      expect(measured.widest).toBe(0)
+    }
+  })
+
+  test('the page itself never scrolls horizontally', async ({ page }) => {
+    // Distinct from the chart case: a chart is *meant* to scroll inside its
+    // card, but the document must not. This is the symptom a reader actually
+    // notices — the whole page sliding sideways on a phone.
+    await page.goto('/training-facility/weight-room/history?preview=demo')
+    await expect(page.getByTestId('weight-room-heatmaps')).toBeVisible()
+
+    const doc = await page.evaluate(() => ({
+      scrollWidth: document.documentElement.scrollWidth,
+      clientWidth: document.documentElement.clientWidth,
+    }))
+    // One pixel of slack for sub-pixel layout rounding.
+    expect(doc.scrollWidth).toBeLessThanOrEqual(doc.clientWidth + 1)
+  })
+})

--- a/e2e/svg-fragments.spec.ts
+++ b/e2e/svg-fragments.spec.ts
@@ -1,0 +1,108 @@
+import { expect, test } from '@playwright/test'
+
+import { bypassHomeIntro } from './helpers/intro'
+
+/**
+ * Pins the #353 class of bug: an SVG fragment reference that resolves to
+ * nothing in the document it renders in.
+ *
+ * The centre-court logo used to render as `<use href="/common/LogoSvg.svg#…">`.
+ * A `<use>` pointing at an *external* file builds a shadow tree whose internal
+ * fragment references — `textPath href="#circlePath"`, `filter="url(#…)"` —
+ * resolve against the **host** document, where those ids don't exist. Browsers
+ * disagree here and iOS Safari drops them, so exactly the parts that depended
+ * on a fragment vanished while everything else drew. The mark looked almost
+ * right, which is why it shipped.
+ *
+ * `LogoSvg.test.tsx` already asserts this at the unit level. The gap was that
+ * no *browser* ever rendered the page — a jsdom unit test cannot reproduce an
+ * engine-specific shadow-tree behaviour. This spec closes that by checking the
+ * property against real rendered output, in WebKit.
+ *
+ * Deliberately generic rather than pinned to one component: it asserts the
+ * invariant over whatever the app actually renders, so a future SVG that
+ * reintroduces the pattern is caught without anyone remembering to add a case.
+ * (Related: #383 — `LogoSvg` currently has no consumers, so the original mark
+ * isn't reachable from any route. This check will cover it the moment it is.)
+ */
+
+/** Routes that render substantial SVG artwork and need no credentials to do it. */
+const SVG_HEAVY_ROUTES = ['/', '/locker-room', '/projects', '/contact'] as const
+
+test.describe('SVG fragment references', () => {
+  for (const route of SVG_HEAVY_ROUTES) {
+    test(`every fragment reference on ${route} resolves in its own document`, async ({ page }) => {
+      await bypassHomeIntro(page)
+      await page.goto(route)
+      // Artwork is the point of these routes, so wait for at least one to exist
+      // rather than racing a still-hydrating scene.
+      await expect(page.locator('svg').first()).toBeAttached()
+
+      const broken = await page.evaluate(() => {
+        /** Attributes whose value can be a `url(#id)` reference. */
+        const URL_REF_ATTRS = [
+          'filter',
+          'fill',
+          'stroke',
+          'mask',
+          'clip-path',
+          'marker-start',
+          'marker-mid',
+          'marker-end',
+        ]
+        const unresolved: string[] = []
+
+        const check = (id: string, where: string): void => {
+          if (id === '') return
+          // `getElementById` searches the whole document, which is the right
+          // scope: a reference is satisfied by any element in the same
+          // document, wherever the defs happen to live.
+          if (document.getElementById(id) === null) unresolved.push(`${where} -> #${id}`)
+        }
+
+        for (const el of document.querySelectorAll('svg *')) {
+          for (const attr of URL_REF_ATTRS) {
+            const value = el.getAttribute(attr)
+            if (value === null) continue
+            const match = /^url\(["']?#([^"')]+)["']?\)$/.exec(value.trim())
+            if (match) check(match[1], `<${el.tagName.toLowerCase()} ${attr}>`)
+          }
+          // `textPath`/`use`/`tref` carry the reference on href (or the legacy
+          // xlink:href). Only same-document fragments are checked — an
+          // external-file href is a different mechanism and resolves fine as
+          // long as the target needs no fragments of its own.
+          const href =
+            el.getAttribute('href') ?? el.getAttribute('xlink:href') ?? ''
+          if (href.startsWith('#')) {
+            check(href.slice(1), `<${el.tagName.toLowerCase()} href>`)
+          }
+        }
+        return unresolved
+      })
+
+      expect(broken, `unresolved SVG fragment references on ${route}`).toEqual([])
+    })
+  }
+
+  test('the rendered mark is not missing pieces that depend on fragments', async ({ page }) => {
+    // The #353 symptom specifically: a `textPath` that renders as an empty box
+    // because its path reference was dropped. Asserting a non-zero bounding
+    // box is what a unit test can't do — jsdom has no layout.
+    await bypassHomeIntro(page)
+    await page.goto('/')
+    await expect(page.locator('svg').first()).toBeAttached()
+
+    const emptyTextPaths = await page.evaluate(() => {
+      const offenders: string[] = []
+      for (const tp of document.querySelectorAll('textPath')) {
+        const text = tp.textContent?.trim() ?? ''
+        if (text === '') continue
+        const box = (tp as unknown as SVGGraphicsElement).getBBox?.()
+        if (box && (box.width === 0 || box.height === 0)) offenders.push(text.slice(0, 40))
+      }
+      return offenders
+    })
+
+    expect(emptyTextPaths, 'textPath elements with content but no rendered box').toEqual([])
+  })
+})

--- a/e2e/svg-fragments.spec.ts
+++ b/e2e/svg-fragments.spec.ts
@@ -68,9 +68,7 @@ test.describe('SVG fragment references', () => {
             if (match) check(match[1], `<${el.tagName.toLowerCase()} ${attr}>`)
           }
           // `textPath`/`use`/`tref` carry the reference on href (or the legacy
-          // xlink:href). Only same-document fragments are checked — an
-          // external-file href is a different mechanism and resolves fine as
-          // long as the target needs no fragments of its own.
+          // xlink:href).
           const href =
             el.getAttribute('href') ?? el.getAttribute('xlink:href') ?? ''
           if (href.startsWith('#')) {
@@ -81,6 +79,55 @@ test.describe('SVG fragment references', () => {
       })
 
       expect(broken, `unresolved SVG fragment references on ${route}`).toEqual([])
+    })
+  }
+
+  for (const route of SVG_HEAVY_ROUTES) {
+    test(`no external <use> on ${route} depends on its own fragments`, async ({ page }) => {
+      // This is the #353 mechanism itself, and the in-document check above
+      // cannot see it: `<use href="/file.svg#id">` builds a *shadow* tree, so
+      // the referenced content never appears in `querySelectorAll` and any
+      // fragment it needs resolves against the host document instead of its
+      // own file. The reference looks fine from the page's side right up until
+      // an engine declines to resolve it.
+      //
+      // So the target file has to be fetched and inspected directly: if the
+      // referenced subtree contains `url(#…)` or a `#`-href of its own, that
+      // is the exact arrangement that dropped the ring text on iOS.
+      await bypassHomeIntro(page)
+      await page.goto(route)
+      await expect(page.locator('svg').first()).toBeAttached()
+
+      const externalUses = await page.evaluate(() =>
+        [...document.querySelectorAll('use')]
+          .map((el) => el.getAttribute('href') ?? el.getAttribute('xlink:href') ?? '')
+          .filter((href) => href !== '' && !href.startsWith('#')),
+      )
+
+      const offenders: string[] = []
+      for (const href of new Set(externalUses)) {
+        const [file, fragment] = href.split('#')
+        const res = await page.request.get(new URL(file, page.url()).toString())
+        expect(res.ok(), `<use> target ${file} should be fetchable`).toBe(true)
+        const svgText = await res.text()
+
+        // The referenced fragment's own markup. Scoped to the element with
+        // that id where one is named, so a file holding several symbols is
+        // judged on the part actually being used.
+        const scoped = fragment
+          ? (new RegExp(`id=["']${fragment}["'][\\s\\S]*`).exec(svgText)?.[0] ?? svgText)
+          : svgText
+
+        if (/url\(["']?#/.test(scoped) || /(?:xlink:)?href=["']#/.test(scoped)) {
+          offenders.push(href)
+        }
+      }
+
+      expect(
+        offenders,
+        'external <use> targets that rely on their own internal fragments — ' +
+          'these resolve against the host document and are dropped by WebKit (#353)',
+      ).toEqual([])
     })
   }
 

--- a/playwright.config.test.ts
+++ b/playwright.config.test.ts
@@ -1,0 +1,73 @@
+import { readdirSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+import config from './playwright.config'
+
+/**
+ * Guards the trap #359 called out: each project's `testMatch` is a literal
+ * filename alternation, so a spec file that isn't named in one of them is
+ * **silently never run**. Add a spec, watch CI go green, and have covered
+ * nothing — with no signal anywhere that it happened.
+ *
+ * These assertions are cheap and turn that into a failing test.
+ */
+
+/** Every `*.spec.ts` under `e2e/`, which is what Playwright's `testDir` collects. */
+function specFiles(): string[] {
+  return readdirSync(join(process.cwd(), 'e2e'))
+    .filter((name) => name.endsWith('.spec.ts'))
+    .sort()
+}
+
+/** The projects declared in the Playwright config, narrowed to what this test needs. */
+function projects(): { name: string; testMatch: RegExp }[] {
+  return (config.projects ?? []).map((p) => ({
+    name: String(p.name),
+    testMatch: p.testMatch as RegExp,
+  }))
+}
+
+describe('playwright config', () => {
+  it('finds spec files to check', () => {
+    // Sanity: an empty list would make every assertion below vacuously true.
+    expect(specFiles().length).toBeGreaterThan(0)
+  })
+
+  it('declares every project with a RegExp testMatch', () => {
+    for (const project of projects()) {
+      expect(project.testMatch, `${project.name} testMatch`).toBeInstanceOf(RegExp)
+    }
+  })
+
+  it('runs every e2e spec in at least one project', () => {
+    const all = projects()
+    const orphans = specFiles().filter(
+      (file) => !all.some((project) => project.testMatch.test(file)),
+    )
+    expect(
+      orphans,
+      `spec files matched by no project's testMatch — they would never run:\n  ${orphans.join('\n  ')}`,
+    ).toEqual([])
+  })
+
+  it('has no project whose testMatch selects nothing', () => {
+    // The mirror failure: a project whose alternation names a spec that was
+    // renamed or deleted quietly stops testing anything.
+    const files = specFiles()
+    const empty = projects()
+      .filter((project) => !files.some((file) => project.testMatch.test(file)))
+      .map((project) => project.name)
+    expect(empty, 'projects matching zero specs').toEqual([])
+  })
+
+  it('covers the rendering specs in the mobile project', () => {
+    // The point of #359: these two exist to be run at phone width in WebKit.
+    // If they drop out of `mobile-webkit`, the coverage gap silently reopens.
+    const mobile = projects().find((p) => p.name === 'mobile-webkit')
+    expect(mobile).toBeDefined()
+    expect(mobile?.testMatch.test('svg-fragments.spec.ts')).toBe(true)
+    expect(mobile?.testMatch.test('chart-overflow.spec.ts')).toBe(true)
+  })
+})

--- a/playwright.config.test.ts
+++ b/playwright.config.test.ts
@@ -70,4 +70,22 @@ describe('playwright config', () => {
     expect(mobile?.testMatch.test('svg-fragments.spec.ts')).toBe(true)
     expect(mobile?.testMatch.test('chart-overflow.spec.ts')).toBe(true)
   })
+
+  it('actually runs the mobile project on WebKit', () => {
+    // The subtle half of the same gap. A device descriptor carries
+    // `defaultBrowserType: 'webkit'`, but the top-level
+    // `use.browserName: 'chromium'` is an *explicit* value and wins the merge —
+    // so omitting `browserName` here silently runs Chromium in an iPhone
+    // user-agent. The suite still passes, the engine coverage just isn't there,
+    // and the user-agent string makes it look like it is.
+    const mobile = (config.projects ?? []).find((p) => p.name === 'mobile-webkit')
+    expect(mobile?.use?.browserName).toBe('webkit')
+  })
+
+  it('sizes the mobile project to a phone viewport', () => {
+    const mobile = (config.projects ?? []).find((p) => p.name === 'mobile-webkit')
+    // The other half of what #355/#356 needed: a real phone width, not just a
+    // different engine.
+    expect(mobile?.use?.viewport?.width).toBeLessThanOrEqual(430)
+  })
 })

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from '@playwright/test'
+import { defineConfig, devices } from '@playwright/test'
 
 /** Base URL for the default route smoke-test project. */
 const DEFAULT_BASE_URL = 'http://127.0.0.1:3007'
@@ -34,15 +34,34 @@ export default defineConfig({
     {
       name: 'default-routes',
       testMatch:
-        /(?:home|rooms|project-detail|resume|draft-room-disabled|training-facility-disabled)\.spec\.ts/,
+        /(?:home|rooms|project-detail|resume|draft-room-disabled|training-facility-disabled|svg-fragments)\.spec\.ts/,
       use: {
         baseURL: DEFAULT_BASE_URL,
       },
     },
     {
       name: 'training-facility-enabled',
-      testMatch: /(?:training-facility-enabled|draft-room-enabled|draft-room-live)\.spec\.ts/,
+      testMatch:
+        /(?:training-facility-enabled|draft-room-enabled|draft-room-live|chart-overflow)\.spec\.ts/,
       use: {
+        baseURL: TRAINING_FACILITY_BASE_URL,
+      },
+    },
+    {
+      // The engine + viewport gap that let #353 and #355/#356 ship (#359).
+      // `iPhone 14` is a WebKit device profile, so one project closes both:
+      // WebKit catches engine-level SVG behaviour Chromium papers over, and
+      // 390px is the only width where a chart meant to scroll actually does.
+      //
+      // Deliberately *not* the whole suite under a third browser — the two
+      // existing projects already run every route, and a naive cross-product
+      // triples e2e wall-clock (CI runs `workers: 1`) to re-assert things that
+      // don't vary by engine. This runs only the two specs whose assertions
+      // are about rendering.
+      name: 'mobile-webkit',
+      testMatch: /(?:svg-fragments|chart-overflow)\.spec\.ts/,
+      use: {
+        ...devices['iPhone 14'],
         baseURL: TRAINING_FACILITY_BASE_URL,
       },
     },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -62,6 +62,14 @@ export default defineConfig({
       testMatch: /(?:svg-fragments|chart-overflow)\.spec\.ts/,
       use: {
         ...devices['iPhone 14'],
+        // `browserName` must be set explicitly, *after* the device spread.
+        // The device descriptor carries `defaultBrowserType: 'webkit'`, but
+        // that is only a default — the top-level `use.browserName: 'chromium'`
+        // is an explicit value and wins the merge. Without this line the
+        // project runs Chromium wearing an iPhone user-agent: the viewport
+        // coverage is real, the engine coverage is not, and nothing in the
+        // output says so.
+        browserName: 'webkit',
         baseURL: TRAINING_FACILITY_BASE_URL,
       },
     },


### PR DESCRIPTION
## Why the suite couldn't catch either bug

Both projects in `playwright.config.ts` ran the **default Chromium at a desktop viewport**, and CI installed `chromium` only. So:

- **#353** was an engine-level `<use>` shadow-tree behaviour that iOS Safari exhibits and Chromium doesn't. No amount of Chromium runs would find it.
- **#355 / #356** only reproduce at a real phone width — the chart never overflowed, so `overflow-x-auto` had nothing to scroll.

Both were found by hand, on a phone.

## One project, not six

`devices['iPhone 14']` is a **WebKit** profile at 390px — so a single `mobile-webkit` project closes the engine gap *and* the viewport gap. It runs only the two rendering specs: the existing projects already cover every route, and re-running them under a second engine mostly re-asserts things that don't vary by engine. A naive cross-product would have tripled e2e wall-clock (CI runs `workers: 1`) for that.

| project | browser | viewport | specs |
|---|---|---|---|
| `default-routes` | Chromium | desktop | unchanged + `svg-fragments` |
| `training-facility-enabled` | Chromium | desktop | unchanged + `chart-overflow` |
| **`mobile-webkit`** | **WebKit** | **390×844** | `svg-fragments`, `chart-overflow` |

## The specs

**`chart-overflow.spec.ts`** pins *both ends* of #355/#356, branching on the measured viewport rather than the project name:

- at **390** a data-sized chart must overflow its card, or there's nothing to drag and a season of data is crushed into ~330px
- at **1280** it must *not*, because a floor above the column width clips every chart behind a scrollbar

Both, because fixing one end is exactly what broke the other. Plus a separate assertion that the *document* never scrolls sideways — the symptom a reader actually notices.

**`svg-fragments.spec.ts`** pins #353 **generically**: it asserts every `url(#…)` reference and every same-document `href` resolves within the page it renders in, across four SVG-heavy routes. Deliberately not pinned to one component, so a future SVG reintroducing the pattern is caught without anyone remembering to add a case. It also asserts no `textPath` renders with content but a zero bounding box — the #353 symptom, and something jsdom cannot check because it has no layout.

## Two things that made this real rather than decorative

**1. The chart specs had nothing to measure in CI.** The e2e job has no Supabase credentials, so those routes render empty. I verified this rather than assuming — a server with the env blanked returns **0 charts and 0 SVGs** on `/gym/otf`, `/gym/overview` and `/weight-room/history`. A chart-overflow spec would have passed by finding nothing, which is precisely the "watch CI go green and have covered nothing" trap the issue warns about.

The History page now honours the existing `?preview=demo` fixture, exactly as `/gym` and `/weight-room` already do — gated on the real data being empty, so a populated deploy ignores the param. Verified against a credential-free server:

| | charts found | overflowing | doc scroll |
|---|---|---|---|
| mobile-webkit 390 | 4 | **4** (widest +458px) | 0 |
| desktop-chromium 1280 | 4 | **0** | 0 |

Reintroduce #355 and mobile drops to 0 → fails. Reintroduce #356 and desktop rises above 0 → fails.

**2. `testMatch` is a literal filename alternation**, so a spec not named in one silently never runs. `playwright.config.test.ts` now fails if any spec is matched by no project, or any project matches no spec — plus an explicit assertion that both rendering specs stay in `mobile-webkit`, so the gap can't quietly reopen.

## CI cost

One line — `npx playwright install --with-deps chromium webkit`. The dev servers are already shared via the config's `webServer` array, so the new project reuses them; the added cost is WebKit's system deps at install time. Suite goes 43 → 57 tests.

## Scope notes

- **`/gym/otf` is not covered.** #355/#356 lived there, but there's no OTF demo fixture — only `CARDIO_DEMO_DATA` and `buildWeightRoomDemoData` — so covering it means inventing one, which is real scope inside a test-infra PR. The History heatmaps are the *same* class (`OtfDetailView`'s own comment says "matching the Weight Room heatmap, which has always sized itself from its data and scrolled") and their fixture already exists. Follow-up filed.
- **#383** — while scoping this I found `LogoSvg` and `public/common/LogoSvg.svg` have **no consumers anywhere**. #353 fixed a component that isn't mounted, so there was no route to point a logo assertion at. That's why the SVG spec is generic; it will cover the mark automatically if it's ever wired in.
- WebKit on a Linux runner is not iOS Safari — it shares the engine, not the platform. A real but partial proxy, as the issue says.

## Test plan

- [ ] CI: the Playwright job shows **three** projects and 57 tests
- [ ] `npm run test:e2e` locally — 57 pass
- [ ] Temporarily revert the breakpoint-aware floor in `OtfDetailView` (or set `MOBILE_MIN_CHART_WIDTH = 280`) and confirm the mobile chart-overflow test **fails** — the assertion should have teeth, not just pass
- [ ] Rename any `e2e/*.spec.ts` without updating `playwright.config.ts` and confirm `playwright.config.test.ts` fails
- [ ] `/training-facility/weight-room/history?preview=demo` on a populated deploy still shows **real** data, not the fixture

Verified locally: `tsc --noEmit` clean, `next build` compiles, **1766 unit tests pass (142 files)**, **57 Playwright e2e pass across 3 projects**, `eslint` clean.

Closes #359.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Preview mode now displays illustrative weight-room history data with a clear preview badge when live data is unavailable.
  * Added mobile WebKit coverage for responsive charts and artwork rendering.

* **Bug Fixes**
  * Improved validation of chart overflow behavior across mobile and desktop layouts.
  * Added checks to detect broken SVG references and ensure artwork renders correctly.

* **Tests**
  * Expanded automated browser and configuration tests for responsive layouts, SVGs, and test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->