### PR TITLE
chore(weight-room): catalog cleanups — drop the dead column, classify by equipment, guard the goal delete (#384)

### DIFF
--- a/app/api/admin/weight-room/goals/[exercise]/route.test.ts
+++ b/app/api/admin/weight-room/goals/[exercise]/route.test.ts
@@ -18,12 +18,29 @@ vi.mock('@/lib/auth/require-admin', () => ({
 }))
 
 const deleteMock = vi.fn()
+const focusMock = vi.fn()
+/**
+ * Table the most recent `.from()` targeted, so `.maybeSingle()` resolves the
+ * right stub. The route reads `weight_room_monthly_focus` first (#384's
+ * active-focus guard) and only then deletes from `weight_room_goals`; a single
+ * shared result would let the guard consume each test's delete stub.
+ */
+let lastTable = ''
 const supabaseChain = {
-  from: vi.fn(() => supabaseChain),
+  from: vi.fn((table: string) => {
+    lastTable = table
+    return supabaseChain
+  }),
   delete: vi.fn(() => supabaseChain),
-  eq: vi.fn(() => supabaseChain),
+  eq: vi.fn((_column: string, _value: unknown) => supabaseChain),
+  // Typed args so `gte.mock.calls[0]` is a readable tuple rather than `[]`.
+  gte: vi.fn((_column: string, _value: string) => supabaseChain),
+  order: vi.fn((_column: string, _options?: unknown) => supabaseChain),
+  limit: vi.fn((_count: number) => supabaseChain),
   select: vi.fn(() => supabaseChain),
-  maybeSingle: vi.fn(() => deleteMock()),
+  maybeSingle: vi.fn(() =>
+    lastTable === 'weight_room_monthly_focus' ? focusMock() : deleteMock(),
+  ),
 }
 vi.mock('@/lib/supabase/admin', () => ({
   createAdminSupabaseClient: () => supabaseChain,
@@ -32,16 +49,32 @@ vi.mock('@/lib/supabase/admin', () => ({
 beforeEach(() => {
   requireAdminMock.mockReset()
   deleteMock.mockReset()
+  focusMock.mockReset()
+  lastTable = ''
   supabaseChain.from.mockClear()
   supabaseChain.delete.mockClear()
   supabaseChain.eq.mockClear()
+  supabaseChain.gte.mockClear()
+  supabaseChain.order.mockClear()
+  supabaseChain.limit.mockClear()
   supabaseChain.select.mockClear()
   supabaseChain.maybeSingle.mockClear()
-  supabaseChain.from.mockReturnValue(supabaseChain)
+  supabaseChain.from.mockImplementation((table: string) => {
+    lastTable = table
+    return supabaseChain
+  })
   supabaseChain.delete.mockReturnValue(supabaseChain)
   supabaseChain.eq.mockReturnValue(supabaseChain)
+  supabaseChain.gte.mockReturnValue(supabaseChain)
+  supabaseChain.order.mockReturnValue(supabaseChain)
+  supabaseChain.limit.mockReturnValue(supabaseChain)
   supabaseChain.select.mockReturnValue(supabaseChain)
-  supabaseChain.maybeSingle.mockImplementation(() => deleteMock())
+  supabaseChain.maybeSingle.mockImplementation(() =>
+    lastTable === 'weight_room_monthly_focus' ? focusMock() : deleteMock(),
+  )
+  // Default: no focus depends on the goal, so the guard waves everything
+  // through and the pre-#384 cases read unchanged.
+  focusMock.mockResolvedValue({ data: null, error: null })
 })
 
 const ctx = (exercise: string) => ({ params: Promise.resolve({ exercise }) })
@@ -99,5 +132,43 @@ describe('DELETE /api/admin/weight-room/goals/[exercise]', () => {
     expect(res.status).toBe(200)
     const body = await res.json()
     expect(body).toEqual(removed)
+  })
+
+  describe('active-focus guard (#384)', () => {
+    beforeEach(() => {
+      requireAdminMock.mockResolvedValue({ ok: true, email: 'a@b.com' })
+    })
+
+    it('refuses with 409 when a focus still runs through a future date', async () => {
+      focusMock.mockResolvedValueOnce({
+        data: { start_date: '2026-08-01', end_date: '2026-08-31' },
+        error: null,
+      })
+      const res = await DELETE(req() as never, ctx('shrugs'))
+      expect(res.status).toBe(409)
+      const body = await res.json()
+      expect(body.error).toMatch(/2026-08-31/)
+      // The delete must not have run — the goal is still there to fix.
+      expect(supabaseChain.delete).not.toHaveBeenCalled()
+    })
+
+    it('only blocks on windows that have not ended yet', async () => {
+      // The route filters with `.gte('end_date', today)`, so a finished focus
+      // never reaches the guard — deleting the goal for a past campaign is
+      // fine, and #363's rotation history is exactly what should outlive it.
+      deleteMock.mockResolvedValueOnce({ data: { exercise: 'shrugs' }, error: null })
+      const res = await DELETE(req() as never, ctx('shrugs'))
+      expect(res.status).toBe(200)
+      const [column, value] = supabaseChain.gte.mock.calls[0]
+      expect(column).toBe('end_date')
+      expect(value).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+    })
+
+    it('returns 500 when the focus lookup itself fails', async () => {
+      focusMock.mockResolvedValueOnce({ data: null, error: { message: 'JWT expired' } })
+      const res = await DELETE(req() as never, ctx('shrugs'))
+      expect(res.status).toBe(500)
+      expect(supabaseChain.delete).not.toHaveBeenCalled()
+    })
   })
 })

--- a/app/api/admin/weight-room/goals/[exercise]/route.ts
+++ b/app/api/admin/weight-room/goals/[exercise]/route.ts
@@ -18,6 +18,7 @@ import { NextResponse, type NextRequest } from 'next/server'
 import { requireAdmin } from '@/lib/auth/require-admin'
 import { createAdminSupabaseClient } from '@/lib/supabase/admin'
 import { withTelemetry } from '@/lib/telemetry/with-telemetry'
+import { pacificDayKey } from '@/lib/training-facility/day-keys'
 
 interface Context {
   params: Promise<{ exercise: string }>
@@ -34,6 +35,7 @@ interface Context {
  * - 401 — not signed in
  * - 403 — not on the allowlist
  * - 404 — no goal exists for `exercise`
+ * - 409 — an active or upcoming monthly focus still depends on this goal (#384)
  * - 500 — unexpected Supabase error
  *
  * @param _request Unused — DELETE has no body. Required by Next.js
@@ -59,6 +61,39 @@ async function handleDELETE(_request: NextRequest, ctx: Context): Promise<NextRe
   }
 
   const supabase = createAdminSupabaseClient()
+
+  // A live or queued monthly focus depends on this goal for its ring (#384).
+  // Before #373 the FK cascaded from here, so deleting the goal took the focus
+  // rows with it — which erased the record that, say, July was shrugs month.
+  // The focus now survives (deliberately: #363's rotation history needs it),
+  // but it would render without its ring, so refuse rather than half-break it.
+  // Past windows are not a blocker: a finished focus is history, and history is
+  // exactly what should outlive the goal.
+  const today = pacificDayKey(new Date())
+  const { data: blockingFocus, error: focusError } = await supabase
+    .from('weight_room_monthly_focus')
+    .select('start_date, end_date')
+    .eq('exercise', trimmed)
+    .gte('end_date', today)
+    .order('start_date', { ascending: true })
+    .limit(1)
+    .maybeSingle()
+
+  if (focusError) {
+    return NextResponse.json(
+      { error: `Failed to check monthly focus: ${focusError.message}` },
+      { status: 500 }
+    )
+  }
+  if (blockingFocus) {
+    return NextResponse.json(
+      {
+        error: `'${trimmed}' has a monthly focus running through ${blockingFocus.end_date}. Remove or end that focus first — deleting the goal now would leave the focus without its daily ring.`,
+      },
+      { status: 409 }
+    )
+  }
+
   const { data, error } = await supabase
     .from('weight_room_goals')
     .delete()

--- a/app/training-facility/weight-room/history/page.tsx
+++ b/app/training-facility/weight-room/history/page.tsx
@@ -140,7 +140,10 @@ export default async function WeightRoomHistoryPage({
     const value = Array.isArray(raw) ? raw[0] : raw
     if (typeof value === 'string' && value !== '') carryParams[key] = value
   }
-  const loads = buildMovementLoads(sets, goals)
+  // The catalog classifies each movement as load- or rep-driven from its
+  // equipment (#384); without it the panel falls back to guessing from the
+  // share of weighted sets.
+  const loads = buildMovementLoads(sets, goals, undefined, data?.exercises ?? [])
   const bodyMass = cardio?.body_mass_trend ?? []
 
   // The relative-strength overlay is featured for pull-ups specifically —

--- a/lib/training-facility/load-management.test.ts
+++ b/lib/training-facility/load-management.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from 'vitest'
 
-import type { StrengthSet } from '@/types/weight-room'
+import type {
+  ExerciseEquipment,
+  StrengthSet,
+  WeightRoomExercise,
+} from '@/types/weight-room'
 
 import { pacificDayKey } from './day-keys'
 import { buildMovementLoads } from './load-management'
@@ -228,5 +232,73 @@ describe('buildMovementLoads', () => {
     ]
     const load = byName(buildMovementLoads(sets, [], NOW)).pushups
     expect(load.acute7d).toBe(60) // the garbage row contributes nothing
+  })
+})
+
+describe('buildMovementLoads — catalog-driven metric (#384)', () => {
+  /** Minimal catalog row; only `slug` and `equipment` affect classification. */
+  function movement(slug: string, equipment: ExerciseEquipment): WeightRoomExercise {
+    return { slug, display_name: slug, equipment, muscle_group: 'full-body' }
+  }
+
+  it('scores a loaded movement by tonnage even when most sets recorded no load', () => {
+    // 1 of 3 sets carries a weight — under the 0.5 threshold, so the pre-#384
+    // heuristic called this rep-driven. The catalog says dumbbell, so the
+    // stress is tonnage and the unweighted sets are a data-entry gap.
+    const sets = [
+      set('2026-07-14', 'shrugs', 20, 60),
+      set('2026-07-14', 'shrugs', 20),
+      set('2026-07-13', 'shrugs', 20),
+    ]
+    const load = byName(
+      buildMovementLoads(sets, [], NOW, [movement('shrugs', 'dumbbell')]),
+    ).shrugs
+    expect(load.metric).toBe('load')
+    expect(load.unitLabel).toBe('lb')
+  })
+
+  it('keeps a loaded movement visible when nothing in the window carried load', () => {
+    // Trusting the catalog unconditionally would score this by a tonnage of
+    // zero, and zero-volume movements are dropped — the movement would
+    // silently disappear from the panel instead of showing its rep volume.
+    const sets = [set('2026-07-14', 'barbell-row', 30), set('2026-07-12', 'barbell-row', 30)]
+    const load = byName(
+      buildMovementLoads(sets, [], NOW, [movement('barbell-row', 'barbell')]),
+    )['barbell-row']
+    expect(load).toBeDefined()
+    expect(load.metric).toBe('reps')
+    expect(load.chronic28d).toBe(60)
+  })
+
+  it('keeps a bodyweight movement rep-driven', () => {
+    const sets = [set('2026-07-14', 'pushups', 100)]
+    const load = byName(
+      buildMovementLoads(sets, [], NOW, [movement('pushups', 'bodyweight')]),
+    ).pushups
+    expect(load.metric).toBe('reps')
+  })
+
+  it('still flips a bodyweight movement to load when it carries added weight', () => {
+    // Weighted pull-ups: catalog says bodyweight, but a dip belt makes the
+    // stress genuinely load-driven, so the threshold still gets a say.
+    const sets = [
+      set('2026-07-14', 'pullups', 5, 45),
+      set('2026-07-13', 'pullups', 5, 45),
+      set('2026-07-12', 'pullups', 5),
+    ]
+    const load = byName(
+      buildMovementLoads(sets, [], NOW, [movement('pullups', 'bodyweight')]),
+    ).pullups
+    expect(load.metric).toBe('load')
+  })
+
+  it('falls back to the pre-#384 threshold for a movement absent from the catalog', () => {
+    const sets = [
+      set('2026-07-14', 'mystery', 10, 50),
+      set('2026-07-13', 'mystery', 10, 50),
+    ]
+    // No catalog at all — identical to omitting the argument entirely.
+    expect(byName(buildMovementLoads(sets, [], NOW, [])).mystery.metric).toBe('load')
+    expect(byName(buildMovementLoads(sets, [], NOW)).mystery.metric).toBe('load')
   })
 })

--- a/lib/training-facility/load-management.test.ts
+++ b/lib/training-facility/load-management.test.ts
@@ -292,6 +292,23 @@ describe('buildMovementLoads — catalog-driven metric (#384)', () => {
     expect(load.metric).toBe('load')
   })
 
+  it("treats 'other' as unclassified, not as a loaded implement", () => {
+    // `ensureWeightRoomExercise` stamps 'other' on every movement provisioned
+    // by the goal form or the focus anchor, so it means "nobody has said yet".
+    // Reading it as loaded would score this mostly-bodyweight movement by
+    // tonnage off its single weighted set.
+    const sets = [
+      set('2026-07-14', 'newmove', 20, 25),
+      set('2026-07-13', 'newmove', 20),
+      set('2026-07-12', 'newmove', 20),
+    ]
+    const load = byName(
+      buildMovementLoads(sets, [], NOW, [movement('newmove', 'other')]),
+    ).newmove
+    expect(load.metric).toBe('reps')
+    expect(load.chronic28d).toBe(60)
+  })
+
   it('falls back to the pre-#384 threshold for a movement absent from the catalog', () => {
     const sets = [
       set('2026-07-14', 'mystery', 10, 50),

--- a/lib/training-facility/load-management.ts
+++ b/lib/training-facility/load-management.ts
@@ -132,7 +132,12 @@ export interface MovementLoad {
  *   without loads would silently vanish from the panel instead of showing its
  *   rep volume.
  *
- * A movement absent from the catalog keeps the pre-#384 behavior exactly.
+ * `'other'` is treated as *unclassified*, not as a loaded implement. It's the
+ * fallback `ensureWeightRoomExercise` stamps on any movement provisioned by the
+ * goal form or the monthly-focus anchor, so it means "nobody has said yet" —
+ * reading it as loaded would score a mostly-bodyweight new movement by tonnage
+ * off a single weighted set. A movement absent from the catalog entirely gets
+ * the same treatment, so both keep the pre-#384 behavior exactly.
  *
  * @param equipment The movement's catalog equipment, or `undefined` when it has
  *   no catalog row.
@@ -146,8 +151,11 @@ function isLoadDriven(
   inWindowWeighted: number,
 ): boolean {
   const meetsThreshold = inWindowWeighted / inWindowSets >= LOADED_SET_FRACTION
-  if (equipment === undefined) return meetsThreshold
-  if (equipment === 'bodyweight') return meetsThreshold
+  // Unknown classification, or a bodyweight movement that may be carrying
+  // added load — the sets are the better evidence in both cases.
+  if (equipment === undefined || equipment === 'other' || equipment === 'bodyweight') {
+    return meetsThreshold
+  }
   return inWindowWeighted > 0
 }
 

--- a/lib/training-facility/load-management.ts
+++ b/lib/training-facility/load-management.ts
@@ -5,7 +5,12 @@ import {
   FLAG_SEVERITY,
   type RampFlag,
 } from '@/constants/ramp-rate'
-import type { ExerciseGoal, StrengthSet } from '@/types/weight-room'
+import type {
+  ExerciseEquipment,
+  ExerciseGoal,
+  StrengthSet,
+  WeightRoomExercise,
+} from '@/types/weight-room'
 
 import { pacificDayKey, shiftDayKey } from './day-keys'
 
@@ -41,6 +46,11 @@ const CHRONIC_DAYS = 28
  * like pull-ups stays rep-based even if it has the occasional weighted
  * set. Decided over the chronic window (not all history) so a movement
  * that recently switched loading regime is scored on its current scale.
+ *
+ * Since #384 this is the *fallback*: a movement in the exercise catalog is
+ * classified from its `equipment` instead — see {@link isLoadDriven}. The
+ * threshold still decides movements the catalog doesn't know, and still
+ * decides bodyweight movements that carry added load.
  */
 const LOADED_SET_FRACTION = 0.5
 
@@ -105,6 +115,43 @@ export interface MovementLoad {
 }
 
 /**
+ * Decide whether a movement's ramp is driven by **load volume** (tonnage) or
+ * **rep volume**.
+ *
+ * Catalog-first as of #384: `equipment` states how a movement is loaded, which
+ * is a fact rather than the inference the share-of-weighted-sets threshold was
+ * making. Two deliberate exceptions keep it honest:
+ *
+ * - **A bodyweight movement that carries added load still falls back to the
+ *   threshold.** Weighted pull-ups and dip-belt dips are `equipment:
+ *   'bodyweight'` but their stress genuinely is load-driven once the belt goes
+ *   on, and the catalog can't know that from the movement alone.
+ * - **A loaded movement with nothing weighted in the window falls back to
+ *   reps.** Trusting the catalog there would score it by a tonnage of zero,
+ *   and the caller drops zero-volume movements — so a barbell movement logged
+ *   without loads would silently vanish from the panel instead of showing its
+ *   rep volume.
+ *
+ * A movement absent from the catalog keeps the pre-#384 behavior exactly.
+ *
+ * @param equipment The movement's catalog equipment, or `undefined` when it has
+ *   no catalog row.
+ * @param inWindowSets Sets inside the chronic window. Never `0` — the caller
+ *   skips dormant movements before calling.
+ * @param inWindowWeighted How many of those carried a positive `weight_lbs`.
+ */
+function isLoadDriven(
+  equipment: ExerciseEquipment | undefined,
+  inWindowSets: number,
+  inWindowWeighted: number,
+): boolean {
+  const meetsThreshold = inWindowWeighted / inWindowSets >= LOADED_SET_FRACTION
+  if (equipment === undefined) return meetsThreshold
+  if (equipment === 'bodyweight') return meetsThreshold
+  return inWindowWeighted > 0
+}
+
+/**
  * Build one {@link MovementLoad} per actively-ramped movement from raw
  * set rows. A movement is included only when it has volume in the
  * trailing 28-day chronic window — dormant movements (last trained months
@@ -122,14 +169,20 @@ export interface MovementLoad {
  *   color lookup.
  * @param now override for the "today" anchor of every window. Defaults to
  *   `new Date()`; tests pass a fixed instant for determinism.
+ * @param exercises the movement catalog (#384), used to classify each movement
+ *   as load- or rep-driven from its `equipment` rather than guessing from the
+ *   share of weighted sets. Omitted or missing a movement falls back to the
+ *   pre-#384 threshold — see {@link isLoadDriven}.
  */
 export function buildMovementLoads(
   sets: readonly StrengthSet[],
   goals: readonly ExerciseGoal[] = [],
   now: Date = new Date(),
+  exercises: readonly WeightRoomExercise[] = [],
 ): MovementLoad[] {
   const todayKey = pacificDayKey(now)
   const colorByExercise = new Map(goals.map(g => [g.exercise, g.color]))
+  const equipmentByExercise = new Map(exercises.map(e => [e.slug, e.equipment]))
 
   // Precompute the trailing chronic-window day keys once — they're shared
   // by every movement. Index 0 is today; index CHRONIC_DAYS-1 is the
@@ -179,7 +232,11 @@ export function buildMovementLoads(
     // the panel only shows what's actively being ramped.
     if (inWindowSets === 0) continue
 
-    const loaded = inWindowWeighted / inWindowSets >= LOADED_SET_FRACTION
+    const loaded = isLoadDriven(
+      equipmentByExercise.get(movement),
+      inWindowSets,
+      inWindowWeighted,
+    )
     const volByOffset = loaded ? loadByOffset : repByOffset
 
     let chronic28d = 0

--- a/supabase/migrations/20260801120000_drop_weight_room_goals_load_multiplier.sql
+++ b/supabase/migrations/20260801120000_drop_weight_room_goals_load_multiplier.sql
@@ -1,0 +1,18 @@
+-- Drop the dead `weight_room_goals.load_multiplier` column (#384, follow-up to #373).
+--
+-- #373 moved this column to `weight_room_exercises` — it describes how a
+-- movement is performed, so it has to exist for movements that have no daily
+-- goal at all. The data layer has joined it back onto `ExerciseGoal` from the
+-- catalog since that migration, and `GOALS_COLUMNS` stopped selecting the goals
+-- copy in the same commit, so nothing has read this column since.
+--
+-- It could not be dropped in #373 itself: production applies migrations *ahead*
+-- of the code that lands with them (see CLAUDE.md), so dropping it while the
+-- deployed build still named it in its `select` would have broken the live
+-- Weight Room read for the window between apply and promote. That window has
+-- closed — production promoted the catalog build (4403960) before this ran.
+--
+-- Idempotent, and harmless on a fresh project where the column never existed.
+
+alter table public.weight_room_goals
+  drop column if exists load_multiplier;


### PR DESCRIPTION
Three of the six follow-ups from #384 — the ones that were deferred for **sequencing** rather than scope. The remaining three (display_name rollout, monthly-focus settings UI, achievements multiplier) stay open on that issue; see below for why.

## 1. Drop `weight_room_goals.load_multiplier`

`20260801120000_drop_weight_room_goals_load_multiplier.sql`, applied to **both** projects (`migrations:check` clean: 27 committed, 27 applied).

#373 moved this column to `weight_room_exercises` and stopped selecting it in the same commit, but couldn't drop it there: production applies migrations ahead of the code that lands with them, so a drop would have broken the live Weight Room read for the window between apply and promote. Confirmed production promoted the catalog build (`4403960`, 01:52) before applying this, and verified afterwards that `shrugs = 2` survives in the catalog where it now lives.

## 2. Classify the load panel by `equipment`, not by guessing

`buildMovementLoads` decided whether a movement's ramp was load- or rep-driven from the *share of its sets carrying a weight* against a 0.5 threshold. The catalog states `equipment` outright, so that's now the primary signal — with two deliberate fallbacks, both of which have tests:

- **A bodyweight movement that carries added load still uses the threshold.** Weighted pull-ups and dip-belt dips are `equipment: 'bodyweight'`, but the stress genuinely is load-driven once the belt is on, and the catalog can't know that from the movement alone.
- **A loaded movement with nothing weighted in the window falls back to reps.** Trusting the catalog there would score it on a tonnage of zero, and the caller drops zero-volume movements — so a barbell movement logged without loads would silently *vanish* from the panel rather than show its rep volume.

A movement absent from the catalog behaves exactly as before.

**The one behavior change** is that a catalog-loaded movement where *some* sets recorded a weight now scores by tonnage where the threshold previously said reps (e.g. 1-of-3 weighted shrug sets). Tonnage is the right stress proxy for a loaded movement, and missing weights are a data-entry gap rather than a modeling question.

**On current data it changes nothing.** Every movement with sets in the trailing 28-day window is unambiguous, so old and new agree exactly:

| movement | equipment | sets (28d) | weighted share | metric |
|---|---|---|---|---|
| shrugs | dumbbell | 125 | 1.00 | load (unchanged) |
| pushups | bodyweight | 288 | 0.00 | reps (unchanged) |
| pullups | bodyweight | 203 | 0.00 | reps (unchanged) |
| squats | bodyweight | 210 | 0.00 | reps (unchanged) |

So this is insurance for the gym movements arriving in #376, not a live re-scoring.

## 3. Guard the goal DELETE against a live monthly focus

Repointing `weight_room_monthly_focus.exercise` at the catalog in #373 means a focus row now survives its goal being deleted. That's deliberate — cascading was the same footgun as the sets cascade, and #363's rotation history needs past windows to outlive the goal — but a *live* focus would render without its daily ring.

So the DELETE now refuses with a 409 naming the end date when a focus is active or upcoming (`end_date >= today`). **Finished windows never block**, which is the point: a completed campaign is history, and history is exactly what should outlive the goal.

## Not in this PR

- **display_name rollout** and **monthly-focus settings UI** — both are real UI work (~10 components plus Playwright text assertions for the first), and mixing them with a schema drop makes an awkward review. Left on #384.
- **Achievements multiplier** — deliberately held. Pooled tiers (`exercise IS NULL`) mean "all movements", so fixing the multiplier without first deciding whether pooled includes gym lifts bakes in that answer ahead of #377, which owns it. It only has to land before #376.

## Test plan

- [ ] `/training-facility/weight-room/history` — Load Management panel renders; shrugs still reads in `lb`, pushups/pullups/squats still read in `reps`.
- [ ] Same page — heatmaps, weekly volume, and per-exercise stats unchanged (the `load_multiplier` join still feeds tonnage from the catalog).
- [ ] `/training-facility/weight-room` — rings and streaks unchanged.
- [ ] **Settings → Exercises**: deleting the `shrugs` goal should be refused with a 409 naming the focus end date, since a focus window is live. Deleting a goal with no active focus should still work and keep its sets.
- [ ] `/training-facility/weight-room/log` — logging a set still works.

Verified locally: `tsc --noEmit` clean, `next build` compiles, 1848 unit tests pass, 65/65 Playwright pass, `migrations:check` clean.

Refs #384.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
