### PR TITLE
test(weight-room): harness for the Log View island's wiring (#366)

### DIFF
--- a/components/training-facility/weight-room/LogDataIsland.test.tsx
+++ b/components/training-facility/weight-room/LogDataIsland.test.tsx
@@ -1,5 +1,7 @@
+import { StrictMode } from 'react'
+
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
 import type { WeightRoomData } from '@/types/weight-room'
@@ -224,54 +226,79 @@ describe('LogDataIsland — write orchestration', () => {
 
   it('surfaces a failed write without wiping the loaded data', async () => {
     const user = userEvent.setup()
-    fetchMock.mockResolvedValue({ ok: false, json: async () => ({ error: 'nope' }) })
+    fetchMock.mockResolvedValue({
+      ok: false,
+      json: async () => ({ error: 'set rejected by the API' }),
+    })
     render(<LogDataIsland />)
     await screen.findByTestId('activity-rings')
 
     await user.click(await screen.findByTestId('quick-log-pullups-10'))
 
-    // The island keeps rendering; a write failure is not a data-loss event.
-    await waitFor(() => expect(fetchMock).toHaveBeenCalled())
+    // The API's own message has to reach the user — a write that fails
+    // silently is worse than one that fails loudly, because the admin walks
+    // away believing the set is logged.
+    const alert = await screen.findByRole('alert')
+    expect(alert).toHaveTextContent(/set rejected by the API/i)
+
+    // ...and the loaded data survives: a failed write is not a data-loss event.
     expect(screen.getByTestId('activity-rings')).toBeInTheDocument()
   })
 })
 
 describe('LogDataIsland — stale response guard', () => {
-  it('does not let a slow mount fetch clobber fresher post-write data', async () => {
-    // The request-id guard exists for exactly this interleaving: a mount
-    // fetch that resolves *after* a write-triggered refetch would otherwise
-    // paint pre-write data over post-write data, and the admin would watch
-    // their just-logged set vanish.
-    const user = userEvent.setup()
-
-    let resolveSlowMount: (v: WeightRoomData) => void = () => {}
-    const slowMount = new Promise<WeightRoomData>((r) => {
-      resolveSlowMount = r
+  it('ignores a stale read that lands after a newer one', async () => {
+    // The guard's real interleaving is React's double-invoked mount effect:
+    // effect runs (id 1), cleanup bumps to 2, effect runs again (id 3). Two
+    // reads are genuinely in flight, and the first is already stale by the
+    // time it resolves. Without the guard its late response paints over the
+    // current one.
+    //
+    // Reaching this through the UI isn't possible — the surface only renders
+    // once a read has resolved, and `busy` disables the log buttons while a
+    // write is in flight, so two overlapping refetches can't be triggered by
+    // clicking. StrictMode is where this actually happens.
+    let resolveStale: (v: WeightRoomData) => void = () => {}
+    const stalePending = new Promise<WeightRoomData>((r) => {
+      resolveStale = r
     })
 
-    // The set the refetch discovers, absent from the stale mount payload.
-    const afterWrite = fixture()
-    afterWrite.sets = [
-      ...afterWrite.sets,
+    // What the *current* read returns: the fixture plus a second set.
+    const fresh = fixture()
+    fresh.sets = [
+      ...fresh.sets,
       { id: 'set-2', logged_at: `${PAST_DAY}T20:00:00Z`, exercise: 'pullups', reps: 10 },
     ]
 
-    getWeightRoomDataMock.mockReturnValueOnce(slowMount)
-    getWeightRoomDataMock.mockResolvedValue(afterWrite)
+    getWeightRoomDataMock.mockReturnValueOnce(stalePending) // first (abandoned) mount
+    getWeightRoomDataMock.mockResolvedValue(fresh) // the mount that counts
 
-    render(<LogDataIsland />)
-    expect(screen.getByTestId('log-loading')).toBeInTheDocument()
+    render(
+      <StrictMode>
+        <LogDataIsland />
+      </StrictMode>,
+    )
 
-    // Resolve the mount fetch so the surface renders, then log — the write's
-    // refetch takes a newer request id.
-    resolveSlowMount(fixture())
     await selectDay(PAST_DAY)
-    await screen.findByTestId('set-row-set-1')
-
-    await user.click(await screen.findByTestId('quick-log-pullups-10'))
-    await waitFor(() => expect(getWeightRoomDataMock).toHaveBeenCalledTimes(2))
-
-    // The refetched set is present and stays present.
+    // The current read won: both sets are on screen.
     expect(await screen.findByTestId('set-row-set-2')).toBeInTheDocument()
+
+    // Now the abandoned read finally lands, carrying data without set-2.
+    //
+    // Flushed inside `act` rather than asserted behind `waitFor`: waitFor
+    // succeeds on its first check, so it would return *before* the stale
+    // response was ever processed and the test would pass no matter what the
+    // component did with it. Draining the microtask queue here means the
+    // stale `setData` has definitely run by the time we assert.
+    await act(async () => {
+      resolveStale(fixture())
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    // It must have been discarded. Without the request-id check, set-2
+    // disappears and the admin watches a set they just logged vanish.
+    expect(screen.getByTestId('set-row-set-2')).toBeInTheDocument()
+    expect(screen.getByTestId('set-row-set-1')).toBeInTheDocument()
   })
 })

--- a/components/training-facility/weight-room/LogDataIsland.test.tsx
+++ b/components/training-facility/weight-room/LogDataIsland.test.tsx
@@ -1,0 +1,277 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import type { WeightRoomData } from '@/types/weight-room'
+
+import { LogDataIsland } from './LogDataIsland'
+
+/**
+ * Harness for the Log View's client island (#366).
+ *
+ * Everything this island *composes* — rings, quick-log, set list, streak
+ * badges — has its own test file. What had none was the island itself: the
+ * fetch/error/race orchestration and the day-scoping that decides which
+ * numbers those children are handed. That gap is why the #365 regression
+ * shipped, where pointing the day picker at a past date scored it against
+ * today's target.
+ *
+ * So these tests deliberately assert the *wiring*, not the children's
+ * rendering. The `ActivityRings` accessible label ("pullups 30 of 30") is the
+ * cheapest honest window onto what the island actually passed down.
+ *
+ * `getWeightRoomData` is stubbed at the data layer, matching
+ * `CombineDataIsland.test.tsx`; the write paths go through global `fetch`, so
+ * that is stubbed too.
+ */
+
+const getWeightRoomDataMock = vi.fn<() => Promise<WeightRoomData | null>>()
+
+vi.mock('@/lib/data/weight-room', async () => {
+  const actual =
+    await vi.importActual<typeof import('@/lib/data/weight-room')>('@/lib/data/weight-room')
+  return { ...actual, getWeightRoomData: () => getWeightRoomDataMock() }
+})
+
+/**
+ * A day far enough in the past that it can't collide with the real "today"
+ * the component computes at mount, and that sits before the goal's raise.
+ */
+const PAST_DAY = '2020-07-15'
+
+/**
+ * Pullups at 50/day now, but 30/day back when {@link PAST_DAY} was logged.
+ * The gap between the two is the whole point: a day scored against the wrong
+ * one is off by a number the assertions can see.
+ */
+function fixture(): WeightRoomData {
+  return {
+    imported_at: '2020-07-15T19:00:00Z',
+    goals: [
+      {
+        exercise: 'pullups',
+        daily_target: 50,
+        color: '#0EA5A1',
+        target_history: [
+          { daily_target: 30, effective_from: '2020-01-01' },
+          { daily_target: 50, effective_from: '2021-01-01' },
+        ],
+      },
+    ],
+    sets: [
+      // 19:00Z is midday Pacific year-round, so this buckets to PAST_DAY in
+      // the Pacific day-keying the app uses (#319) regardless of the runner.
+      { id: 'set-1', logged_at: `${PAST_DAY}T19:00:00Z`, exercise: 'pullups', reps: 30 },
+    ],
+    monthly_focus: [],
+  }
+}
+
+/** The rings' accessible label, which spells out "<exercise> <reps> of <target>". */
+async function ringsLabel(): Promise<string> {
+  const rings = await screen.findByTestId('activity-rings')
+  return rings.querySelector('svg')?.getAttribute('aria-label') ?? ''
+}
+
+/**
+ * Point the day picker at `day`.
+ *
+ * `fireEvent.change` rather than `user.type`: the picker is a controlled
+ * `<input type="date">` whose handler ignores anything that isn't already a
+ * complete `YYYY-MM-DD`, so character-by-character typing never yields a
+ * value it accepts. A date input is set wholesale by real users too — the
+ * native picker emits one change, not ten.
+ */
+async function selectDay(day: string): Promise<void> {
+  const input = await screen.findByTestId('log-day-input')
+  fireEvent.change(input, { target: { value: day } })
+}
+
+let fetchMock: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  getWeightRoomDataMock.mockReset()
+  getWeightRoomDataMock.mockResolvedValue(fixture())
+  fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) })
+  vi.stubGlobal('fetch', fetchMock)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('LogDataIsland — day scoping (#365 regression)', () => {
+  it('scores a past day against the target that was live that day', async () => {
+    render(<LogDataIsland />)
+    await selectDay(PAST_DAY)
+
+    // 30 reps against the 30 goal in force in 2020 — not 30 against today's
+    // 50, which is what reading `goal.daily_target` directly produced.
+    await waitFor(async () => {
+      expect(await ringsLabel()).toContain('pullups 30 of 30')
+    })
+  })
+
+  it('scores today against the current target', async () => {
+    render(<LogDataIsland />)
+    // No sets today, and the 2021 raise is the newest entry.
+    await waitFor(async () => {
+      expect(await ringsLabel()).toContain('pullups 0 of 50')
+    })
+  })
+
+  it('shows the past day’s sets, not today’s', async () => {
+    render(<LogDataIsland />)
+    // Today has no sets at all.
+    expect(await screen.findByTestId('set-list-empty')).toBeInTheDocument()
+
+    await selectDay(PAST_DAY)
+    expect(await screen.findByTestId('set-row-set-1')).toBeInTheDocument()
+  })
+
+  it('keeps streaks all-time when the viewed day changes', async () => {
+    // Streaks span the whole log by design, so they must not follow the
+    // picker — the one thing on this surface that is deliberately *not*
+    // day-scoped.
+    render(<LogDataIsland />)
+    const before = (await screen.findByText(/longest/i)).closest('div')?.textContent
+
+    await selectDay(PAST_DAY)
+    await screen.findByTestId('set-row-set-1')
+
+    const after = (await screen.findByText(/longest/i)).closest('div')?.textContent
+    expect(after).toBe(before)
+  })
+})
+
+describe('LogDataIsland — load states', () => {
+  it('shows the loading state until the first fetch settles', async () => {
+    let resolve: (v: WeightRoomData) => void = () => {}
+    getWeightRoomDataMock.mockReturnValue(
+      new Promise<WeightRoomData>((r) => {
+        resolve = r
+      }),
+    )
+    render(<LogDataIsland />)
+    expect(screen.getByTestId('log-loading')).toBeInTheDocument()
+
+    resolve(fixture())
+    await screen.findByTestId('activity-rings')
+  })
+
+  it('distinguishes a fetch failure from genuinely empty tables', async () => {
+    // The split matters: an empty database should invite the admin to log a
+    // set, whereas a transient Supabase blip must not masquerade as "no data
+    // yet" and imply the log is gone.
+    getWeightRoomDataMock.mockRejectedValue(new Error('supabase exploded'))
+    render(<LogDataIsland />)
+
+    expect(await screen.findByText(/supabase exploded/i)).toBeInTheDocument()
+  })
+
+  it('renders the log surface with no error banner when the tables are empty', async () => {
+    getWeightRoomDataMock.mockResolvedValue(null)
+    render(<LogDataIsland />)
+
+    // Empty is a legitimate steady state — no goals configured yet.
+    expect(await screen.findByText(/add one in settings/i)).toBeInTheDocument()
+    expect(screen.queryByText(/failed to load/i)).toBeNull()
+  })
+})
+
+describe('LogDataIsland — write orchestration', () => {
+  it('stamps a backdated log with the selected day, not now', async () => {
+    const user = userEvent.setup()
+    render(<LogDataIsland />)
+    await selectDay(PAST_DAY)
+    await screen.findByTestId('set-row-set-1')
+
+    await user.click(await screen.findByTestId('quick-log-pullups-10'))
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled())
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe('/api/admin/weight-room/sets')
+    const body = JSON.parse((init as RequestInit).body as string)
+    expect(body.exercise).toBe('pullups')
+    expect(body.reps).toBe(10)
+    // Pacific midday of the picked day (#319), so the set buckets back onto
+    // the square the admin was looking at rather than an adjacent one.
+    expect(body.logged_at).toBe(`${PAST_DAY}T19:00:00.000Z`)
+  })
+
+  it('omits logged_at for a same-day log so the API keeps its now() default', async () => {
+    const user = userEvent.setup()
+    render(<LogDataIsland />)
+    await screen.findByTestId('activity-rings')
+
+    await user.click(await screen.findByTestId('quick-log-pullups-10'))
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled())
+    const body = JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string)
+    expect(body.logged_at).toBeUndefined()
+  })
+
+  it('refetches after a successful log so the new set appears', async () => {
+    const user = userEvent.setup()
+    render(<LogDataIsland />)
+    await screen.findByTestId('activity-rings')
+    expect(getWeightRoomDataMock).toHaveBeenCalledTimes(1)
+
+    await user.click(await screen.findByTestId('quick-log-pullups-10'))
+
+    await waitFor(() => expect(getWeightRoomDataMock).toHaveBeenCalledTimes(2))
+  })
+
+  it('surfaces a failed write without wiping the loaded data', async () => {
+    const user = userEvent.setup()
+    fetchMock.mockResolvedValue({ ok: false, json: async () => ({ error: 'nope' }) })
+    render(<LogDataIsland />)
+    await screen.findByTestId('activity-rings')
+
+    await user.click(await screen.findByTestId('quick-log-pullups-10'))
+
+    // The island keeps rendering; a write failure is not a data-loss event.
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled())
+    expect(screen.getByTestId('activity-rings')).toBeInTheDocument()
+  })
+})
+
+describe('LogDataIsland — stale response guard', () => {
+  it('does not let a slow mount fetch clobber fresher post-write data', async () => {
+    // The request-id guard exists for exactly this interleaving: a mount
+    // fetch that resolves *after* a write-triggered refetch would otherwise
+    // paint pre-write data over post-write data, and the admin would watch
+    // their just-logged set vanish.
+    const user = userEvent.setup()
+
+    let resolveSlowMount: (v: WeightRoomData) => void = () => {}
+    const slowMount = new Promise<WeightRoomData>((r) => {
+      resolveSlowMount = r
+    })
+
+    // The set the refetch discovers, absent from the stale mount payload.
+    const afterWrite = fixture()
+    afterWrite.sets = [
+      ...afterWrite.sets,
+      { id: 'set-2', logged_at: `${PAST_DAY}T20:00:00Z`, exercise: 'pullups', reps: 10 },
+    ]
+
+    getWeightRoomDataMock.mockReturnValueOnce(slowMount)
+    getWeightRoomDataMock.mockResolvedValue(afterWrite)
+
+    render(<LogDataIsland />)
+    expect(screen.getByTestId('log-loading')).toBeInTheDocument()
+
+    // Resolve the mount fetch so the surface renders, then log — the write's
+    // refetch takes a newer request id.
+    resolveSlowMount(fixture())
+    await selectDay(PAST_DAY)
+    await screen.findByTestId('set-row-set-1')
+
+    await user.click(await screen.findByTestId('quick-log-pullups-10'))
+    await waitFor(() => expect(getWeightRoomDataMock).toHaveBeenCalledTimes(2))
+
+    // The refetched set is present and stays present.
+    expect(await screen.findByTestId('set-row-set-2')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Why this gap existed

Every component `LogDataIsland` composes — `ActivityRings`, `QuickLog`, `SetList`, `StreakBadge`, `LogDayPicker` — has its own test file. The island had none, because it fetches its own data via `getWeightRoomData()` and nothing existed to hang a test on.

That is precisely how the #365 regression shipped: pointing the day picker at a past date scored it against **today's** target, and the fix went in with no test. Second time day-scoping has gone wrong on this surface.

## What's covered

The **wiring**, not the children's rendering — each child is already tested directly, so re-asserting them through a slower mounted parent buys nothing.

| | why it's only testable here |
|---|---|
| past day scores against that day's target | the #365 regression itself |
| today scores against the current target | the other side of the same branch |
| the picker swaps which day's sets show | day-scoping reaches `SetList` too |
| streaks stay all-time as the picker moves | the one thing deliberately *not* day-scoped |
| fetch failure ≠ empty tables | a Supabase blip must not read as "your log is gone" |
| backdated log stamps the selected day | `logged_at` is computed at tap time, not render time |
| same-day log omits `logged_at` | so the API keeps its `now()` default |
| write → refetch | the contract that makes a new set appear |
| a failed write doesn't wipe loaded data | |
| slow mount fetch can't clobber post-write data | the `requestIdRef` guard, invisible from outside |

## The regression test bites

A test that can't fail isn't coverage. Temporarily reverting the #365 fix — `forSelectedDay` back to an identity function — fails exactly one test and nothing else:

```
× scores a past day against the target that was live that day
  Tests  1 failed | 11 passed (12)
```

Restored, all 12 pass.

## Notes on approach

- **Mocks `getWeightRoomData` at the data layer**, matching `CombineDataIsland.test.tsx`, which is the existing precedent for a client island in this repo. Writes go through global `fetch`, so that's stubbed too.
- **Day selection uses `fireEvent.change`, not `user.type`.** `LogDayPicker` is a controlled `<input type="date">` whose handler rejects anything that isn't already a complete `YYYY-MM-DD`, so per-character typing never yields a value it accepts. A native date picker also emits one change, not ten — so this is closer to the real interaction, not a workaround.
- **The fixture's dates are fixed in 2020**, well before any plausible "today", with the goal raised 30 → 50 effective 2021. That keeps the assertions deterministic without fake timers, and makes a mis-scored day off by a visible number rather than a subtle one.
- Set timestamps use `19:00Z` — midday Pacific year-round — so they bucket to the intended day under the Pacific day-keying from #319 regardless of the runner's timezone.

## Heads-up on #376

This component is slated for a substantial rewrite in **#376** (live workout recording), which the gym-workouts epic owns. That's an argument *for* landing this now rather than against: the rewrite gets a behavioural safety net it currently doesn't have. The tests assert observable output (the rings' accessible label, rendered set rows, the request body) rather than internals, so they should survive a restructure that preserves behaviour — and fail loudly on one that doesn't.

## Test plan

- [ ] `npx vitest run components/training-facility/weight-room/LogDataIsland.test.tsx` — 12 pass
- [ ] **Confirm it bites**: in `LogDataIsland.tsx`, change `forSelectedDay` to `(goal) => goal`, re-run, and see exactly one failure; revert
- [ ] `npm test` — full suite green (1861)
- [ ] `/training-facility/weight-room/log` still behaves: pick a past day, rings/set list follow it, logging stamps that day, "Back to today" resets

No behaviour changes — this PR adds a test file and touches no source.

Verified locally: `tsc --noEmit` clean, `next build` compiles, **1861 unit tests pass (146 files)**, `eslint` clean. E2E skipped: no route, DOM, or component source changed.

Closes #366.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded coverage for weight-room logging, including daily goals, historical entries, streaks, loading and empty states.
  - Added validation for successful and failed saves, backdated entries, data refreshes, and protection against outdated responses.
  - Improves confidence that training logs and progress indicators remain accurate and reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->