### PR TITLE
feat(weight-room): workout sessions — group sets into a bounded workout (#374)

### DIFF
--- a/app/api/admin/weight-room/sets/route.ts
+++ b/app/api/admin/weight-room/sets/route.ts
@@ -27,8 +27,9 @@ import { withTelemetry } from '@/lib/telemetry/with-telemetry'
  * - 400 — payload failed Zod validation or wasn't valid JSON
  * - 401 — not signed in
  * - 403 — signed in but email not on the allowlist
- * - 409 — `exercise` isn't in the `weight_room_exercises` roster (FK
- *   violation; add it via the settings catalog first)
+ * - 409 — `exercise` isn't in the `weight_room_exercises` roster (add it via
+ *   the settings catalog first), or `workout_id` names a session that doesn't
+ *   exist (#374)
  * - 500 — unexpected Supabase error
  *
  * @param request Incoming JSON request whose body matches
@@ -71,6 +72,11 @@ async function handlePOST(request: NextRequest): Promise<NextResponse> {
     // than writing an empty-string bucket the History View would have
     // to special-case.
     ...(entry.variant != null ? { variant: entry.variant } : {}),
+    // Session membership (#374), only when the caller asked for it. There is
+    // deliberately no "attach to whatever workout is open" fallback: a
+    // grease-the-groove set logged during a gym window must stay loose.
+    ...(entry.workout_id != null ? { workout_id: entry.workout_id } : {}),
+    ...(entry.position != null ? { position: entry.position } : {}),
   }
   const { data, error } = await supabase
     .from('weight_room_sets')
@@ -79,10 +85,19 @@ async function handlePOST(request: NextRequest): Promise<NextResponse> {
     .single()
 
   if (error) {
-    // Postgres FK violation — exercise isn't in the weight_room_exercises
-    // roster (#373). Note the movement does NOT need a daily goal to be
-    // loggable any more; it only needs a catalog row.
+    // Postgres FK violation. Two FKs can fire here now, so name the right one
+    // — blaming the exercise for a bad workout_id sends the caller to the
+    // settings page to fix something that isn't broken. The violated
+    // constraint's name is in the message; match on the workout FK first
+    // since the exercise one is the far more common case and reads as the
+    // sensible default.
     if (error.code === '23503') {
+      if (error.message.includes('workout_id')) {
+        return NextResponse.json(
+          { error: `Workout '${entry.workout_id}' does not exist.` },
+          { status: 409 }
+        )
+      }
       return NextResponse.json(
         {
           error: `Exercise '${entry.exercise}' is not in the movement catalog. Add it in settings before logging sets.`,

--- a/app/api/admin/weight-room/workouts/[id]/route.test.ts
+++ b/app/api/admin/weight-room/workouts/[id]/route.test.ts
@@ -1,0 +1,183 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextResponse } from 'next/server'
+
+import { DELETE, PATCH } from './route'
+
+/**
+ * Tests for the workout-session item endpoints (#374). The behaviour worth
+ * pinning: deleting a session must never delete its sets, ending validates the
+ * window against the *stored* start, and reopening can collide with the
+ * one-open-session rule.
+ */
+
+const requireAdminMock = vi.fn()
+vi.mock('@/lib/auth/require-admin', () => ({
+  requireAdmin: () => requireAdminMock(),
+}))
+
+interface Results {
+  /** `select started_at ... maybeSingle()` — the stored-window read. */
+  read: { data: unknown; error: unknown }
+  /** `update ... maybeSingle()`. */
+  update: { data: unknown; error: unknown }
+  /** `delete ... maybeSingle()`. */
+  remove: { data: unknown; error: unknown }
+}
+
+let results: Results
+let updates: Record<string, unknown>[]
+
+function makeChain() {
+  let isUpdate = false
+  let isDelete = false
+
+  const chain: Record<string, unknown> = {
+    select: vi.fn(() => chain),
+    eq: vi.fn(() => chain),
+    update: vi.fn((row: Record<string, unknown>) => {
+      isUpdate = true
+      updates.push(row)
+      return chain
+    }),
+    delete: vi.fn(() => {
+      isDelete = true
+      return chain
+    }),
+    maybeSingle: vi.fn(() =>
+      Promise.resolve(isUpdate ? results.update : isDelete ? results.remove : results.read),
+    ),
+  }
+  return chain
+}
+
+const fromMock = vi.fn(() => makeChain())
+vi.mock('@/lib/supabase/admin', () => ({
+  createAdminSupabaseClient: () => ({ from: fromMock }),
+}))
+
+beforeEach(() => {
+  requireAdminMock.mockReset()
+  requireAdminMock.mockResolvedValue({ ok: true, email: 'a@b.com' })
+  fromMock.mockClear()
+  updates = []
+  results = {
+    read: { data: { started_at: '2026-07-15T18:00:00Z' }, error: null },
+    update: { data: { id: 'w1', started_at: '2026-07-15T18:00:00Z' }, error: null },
+    remove: { data: { id: 'w1', started_at: '2026-07-15T18:00:00Z' }, error: null },
+  }
+})
+
+const ctx = (id: string) => ({ params: Promise.resolve({ id }) })
+
+function patchRequest(body: unknown): Request {
+  return new Request('http://localhost/api/admin/weight-room/workouts/w1', {
+    method: 'PATCH',
+    headers: { 'content-type': 'application/json' },
+    body: typeof body === 'string' ? body : JSON.stringify(body),
+  })
+}
+
+const deleteRequest = () =>
+  new Request('http://localhost/api/admin/weight-room/workouts/w1', { method: 'DELETE' })
+
+describe('PATCH /api/admin/weight-room/workouts/[id]', () => {
+  it('returns 401 when not signed in', async () => {
+    requireAdminMock.mockResolvedValueOnce({
+      ok: false,
+      response: NextResponse.json({ error: 'Sign in required.' }, { status: 401 }),
+    })
+    const res = await PATCH(patchRequest({ ended_at: '2026-07-15T19:00:00Z' }) as never, ctx('w1'))
+    expect(res.status).toBe(401)
+  })
+
+  it('rejects an empty patch', async () => {
+    const res = await PATCH(patchRequest({}) as never, ctx('w1'))
+    expect(res.status).toBe(400)
+  })
+
+  it('ends a session', async () => {
+    const res = await PATCH(patchRequest({ ended_at: '2026-07-15T19:00:00Z' }) as never, ctx('w1'))
+    expect(res.status).toBe(200)
+    expect(updates[0].ended_at).toBe('2026-07-15T19:00:00Z')
+  })
+
+  it('validates ended_at against the stored start, not the caller', async () => {
+    const res = await PATCH(patchRequest({ ended_at: '2026-07-15T17:00:00Z' }) as never, ctx('w1'))
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.error).toMatch(/before started_at/i)
+    expect(updates).toHaveLength(0)
+  })
+
+  it('404s when ending a workout that does not exist', async () => {
+    results.read = { data: null, error: null }
+    const res = await PATCH(patchRequest({ ended_at: '2026-07-15T19:00:00Z' }) as never, ctx('nope'))
+    expect(res.status).toBe(404)
+  })
+
+  it('accepts ended_at: null to reopen a mis-ended session', async () => {
+    const res = await PATCH(patchRequest({ ended_at: null }) as never, ctx('w1'))
+    expect(res.status).toBe(200)
+    expect(updates[0].ended_at).toBeNull()
+  })
+
+  it('maps a unique violation on reopen to 409', async () => {
+    results.update = { data: null, error: { code: '23505', message: 'duplicate key' } }
+    const res = await PATCH(patchRequest({ ended_at: null }) as never, ctx('w1'))
+    expect(res.status).toBe(409)
+    const body = await res.json()
+    expect(body.error).toMatch(/already in progress/i)
+  })
+
+  it('maps a malformed uuid to 404 rather than a 500', async () => {
+    results.update = { data: null, error: { code: '22P02', message: 'invalid input syntax' } }
+    const res = await PATCH(patchRequest({ title: 'Push Day' }) as never, ctx('not-a-uuid'))
+    expect(res.status).toBe(404)
+  })
+
+  it('clears the title when it is patched to whitespace', async () => {
+    // PATCH semantics: emptying the field in an editor and saving means
+    // "remove the title", so it must write null. Collapsing it to undefined
+    // would make the save a silent no-op and the old title would persist.
+    await PATCH(patchRequest({ title: '   ' }) as never, ctx('w1'))
+    expect(updates[0].title).toBeNull()
+  })
+
+  it('leaves untouched fields out of the update entirely', async () => {
+    // Absent key means "leave this alone" — it must not reach Supabase as an
+    // undefined that could be read as a clear.
+    await PATCH(patchRequest({ title: 'Push Day' }) as never, ctx('w1'))
+    expect(updates[0]).not.toHaveProperty('notes')
+    expect(updates[0]).not.toHaveProperty('location')
+    expect(updates[0]).not.toHaveProperty('ended_at')
+  })
+})
+
+describe('DELETE /api/admin/weight-room/workouts/[id]', () => {
+  it('returns 200 with the removed row', async () => {
+    const res = await DELETE(deleteRequest() as never, ctx('w1'))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.id).toBe('w1')
+  })
+
+  it('404s for an unknown id', async () => {
+    results.remove = { data: null, error: null }
+    const res = await DELETE(deleteRequest() as never, ctx('nope'))
+    expect(res.status).toBe(404)
+  })
+
+  it('never issues a delete against weight_room_sets', async () => {
+    // The sets survive as loose sets via `on delete set null`. If this route
+    // ever starts touching the sets table, that is training history being
+    // destroyed by a container delete — the exact bug #373 removed.
+    await DELETE(deleteRequest() as never, ctx('w1'))
+    expect(fromMock).not.toHaveBeenCalledWith('weight_room_sets')
+  })
+
+  it('maps a malformed uuid to 404', async () => {
+    results.remove = { data: null, error: { code: '22P02', message: 'invalid input syntax' } }
+    const res = await DELETE(deleteRequest() as never, ctx('not-a-uuid'))
+    expect(res.status).toBe(404)
+  })
+})

--- a/app/api/admin/weight-room/workouts/[id]/route.ts
+++ b/app/api/admin/weight-room/workouts/[id]/route.ts
@@ -16,6 +16,7 @@ import { requireAdmin } from '@/lib/auth/require-admin'
 import { WeightRoomWorkoutUpdateSchema } from '@/lib/schemas/weight-room'
 import { createAdminSupabaseClient } from '@/lib/supabase/admin'
 import { withTelemetry } from '@/lib/telemetry/with-telemetry'
+import { endsBeforeStart } from '@/lib/training-facility/workout-sessions'
 
 interface Context {
   params: Promise<{ id: string }>
@@ -102,7 +103,17 @@ async function handlePATCH(request: NextRequest, ctx: Context): Promise<NextResp
     if (!existing) {
       return NextResponse.json({ error: `No workout for '${workoutId}'.` }, { status: 404 })
     }
-    if (patch.ended_at < existing.started_at) {
+    // Instants, not strings: ISO 8601 only sorts lexicographically when every
+    // value shares one UTC offset, and this codebase mixes `Z` with Pacific
+    // offsets. See {@link endsBeforeStart}.
+    const inverted = endsBeforeStart(existing.started_at, patch.ended_at)
+    if (inverted === null) {
+      return NextResponse.json(
+        { error: 'ended_at must be a valid ISO 8601 timestamp.' },
+        { status: 400 }
+      )
+    }
+    if (inverted) {
       return NextResponse.json(
         { error: 'ended_at cannot be before started_at.' },
         { status: 400 }

--- a/app/api/admin/weight-room/workouts/[id]/route.ts
+++ b/app/api/admin/weight-room/workouts/[id]/route.ts
@@ -1,0 +1,207 @@
+/**
+ * Admin-only item endpoints for Weight Room workout sessions (#374) — end /
+ * rename / annotate, and delete.
+ *
+ * DELETE removes the *session*, never its sets. `weight_room_sets.workout_id`
+ * is `on delete set null`, so the sets fall back to loose sets — exactly what
+ * they were before the session existed. Deleting a container must not delete
+ * training history; that lesson is the whole reason #373 moved the roster off a
+ * cascading FK.
+ */
+
+import { NextResponse, type NextRequest } from 'next/server'
+import { ZodError } from 'zod'
+
+import { requireAdmin } from '@/lib/auth/require-admin'
+import { WeightRoomWorkoutUpdateSchema } from '@/lib/schemas/weight-room'
+import { createAdminSupabaseClient } from '@/lib/supabase/admin'
+import { withTelemetry } from '@/lib/telemetry/with-telemetry'
+
+interface Context {
+  params: Promise<{ id: string }>
+}
+
+/** Columns echoed back by both handlers, matching `WeightRoomWorkoutRowSchema`. */
+const WORKOUT_COLUMNS = 'id, started_at, ended_at, title, location, notes'
+
+/** Postgres `invalid_text_representation` — a route segment that isn't a UUID. */
+const INVALID_UUID = '22P02'
+
+/**
+ * End, rename, or annotate a session. Body must conform to
+ * {@link WeightRoomWorkoutUpdateSchema} — every field optional, at least one
+ * required.
+ *
+ * Ending is `{ ended_at }`. Passing `ended_at: null` **reopens** a session,
+ * which is the escape hatch for a mis-tapped "end" — it can fail with 409 when
+ * another session is already open, since only one may be in progress.
+ *
+ * Status codes:
+ * - 200 — updated (response echoes the row)
+ * - 400 — invalid JSON, failed Zod validation, or `ended_at` before `started_at`
+ * - 401 / 403 — not signed in / not on the allowlist
+ * - 404 — no workout with that id
+ * - 409 — reopening would leave two sessions in progress
+ * - 500 — unexpected Supabase error
+ *
+ * @param request Incoming JSON request whose body matches
+ *   {@link WeightRoomWorkoutUpdateSchema}.
+ * @param ctx Next.js route context; `ctx.params.id` is the workout UUID.
+ * @throws when Supabase env vars are missing (misconfigured deploy).
+ */
+async function handlePATCH(request: NextRequest, ctx: Context): Promise<NextResponse> {
+  const auth = await requireAdmin()
+  if (!auth.ok) return auth.response
+
+  const { id } = await ctx.params
+  const workoutId = id.trim()
+  if (workoutId.length === 0) {
+    return NextResponse.json({ error: 'id must be non-empty.' }, { status: 400 })
+  }
+
+  let payload: unknown
+  try {
+    payload = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Body must be valid JSON.' }, { status: 400 })
+  }
+
+  let patch
+  try {
+    patch = WeightRoomWorkoutUpdateSchema.parse(payload)
+  } catch (err) {
+    if (err instanceof ZodError) {
+      return NextResponse.json(
+        { error: 'Validation failed.', issues: err.flatten() },
+        { status: 400 }
+      )
+    }
+    throw err
+  }
+
+  const supabase = createAdminSupabaseClient()
+
+  // Validate the window against the stored start rather than trusting the
+  // caller, so a 400 explains the problem instead of a 500 wrapping the CHECK.
+  if (typeof patch.ended_at === 'string') {
+    const { data: existing, error: readError } = await supabase
+      .from('weight_room_workouts')
+      .select('started_at')
+      .eq('id', workoutId)
+      .maybeSingle()
+
+    if (readError) {
+      if (readError.code === INVALID_UUID) {
+        return NextResponse.json({ error: `No workout for '${workoutId}'.` }, { status: 404 })
+      }
+      return NextResponse.json(
+        { error: `Failed to read workout: ${readError.message}` },
+        { status: 500 }
+      )
+    }
+    if (!existing) {
+      return NextResponse.json({ error: `No workout for '${workoutId}'.` }, { status: 404 })
+    }
+    if (patch.ended_at < existing.started_at) {
+      return NextResponse.json(
+        { error: 'ended_at cannot be before started_at.' },
+        { status: 400 }
+      )
+    }
+  }
+
+  // Zod's field transforms always materialize the key, so an omitted field
+  // arrives as `title: undefined` rather than as an absent key. Strip those or
+  // "leave this alone" becomes indistinguishable from "clear this" — the exact
+  // distinction {@link clearableTextField} exists to preserve.
+  const changes: Record<string, unknown> = { updated_at: new Date().toISOString() }
+  for (const [key, value] of Object.entries(patch)) {
+    if (value !== undefined) changes[key] = value
+  }
+
+  const { data, error } = await supabase
+    .from('weight_room_workouts')
+    .update(changes)
+    .eq('id', workoutId)
+    .select(WORKOUT_COLUMNS)
+    .maybeSingle()
+
+  if (error) {
+    if (error.code === INVALID_UUID) {
+      return NextResponse.json({ error: `No workout for '${workoutId}'.` }, { status: 404 })
+    }
+    // Reopening while another session is open trips the partial unique index.
+    if (error.code === '23505') {
+      return NextResponse.json(
+        {
+          error:
+            'Another workout is already in progress, so this one cannot be reopened. End that one first.',
+        },
+        { status: 409 }
+      )
+    }
+    return NextResponse.json(
+      { error: `Failed to update workout: ${error.message}` },
+      { status: 500 }
+    )
+  }
+  if (!data) {
+    return NextResponse.json({ error: `No workout for '${workoutId}'.` }, { status: 404 })
+  }
+  return NextResponse.json(data, { status: 200 })
+}
+
+/**
+ * Delete a session. Its sets survive as loose sets — `workout_id` is
+ * `on delete set null`, so no training history is lost.
+ *
+ * Status codes:
+ * - 200 — deleted (response echoes the removed row)
+ * - 400 — empty `id` segment
+ * - 401 / 403 — not signed in / not on the allowlist
+ * - 404 — no workout with that id
+ * - 500 — unexpected Supabase error
+ *
+ * @param _request Unused — DELETE has no body. Required by the Next.js handler
+ *   signature.
+ * @param ctx Next.js route context; `ctx.params.id` is the workout UUID.
+ * @throws when Supabase env vars are missing (misconfigured deploy).
+ */
+async function handleDELETE(_request: NextRequest, ctx: Context): Promise<NextResponse> {
+  const auth = await requireAdmin()
+  if (!auth.ok) return auth.response
+
+  const { id } = await ctx.params
+  const workoutId = id.trim()
+  if (workoutId.length === 0) {
+    return NextResponse.json({ error: 'id must be non-empty.' }, { status: 400 })
+  }
+
+  const supabase = createAdminSupabaseClient()
+  const { data, error } = await supabase
+    .from('weight_room_workouts')
+    .delete()
+    .eq('id', workoutId)
+    .select(WORKOUT_COLUMNS)
+    .maybeSingle()
+
+  if (error) {
+    if (error.code === INVALID_UUID) {
+      return NextResponse.json({ error: `No workout for '${workoutId}'.` }, { status: 404 })
+    }
+    return NextResponse.json(
+      { error: `Failed to delete workout: ${error.message}` },
+      { status: 500 }
+    )
+  }
+  if (!data) {
+    return NextResponse.json({ error: `No workout for '${workoutId}'.` }, { status: 404 })
+  }
+  return NextResponse.json(data, { status: 200 })
+}
+
+/** `handlePATCH` wrapped with one-event-per-request telemetry (#220). */
+export const PATCH = withTelemetry('PATCH /api/admin/weight-room/workouts/[id]', handlePATCH)
+
+/** `handleDELETE` wrapped with one-event-per-request telemetry (#220). */
+export const DELETE = withTelemetry('DELETE /api/admin/weight-room/workouts/[id]', handleDELETE)

--- a/app/api/admin/weight-room/workouts/route.test.ts
+++ b/app/api/admin/weight-room/workouts/route.test.ts
@@ -166,6 +166,16 @@ describe('POST /api/admin/weight-room/workouts', () => {
     expect(res.status).toBe(201)
   })
 
+  it('rejects an unparseable started_at even with no ended_at to compare against', async () => {
+    // The window check below only runs when ended_at is supplied, so without
+    // this guard a garbage started_at would reach Postgres as a 500.
+    const res = await POST(postRequest({ started_at: 'tuesday' }) as never)
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.error).toMatch(/started_at must be a valid ISO/i)
+    expect(inserts).toHaveLength(0)
+  })
+
   it('rejects an unparseable ended_at with a 400 rather than passing it to Postgres', async () => {
     const res = await POST(
       postRequest({ started_at: '2026-08-01T10:00:00Z', ended_at: 'yesterday' }) as never,

--- a/app/api/admin/weight-room/workouts/route.test.ts
+++ b/app/api/admin/weight-room/workouts/route.test.ts
@@ -33,6 +33,8 @@ let results: Results
 /** Every write the route issued, for assertion. */
 let updates: Record<string, unknown>[]
 let inserts: Record<string, unknown>[]
+/** `.is(column, value)` filters applied to an update chain. */
+let updateFilters: [string, unknown][]
 
 function freshResults(): Results {
   return {
@@ -63,8 +65,11 @@ function makeChain(table: string) {
       return chain
     }),
     limit: vi.fn(() => chain),
-    is: vi.fn(() => {
-      isOpenProbe = true
+    is: vi.fn((column: string, value: unknown) => {
+      // On an update chain this is the conditional-close guard; anywhere else
+      // it's the open-session probe.
+      if (isUpdate) updateFilters.push([column, value])
+      else isOpenProbe = true
       return chain
     }),
     insert: vi.fn((row: Record<string, unknown>) => {
@@ -108,6 +113,7 @@ beforeEach(() => {
   results = freshResults()
   updates = []
   inserts = []
+  updateFilters = []
   vi.useRealTimers()
 })
 
@@ -146,6 +152,27 @@ describe('POST /api/admin/weight-room/workouts', () => {
   it('rejects an unknown field via .strict()', async () => {
     const res = await POST(postRequest({ sneaky: 1 }) as never)
     expect(res.status).toBe(400)
+  })
+
+  it('accepts a window whose end sorts before its start but is later in time', async () => {
+    // 05:00-07:00 is 12:00Z — two hours after 10:00Z. A string comparison
+    // would reject this valid session.
+    const res = await POST(
+      postRequest({
+        started_at: '2026-08-01T10:00:00Z',
+        ended_at: '2026-08-01T05:00:00-07:00',
+      }) as never,
+    )
+    expect(res.status).toBe(201)
+  })
+
+  it('rejects an unparseable ended_at with a 400 rather than passing it to Postgres', async () => {
+    const res = await POST(
+      postRequest({ started_at: '2026-08-01T10:00:00Z', ended_at: 'yesterday' }) as never,
+    )
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.error).toMatch(/valid ISO/i)
   })
 
   it('rejects ended_at before started_at with a 400, not a constraint 500', async () => {
@@ -188,6 +215,18 @@ describe('POST /api/admin/weight-room/workouts', () => {
     // invent two days of session that never happened.
     expect(updates[0].ended_at).toBe(lastSetAt)
     expect(inserts).toHaveLength(1)
+  })
+
+  it('closes a stale session only while it is still open', async () => {
+    // Without the `ended_at is null` filter, a request that explicitly ended
+    // this session between the probe and the update would have its chosen
+    // ended_at silently overwritten by the auto-end timestamp.
+    const startedAt = new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString()
+    results.openWorkout = { data: { id: 'w-stale', started_at: startedAt }, error: null }
+
+    await POST(postRequest({}) as never)
+
+    expect(updateFilters).toContainEqual(['ended_at', null])
   })
 
   it('never ends a stale session before it started', async () => {

--- a/app/api/admin/weight-room/workouts/route.test.ts
+++ b/app/api/admin/weight-room/workouts/route.test.ts
@@ -1,0 +1,275 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextResponse } from 'next/server'
+
+import { GET, POST } from './route'
+
+/**
+ * Tests for the workout-session collection endpoints (#374). Auth gate and the
+ * Supabase service-role client are mocked; the route's own logic — the
+ * stale-session rule, the open-slot 409, and after-the-fact recording — is
+ * exercised in isolation.
+ */
+
+const requireAdminMock = vi.fn()
+vi.mock('@/lib/auth/require-admin', () => ({
+  requireAdmin: () => requireAdminMock(),
+}))
+
+/** Programmed results, keyed by the logical query the route issues. */
+interface Results {
+  /** `select ... is('ended_at', null)` on workouts — the open-session probe. */
+  openWorkout: { data: unknown; error: unknown }
+  /** `select logged_at` on sets — newest set in the stale session. */
+  lastSet: { data: unknown; error: unknown }
+  /** `update` on workouts — auto-closing the stale session. */
+  closeStale: { error: unknown }
+  /** `insert ... single()` on workouts — the new session. */
+  insert: { data: unknown; error: unknown }
+  /** `select ... order ... limit` on workouts — the list read. */
+  list: { data: unknown; error: unknown }
+}
+
+let results: Results
+/** Every write the route issued, for assertion. */
+let updates: Record<string, unknown>[]
+let inserts: Record<string, unknown>[]
+
+function freshResults(): Results {
+  return {
+    openWorkout: { data: null, error: null },
+    lastSet: { data: null, error: null },
+    closeStale: { error: null },
+    insert: { data: { id: 'w-new', started_at: '2026-07-15T18:00:00.000Z' }, error: null },
+    list: { data: [], error: null },
+  }
+}
+
+/**
+ * Chainable, thenable Supabase stub. Each chain records which table it targets
+ * and which terminal it hit, so a test can program one leg without knowing the
+ * route's exact call order.
+ */
+function makeChain(table: string) {
+  let isOpenProbe = false
+  let isUpdate = false
+  let isInsert = false
+  let isList = false
+
+  const chain: Record<string, unknown> = {
+    select: vi.fn(() => chain),
+    eq: vi.fn(() => chain),
+    order: vi.fn(() => {
+      isList = true
+      return chain
+    }),
+    limit: vi.fn(() => chain),
+    is: vi.fn(() => {
+      isOpenProbe = true
+      return chain
+    }),
+    insert: vi.fn((row: Record<string, unknown>) => {
+      isInsert = true
+      inserts.push(row)
+      return chain
+    }),
+    update: vi.fn((row: Record<string, unknown>) => {
+      isUpdate = true
+      updates.push(row)
+      return chain
+    }),
+    maybeSingle: vi.fn(() => {
+      if (table === 'weight_room_sets') return Promise.resolve(results.lastSet)
+      if (isOpenProbe) return Promise.resolve(results.openWorkout)
+      return Promise.resolve(results.list)
+    }),
+    single: vi.fn(() => Promise.resolve(results.insert)),
+    then: (onFulfilled: (v: unknown) => unknown, onRejected?: (e: unknown) => unknown) => {
+      const settled = isUpdate
+        ? results.closeStale
+        : isInsert
+          ? results.insert
+          : isList
+            ? results.list
+            : results.openWorkout
+      return Promise.resolve(settled).then(onFulfilled, onRejected)
+    },
+  }
+  return chain
+}
+
+const fromMock = vi.fn((table: string) => makeChain(table))
+vi.mock('@/lib/supabase/admin', () => ({
+  createAdminSupabaseClient: () => ({ from: fromMock }),
+}))
+
+beforeEach(() => {
+  requireAdminMock.mockReset()
+  fromMock.mockClear()
+  results = freshResults()
+  updates = []
+  inserts = []
+  vi.useRealTimers()
+})
+
+function postRequest(body: unknown): Request {
+  return new Request('http://localhost/api/admin/weight-room/workouts', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: typeof body === 'string' ? body : JSON.stringify(body),
+  })
+}
+
+function getRequest(query = ''): Request {
+  return new Request(`http://localhost/api/admin/weight-room/workouts${query}`)
+}
+
+describe('POST /api/admin/weight-room/workouts', () => {
+  beforeEach(() => {
+    requireAdminMock.mockResolvedValue({ ok: true, email: 'a@b.com' })
+  })
+
+  it('returns 401 when not signed in', async () => {
+    requireAdminMock.mockResolvedValueOnce({
+      ok: false,
+      response: NextResponse.json({ error: 'Sign in required.' }, { status: 401 }),
+    })
+    const res = await POST(postRequest({}) as never)
+    expect(res.status).toBe(401)
+  })
+
+  it('starts a session from an empty body, stamping started_at', async () => {
+    const res = await POST(postRequest({}) as never)
+    expect(res.status).toBe(201)
+    expect(inserts[0].started_at).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+  })
+
+  it('rejects an unknown field via .strict()', async () => {
+    const res = await POST(postRequest({ sneaky: 1 }) as never)
+    expect(res.status).toBe(400)
+  })
+
+  it('rejects ended_at before started_at with a 400, not a constraint 500', async () => {
+    const res = await POST(
+      postRequest({
+        started_at: '2026-07-15T18:00:00Z',
+        ended_at: '2026-07-15T17:00:00Z',
+      }) as never,
+    )
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.error).toMatch(/before started_at/i)
+  })
+
+  it('refuses with 409 when a recent session is still open', async () => {
+    const startedAt = new Date(Date.now() - 60 * 60 * 1000).toISOString()
+    results.openWorkout = { data: { id: 'w-open', started_at: startedAt }, error: null }
+
+    const res = await POST(postRequest({}) as never)
+    expect(res.status).toBe(409)
+    const body = await res.json()
+    expect(body.open_workout_id).toBe('w-open')
+    // Nothing was written — the caller decides whether to end it.
+    expect(updates).toHaveLength(0)
+    expect(inserts).toHaveLength(0)
+  })
+
+  it('auto-ends a stale session at its last set, then starts the new one', async () => {
+    const startedAt = new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString()
+    // An hour into that session — the dates have to be coherent or the
+    // never-end-before-you-started clamp fires instead, which is a different
+    // behavior (covered below).
+    const lastSetAt = new Date(Date.now() - 47 * 60 * 60 * 1000).toISOString()
+    results.openWorkout = { data: { id: 'w-stale', started_at: startedAt }, error: null }
+    results.lastSet = { data: { logged_at: lastSetAt }, error: null }
+
+    const res = await POST(postRequest({}) as never)
+    expect(res.status).toBe(201)
+    // Closed at the last real evidence of training — not "now", which would
+    // invent two days of session that never happened.
+    expect(updates[0].ended_at).toBe(lastSetAt)
+    expect(inserts).toHaveLength(1)
+  })
+
+  it('never ends a stale session before it started', async () => {
+    // A set backdated earlier than its own session would otherwise produce an
+    // ended_at < started_at and fail the table's CHECK.
+    const startedAt = new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString()
+    results.openWorkout = { data: { id: 'w-stale', started_at: startedAt }, error: null }
+    results.lastSet = { data: { logged_at: '2020-01-01T00:00:00.000Z' }, error: null }
+
+    const res = await POST(postRequest({}) as never)
+    expect(res.status).toBe(201)
+    expect(updates[0].ended_at).toBe(startedAt)
+  })
+
+  it('collapses a stale session with no sets to zero duration', async () => {
+    const startedAt = new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString()
+    results.openWorkout = { data: { id: 'w-stale', started_at: startedAt }, error: null }
+    results.lastSet = { data: null, error: null }
+
+    const res = await POST(postRequest({}) as never)
+    expect(res.status).toBe(201)
+    expect(updates[0].ended_at).toBe(startedAt)
+  })
+
+  it('records an already-finished session without touching the open slot', async () => {
+    // An after-the-fact workout carries its own end, so it never contends for
+    // the single in-progress slot — even with one genuinely open.
+    const startedAt = new Date(Date.now() - 60 * 60 * 1000).toISOString()
+    results.openWorkout = { data: { id: 'w-open', started_at: startedAt }, error: null }
+
+    const res = await POST(
+      postRequest({
+        started_at: '2026-07-13T18:00:00Z',
+        ended_at: '2026-07-13T19:00:00Z',
+      }) as never,
+    )
+    expect(res.status).toBe(201)
+    expect(updates).toHaveLength(0)
+  })
+
+  it('maps a unique-violation from the index to 409, not 500', async () => {
+    results.insert = { data: null, error: { code: '23505', message: 'duplicate key' } }
+    const res = await POST(postRequest({}) as never)
+    expect(res.status).toBe(409)
+  })
+
+  it('normalizes an empty title to an omitted column', async () => {
+    await POST(postRequest({ title: '   ' }) as never)
+    expect(inserts[0]).not.toHaveProperty('title')
+  })
+})
+
+describe('GET /api/admin/weight-room/workouts', () => {
+  beforeEach(() => {
+    requireAdminMock.mockResolvedValue({ ok: true, email: 'a@b.com' })
+  })
+
+  it('returns null rather than 404 when nothing is open', async () => {
+    // "Am I mid-workout?" is a question with a legitimate "no" — the recording
+    // surface asks it on every load.
+    results.openWorkout = { data: null, error: null }
+    const res = await GET(getRequest('?open=true') as never)
+    expect(res.status).toBe(200)
+    expect(await res.json()).toBeNull()
+  })
+
+  it('returns the open session when there is one', async () => {
+    results.openWorkout = { data: { id: 'w-open' }, error: null }
+    const res = await GET(getRequest('?open=true') as never)
+    expect(await res.json()).toEqual({ id: 'w-open' })
+  })
+
+  it('lists sessions newest first', async () => {
+    results.list = { data: [{ id: 'w2' }, { id: 'w1' }], error: null }
+    const res = await GET(getRequest() as never)
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual([{ id: 'w2' }, { id: 'w1' }])
+  })
+
+  it('surfaces a read failure as 500', async () => {
+    results.list = { data: null, error: { message: 'JWT expired' } }
+    const res = await GET(getRequest() as never)
+    expect(res.status).toBe(500)
+  })
+})

--- a/app/api/admin/weight-room/workouts/route.ts
+++ b/app/api/admin/weight-room/workouts/route.ts
@@ -145,6 +145,17 @@ async function handlePOST(request: NextRequest): Promise<NextResponse> {
   const now = new Date()
   const startedAt = entry.started_at ?? now.toISOString()
 
+  // The schema only checks `started_at` is a non-empty string, so a supplied
+  // one still has to be a real instant. Without this, a body carrying garbage
+  // and no `ended_at` skips the window check below entirely and the value
+  // reaches Postgres as a 500.
+  if (entry.started_at !== undefined && !Number.isFinite(new Date(entry.started_at).getTime())) {
+    return NextResponse.json(
+      { error: 'started_at must be a valid ISO 8601 timestamp.' },
+      { status: 400 }
+    )
+  }
+
   // Checked here as well as by the table's CHECK so the caller gets a 400 with
   // an explanation rather than a 500 wrapping a constraint name. Compared as
   // instants, not strings — see {@link endsBeforeStart}.

--- a/app/api/admin/weight-room/workouts/route.ts
+++ b/app/api/admin/weight-room/workouts/route.ts
@@ -19,7 +19,11 @@ import { requireAdmin } from '@/lib/auth/require-admin'
 import { WeightRoomWorkoutCreateSchema } from '@/lib/schemas/weight-room'
 import { createAdminSupabaseClient } from '@/lib/supabase/admin'
 import { withTelemetry } from '@/lib/telemetry/with-telemetry'
-import { autoEndTimestamp, isStaleOpenWorkout } from '@/lib/training-facility/workout-sessions'
+import {
+  autoEndTimestamp,
+  endsBeforeStart,
+  isStaleOpenWorkout,
+} from '@/lib/training-facility/workout-sessions'
 
 /** Columns returned by both handlers, matching `WeightRoomWorkoutRowSchema`. */
 const WORKOUT_COLUMNS = 'id, started_at, ended_at, title, location, notes'
@@ -142,12 +146,22 @@ async function handlePOST(request: NextRequest): Promise<NextResponse> {
   const startedAt = entry.started_at ?? now.toISOString()
 
   // Checked here as well as by the table's CHECK so the caller gets a 400 with
-  // an explanation rather than a 500 wrapping a constraint name.
-  if (entry.ended_at !== undefined && entry.ended_at < startedAt) {
-    return NextResponse.json(
-      { error: 'ended_at cannot be before started_at.' },
-      { status: 400 }
-    )
+  // an explanation rather than a 500 wrapping a constraint name. Compared as
+  // instants, not strings — see {@link endsBeforeStart}.
+  if (entry.ended_at !== undefined) {
+    const inverted = endsBeforeStart(startedAt, entry.ended_at)
+    if (inverted === null) {
+      return NextResponse.json(
+        { error: 'started_at and ended_at must be valid ISO 8601 timestamps.' },
+        { status: 400 }
+      )
+    }
+    if (inverted) {
+      return NextResponse.json(
+        { error: 'ended_at cannot be before started_at.' },
+        { status: 400 }
+      )
+    }
   }
 
   const supabase = createAdminSupabaseClient()
@@ -244,6 +258,11 @@ async function resolveOpenWorkout(
     )
   }
 
+  // `.is('ended_at', null)` makes the close conditional: if another request
+  // ended this session between the probe above and now, the update matches
+  // nothing and that request's chosen `ended_at` stands, rather than being
+  // silently overwritten with the auto-end timestamp. Matching zero rows is
+  // success here — either way the slot is free.
   const { error: closeError } = await supabase
     .from('weight_room_workouts')
     .update({
@@ -251,6 +270,7 @@ async function resolveOpenWorkout(
       updated_at: now.toISOString(),
     })
     .eq('id', open.id)
+    .is('ended_at', null)
 
   if (closeError) {
     return NextResponse.json(

--- a/app/api/admin/weight-room/workouts/route.ts
+++ b/app/api/admin/weight-room/workouts/route.ts
@@ -1,0 +1,268 @@
+/**
+ * Admin-only collection endpoints for Weight Room workout sessions (#374).
+ *
+ * `GET` lists sessions (newest first) and, with `?open=true`, returns just the
+ * in-progress one — which is what a recording surface asks for on load to
+ * decide whether to resume. `POST` starts a session.
+ *
+ * At most one workout may be in progress at a time, enforced by a partial
+ * unique index rather than by this route, so a concurrent double-start fails at
+ * the database instead of racing past an application check.
+ *
+ * Pair with `[id]/route.ts` for PATCH (end / rename / annotate) and DELETE.
+ */
+
+import { NextResponse, type NextRequest } from 'next/server'
+import { ZodError } from 'zod'
+
+import { requireAdmin } from '@/lib/auth/require-admin'
+import { WeightRoomWorkoutCreateSchema } from '@/lib/schemas/weight-room'
+import { createAdminSupabaseClient } from '@/lib/supabase/admin'
+import { withTelemetry } from '@/lib/telemetry/with-telemetry'
+import { autoEndTimestamp, isStaleOpenWorkout } from '@/lib/training-facility/workout-sessions'
+
+/** Columns returned by both handlers, matching `WeightRoomWorkoutRowSchema`. */
+const WORKOUT_COLUMNS = 'id, started_at, ended_at, title, location, notes'
+
+/** How many sessions `GET` returns without `?open=true`. */
+const DEFAULT_LIMIT = 50
+
+/**
+ * List workout sessions, newest first.
+ *
+ * `?open=true` narrows to the single in-progress session and returns `null`
+ * when there isn't one — the shape a recording surface wants on load, rather
+ * than making it filter a list to answer "am I mid-workout?".
+ *
+ * Status codes:
+ * - 200 — a list, or (with `?open=true`) the open workout or `null`
+ * - 401 / 403 — not signed in / not on the allowlist
+ * - 500 — unexpected Supabase error
+ *
+ * @param request Incoming request; `open` is the only recognized query param.
+ * @throws when Supabase env vars are missing (misconfigured deploy).
+ */
+async function handleGET(request: NextRequest): Promise<NextResponse> {
+  const auth = await requireAdmin()
+  if (!auth.ok) return auth.response
+
+  const supabase = createAdminSupabaseClient()
+  // `new URL(request.url)` rather than `request.nextUrl` — identical under
+  // Next, but it also works on a plain `Request`, which is what the route
+  // tests construct.
+  const wantsOpenOnly = new URL(request.url).searchParams.get('open') === 'true'
+
+  if (wantsOpenOnly) {
+    const { data, error } = await supabase
+      .from('weight_room_workouts')
+      .select(WORKOUT_COLUMNS)
+      .is('ended_at', null)
+      .maybeSingle()
+
+    if (error) {
+      return NextResponse.json(
+        { error: `Failed to read open workout: ${error.message}` },
+        { status: 500 }
+      )
+    }
+    return NextResponse.json(data ?? null, { status: 200 })
+  }
+
+  const { data, error } = await supabase
+    .from('weight_room_workouts')
+    .select(WORKOUT_COLUMNS)
+    .order('started_at', { ascending: false })
+    .limit(DEFAULT_LIMIT)
+
+  if (error) {
+    return NextResponse.json(
+      { error: `Failed to list workouts: ${error.message}` },
+      { status: 500 }
+    )
+  }
+  return NextResponse.json(data ?? [], { status: 200 })
+}
+
+/**
+ * Start a workout session. Body must conform to
+ * {@link WeightRoomWorkoutCreateSchema} — every field optional, so the common
+ * case is an empty body and a session stamped `now()`.
+ *
+ * **Stale sessions are auto-ended rather than blocking the new one.** Forgetting
+ * to hit "end" is the normal failure mode, and discovering it as an error at
+ * the gym two days later is the wrong place to find out. So:
+ *
+ * - An open session younger than the staleness horizon → **409**. You are
+ *   plausibly still in it; ending it is an explicit decision.
+ * - An open session older than the horizon → auto-ended at its **last set's
+ *   `logged_at`** (or `started_at` when it recorded nothing), then the new
+ *   session starts. That timestamp is the last real evidence of training, not
+ *   a guess, and it never invents duration that didn't happen.
+ *
+ * A body carrying `ended_at` records an already-finished session in one call
+ * (how #378 will narrate a workout after the fact); it doesn't occupy the
+ * single open-session slot, so it never collides.
+ *
+ * Status codes:
+ * - 201 — created (response echoes the row)
+ * - 400 — invalid JSON, failed Zod validation, or `ended_at` before `started_at`
+ * - 401 / 403 — not signed in / not on the allowlist
+ * - 409 — a recent session is still open
+ * - 500 — unexpected Supabase error
+ *
+ * @param request Incoming JSON request whose body matches
+ *   {@link WeightRoomWorkoutCreateSchema}.
+ * @throws when Supabase env vars are missing (misconfigured deploy).
+ */
+async function handlePOST(request: NextRequest): Promise<NextResponse> {
+  const auth = await requireAdmin()
+  if (!auth.ok) return auth.response
+
+  let payload: unknown
+  try {
+    payload = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Body must be valid JSON.' }, { status: 400 })
+  }
+
+  let entry
+  try {
+    entry = WeightRoomWorkoutCreateSchema.parse(payload)
+  } catch (err) {
+    if (err instanceof ZodError) {
+      return NextResponse.json(
+        { error: 'Validation failed.', issues: err.flatten() },
+        { status: 400 }
+      )
+    }
+    throw err
+  }
+
+  const now = new Date()
+  const startedAt = entry.started_at ?? now.toISOString()
+
+  // Checked here as well as by the table's CHECK so the caller gets a 400 with
+  // an explanation rather than a 500 wrapping a constraint name.
+  if (entry.ended_at !== undefined && entry.ended_at < startedAt) {
+    return NextResponse.json(
+      { error: 'ended_at cannot be before started_at.' },
+      { status: 400 }
+    )
+  }
+
+  const supabase = createAdminSupabaseClient()
+
+  // A session being recorded after the fact already carries its end, so it
+  // never contends for the single open slot — skip the whole dance.
+  if (entry.ended_at === undefined) {
+    const conflict = await resolveOpenWorkout(supabase, now)
+    if (conflict !== null) return conflict
+  }
+
+  const insertRow = {
+    started_at: startedAt,
+    ...(entry.ended_at != null ? { ended_at: entry.ended_at } : {}),
+    ...(entry.title != null ? { title: entry.title } : {}),
+    ...(entry.location != null ? { location: entry.location } : {}),
+    ...(entry.notes != null ? { notes: entry.notes } : {}),
+  }
+
+  const { data, error } = await supabase
+    .from('weight_room_workouts')
+    .insert(insertRow)
+    .select(WORKOUT_COLUMNS)
+    .single()
+
+  if (error) {
+    // The partial unique index is the real guard — a concurrent start that
+    // slipped past the check above lands here.
+    if (error.code === '23505') {
+      return NextResponse.json(
+        { error: 'A workout is already in progress. End it before starting another.' },
+        { status: 409 }
+      )
+    }
+    return NextResponse.json(
+      { error: `Failed to start workout: ${error.message}` },
+      { status: 500 }
+    )
+  }
+
+  return NextResponse.json(data, { status: 201 })
+}
+
+/**
+ * Clear the way for a new session: auto-end a stale open workout, or refuse.
+ *
+ * @param supabase Service-role client.
+ * @param now Evaluation instant for the staleness comparison.
+ * @returns `null` when the slot is free (nothing open, or the stale one was
+ *   closed); otherwise the response to return — a 409 for a session still
+ *   plausibly in progress, or a 500 if a read/write failed.
+ */
+async function resolveOpenWorkout(
+  supabase: ReturnType<typeof createAdminSupabaseClient>,
+  now: Date
+): Promise<NextResponse | null> {
+  const { data: open, error: openError } = await supabase
+    .from('weight_room_workouts')
+    .select('id, started_at')
+    .is('ended_at', null)
+    .maybeSingle()
+
+  if (openError) {
+    return NextResponse.json(
+      { error: `Failed to check for an open workout: ${openError.message}` },
+      { status: 500 }
+    )
+  }
+  if (!open) return null
+
+  if (!isStaleOpenWorkout(open.started_at, now)) {
+    return NextResponse.json(
+      {
+        error: `A workout started ${open.started_at} is still in progress. End it before starting another.`,
+        open_workout_id: open.id,
+      },
+      { status: 409 }
+    )
+  }
+
+  // Stale. Close it at its last set — the last evidence the user was training.
+  const { data: lastSet, error: lastSetError } = await supabase
+    .from('weight_room_sets')
+    .select('logged_at')
+    .eq('workout_id', open.id)
+    .order('logged_at', { ascending: false })
+    .limit(1)
+    .maybeSingle()
+
+  if (lastSetError) {
+    return NextResponse.json(
+      { error: `Failed to read the stale workout's sets: ${lastSetError.message}` },
+      { status: 500 }
+    )
+  }
+
+  const { error: closeError } = await supabase
+    .from('weight_room_workouts')
+    .update({
+      ended_at: autoEndTimestamp(open.started_at, lastSet?.logged_at ?? null),
+      updated_at: now.toISOString(),
+    })
+    .eq('id', open.id)
+
+  if (closeError) {
+    return NextResponse.json(
+      { error: `Failed to close the stale workout: ${closeError.message}` },
+      { status: 500 }
+    )
+  }
+  return null
+}
+
+/** `handleGET` wrapped with one-event-per-request telemetry (#220). */
+export const GET = withTelemetry('GET /api/admin/weight-room/workouts', handleGET)
+
+/** `handlePOST` wrapped with one-event-per-request telemetry (#220). */
+export const POST = withTelemetry('POST /api/admin/weight-room/workouts', handlePOST)

--- a/lib/data/weight-room-shared.ts
+++ b/lib/data/weight-room-shared.ts
@@ -44,7 +44,12 @@ const GOAL_TARGETS_TABLE = 'weight_room_goal_targets'
 const EXERCISES_TABLE = 'weight_room_exercises'
 
 /** Whitelisted column lists for each table; `updated_at` rides along for `imported_at` computation. */
-const SETS_COLUMNS = 'id, logged_at, exercise, reps, weight_lbs, variant, updated_at'
+// `workout_id` / `position` (#374) ride along so a set knows which session it
+// belongs to. Every existing aggregation ignores both — an attached set counts
+// exactly as a loose one — but reading them is what lets #376/#377 group sets
+// into a workout without another round trip.
+const SETS_COLUMNS =
+  'id, logged_at, exercise, reps, weight_lbs, variant, workout_id, position, updated_at'
 // `load_multiplier` deliberately absent (#373) — it moved to the catalog and is
 // joined on below. The goals column still exists (dropping it while the
 // deployed build still selected it would break the live read) but is dead.

--- a/lib/data/weight-room-shared.ts
+++ b/lib/data/weight-room-shared.ts
@@ -44,10 +44,15 @@ const GOAL_TARGETS_TABLE = 'weight_room_goal_targets'
 const EXERCISES_TABLE = 'weight_room_exercises'
 
 /** Whitelisted column lists for each table; `updated_at` rides along for `imported_at` computation. */
-// `workout_id` / `position` (#374) ride along so a set knows which session it
-// belongs to. Every existing aggregation ignores both — an attached set counts
-// exactly as a loose one — but reading them is what lets #376/#377 group sets
-// into a workout without another round trip.
+/**
+ * Whitelisted columns for `weight_room_sets`, in sync with
+ * {@link WeightRoomSetRowSchema}.
+ *
+ * `workout_id` / `position` (#374) ride along so a set knows which session it
+ * belongs to. Every existing aggregation ignores both — an attached set counts
+ * exactly as a loose one — but reading them is what lets #376/#377 group sets
+ * into a workout without another round trip.
+ */
 const SETS_COLUMNS =
   'id, logged_at, exercise, reps, weight_lbs, variant, workout_id, position, updated_at'
 // `load_multiplier` deliberately absent (#373) — it moved to the catalog and is

--- a/lib/data/weight-room.test.ts
+++ b/lib/data/weight-room.test.ts
@@ -313,6 +313,52 @@ describe('getWeightRoomData', () => {
   })
 })
 
+describe('getWeightRoomData — session membership (#374)', () => {
+  it('carries workout_id and position through to the assembled set', async () => {
+    stubTable('weight_room_sets', [
+      {
+        id: '11111111-1111-4111-8111-111111111111',
+        logged_at: '2026-07-15T18:05:00Z',
+        exercise: 'pushups',
+        reps: 20,
+        workout_id: '22222222-2222-4222-8222-222222222222',
+        position: 0,
+        updated_at: '2026-07-15T18:05:01Z',
+      },
+    ])
+    stubTable('weight_room_goals', [])
+
+    const data = await getWeightRoomData()
+
+    expect(data?.sets[0]).toMatchObject({
+      workout_id: '22222222-2222-4222-8222-222222222222',
+      position: 0,
+    })
+  })
+
+  it('omits both for a loose set rather than surfacing nulls', async () => {
+    // The overwhelming majority — every grease-the-groove set ever logged.
+    // Absent is the real answer, so consumers test for it rather than for null.
+    stubTable('weight_room_sets', [
+      {
+        id: '33333333-3333-4333-8333-333333333333',
+        logged_at: '2026-07-15T18:05:00Z',
+        exercise: 'pushups',
+        reps: 20,
+        workout_id: null,
+        position: null,
+        updated_at: '2026-07-15T18:05:01Z',
+      },
+    ])
+    stubTable('weight_room_goals', [])
+
+    const data = await getWeightRoomData()
+
+    expect(data?.sets[0]).not.toHaveProperty('workout_id')
+    expect(data?.sets[0]).not.toHaveProperty('position')
+  })
+})
+
 describe('getWeightRoomData — exercise catalog (#373)', () => {
   /** One catalog row, with the not-null columns PostgREST always returns. */
   function catalogRow(

--- a/lib/schemas/weight-room.test.ts
+++ b/lib/schemas/weight-room.test.ts
@@ -12,6 +12,8 @@ import {
   WeightRoomMonthlyFocusRowSchema,
   WeightRoomSetCreateSchema,
   WeightRoomSetRowSchema,
+  WeightRoomWorkoutCreateSchema,
+  WeightRoomWorkoutUpdateSchema,
   exerciseRowToWeightRoomExercise,
   setRowToStrengthSet,
 } from './weight-room'
@@ -198,6 +200,85 @@ describe('WeightRoomExerciseUpdateSchema (patch body, #373)', () => {
     expect(() =>
       WeightRoomExerciseUpdateSchema.parse({ slug: 'renamed' }),
     ).toThrow()
+  })
+})
+
+describe('WeightRoomWorkoutCreateSchema (write body, #374)', () => {
+  it('accepts an empty body — the common case is just tapping start', () => {
+    expect(() => WeightRoomWorkoutCreateSchema.parse({})).not.toThrow()
+  })
+
+  it('normalizes an empty title to undefined so the column is omitted', () => {
+    // On create, "" means "I didn't supply one" — the DB default of null is
+    // the right outcome, not an empty string the read side must special-case.
+    expect(WeightRoomWorkoutCreateSchema.parse({ title: '   ' }).title).toBeUndefined()
+  })
+
+  it('trims a supplied title', () => {
+    expect(WeightRoomWorkoutCreateSchema.parse({ title: '  Push Day  ' }).title).toBe('Push Day')
+  })
+
+  it('rejects a location outside the check constraint', () => {
+    expect(() => WeightRoomWorkoutCreateSchema.parse({ location: 'moon' })).toThrow()
+  })
+
+  it('rejects an over-long title', () => {
+    expect(() =>
+      WeightRoomWorkoutCreateSchema.parse({ title: 'x'.repeat(81) }),
+    ).toThrow()
+  })
+
+  it('rejects an unknown key', () => {
+    expect(() => WeightRoomWorkoutCreateSchema.parse({ duration: 60 })).toThrow()
+  })
+})
+
+describe('WeightRoomWorkoutUpdateSchema (patch body, #374)', () => {
+  it('rejects an empty patch', () => {
+    // The field transforms materialize every key, so this can only be caught
+    // by inspecting values — a keys-length check would wave `{}` straight
+    // through and issue an update that changes nothing but `updated_at`.
+    expect(() => WeightRoomWorkoutUpdateSchema.parse({})).toThrow()
+  })
+
+  it('distinguishes clearing a title from leaving it alone', () => {
+    // Clearing writes null; omitting must stay undefined so the route can
+    // strip it and leave the stored value intact.
+    expect(WeightRoomWorkoutUpdateSchema.parse({ title: '' }).title).toBeNull()
+    expect(WeightRoomWorkoutUpdateSchema.parse({ notes: 'x' }).title).toBeUndefined()
+  })
+
+  it('accepts ended_at: null to reopen a session', () => {
+    expect(WeightRoomWorkoutUpdateSchema.parse({ ended_at: null }).ended_at).toBeNull()
+  })
+
+  it('accepts an ISO ended_at to close one', () => {
+    expect(
+      WeightRoomWorkoutUpdateSchema.parse({ ended_at: '2026-07-15T19:00:00Z' }).ended_at,
+    ).toBe('2026-07-15T19:00:00Z')
+  })
+})
+
+describe('WeightRoomSetCreateSchema — session membership (#374)', () => {
+  const base = { exercise: 'pushups', reps: 20 }
+
+  it('accepts a workout_id and a 0-based position', () => {
+    const parsed = WeightRoomSetCreateSchema.parse({
+      ...base,
+      workout_id: '11111111-1111-4111-8111-111111111111',
+      position: 0,
+    })
+    expect(parsed.position).toBe(0)
+  })
+
+  it('still accepts a loose set with neither', () => {
+    const parsed = WeightRoomSetCreateSchema.parse(base)
+    expect(parsed).not.toHaveProperty('workout_id')
+  })
+
+  it('rejects a non-uuid workout_id and a negative position', () => {
+    expect(() => WeightRoomSetCreateSchema.parse({ ...base, workout_id: 'w1' })).toThrow()
+    expect(() => WeightRoomSetCreateSchema.parse({ ...base, position: -1 })).toThrow()
   })
 })
 

--- a/lib/schemas/weight-room.ts
+++ b/lib/schemas/weight-room.ts
@@ -22,6 +22,8 @@ import type {
   StrengthSet,
   WeightRoomAchievement,
   WeightRoomExercise,
+  WeightRoomWorkout,
+  WorkoutLocation,
 } from '@/types/weight-room'
 
 /**
@@ -61,6 +63,17 @@ const positiveInt = (): z.ZodType<number> =>
   z
     .number()
     .refine((n) => Number.isInteger(n) && n > 0, 'must be a positive integer')
+
+/**
+ * Non-negative-integer Zod check, for `position` (#374) — set order within a
+ * workout, which is 0-based. Same inlined-`.refine` reasoning as
+ * {@link positiveInt}: the Turbopack dev bundler mis-transpiles
+ * `z.number().int()` when this module is pulled into a client bundle.
+ */
+const nonNegativeInt = (): z.ZodType<number> =>
+  z
+    .number()
+    .refine((n) => Number.isInteger(n) && n >= 0, 'must be a non-negative integer')
 
 /**
  * Write-only `exercise` field — non-empty string, lowercased on parse.
@@ -129,6 +142,10 @@ export const WeightRoomSetRowSchema = z
     // {@link variantWriteField}. Normalized to absent by the row
     // converter so {@link StrengthSet.variant} stays `string | undefined`.
     variant: z.string().nullable().optional(),
+    // Session membership (#374). Null is the overwhelming majority — every
+    // grease-the-groove set ever logged — and means "loose", not "missing".
+    workout_id: z.string().uuid().nullable().optional(),
+    position: nonNegativeInt().nullable().optional(),
   })
   .strict()
 
@@ -224,6 +241,11 @@ export const WeightRoomSetCreateSchema = z
     // empty / whitespace / null all normalize to `undefined` so the
     // route omits the column and the DB stores `null` (unspecified).
     variant: variantWriteField(),
+    // Session membership (#374). Explicit only — the route never infers it
+    // from whichever workout happens to be open, so a desk pushup set can't
+    // silently join the morning's gym session.
+    workout_id: z.string().uuid().optional(),
+    position: nonNegativeInt().optional(),
   })
   .strict()
 
@@ -249,8 +271,145 @@ export function setRowToStrengthSet(row: WeightRoomSetRow): StrengthSet {
     // collapse to absent so an unspecified set never surfaces a phantom
     // "" variant bucket in the History View breakdown.
     ...(row.variant != null && row.variant !== '' ? { variant: row.variant } : {}),
+    // Session membership (#374); same absent-not-null treatment.
+    ...(row.workout_id != null ? { workout_id: row.workout_id } : {}),
+    ...(row.position != null ? { position: row.position } : {}),
   }
 }
+
+/** Workout locations, as a Zod enum reused by the row + write schemas (#374). */
+const workoutLocation = (): z.ZodType<WorkoutLocation> =>
+  z.enum(['gym', 'home', 'travel', 'other'])
+
+/**
+ * Zod schema for one row of `public.weight_room_workouts` (#374). Mirrors the
+ * table in `supabase/migrations/20260802120000_weight_room_workouts.sql`.
+ *
+ * `ended_at` nullable is load-bearing rather than lenient: `null` *means* "in
+ * progress", so it can't be collapsed to absent the way a merely-unsupplied
+ * field would be — same reasoning the achievements schema documents for its
+ * pooled `exercise`.
+ */
+export const WeightRoomWorkoutRowSchema = z
+  .object({
+    id: z.string().uuid(),
+    started_at: z.string().min(1, 'started_at must be an ISO timestamp'),
+    ended_at: z.string().nullable().optional(),
+    title: z.string().nullable().optional(),
+    location: workoutLocation().nullable().optional(),
+    notes: z.string().nullable().optional(),
+  })
+  .strict()
+
+/** Validated `weight_room_workouts` row inferred from {@link WeightRoomWorkoutRowSchema}. */
+export type WeightRoomWorkoutRow = z.infer<typeof WeightRoomWorkoutRowSchema>
+
+/**
+ * Translate a validated `weight_room_workouts` row into the public
+ * {@link WeightRoomWorkout} shape. Null optionals are omitted so each stays
+ * `T | undefined`; an absent `ended_at` is what every read site tests for to
+ * mean "in progress".
+ */
+export function workoutRowToWeightRoomWorkout(row: WeightRoomWorkoutRow): WeightRoomWorkout {
+  return {
+    id: row.id,
+    started_at: row.started_at,
+    ...(row.ended_at != null ? { ended_at: row.ended_at } : {}),
+    ...(row.title != null && row.title !== '' ? { title: row.title } : {}),
+    ...(row.location != null ? { location: row.location } : {}),
+    ...(row.notes != null && row.notes !== '' ? { notes: row.notes } : {}),
+  }
+}
+
+/**
+ * Free-text write field shared by `title` and `notes` — trims, and normalizes
+ * empty / whitespace-only / `null` / absent all to `undefined` so the route
+ * omits the column and the DB keeps its `null` default rather than storing an
+ * empty string the read side would have to special-case. Mirrors
+ * {@link variantWriteField} minus the lowercasing (these are prose, not keys).
+ */
+const optionalTextField = (max: number) =>
+  z
+    .union([z.string(), z.null()])
+    .optional()
+    .transform((v) => {
+      if (v == null) return undefined
+      const trimmed = v.trim()
+      return trimmed === '' ? undefined : trimmed
+    })
+    .refine((v) => v === undefined || v.length <= max, `must be ${max} characters or fewer`)
+
+/**
+ * Free-text **patch** field — same trimming as {@link optionalTextField}, but
+ * empty / whitespace-only / `null` all normalize to **`null`**, not `undefined`.
+ *
+ * The distinction is the whole point of PATCH semantics. On create, "" means
+ * "I didn't supply one", so omitting the column and letting the DB default to
+ * null is right. On update, clearing the field in an editor and saving means
+ * "remove the title I set earlier" — collapsing that to `undefined` would make
+ * the write a silent no-op and the title would stubbornly persist. Only an
+ * *absent* key means "leave this alone".
+ */
+const clearableTextField = (max: number) =>
+  z
+    .union([z.string(), z.null()])
+    .optional()
+    .transform((v) => {
+      if (v === undefined) return undefined
+      if (v === null) return null
+      const trimmed = v.trim()
+      return trimmed === '' ? null : trimmed
+    })
+    .refine(
+      (v) => v == null || v.length <= max,
+      `must be ${max} characters or fewer`,
+    )
+
+/**
+ * Request-body schema for `POST /api/admin/weight-room/workouts` (#374) — start
+ * a session.
+ *
+ * Every field is optional: the common case is tapping "start" and getting a
+ * session stamped `now()`. `started_at` is accepted so a workout can be
+ * reconstructed after the fact, and `ended_at` alongside it so a whole finished
+ * session can be recorded in one call — which is how the `log-workout` skill
+ * (#378) will narrate a workout that already happened.
+ */
+export const WeightRoomWorkoutCreateSchema = z
+  .object({
+    started_at: z.string().min(1).optional(),
+    ended_at: z.string().min(1).optional(),
+    title: optionalTextField(80),
+    location: workoutLocation().optional(),
+    notes: optionalTextField(2000),
+  })
+  .strict()
+
+/** Validated body of `POST /api/admin/weight-room/workouts`. */
+export type WeightRoomWorkoutCreate = z.infer<typeof WeightRoomWorkoutCreateSchema>
+
+/**
+ * Request-body schema for `PATCH /api/admin/weight-room/workouts/[id]` (#374).
+ *
+ * `ended_at` accepts an explicit `null` to *reopen* a session — the one case
+ * where a null is a value rather than an omission, and the reason this can't be
+ * a `.partial()` of the create schema. Every field optional, at least one
+ * required; an empty patch is a client bug, not a no-op.
+ */
+export const WeightRoomWorkoutUpdateSchema = z
+  .object({
+    ended_at: z.union([z.string().min(1), z.null()]).optional(),
+    title: clearableTextField(80),
+    location: z.union([workoutLocation(), z.null()]).optional(),
+    notes: clearableTextField(2000),
+  })
+  .strict()
+  .refine((patch) => Object.values(patch).some((v) => v !== undefined), {
+    message: 'At least one field (ended_at, title, location, or notes) is required.',
+  })
+
+/** Validated body of `PATCH /api/admin/weight-room/workouts/[id]`. */
+export type WeightRoomWorkoutUpdate = z.infer<typeof WeightRoomWorkoutUpdateSchema>
 
 /**
  * Translate a validated `weight_room_goals` row into the public

--- a/lib/training-facility/workout-sessions.test.ts
+++ b/lib/training-facility/workout-sessions.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import {
   STALE_WORKOUT_HOURS,
   autoEndTimestamp,
+  endsBeforeStart,
   isStaleOpenWorkout,
   workoutDayKey,
   workoutDurationMinutes,
@@ -83,6 +84,36 @@ describe('autoEndTimestamp', () => {
 
   it('falls back to started_at when the set timestamp is unparseable', () => {
     expect(autoEndTimestamp(started, 'not-a-date')).toBe(started)
+  })
+})
+
+describe('endsBeforeStart', () => {
+  it('compares instants, not strings, across mixed UTC offsets', () => {
+    // 05:00-07:00 is 12:00Z — two hours *after* 10:00Z — but sorts before it
+    // as a string. This repo mixes offsets: dayKeyToPacificNoonIso emits
+    // -07:00/-08:00 while toISOString() emits Z, so this is reachable.
+    expect(endsBeforeStart('2026-08-01T10:00:00Z', '2026-08-01T05:00:00-07:00')).toBe(false)
+  })
+
+  it('catches a genuinely inverted window that sorts as fine', () => {
+    // 20:00Z is before 14:00-07:00 (= 21:00Z), so a naive string compare
+    // would wave this through.
+    expect(endsBeforeStart('2026-08-01T14:00:00-07:00', '2026-08-01T20:00:00Z')).toBe(true)
+  })
+
+  it('is false for an ordinary well-formed window', () => {
+    expect(endsBeforeStart('2026-08-01T18:00:00Z', '2026-08-01T19:00:00Z')).toBe(false)
+  })
+
+  it('treats identical instants as not inverted', () => {
+    // The table's CHECK is `ended_at >= started_at`, so a zero-length session
+    // is legal — that's what an auto-closed session with no sets becomes.
+    expect(endsBeforeStart('2026-08-01T18:00:00Z', '2026-08-01T11:00:00-07:00')).toBe(false)
+  })
+
+  it('returns null for an unparseable timestamp so the caller can 400', () => {
+    expect(endsBeforeStart('2026-08-01T18:00:00Z', 'not-a-date')).toBeNull()
+    expect(endsBeforeStart('garbage', '2026-08-01T18:00:00Z')).toBeNull()
   })
 })
 

--- a/lib/training-facility/workout-sessions.test.ts
+++ b/lib/training-facility/workout-sessions.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  STALE_WORKOUT_HOURS,
+  autoEndTimestamp,
+  isStaleOpenWorkout,
+  workoutDayKey,
+  workoutDurationMinutes,
+} from './workout-sessions'
+
+/**
+ * Coverage for the pure workout-session rules (#374): which day a session
+ * belongs to, when an in-progress one counts as abandoned, and what timestamp
+ * closing it should carry.
+ */
+
+describe('workoutDayKey', () => {
+  it('buckets to the Pacific day the session started', () => {
+    // 02:00 UTC = 19:00 PDT the previous day.
+    expect(workoutDayKey({ started_at: '2026-07-16T02:00:00Z' })).toBe('2026-07-15')
+  })
+
+  it('keeps a session that crosses midnight on its start day', () => {
+    // Starts 23:30 PDT on the 15th; whatever time it ends, it is the 15th's
+    // workout. Splitting it across two days would be wrong in every rollup.
+    expect(
+      workoutDayKey({ started_at: '2026-07-16T06:30:00Z' }),
+    ).toBe('2026-07-15')
+  })
+
+  it('tracks the winter offset', () => {
+    // 07:30 UTC in January = 23:30 PST on the 11th.
+    expect(workoutDayKey({ started_at: '2026-01-12T07:30:00Z' })).toBe('2026-01-11')
+  })
+
+  it('returns null for an unparseable timestamp rather than a bogus day', () => {
+    expect(workoutDayKey({ started_at: 'not-a-date' })).toBeNull()
+  })
+})
+
+describe('isStaleOpenWorkout', () => {
+  const now = new Date('2026-07-15T20:00:00Z')
+
+  it('is false for a session that started moments ago', () => {
+    expect(isStaleOpenWorkout('2026-07-15T19:30:00Z', now)).toBe(false)
+  })
+
+  it('is false for a long-but-plausible session just inside the horizon', () => {
+    const justInside = new Date(now.getTime() - (STALE_WORKOUT_HOURS - 1) * 3600_000)
+    expect(isStaleOpenWorkout(justInside.toISOString(), now)).toBe(false)
+  })
+
+  it('is true once the session is older than the horizon', () => {
+    const justOutside = new Date(now.getTime() - (STALE_WORKOUT_HOURS + 1) * 3600_000)
+    expect(isStaleOpenWorkout(justOutside.toISOString(), now)).toBe(true)
+  })
+
+  it('is false for an unparseable timestamp', () => {
+    // A bug in the stored value must not be read as licence to auto-end a
+    // session the user may still be in.
+    expect(isStaleOpenWorkout('garbage', now)).toBe(false)
+  })
+})
+
+describe('autoEndTimestamp', () => {
+  const started = '2026-07-13T18:00:00Z'
+
+  it('closes at the last set logged into the session', () => {
+    // The last real evidence of activity — not "now", which would invent two
+    // days of session that never happened.
+    expect(autoEndTimestamp(started, '2026-07-13T19:12:00Z')).toBe('2026-07-13T19:12:00Z')
+  })
+
+  it('collapses a session with no sets to zero duration', () => {
+    expect(autoEndTimestamp(started, null)).toBe(started)
+  })
+
+  it('never ends before it started, even if a set is stamped earlier', () => {
+    // Backdating slop would otherwise violate the table's
+    // `ended_at >= started_at` check and fail the write.
+    expect(autoEndTimestamp(started, '2026-07-13T17:00:00Z')).toBe(started)
+  })
+
+  it('falls back to started_at when the set timestamp is unparseable', () => {
+    expect(autoEndTimestamp(started, 'not-a-date')).toBe(started)
+  })
+})
+
+describe('workoutDurationMinutes', () => {
+  it('measures a completed session', () => {
+    expect(
+      workoutDurationMinutes({
+        started_at: '2026-07-15T18:00:00Z',
+        ended_at: '2026-07-15T18:52:00Z',
+      }),
+    ).toBe(52)
+  })
+
+  it('returns null while the session is still open', () => {
+    expect(workoutDurationMinutes({ started_at: '2026-07-15T18:00:00Z' })).toBeNull()
+  })
+
+  it('returns null rather than NaN on an unparseable timestamp', () => {
+    expect(
+      workoutDurationMinutes({ started_at: 'nope', ended_at: '2026-07-15T18:52:00Z' }),
+    ).toBeNull()
+  })
+})

--- a/lib/training-facility/workout-sessions.ts
+++ b/lib/training-facility/workout-sessions.ts
@@ -1,0 +1,112 @@
+import type { WeightRoomWorkout } from '@/types/weight-room'
+
+import { pacificDayKey } from './day-keys'
+
+/**
+ * Pure helpers for bounded workout sessions (#374).
+ *
+ * Everything here is date/duration arithmetic with no Supabase involvement, so
+ * the admin routes stay thin and the two rules worth getting right — which day
+ * a session belongs to, and what happens to one you forgot to end — are
+ * unit-testable in isolation.
+ */
+
+/**
+ * How long an in-progress workout may sit before the next `start` treats it as
+ * abandoned rather than as a session you're still in the middle of.
+ *
+ * Twelve hours comfortably clears any real session (the longest gym visit is a
+ * couple of hours) while still catching "started Monday evening, forgot to hit
+ * end, back Wednesday". Below that, an honest long session — a hike, a
+ * two-a-day logged as one — could be closed out from under you.
+ */
+export const STALE_WORKOUT_HOURS = 12
+
+/** Milliseconds in {@link STALE_WORKOUT_HOURS}. */
+const STALE_WORKOUT_MS = STALE_WORKOUT_HOURS * 60 * 60 * 1000
+
+/**
+ * Which calendar day a workout belongs to, as a Pacific `YYYY-MM-DD` key.
+ *
+ * Derived from {@link WeightRoomWorkout.started_at}, never from `ended_at`: a
+ * session that crosses midnight belongs wholly to the day it began, because
+ * splitting one workout across two days would be wrong in every rollup that
+ * consumes it.
+ *
+ * Pacific rather than the server's zone for the reason #319 unified on — Vercel
+ * runs the server in UTC, so local-time bucketing would silently shift every
+ * boundary between SSR and the browser.
+ *
+ * @param workout The session to place.
+ * @returns The day key, or `null` when `started_at` isn't a parseable timestamp.
+ */
+export function workoutDayKey(workout: Pick<WeightRoomWorkout, 'started_at'>): string | null {
+  const started = new Date(workout.started_at)
+  if (!Number.isFinite(started.getTime())) return null
+  return pacificDayKey(started)
+}
+
+/**
+ * Whether an in-progress workout has been open long enough to count as
+ * abandoned.
+ *
+ * @param startedAt ISO timestamp the session began.
+ * @param now Evaluation instant; defaults to the current time.
+ * @returns `false` when `startedAt` is unparseable — an unreadable timestamp is
+ *   not evidence of staleness, and auto-ending on it would destroy a session on
+ *   the strength of a bug.
+ */
+export function isStaleOpenWorkout(startedAt: string, now: Date = new Date()): boolean {
+  const started = new Date(startedAt)
+  if (!Number.isFinite(started.getTime())) return false
+  return now.getTime() - started.getTime() > STALE_WORKOUT_MS
+}
+
+/**
+ * The `ended_at` to stamp on a stale session being auto-closed.
+ *
+ * Uses the **last set logged into that session** — the last real evidence the
+ * user was training — rather than "now", which would invent hours of session
+ * that never happened, or the staleness horizon, which is an arbitrary clock
+ * boundary. A session with no sets at all collapses to zero duration at
+ * `started_at`, which is honest: nothing was recorded, so nothing happened.
+ *
+ * Never returns a value before `started_at`; a set stamped earlier than its own
+ * session (backdating slop) would otherwise violate the table's
+ * `ended_at >= started_at` check.
+ *
+ * @param startedAt ISO timestamp the session began.
+ * @param lastSetLoggedAt ISO timestamp of the newest set in the session, or
+ *   `null` when it has none.
+ */
+export function autoEndTimestamp(
+  startedAt: string,
+  lastSetLoggedAt: string | null,
+): string {
+  if (lastSetLoggedAt === null) return startedAt
+  const started = new Date(startedAt)
+  const lastSet = new Date(lastSetLoggedAt)
+  if (!Number.isFinite(lastSet.getTime()) || !Number.isFinite(started.getTime())) {
+    return startedAt
+  }
+  return lastSet.getTime() < started.getTime() ? startedAt : lastSetLoggedAt
+}
+
+/**
+ * Elapsed minutes of a session, or `null` while it's still in progress.
+ *
+ * Rounded to the nearest minute — the consuming surfaces (#377) display whole
+ * minutes, so rounding here keeps a displayed duration and any derived rate
+ * computed from one value.
+ *
+ * @param workout The session to measure.
+ */
+export function workoutDurationMinutes(
+  workout: Pick<WeightRoomWorkout, 'started_at' | 'ended_at'>,
+): number | null {
+  if (workout.ended_at === undefined) return null
+  const started = new Date(workout.started_at)
+  const ended = new Date(workout.ended_at)
+  if (!Number.isFinite(started.getTime()) || !Number.isFinite(ended.getTime())) return null
+  return Math.round((ended.getTime() - started.getTime()) / 60000)
+}

--- a/lib/training-facility/workout-sessions.ts
+++ b/lib/training-facility/workout-sessions.ts
@@ -93,6 +93,28 @@ export function autoEndTimestamp(
 }
 
 /**
+ * Whether `endedAt` lands strictly before `startedAt`, compared as **instants**.
+ *
+ * String comparison is wrong here even though both sides are ISO 8601: the
+ * format only sorts lexicographically when every value shares one UTC offset,
+ * and this codebase mixes them — `dayKeyToPacificNoonIso` emits `-07:00`/`-08:00`
+ * offsets while `new Date().toISOString()` emits `Z`. `2026-08-01T05:00:00-07:00`
+ * is two hours *after* `2026-08-01T10:00:00Z` and sorts before it.
+ *
+ * @param startedAt ISO timestamp the session began.
+ * @param endedAt ISO timestamp the session ended.
+ * @returns `true` when the end precedes the start, `false` when it doesn't, and
+ *   `null` when either value isn't a parseable timestamp — which the caller
+ *   should reject rather than forward to Postgres as a 500.
+ */
+export function endsBeforeStart(startedAt: string, endedAt: string): boolean | null {
+  const started = new Date(startedAt).getTime()
+  const ended = new Date(endedAt).getTime()
+  if (!Number.isFinite(started) || !Number.isFinite(ended)) return null
+  return ended < started
+}
+
+/**
  * Elapsed minutes of a session, or `null` while it's still in progress.
  *
  * Rounded to the nearest minute — the consuming surfaces (#377) display whole

--- a/supabase/migrations/20260802120000_weight_room_workouts.sql
+++ b/supabase/migrations/20260802120000_weight_room_workouts.sql
@@ -1,0 +1,101 @@
+-- Workout sessions (#374) — group sets into a bounded workout.
+--
+-- A gym workout is an *event*: walk in, do five movements, walk out. Nothing in
+-- the Weight Room model could represent that. `weight_room_sets` carries only
+-- `logged_at`, and every consumer buckets by calendar day — correct for
+-- grease-the-groove, where the day genuinely is the unit, and useless for
+-- "how long was that session and how did it compare to the last one".
+--
+-- Two columns land on `weight_room_sets`, both nullable, and there is **no
+-- backfill**. Historical GTG sets were not workouts; they were sets scattered
+-- through a day. Synthesising sessions for them would invent structure that
+-- never existed, so a null `workout_id` means "logged loose" — permanently and
+-- correctly. Everything that exists today keeps working because everything that
+-- exists today ignores these columns.
+--
+-- **One open workout at a time.** Enforced by a partial unique index on
+-- `(ended_at is null) where ended_at is null` — every matching row indexes the
+-- same constant `true`, so at most one can exist. Deliberately shaped this way
+-- rather than as an application check: when #330 adds household profiles the
+-- index becomes `(profile_id) where ended_at is null` and the rule turns into
+-- "one open workout *per profile*" with no other change.
+--
+-- RLS mirrors every sibling table: anon + authenticated SELECT only; writes go
+-- through the service-role key via `app/api/admin/weight-room/*`.
+--
+-- All DDL is idempotent.
+
+create table if not exists public.weight_room_workouts (
+  id uuid primary key default gen_random_uuid(),
+  started_at timestamptz not null,
+  ended_at timestamptz null,
+  title text null check (title is null or btrim(title) <> ''),
+  location text null check (location is null or location in ('gym', 'home', 'travel', 'other')),
+  notes text null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint weight_room_workouts_window_check
+    check (ended_at is null or ended_at >= started_at)
+);
+
+comment on table public.weight_room_workouts is
+  'Bounded workout sessions for the Weight Room (#374). A row is one gym visit: started_at .. ended_at, with sets pointing back via weight_room_sets.workout_id. ended_at NULL means in progress. Grease-the-groove sets stay session-less by design — a null workout_id on a set means "logged loose", not "missing data".';
+
+comment on column public.weight_room_workouts.started_at is
+  'When the session began. Also the anchor for which calendar day the workout belongs to: a session crossing midnight belongs wholly to its start day, resolved in Pacific via lib/training-facility/day-keys.';
+
+comment on column public.weight_room_workouts.ended_at is
+  'When the session finished; NULL while in progress. At most one row may be NULL at a time (see the partial unique index). A session left open past the staleness horizon is auto-ended when the next one starts, stamped at its last set''s logged_at.';
+
+create index if not exists weight_room_workouts_started_at_idx
+  on public.weight_room_workouts (started_at desc);
+
+-- At most one in-progress workout. Every open row indexes the same constant
+-- `true`, so the unique constraint permits exactly one. Swapping the indexed
+-- expression for `(profile_id)` later turns this into one-per-profile (#330).
+create unique index if not exists weight_room_workouts_single_open_idx
+  on public.weight_room_workouts ((ended_at is null))
+  where ended_at is null;
+
+alter table public.weight_room_workouts enable row level security;
+
+do $$
+begin
+  create policy "anon and authenticated can read weight room workouts"
+    on public.weight_room_workouts
+    for select
+    to anon, authenticated
+    using (true);
+exception when duplicate_object then null;
+end $$;
+
+-- ---------------------------------------------------------------------------
+-- Sets join a workout, optionally
+-- ---------------------------------------------------------------------------
+-- `on delete set null`: deleting a session must never delete training history.
+-- The sets fall back to loose sets, which is exactly what they were before the
+-- session existed. Same reasoning as #373's move from cascade to restrict.
+
+alter table public.weight_room_sets
+  add column if not exists workout_id uuid null
+  references public.weight_room_workouts(id) on delete set null;
+
+alter table public.weight_room_sets
+  add column if not exists position integer null;
+
+do $$
+begin
+  alter table public.weight_room_sets
+    add constraint weight_room_sets_position_check check (position is null or position >= 0);
+exception when duplicate_object then null;
+end $$;
+
+comment on column public.weight_room_sets.workout_id is
+  'The bounded session this set belongs to (#374), or NULL for a set logged loose — a grease-the-groove set at a desk, and every set predating workouts. Never backfilled: NULL is a real answer, not missing data.';
+
+comment on column public.weight_room_sets.position is
+  'Order of this set *within its workout*, not within its exercise — so an interleaved superset or a set squeezed in while waiting on a rack renders in the order it actually happened. Nullable, and gaps are fine; nothing renumbers.';
+
+create index if not exists weight_room_sets_workout_idx
+  on public.weight_room_sets (workout_id, position)
+  where workout_id is not null;

--- a/types/weight-room.ts
+++ b/types/weight-room.ts
@@ -49,6 +49,74 @@ export interface StrengthSet {
    * *slice* volume by variant in the History View, never to split it.
    */
   variant?: string
+  /**
+   * The bounded {@link WeightRoomWorkout} this set belongs to (#374), or absent
+   * for a set logged **loose** — a grease-the-groove set at a desk, and every
+   * set predating workouts.
+   *
+   * Absent is a real answer, not missing data: historical GTG sets were never
+   * workouts, and nothing backfills them. The API never infers this either — a
+   * set joins a session only when the caller passes it explicitly, so an
+   * afternoon pushup set can't silently become part of the morning's gym visit.
+   */
+  workout_id?: string
+  /**
+   * Order of this set *within its workout* — not within its exercise — so an
+   * interleaved superset, or a set squeezed in while waiting on a rack, renders
+   * in the order it actually happened. Absent for loose sets and wherever the
+   * writer didn't care. Gaps are fine; nothing renumbers.
+   */
+  position?: number
+}
+
+/**
+ * Where a {@link WeightRoomWorkout} happened (#374). Coarse on purpose — it
+ * exists to separate "at the gym" from "in the living room" when reading back
+ * a session, not to model venues.
+ */
+export type WorkoutLocation = 'gym' | 'home' | 'travel' | 'other'
+
+/**
+ * One bounded training session (#374) — mirrors a row of
+ * `public.weight_room_workouts`.
+ *
+ * A workout is an *event* (walk in, do five movements, walk out), which is a
+ * different unit from the calendar day every other Weight Room aggregation is
+ * built on. That difference is the point: duration, density, and per-session
+ * comparison are inexpressible when the day is the only bucket.
+ *
+ * Grease-the-groove sets deliberately have no workout. A null
+ * {@link StrengthSet.workout_id} means "logged loose", permanently.
+ */
+export interface WeightRoomWorkout {
+  /** UUID primary key, generated server-side. */
+  id: string
+  /**
+   * ISO 8601 timestamp the session began.
+   *
+   * Also decides which calendar day the workout belongs to: a session crossing
+   * midnight belongs **wholly to its start day**, resolved in Pacific via
+   * {@link import('@/lib/training-facility/day-keys').pacificDayKey}. Splitting
+   * one across two days would be wrong in every stat.
+   */
+  started_at: string
+  /**
+   * ISO 8601 timestamp the session finished, or absent while **in progress**.
+   *
+   * At most one workout may be in progress at a time (a partial unique index
+   * enforces it). One left open past
+   * {@link import('@/lib/training-facility/workout-sessions').STALE_WORKOUT_HOURS}
+   * is auto-ended when the next session starts — stamped at its last set's
+   * `logged_at`, which is the last real evidence of activity rather than a
+   * guess.
+   */
+  ended_at?: string
+  /** Free-text label, e.g. `Push Day`. Absent when unnamed. */
+  title?: string
+  /** Where it happened. Absent when unspecified. */
+  location?: WorkoutLocation
+  /** Free-text notes captured when ending the session. Absent when none. */
+  notes?: string
 }
 
 /**


### PR DESCRIPTION
The second link in #372, and the one everything else queues behind. Schema + API only — no UI, by design; #376 builds the recording surface on top.

## Why

A gym workout is a **bounded event** — walk in, do five movements, walk out. `weight_room_sets` carries only `logged_at`, and every consumer buckets by calendar day. That's correct for grease-the-groove, where the day genuinely *is* the unit, and it makes duration, density, and "how did tonight compare to last Tuesday" inexpressible.

`weight_room_workouts` gives the event a row; `weight_room_sets` gains a nullable `workout_id` and `position`.

## Three decisions worth reviewing

**Nullable, with no backfill.** Historical GTG sets were not workouts — they were sets scattered through a day. Synthesising sessions for them would invent structure that never existed, so a null `workout_id` means "logged loose", permanently. Every existing aggregation keeps working because every existing aggregation ignores it.

**One open workout, enforced by a partial unique index** on `(ended_at is null) where ended_at is null` — every open row indexes the same constant, so only one can exist. Deliberately a DB constraint rather than an application check, so a concurrent double-start fails at the database instead of racing past a read. It's shaped this way so #330 turns it into one-per-profile by swapping the indexed expression to `(profile_id)` and changing nothing else.

**A stale session is auto-ended rather than blocking you.** Forgetting to hit "end" is the normal failure mode, and finding out at the gym two days later is the wrong place for it. So an open session under 12h returns 409 (you're plausibly still in it), and one over 12h is auto-ended at its **last set's `logged_at`** — the last real evidence of training. Never "now", which would invent two days of session; never the horizon, which is an arbitrary clock boundary. A session that recorded nothing collapses to zero duration at `started_at`, which is honest.

**Sets never auto-attach.** A set joins a session only when the caller passes `workout_id`. No "attach to whatever is open" fallback, so a desk pushup set logged during a gym window stays loose. #376 and #378 each decide to attach.

## Deleting a session never deletes its sets

`workout_id` is `on delete set null`, so removing a workout drops the sets back to loose sets — exactly what they were before it existed. There's a test asserting the DELETE route never touches `weight_room_sets` at all, because a container delete destroying training history is the specific bug #373 removed.

## Migration

`20260802120000_weight_room_workouts.sql`, applied to **both** projects (`migrations:check`: 28 committed, 28 applied). Rehearsed on staging inside a transaction that rolled back:

```
REHEARSAL OK: second open workout blocked; closing frees the slot;
workout delete kept the set and nulled its workout_id.
```

Production verified afterwards: 1,234 sets, 0 attached, both columns present, nothing modified.

`position` is a SQL keyword, which the mocked route tests can't exercise, so I probed PostgREST directly — select, `order=position.asc.nullsfirst`, filtering on `workout_id`, and the new table's anon RLS all round-trip cleanly.

## Test plan

Nothing to click — the surfaces are admin API routes. What to verify:

- [ ] `/training-facility/weight-room` — rings, streaks, totals unchanged (the read path now selects two more columns).
- [ ] `/training-facility/weight-room/history` — heatmaps, weekly volume, load panel unchanged.
- [ ] `/training-facility/weight-room/log` — logging a set still works and still produces a loose set.
- [ ] Optionally, against the preview with an admin session:
  - `POST /api/admin/weight-room/workouts` `{}` → 201
  - `POST` again → 409 with `open_workout_id`
  - `PATCH /api/admin/weight-room/workouts/<id>` `{"ended_at":"<now>"}` → 200
  - `DELETE` it → 200, and any sets you attached survive with a null `workout_id`

Verified locally: `tsc --noEmit` clean, `next build` compiles (both routes registered), 1908 unit tests pass, 65/65 Playwright pass, `migrations:check` clean.

Closes #374.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added workout session management for the Weight Room, including creating, viewing, editing, closing, reopening, and deleting sessions.
  * Added workout titles, locations, notes, timestamps, and session status tracking.
  * Sets can now be associated with workouts and retain their order.
  * Unassigned sets remain available and are preserved when workouts are deleted.
  * Added validation for session details, timestamps, duplicate sessions, and invalid workout references.

* **Bug Fixes**
  * Improved handling and messaging for invalid workout and exercise references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->