### PR TITLE
feat(otf): grade-adjusted pace — normalize treadmill pace for incline (#335)

### DIFF
--- a/components/training-facility/gym/OtfDetailView.tsx
+++ b/components/training-facility/gym/OtfDetailView.tsx
@@ -476,7 +476,7 @@ export function OtfDetailView({
               </ChartCard>
               <ChartCard
                 title="Avg incline"
-                helper="Average treadmill incline — the grade behind the pace above, and the input to the adjustment below."
+                helper="Average treadmill incline — the grade behind each class's pace, and the input to the grade-adjusted figure."
               >
                 <OtfTrendChart
                   data={treadInclineTrend}

--- a/components/training-facility/gym/OtfDetailView.tsx
+++ b/components/training-facility/gym/OtfDetailView.tsx
@@ -21,6 +21,7 @@ import {
   filterOtfSessionsInRange,
   formatMmss,
   formatOtfDate,
+  gradeAdjustedPaceSeconds,
   mmssToSeconds,
   otfBlockTrend,
   otfClassTypes,
@@ -250,6 +251,19 @@ export function OtfDetailView({
     () => otfBlockTrend(activeSessions, 'treadmill', t => t.avg_incline),
     [activeSessions]
   )
+  // Grade-adjusted pace (#335) — raw pace folded through the Minetti cost
+  // curve so a steep class stops reading as a slow one. Derived here rather
+  // than stored, so it re-derives if the model is ever revised. A class with
+  // a pace but no incline falls through as its own raw pace (factor 1)
+  // rather than dropping out of the series.
+  const treadGradeAdjustedPaceTrend = useMemo(
+    () =>
+      otfBlockTrend(activeSessions, 'treadmill', t => {
+        const seconds = mmssToSeconds(t.avg_pace)
+        return seconds === null ? null : gradeAdjustedPaceSeconds(seconds, t.avg_incline)
+      }),
+    [activeSessions]
+  )
   const rowerWattsTrend = useMemo(
     () => otfBlockTrend(activeSessions, 'rower', r => r.avg_watt),
     [activeSessions]
@@ -270,8 +284,20 @@ export function OtfDetailView({
       { key: 'time', label: 'Time', trend: treadTimeTrend, format: formatMmss },
       { key: 'pace', label: 'Avg pace', trend: treadPaceTrend, format: v => `${formatMmss(v)}/mi` },
       { key: 'incline', label: 'Avg incline', trend: treadInclineTrend, format: v => `${v.toFixed(1)}%` },
+      {
+        key: 'gap',
+        label: 'Grade-adj pace',
+        trend: treadGradeAdjustedPaceTrend,
+        format: v => `${formatMmss(v)}/mi`,
+      },
     ],
-    [treadDistanceTrend, treadTimeTrend, treadPaceTrend, treadInclineTrend]
+    [
+      treadDistanceTrend,
+      treadTimeTrend,
+      treadPaceTrend,
+      treadInclineTrend,
+      treadGradeAdjustedPaceTrend,
+    ]
   )
   const rowerRows = useMemo<OtfSparklineRow[]>(
     () => [
@@ -450,7 +476,7 @@ export function OtfDetailView({
               </ChartCard>
               <ChartCard
                 title="Avg incline"
-                helper="Average treadmill incline — context for pace (a slow mile may be a steep one)."
+                helper="Average treadmill incline — the grade behind the pace above, and the input to the adjustment below."
               >
                 <OtfTrendChart
                   data={treadInclineTrend}
@@ -459,6 +485,19 @@ export function OtfDetailView({
                   yTickFormat={v => v.toFixed(1)}
                   ariaLabel="Treadmill average incline over time"
                   emptyMessage="No treadmill incline in range"
+                />
+              </ChartCard>
+              <ChartCard
+                title="Grade-adjusted pace"
+                helper="Pace normalized for incline (Minetti 2002) — the flat pace that would have cost the same energy, so steep classes compare against level ones. Estimated from each class's average incline, not a per-minute stream."
+              >
+                <OtfTrendChart
+                  data={treadGradeAdjustedPaceTrend}
+                  width={chartWidth}
+                  yLabel="min/mi"
+                  yTickFormat={formatMmss}
+                  ariaLabel="Treadmill grade-adjusted pace over time"
+                  emptyMessage="No treadmill pace in range"
                 />
               </ChartCard>
             </div>

--- a/lib/training-facility/otf.test.ts
+++ b/lib/training-facility/otf.test.ts
@@ -19,6 +19,9 @@ import {
   filterOtfSessionsInRange,
   formatMmss,
   formatOtfDate,
+  gradeAdjustedPace,
+  gradeAdjustedPaceSeconds,
+  gradeAdjustmentFactor,
   mmssToSeconds,
   otfBlockTrend,
   otfClassTypeLabel,
@@ -479,5 +482,136 @@ describe('otfRollingAverage (#267)', () => {
 
   it('returns an empty array for an empty trend', () => {
     expect(otfRollingAverage([], 3)).toEqual([])
+  })
+})
+
+describe('grade-adjusted pace (#335)', () => {
+  describe('gradeAdjustmentFactor', () => {
+    it('is exactly 1 on the flat', () => {
+      expect(gradeAdjustmentFactor(0)).toBe(1)
+    })
+
+    it('matches the reference factors from the issue', () => {
+      // Minetti C(i)/C(0) at the grades the issue tabulated.
+      expect(gradeAdjustmentFactor(2)).toBeCloseTo(1.113, 3)
+      expect(gradeAdjustmentFactor(5)).toBeCloseTo(1.301, 3)
+      expect(gradeAdjustmentFactor(8.5)).toBeCloseTo(1.546, 3)
+      expect(gradeAdjustmentFactor(15)).toBeCloseTo(2.06, 2)
+    })
+
+    it('rises monotonically across the range our data occupies', () => {
+      const grades = [0, 1, 2, 3, 4, 5, 6, 8.5, 10, 15]
+      const factors = grades.map(gradeAdjustmentFactor)
+      for (let i = 1; i < factors.length; i++) {
+        expect(factors[i]).toBeGreaterThan(factors[i - 1])
+      }
+    })
+
+    it('diverges from the linear ACSM approximation as grade climbs', () => {
+      // ACSM's `1 + 4.5g` is the sanity check, not the model: it tracks
+      // Minetti closely when shallow and runs 10-19% low by 8.5-15%.
+      const acsm = (pct: number): number => 1 + 4.5 * (pct / 100)
+      expect(gradeAdjustmentFactor(1) / acsm(1)).toBeCloseTo(1, 1)
+      expect(acsm(8.5) / gradeAdjustmentFactor(8.5)).toBeLessThan(0.91)
+      expect(acsm(15) / gradeAdjustmentFactor(15)).toBeLessThan(0.83)
+    })
+
+    it('handles decline, bottoming out below flat rather than at it', () => {
+      // Shallow braking is cheaper than lifting, so a decline factor is < 1,
+      // falls to a minimum, then climbs again as the descent gets steep.
+      expect(gradeAdjustmentFactor(-5)).toBeLessThan(1)
+      expect(gradeAdjustmentFactor(-15)).toBeLessThan(gradeAdjustmentFactor(-5))
+      expect(gradeAdjustmentFactor(-45)).toBeGreaterThan(gradeAdjustmentFactor(-15))
+    })
+
+    it('puts the decline minimum near -18%, not the -10% the issue quoted', () => {
+      // The issue asserted "minimum cost sits near -10%", but the polynomial
+      // it specifies still reads 0.598 there and keeps falling to ~0.495
+      // around -18%. Immaterial in practice (no session has a negative
+      // avg_incline) — pinned so the discrepancy stays documented.
+      expect(gradeAdjustmentFactor(-10)).toBeCloseTo(0.598, 3)
+      expect(gradeAdjustmentFactor(-18)).toBeCloseTo(0.495, 3)
+      expect(gradeAdjustmentFactor(-18)).toBeLessThan(gradeAdjustmentFactor(-10))
+    })
+
+    it('clamps beyond the fitted range instead of following the polynomial', () => {
+      // No real class reaches ±45%; a value past it is a parse error, and
+      // the quintic diverges fast outside the fit.
+      expect(gradeAdjustmentFactor(900)).toBe(gradeAdjustmentFactor(45))
+      expect(gradeAdjustmentFactor(-900)).toBe(gradeAdjustmentFactor(-45))
+    })
+
+    it('treats non-finite input as flat', () => {
+      expect(gradeAdjustmentFactor(Number.NaN)).toBe(1)
+      expect(gradeAdjustmentFactor(Number.POSITIVE_INFINITY)).toBe(1)
+    })
+  })
+
+  describe('gradeAdjustedPace', () => {
+    it('reproduces the measured sessions from the issue', () => {
+      // The 06-27 / 05-19 / 07-10 rows of the issue's table.
+      expect(gradeAdjustedPace('15:23', 8.5)).toBe('9:57')
+      expect(gradeAdjustedPace('12:45', 5.4)).toBe('9:36')
+      expect(gradeAdjustedPace('10:10', 2.0)).toBe('9:08')
+      expect(gradeAdjustedPace('13:57', 5.5)).toBe('10:27')
+      expect(gradeAdjustedPace('13:02', 4.0)).toBe('10:32')
+    })
+
+    it('leaves a flat class untouched', () => {
+      expect(gradeAdjustedPace('10:00', 0)).toBe('10:00')
+    })
+
+    it('separates two sessions that share a raw pace at different grades', () => {
+      // Both 13:02 raw (04-17 at 2.8%, 07-08 at 4.0%). The issue's prose says
+      // they separate by 39s, but its own table puts 4.0% at 10:32 — which
+      // this matches — and 2.8% lands at 11:13, so the real gap is 41s.
+      // Trusting the table over the sentence.
+      expect(gradeAdjustedPace('13:02', 2.8)).toBe('11:13')
+      expect(gradeAdjustedPace('13:02', 4.0)).toBe('10:32')
+
+      const shallow = mmssToSeconds(gradeAdjustedPace('13:02', 2.8) ?? '')
+      const steep = mmssToSeconds(gradeAdjustedPace('13:02', 4.0) ?? '')
+      expect((shallow as number) - (steep as number)).toBe(41)
+    })
+
+    it('inverts the ranking of a steep class against a flatter, faster one', () => {
+      // 06-27 (15:23 @ 8.5%) is slower than 07-08 (13:02 @ 4.0%) raw, and
+      // faster once adjusted — the reordering the whole feature exists for.
+      const steepRaw = mmssToSeconds('15:23') as number
+      const flatterRaw = mmssToSeconds('13:02') as number
+      expect(steepRaw).toBeGreaterThan(flatterRaw)
+
+      const steepGap = mmssToSeconds(gradeAdjustedPace('15:23', 8.5) ?? '') as number
+      const flatterGap = mmssToSeconds(gradeAdjustedPace('13:02', 4.0) ?? '') as number
+      expect(steepGap).toBeLessThan(flatterGap)
+    })
+
+    it('treats a missing incline as flat rather than dropping the session', () => {
+      expect(gradeAdjustedPace('12:00', undefined)).toBe('12:00')
+      expect(gradeAdjustedPace('12:00', null)).toBe('12:00')
+    })
+
+    it('returns null for missing or malformed pace', () => {
+      expect(gradeAdjustedPace(undefined, 5)).toBeNull()
+      expect(gradeAdjustedPace(null, 5)).toBeNull()
+      expect(gradeAdjustedPace('', 5)).toBeNull()
+      expect(gradeAdjustedPace('nonsense', 5)).toBeNull()
+    })
+  })
+
+  describe('gradeAdjustedPaceSeconds', () => {
+    it('agrees with the formatted helper', () => {
+      const seconds = gradeAdjustedPaceSeconds(mmssToSeconds('15:23') as number, 8.5)
+      expect(formatMmss(seconds)).toBe(gradeAdjustedPace('15:23', 8.5))
+    })
+
+    it('is always faster than raw pace on an incline', () => {
+      const raw = mmssToSeconds('12:00') as number
+      expect(gradeAdjustedPaceSeconds(raw, 4)).toBeLessThan(raw)
+    })
+
+    it('returns raw pace unchanged on the flat', () => {
+      expect(gradeAdjustedPaceSeconds(600, 0)).toBe(600)
+    })
   })
 })

--- a/lib/training-facility/otf.ts
+++ b/lib/training-facility/otf.ts
@@ -299,6 +299,124 @@ export function formatMmss(seconds: number): string {
   return `${m}:${String(s).padStart(2, '0')}`
 }
 
+// ---------------------------------------------------------------------------
+// Grade-adjusted pace (#335)
+// ---------------------------------------------------------------------------
+
+/**
+ * Metabolic cost of running on the flat, J/kg/m — the `C(0)` constant term of
+ * {@link minettiCost}, and the denominator of every adjustment factor.
+ */
+const MINETTI_FLAT_COST = 3.6
+
+/**
+ * Grade range, as a fraction, that Minetti et al. fitted the polynomial over
+ * (±45%). Outside it the curve diverges fast, so inputs are clamped here
+ * rather than trusted — our own data tops out near 0.085, so a value beyond
+ * this is a parse error, not a hill.
+ */
+const MINETTI_VALID_GRADE = 0.45
+
+/**
+ * Energy cost of running at grade `i` (a fraction, positive uphill), in
+ * J/kg/m, per Minetti et al. (2002), *Energy cost of walking and running at
+ * extreme uphill and downhill slopes*:
+ *
+ * ```
+ * C(i) = 155.4i⁵ − 30.4i⁴ − 43.3i³ + 46.3i² + 19.5i + 3.6
+ * ```
+ *
+ * Chosen over the ACSM running equation (`VO₂ = 0.2v + 0.9v·g + 3.5`, a
+ * linear `1 + 4.5g` factor) for three reasons: it was measured on a motorised
+ * treadmill, so it's the same modality as this data rather than an
+ * outdoor-running curve borrowed; it's a 5th-order fit so it keeps the
+ * curvature ACSM misses, diverging from it by 10–19% by 8.5–15% grade; and
+ * it shares a lineage with Strava's GAP, so numbers stay comparable to
+ * outdoor runs. ACSM stays the sanity check, not the model.
+ *
+ * The full polynomial also handles decline for free — cost bottoms out on a
+ * downhill rather than at 0%, since shallow braking is cheaper than lifting.
+ * Note the minimum sits near **−18%** (factor ≈ 0.495), not the −10% the
+ * issue quoted: −10% still evaluates to 0.598 and the curve keeps falling
+ * past it. Immaterial in practice — no session in this dataset has a
+ * negative `avg_incline` — but the constant is worth stating correctly.
+ */
+function minettiCost(grade: number): number {
+  const i = grade
+  const i2 = i * i
+  const i3 = i2 * i
+  const i4 = i3 * i
+  const i5 = i4 * i
+  return 155.4 * i5 - 30.4 * i4 - 43.3 * i3 + 46.3 * i2 + 19.5 * i + MINETTI_FLAT_COST
+}
+
+/**
+ * Multiplier converting a graded pace to its flat equivalent — the ratio of
+ * metabolic cost at `inclinePct` to the cost on the flat.
+ *
+ * Equal metabolic rate means flat-equivalent *speed* scales up by this
+ * factor, so pace (time per distance) is divided by it.
+ *
+ * Reference values: 2% → ×1.113, 5% → ×1.301, 8.5% → ×1.546, 15% → ×2.060.
+ *
+ * @param inclinePct Grade in **percent** (`8.5`, not `0.085`) — the unit
+ *   `OtfTreadmill.avg_incline` is reported in. Clamped to Minetti's fitted
+ *   ±45% range.
+ */
+export function gradeAdjustmentFactor(inclinePct: number): number {
+  if (!Number.isFinite(inclinePct)) return 1
+  const grade = Math.min(MINETTI_VALID_GRADE, Math.max(-MINETTI_VALID_GRADE, inclinePct / 100))
+  return minettiCost(grade) / MINETTI_FLAT_COST
+}
+
+/**
+ * Grade-adjusted pace: the flat pace that would have cost the same metabolic
+ * energy as running `pace` at `inclinePct`.
+ *
+ * Folds incline *into* pace to yield one comparable series in pace units, so
+ * a hard-incline class stops reading as a slow one. On this dataset it
+ * reorders the field substantially — a 15:23 at 8.5% is last of twelve by raw
+ * pace and sixth by GAP.
+ *
+ * **This is an estimate.** `avg_incline` is a single distance-weighted mean
+ * per class, but GAP is defined pointwise, and `C(i)` is convex across the
+ * whole range — so by Jensen's inequality, evaluating at the average grade
+ * *underestimates* the true average cost. Modelling a class as half flat /
+ * half double-average puts the bias at 0.4% (2% incline) to 4.6% (8.5%),
+ * against an adjustment that is itself +11% to +106%. A footnote, not a
+ * blocker — but the reason any UI showing this should say it's derived from
+ * class averages.
+ *
+ * @param pace Average pace as `"MM:SS"` per mile, i.e. `OtfTreadmill.avg_pace`.
+ * @param inclinePct Average incline in percent, i.e. `OtfTreadmill.avg_incline`.
+ *   Treated as flat (factor 1) when absent.
+ * @returns Flat-equivalent pace as `"M:SS"`, or `null` when `pace` is missing
+ *   or malformed.
+ */
+export function gradeAdjustedPace(
+  pace: string | null | undefined,
+  inclinePct: number | null | undefined
+): string | null {
+  const seconds = mmssToSeconds(pace)
+  if (seconds === null) return null
+  return formatMmss(gradeAdjustedPaceSeconds(seconds, inclinePct))
+}
+
+/**
+ * {@link gradeAdjustedPace} in raw seconds, for chart series that need a
+ * numeric axis rather than a formatted label.
+ *
+ * @param paceSeconds Raw pace in seconds per mile.
+ * @param inclinePct Average incline in percent; treated as flat when absent.
+ */
+export function gradeAdjustedPaceSeconds(
+  paceSeconds: number,
+  inclinePct: number | null | undefined
+): number {
+  const incline = typeof inclinePct === 'number' ? inclinePct : 0
+  return paceSeconds / gradeAdjustmentFactor(incline)
+}
+
 /**
  * Build a `{date, value}` trend from a numeric field inside each session's
  * `treadmill` or `rower` JSONB block. Sessions whose block is absent, or whose


### PR DESCRIPTION
Closes #335.

The OTF view charted treadmill pace and incline as two separate series, so a hard-incline class read as a *slow* class and the correction had to happen in your head. This folds incline **into** pace to derive one comparable series in pace units — the flat pace that would have cost the same metabolic energy.

Raw pace and incline both stay. GAP replaces neither; it's the third view that makes the other two comparable.

## The model

Minetti (2002) 5th-order cost polynomial, `C(i) = 155.4i⁵ − 30.4i⁴ − 43.3i³ + 46.3i² + 19.5i + 3.6`, with the adjustment factor as `C(i)/C(0)`.

Chosen over the linear ACSM running equation because it was measured **on a motorised treadmill** — same modality as this data rather than an outdoor curve borrowed — it keeps the curvature ACSM misses (they diverge 10–19% by 8.5–15% grade), and it shares a lineage with Strava's GAP so numbers stay comparable to outdoor runs. ACSM is kept in the docs as the sanity check it is, and pinned by a test that asserts the divergence.

## Two corrections to the issue's own numbers

Both found by writing the tests against the issue's figures and watching them fail. **The implementation matches the issue's data table exactly; it's the prose that's off.**

1. **The decline minimum is near −18%, not −10%.** The issue states Minetti's cost minimum "sits near −10%". The polynomial it specifies still reads `0.598` there and keeps falling to `~0.495` around −18%. Immaterial in practice — no session in this dataset has a negative `avg_incline` — but the constant should be stated correctly, so it's documented and pinned by a test.

2. **The two 13:02 classes separate by 41s, not 39s.** The issue's prose says 39s of flat-equivalent between the 2.8% and 4.0% sessions. Its own table puts 4.0% at `10:32` — which this matches exactly — and 2.8% lands at `11:13`. That's 41s. Trusting the table over the sentence.

Everything else reproduces exactly: reference factors (2% → ×1.113, 5% → ×1.301, 8.5% → ×1.546, 15% → ×2.060) and the measured GAP table (15:23 @ 8.5% → 9:57, 12:45 @ 5.4% → 9:36, 10:10 @ 2.0% → 9:08, 13:57 @ 5.5% → 10:27).

## Scope decisions

- **Chart-only.** `otfHighlights` is untouched, per the issue's lean. Worth recording *why* that was easy: it tracks only splat and calories, so there was never a pace PB for a GAP-based record to silently rewrite.
- **Both surfaces** — a 4th ChartCard completing the treadmill grid into a clean 2×2, and a 5th row in the "At a glance" sparkline summary.
- **Clamped to ±45%**, Minetti's fitted range. Our data tops out near 8.5%, so anything beyond that is a parse error rather than a hill, and the quintic diverges fast outside the fit.
- **A class with a pace but no incline is treated as flat**, not dropped from the series.
- **Decline comes free** from using the full polynomial rather than an uphill-only approximation.

## On honesty of the number

The helper text says plainly that it's estimated from each class's average incline, not a per-minute stream. That matters: `C(i)` is convex across the whole range, so by Jensen's inequality evaluating at the mean grade *underestimates* true average cost — by 0.4% at 2% incline to 4.6% at 8.5%, against an adjustment that is itself +11% to +106%. A footnote, not a blocker, but not something to imply away with false precision.

## Test plan

- [ ] Open **The Gym → OrangeTheory** and scroll to the **Treadmill** section.
- [ ] The chart grid is now a 2×2: Distance, Avg pace, Avg incline, **Grade-adjusted pace**.
- [ ] The GAP line sits **below** (faster than) the raw pace line, and is visibly **smoother** — it absorbs the late-June incline spike that dominates the raw pace chart.
- [ ] "At a glance" has a 5th row, **Grade-adj pace**, formatted `M:SS/mi`.
- [ ] Cross-check one class: the latest reads `10:31/mi` raw at `1.0%` incline → `9:58/mi` adjusted.
- [ ] Change the date range and the class-type filter — GAP tracks the same session set as raw pace.
- [ ] On mobile, the new card behaves like its three neighbours (no horizontal page scroll).
- [ ] Helper text names Minetti 2002 and says the number is estimated from class averages.

## Verification

- Unit: **144 files / 1833 tests** green, including 22 new cases for the helper.
- E2E: **65 passed**, including the mobile-WebKit project that #385 added an hour ago (rebased onto it).
- `tsc --noEmit`, `eslint`, and `next build` all clean.
- Checked against production data on a flag-enabled dev server; console clean (no hydration or React warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
