### PR TITLE
feat(weight-room): render catalog display names instead of raw slugs (#384)

### DIFF
--- a/app/training-facility/weight-room/achievements/page.tsx
+++ b/app/training-facility/weight-room/achievements/page.tsx
@@ -39,7 +39,12 @@ export default async function WeightRoomAchievementsPage(): Promise<JSX.Element>
     isAdminRequest().catch(() => false),
   ])
 
-  const view = buildTrophyRoomView(data?.sets ?? [], data?.goals ?? [], achievements)
+  const view = buildTrophyRoomView(
+    data?.sets ?? [],
+    data?.goals ?? [],
+    achievements,
+    data?.exercises ?? [],
+  )
 
   return (
     <div className="relative min-h-svh overflow-hidden bg-[#120d0a] text-[#f7ead9]">

--- a/app/training-facility/weight-room/history/page.tsx
+++ b/app/training-facility/weight-room/history/page.tsx
@@ -25,6 +25,7 @@ import {
   parseExerciseSelection,
 } from '@/lib/training-facility/exercise-filter'
 import { pacificDayKey } from '@/lib/training-facility/day-keys'
+import { exerciseLabel } from '@/lib/training-facility/exercise-labels'
 import { buildMovementLoads } from '@/lib/training-facility/load-management'
 import {
   TRAINING_FACILITY_PREVIEW_PARAM,
@@ -272,6 +273,7 @@ export default async function WeightRoomHistoryPage({
             <ExerciseFilterChips
               exercises={goals.map(goal => ({
                 exercise: goal.exercise,
+                displayName: goal.display_name,
                 color: goal.color,
                 isFocus: goal.kind === 'focus',
               }))}
@@ -296,7 +298,7 @@ export default async function WeightRoomHistoryPage({
                         className="font-mono text-sm font-bold uppercase tracking-[0.2em]"
                         style={{ color: goal.color }}
                       >
-                        {goal.exercise}
+                        {exerciseLabel(goal)}
                       </h2>
                       <span className="font-mono text-[10px] uppercase tracking-[0.22em] text-[#e8d5be]/60">
                         goal {goal.daily_target}/day

--- a/components/training-facility/scenes/assets/weight-room-fixtures.tsx
+++ b/components/training-facility/scenes/assets/weight-room-fixtures.tsx
@@ -12,6 +12,7 @@ import type { WeightRoomData } from '@/types/weight-room'
 
 import { HANDWRITING_FONT, SCENE_PALETTE } from '../scene-primitives'
 import { RoughRect } from './rough-shapes'
+import { exerciseLabel } from '@/lib/training-facility/exercise-labels'
 
 /** Props for {@link WallActivityRings}. */
 export interface WallActivityRingsProps {
@@ -105,6 +106,8 @@ export function WallActivityRings({
 
   const rings = goals.map((goal) => ({
     exercise: goal.exercise,
+    // Slug stays the identity (test ids, keys); the label is what's drawn.
+    label: exerciseLabel(goal),
     color: goal.color,
     target: goal.daily_target,
     total: totals.get(goal.exercise) ?? 0,
@@ -288,7 +291,7 @@ export function WallActivityRings({
             fontFamily={HANDWRITING_FONT}
             fontSize={tallyFontSize}
           >
-            {ring.exercise} {ring.total}/{ring.target}
+            {ring.label} {ring.total}/{ring.target}
             {ring.streak > 0 ? `  ·  🔥${ring.streak}d` : ''}
           </text>
         ))

--- a/components/training-facility/weight-room/ActivityRings.tsx
+++ b/components/training-facility/weight-room/ActivityRings.tsx
@@ -1,6 +1,7 @@
 import type { JSX } from 'react'
 
 import type { ExerciseGoal } from '@/types/weight-room'
+import { exerciseLabel } from '@/lib/training-facility/exercise-labels'
 
 /** Per-exercise progress slice consumed by {@link ActivityRings}. */
 export interface RingProgress {
@@ -124,7 +125,7 @@ export function ActivityRings({
         aria-label={`Activity rings: ${rings
           .map(
             (r) =>
-              `${r.goal.exercise} ${r.totalReps} of ${r.goal.daily_target}`,
+              `${exerciseLabel(r.goal)} ${r.totalReps} of ${r.goal.daily_target}`,
           )
           .join(', ')}`}
         className="block w-full h-auto -rotate-90"
@@ -182,7 +183,7 @@ export function ActivityRings({
           flipping the text. */}
       <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center text-center">
         <span className="font-mono text-[10px] uppercase tracking-[0.32em] text-white/55">
-          {primary.goal.exercise}
+          {exerciseLabel(primary.goal)}
         </span>
         <span className="mt-1 font-mono text-3xl font-semibold tabular-nums text-white sm:text-4xl">
           {primary.totalReps}

--- a/components/training-facility/weight-room/ExerciseFilterChips.test.tsx
+++ b/components/training-facility/weight-room/ExerciseFilterChips.test.tsx
@@ -113,3 +113,31 @@ describe('ExerciseFilterChips', () => {
     expect(getByRole('navigation', { name: /show/i })).toBeInTheDocument()
   })
 })
+
+describe('ExerciseFilterChips — catalog labels (#384)', () => {
+  // Two movements, so toggling one produces a real filter param — with a
+  // single movement "selected" collapses to "all", which needs no param.
+  const LABELLED = [
+    { exercise: 'barbell-bench-press', displayName: 'Barbell Bench Press', color: '#EA580C', isFocus: false },
+    { exercise: 'barbell-row', displayName: 'Barbell Row', color: '#0EA5A1', isFocus: false },
+  ]
+
+  it('shows the display name but keeps the slug as the URL token', () => {
+    const { getByTestId, getByText } = render(
+      <ExerciseFilterChips exercises={LABELLED} selected={[]} pathname={PATH} />,
+    )
+    expect(getByText('Barbell Bench Press')).toBeInTheDocument()
+    // The href must stay slug-based or a shared filtered link breaks.
+    const chip = getByTestId('exercise-chip-barbell-bench-press')
+    expect(chip.getAttribute('href')).toContain('barbell-bench-press')
+    expect(chip.getAttribute('href')).not.toContain('Barbell')
+  })
+
+  it('names the toggle by the label for screen readers', () => {
+    const { getByLabelText } = render(
+      <ExerciseFilterChips exercises={LABELLED} selected={[]} pathname={PATH} />,
+    )
+    expect(getByLabelText('Show Barbell Bench Press')).toBeInTheDocument()
+  })
+})
+

--- a/components/training-facility/weight-room/ExerciseFilterChips.tsx
+++ b/components/training-facility/weight-room/ExerciseFilterChips.tsx
@@ -9,8 +9,14 @@ import {
 
 /** One selectable exercise, in render order. */
 export interface FilterableExercise {
-  /** Exercise name; the chip label and the URL token. */
+  /** Exercise slug; the URL token and the chip's identity. */
   exercise: string
+  /**
+   * Human label for the chip (#384). Absent falls back to {@link exercise}.
+   * The URL token always stays the slug, so a filtered link keeps working
+   * regardless of what the catalog calls the movement.
+   */
+  displayName?: string
   /** Hex accent from the goal, used to tint the chip when selected. */
   color: string
   /** Whether this is a "grease the groove" focus anchor rather than a permanent goal. */
@@ -78,7 +84,7 @@ export function ExerciseFilterChips({
         Show
       </span>
       <nav aria-labelledby="exercise-filter-label" className="flex flex-wrap gap-2">
-        {exercises.map(({ exercise, color, isFocus }) => {
+        {exercises.map(({ exercise, displayName, color, isFocus }) => {
           const isOn = selectedSet.has(exercise)
           return (
             <Link
@@ -87,7 +93,7 @@ export function ExerciseFilterChips({
               scroll={false}
               data-testid={`exercise-chip-${exercise}`}
               data-selected={isOn}
-              aria-label={`${isOn ? 'Hide' : 'Show'} ${exercise}`}
+              aria-label={`${isOn ? 'Hide' : 'Show'} ${displayName ?? exercise}`}
               className={`rounded-full border px-3 py-1 font-mono text-[11px] tracking-[0.12em] transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-300 ${
                 isOn
                   ? 'border-transparent text-[#0a0a0a]'
@@ -95,7 +101,7 @@ export function ExerciseFilterChips({
               }`}
               style={isOn ? { backgroundColor: color } : undefined}
             >
-              {exercise}
+              {displayName ?? exercise}
               {isFocus ? <span className="ml-1.5 opacity-70">GTG</span> : null}
             </Link>
           )

--- a/components/training-facility/weight-room/FocusLaneHeatmap.tsx
+++ b/components/training-facility/weight-room/FocusLaneHeatmap.tsx
@@ -8,6 +8,7 @@ import {
 import { intensityFromPct } from '@/lib/training-facility/weight-room-history'
 import type { FocusDayCell } from '@/lib/training-facility/monthly-focus'
 import type { MonthlyFocus } from '@/types/weight-room'
+import { exerciseLabel } from '@/lib/training-facility/exercise-labels'
 
 // ---------------------------------------------------------------------------
 // Layout constants — match StrengthHeatmap.tsx so the two components sit in
@@ -179,11 +180,11 @@ function describeSlot(slot: GridSlot): string {
   if (slot.cell === null) return dateLabel
   const { cell } = slot
   if (cell.focus === null) return `${dateLabel} (no focus)`
-  if (cell.volume === 0) return `${dateLabel}: ${cell.focus.exercise} — none logged`
+  if (cell.volume === 0) return `${dateLabel}: ${exerciseLabel(cell.focus)} — none logged`
 
   const unit = cell.focus.target_kind === 'sets' ? 'sets' : 'reps'
   const pctLabel = `${Math.round(cell.pct * 100)}% of daily goal`
-  return `${dateLabel}: ${cell.volume} ${unit} ${cell.focus.exercise} (${pctLabel})`
+  return `${dateLabel}: ${cell.volume} ${unit} ${exerciseLabel(cell.focus)} (${pctLabel})`
 }
 
 /**
@@ -438,7 +439,7 @@ export function FocusLaneHeatmap({
               fontSize={SMALL_LABEL_FONT_SIZE}
               fill={LABEL_FILL}
             >
-              {focus.exercise}
+              {exerciseLabel(focus)}
             </text>
           </g>
         ))}

--- a/components/training-facility/weight-room/LoadManagementPanel.tsx
+++ b/components/training-facility/weight-room/LoadManagementPanel.tsx
@@ -62,7 +62,7 @@ function MovementLoadCard({ load }: MovementLoadCardProps): JSX.Element {
     <article
       data-testid={`load-card-${load.movement}`}
       data-flag={load.flag}
-      aria-label={`${load.movement}: ${flagMeta.label}`}
+      aria-label={`${load.displayName ?? load.movement}: ${flagMeta.label}`}
       className="rounded-[1.2rem] border border-white/10 bg-[#f5f1e6] p-5 text-[#0a0a0a] shadow-[0_12px_32px_rgba(0,0,0,0.28)]"
     >
       <header className="flex items-baseline justify-between gap-3">
@@ -70,7 +70,7 @@ function MovementLoadCard({ load }: MovementLoadCardProps): JSX.Element {
           className="font-mono text-sm font-bold uppercase tracking-[0.2em]"
           style={{ color: load.color }}
         >
-          {load.movement}
+          {load.displayName ?? load.movement}
         </h3>
         <span className="flex items-center gap-1.5">
           <span
@@ -113,7 +113,7 @@ function MovementLoadCard({ load }: MovementLoadCardProps): JSX.Element {
             width={SPARK_WIDTH}
             height={SPARK_HEIGHT}
             stroke={load.color}
-            ariaLabel={`${load.movement} 28-day ${load.metric === 'load' ? 'load' : 'rep'} volume trend`}
+            ariaLabel={`${load.displayName ?? load.movement} 28-day ${load.metric === 'load' ? 'load' : 'rep'} volume trend`}
           />
         </div>
       </div>

--- a/components/training-facility/weight-room/LogDataIsland.tsx
+++ b/components/training-facility/weight-room/LogDataIsland.tsx
@@ -32,7 +32,11 @@ import { QuickLog } from './QuickLog'
 import { SetList } from './SetList'
 import { StreakBadge } from './StreakBadge'
 import { UpcomingFocusStrip } from './UpcomingFocusStrip'
-import { exerciseLabel, slugLabel } from '@/lib/training-facility/exercise-labels'
+import {
+  buildExerciseLabels,
+  exerciseLabel,
+  slugLabel,
+} from '@/lib/training-facility/exercise-labels'
 
 /**
  * Admin Log View data island (#197). Owns the strength dataset that
@@ -180,6 +184,7 @@ export function LogDataIsland(): JSX.Element {
   const streaks = computeStrengthStreaks(surfaceData.sets, visibleGoals)
   // SetList color/label lookup spans *all* goals (incl. inactive focuses)
   // so a backfilled out-of-window set still resolves its exercise.
+  const exerciseLabels = buildExerciseLabels(surfaceData.exercises)
   const goalsByExercise = Object.fromEntries(
     surfaceData.goals.map((g) => [g.exercise, forSelectedDay(g)]),
   )
@@ -281,8 +286,14 @@ export function LogDataIsland(): JSX.Element {
           <SetList
             setsToday={setsForDay}
             goalsByExercise={goalsByExercise}
+            labels={exerciseLabels}
             onDelete={(s) =>
-              deleteSet(s, setBusy, refetch, slugLabel(s.exercise, goalsByExercise[s.exercise]))
+              deleteSet(
+                s,
+                setBusy,
+                refetch,
+                slugLabel(s.exercise, goalsByExercise[s.exercise], exerciseLabels),
+              )
             }
             busy={busy}
             dayLabel={isBackfilling ? formatDayLabel(selectedDay) || selectedDay : 'Today'}

--- a/components/training-facility/weight-room/LogDataIsland.tsx
+++ b/components/training-facility/weight-room/LogDataIsland.tsx
@@ -32,6 +32,7 @@ import { QuickLog } from './QuickLog'
 import { SetList } from './SetList'
 import { StreakBadge } from './StreakBadge'
 import { UpcomingFocusStrip } from './UpcomingFocusStrip'
+import { exerciseLabel, slugLabel } from '@/lib/training-facility/exercise-labels'
 
 /**
  * Admin Log View data island (#197). Owns the strength dataset that
@@ -218,7 +219,7 @@ export function LogDataIsland(): JSX.Element {
             {visibleGoals.map((goal) => (
               <StreakBadge
                 key={goal.exercise}
-                exercise={goal.exercise}
+                exercise={exerciseLabel(goal)}
                 streak={streaks[goal.exercise] ?? { current: 0, longest: 0 }}
                 accentColor={goal.color}
               />
@@ -280,7 +281,9 @@ export function LogDataIsland(): JSX.Element {
           <SetList
             setsToday={setsForDay}
             goalsByExercise={goalsByExercise}
-            onDelete={(s) => deleteSet(s, setBusy, refetch)}
+            onDelete={(s) =>
+              deleteSet(s, setBusy, refetch, slugLabel(s.exercise, goalsByExercise[s.exercise]))
+            }
             busy={busy}
             dayLabel={isBackfilling ? formatDayLabel(selectedDay) || selectedDay : 'Today'}
           />
@@ -340,8 +343,9 @@ async function deleteSet(
   set: StrengthSet,
   setBusy: (v: boolean) => void,
   refetch: () => Promise<void>,
+  label: string = set.exercise,
 ): Promise<void> {
-  const ok = window.confirm(`Delete this set of ${set.reps} ${set.exercise}?`)
+  const ok = window.confirm(`Delete this set of ${set.reps} ${label}?`)
   if (!ok) return
   setBusy(true)
   try {

--- a/components/training-facility/weight-room/MonthlyFocusCard.test.tsx
+++ b/components/training-facility/weight-room/MonthlyFocusCard.test.tsx
@@ -188,3 +188,21 @@ describe('MonthlyFocusCard', () => {
     expect(screen.getByText(/\/ 5 sets today/)).toBeInTheDocument()
   })
 })
+
+describe('MonthlyFocusCard — catalog labels (#384)', () => {
+  it('renders the catalog label and keys off the slug', () => {
+    const focus = { ...FOCUS, exercise: 'farmers-carry', display_name: "Farmer's Carry" }
+    const { getByText, queryByText, getByTestId } = render(
+      <MonthlyFocusCard
+        focus={focus}
+        todayProgress={60}
+        adherence={ADHERENCE}
+        loadStats={WEIGHTED_LOAD}
+      />,
+    )
+    expect(getByText("Farmer's Carry")).toBeInTheDocument()
+    expect(queryByText('farmers-carry')).toBeNull()
+    expect(getByTestId('monthly-focus-farmers-carry')).toBeInTheDocument()
+  })
+})
+

--- a/components/training-facility/weight-room/MonthlyFocusCard.tsx
+++ b/components/training-facility/weight-room/MonthlyFocusCard.tsx
@@ -6,6 +6,7 @@ import {
   type FocusLoadStats,
 } from '@/lib/training-facility/monthly-focus'
 import type { MonthlyFocus } from '@/types/weight-room'
+import { exerciseLabel } from '@/lib/training-facility/exercise-labels'
 
 /** Props for {@link MonthlyFocusCard}. */
 export interface MonthlyFocusCardProps {
@@ -67,7 +68,7 @@ export function MonthlyFocusCard({
           className="font-mono text-[10px] font-semibold uppercase tracking-[0.2em]"
           style={{ color: focus.color }}
         >
-          {focus.exercise}
+          {exerciseLabel(focus)}
         </span>
       </div>
 

--- a/components/training-facility/weight-room/PastFocusCard.tsx
+++ b/components/training-facility/weight-room/PastFocusCard.tsx
@@ -9,6 +9,7 @@ import {
   type FocusLoadStats,
 } from '@/lib/training-facility/monthly-focus'
 import type { MonthlyFocus } from '@/types/weight-room'
+import { exerciseLabel } from '@/lib/training-facility/exercise-labels'
 
 // ---------------------------------------------------------------------------
 // Ring animation constants
@@ -127,7 +128,7 @@ export function PastFocusCard({ focus, adherence, loadStats }: PastFocusCardProp
           height={88}
           viewBox="0 0 88 88"
           role="img"
-          aria-label={`${Math.round(pct * 100)}% adherence for ${focus.exercise}`}
+          aria-label={`${Math.round(pct * 100)}% adherence for ${exerciseLabel(focus)}`}
         >
           {/* Background track */}
           <circle
@@ -181,7 +182,7 @@ export function PastFocusCard({ focus, adherence, loadStats }: PastFocusCardProp
             className="font-mono text-[10px] font-semibold uppercase tracking-[0.2em]"
             style={{ color: focus.color }}
           >
-            {focus.exercise}
+            {exerciseLabel(focus)}
           </span>
         </div>
 

--- a/components/training-facility/weight-room/QuickLog.tsx
+++ b/components/training-facility/weight-room/QuickLog.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useId, useState, type FormEvent, type JSX } from 'react'
 
 import type { ExerciseGoal } from '@/types/weight-room'
+import { exerciseLabel, slugLabel } from '@/lib/training-facility/exercise-labels'
 
 /** Props for {@link QuickLog}. */
 export interface QuickLogProps {
@@ -120,7 +121,9 @@ export function QuickLog({
       await onLog({ exercise, reps, ...(trimmed ? { variant: trimmed } : {}) })
     } catch (err) {
       setError(
-        err instanceof Error ? err.message : `Couldn’t log ${reps} ${exercise}.`,
+        err instanceof Error
+          ? err.message
+          : `Couldn’t log ${reps} ${slugLabel(exercise, goals.find((g) => g.exercise === exercise))}.`,
       )
     } finally {
       setPendingExercise(null)
@@ -267,7 +270,7 @@ function QuickLogRow({
           className="font-mono text-sm font-semibold uppercase tracking-[0.18em]"
           style={{ color: goal.color }}
         >
-          {goal.exercise}
+          {exerciseLabel(goal)}
         </span>
         <span className="font-mono text-[10px] uppercase tracking-[0.22em] text-white/45">
           target {goal.daily_target}
@@ -308,7 +311,7 @@ function QuickLogRow({
           value={gripSelectValue}
           onChange={(e) => handleGripSelect(e.target.value)}
           disabled={disabled}
-          aria-label={`Grip for ${goal.exercise} (optional)`}
+          aria-label={`Grip for ${exerciseLabel(goal)} (optional)`}
           data-testid={`quick-log-${goal.exercise}-grip`}
           className="rounded border border-white/15 bg-black/40 px-2 py-1.5 font-mono text-sm text-white focus:border-amber-300/60 focus:outline-none disabled:cursor-not-allowed disabled:opacity-40"
         >
@@ -328,7 +331,7 @@ function QuickLogRow({
             onChange={(e) => setVariant(e.target.value)}
             disabled={disabled}
             placeholder="type a grip"
-            aria-label={`Custom grip for ${goal.exercise}`}
+            aria-label={`Custom grip for ${exerciseLabel(goal)}`}
             data-testid={`quick-log-${goal.exercise}-variant`}
             className="w-32 rounded border border-white/15 bg-black/40 px-2 py-1.5 font-mono text-sm text-white placeholder:text-white/30 focus:border-amber-300/60 focus:outline-none disabled:cursor-not-allowed disabled:opacity-40"
           />

--- a/components/training-facility/weight-room/SetList.test.tsx
+++ b/components/training-facility/weight-room/SetList.test.tsx
@@ -180,8 +180,34 @@ describe('SetList — catalog labels (#384)', () => {
     expect(screen.getByTestId('set-list-total-barbell-bench-press')).toBeInTheDocument()
   })
 
-  it('falls back to the slug for a set whose goal was deleted', () => {
-    // Sets outlive their goal by design (#373), so this is a live path.
+  it('still labels a set whose goal was deleted, from the catalog', () => {
+    // Sets outlive their goal by design (#373), so this is a live path — and
+    // the catalog still holds the label even though the goal is gone.
+    render(
+      <SetList
+        setsToday={[set({ id: 'a', exercise: 'barbell-bench-press', reps: 5 })]}
+        goalsByExercise={{}}
+        labels={new Map([['barbell-bench-press', 'Barbell Bench Press']])}
+      />,
+    )
+    expect(screen.getAllByText('Barbell Bench Press').length).toBeGreaterThan(0)
+    expect(screen.queryByText('barbell-bench-press')).toBeNull()
+  })
+
+  it('prefers the catalog label over a stale one joined onto the goal', () => {
+    // The catalog is the owner; a goal's joined copy is a read-time convenience.
+    render(
+      <SetList
+        setsToday={[set({ id: 'a', exercise: 'barbell-bench-press', reps: 5 })]}
+        goalsByExercise={{ 'barbell-bench-press': { ...BENCH, display_name: 'Stale Name' } }}
+        labels={new Map([['barbell-bench-press', 'Barbell Bench Press']])}
+      />,
+    )
+    expect(screen.getAllByText('Barbell Bench Press').length).toBeGreaterThan(0)
+    expect(screen.queryByText('Stale Name')).toBeNull()
+  })
+
+  it('falls back to the slug with neither catalog nor goal', () => {
     render(
       <SetList
         setsToday={[set({ id: 'a', exercise: 'barbell-bench-press', reps: 5 })]}

--- a/components/training-facility/weight-room/SetList.test.tsx
+++ b/components/training-facility/weight-room/SetList.test.tsx
@@ -157,3 +157,50 @@ describe('SetList', () => {
     expect(total).not.toHaveTextContent('/')
   })
 })
+
+describe('SetList — catalog labels (#384)', () => {
+  const BENCH: ExerciseGoal = {
+    exercise: 'barbell-bench-press',
+    display_name: 'Barbell Bench Press',
+    daily_target: 30,
+    color: '#0EA5A1',
+  }
+
+  it('labels both the running total and each set row from the catalog', () => {
+    render(
+      <SetList
+        setsToday={[set({ id: 'a', exercise: 'barbell-bench-press', reps: 5 })]}
+        goalsByExercise={{ 'barbell-bench-press': BENCH }}
+      />,
+    )
+    // Totals strip + the set row itself.
+    expect(screen.getAllByText('Barbell Bench Press').length).toBeGreaterThanOrEqual(2)
+    expect(screen.queryByText('barbell-bench-press')).toBeNull()
+    // Identity hook stays on the slug.
+    expect(screen.getByTestId('set-list-total-barbell-bench-press')).toBeInTheDocument()
+  })
+
+  it('falls back to the slug for a set whose goal was deleted', () => {
+    // Sets outlive their goal by design (#373), so this is a live path.
+    render(
+      <SetList
+        setsToday={[set({ id: 'a', exercise: 'barbell-bench-press', reps: 5 })]}
+        goalsByExercise={{}}
+      />,
+    )
+    expect(screen.getAllByText('barbell-bench-press').length).toBeGreaterThan(0)
+  })
+
+  it('names the delete control with the label', async () => {
+    const onDelete = vi.fn()
+    render(
+      <SetList
+        setsToday={[set({ id: 'a', exercise: 'barbell-bench-press', reps: 5 })]}
+        goalsByExercise={{ 'barbell-bench-press': BENCH }}
+        onDelete={onDelete}
+      />,
+    )
+    expect(screen.getByLabelText('Delete set of 5 Barbell Bench Press')).toBeInTheDocument()
+  })
+})
+

--- a/components/training-facility/weight-room/SetList.tsx
+++ b/components/training-facility/weight-room/SetList.tsx
@@ -3,6 +3,7 @@
 import { useState, type JSX } from 'react'
 
 import type { ExerciseGoal, StrengthSet } from '@/types/weight-room'
+import { slugLabel } from '@/lib/training-facility/exercise-labels'
 
 /** Props for {@link SetList}. */
 export interface SetListProps {
@@ -141,7 +142,7 @@ export function SetList({
                   className="text-[10px] font-semibold uppercase tracking-[0.18em]"
                   style={{ color }}
                 >
-                  {exercise}
+                  {slugLabel(exercise, goal)}
                 </span>
                 <span className="text-sm font-semibold tabular-nums text-white">
                   {total}
@@ -177,7 +178,7 @@ export function SetList({
                 className="min-w-[80px] font-mono text-sm font-semibold uppercase tracking-[0.18em]"
                 style={{ color }}
               >
-                {s.exercise}
+                {slugLabel(s.exercise, goalsByExercise[s.exercise])}
               </span>
               <span className="font-mono text-base font-semibold tabular-nums text-white">
                 {s.reps}
@@ -196,7 +197,7 @@ export function SetList({
               {onDelete ? (
                 <button
                   type="button"
-                  aria-label={`Delete set of ${s.reps} ${s.exercise}`}
+                  aria-label={`Delete set of ${s.reps} ${slugLabel(s.exercise, goalsByExercise[s.exercise])}`}
                   disabled={busy || isPending}
                   onClick={() => void handleDelete(s)}
                   className="rounded-full border border-rose-300/25 bg-rose-300/5 px-3 py-1 font-mono text-[10px] uppercase tracking-[0.22em] text-rose-200 transition hover:bg-rose-300/15 disabled:cursor-not-allowed disabled:opacity-40"

--- a/components/training-facility/weight-room/SetList.tsx
+++ b/components/training-facility/weight-room/SetList.tsx
@@ -3,7 +3,7 @@
 import { useState, type JSX } from 'react'
 
 import type { ExerciseGoal, StrengthSet } from '@/types/weight-room'
-import { slugLabel } from '@/lib/training-facility/exercise-labels'
+import { slugLabel, type ExerciseLabels } from '@/lib/training-facility/exercise-labels'
 
 /** Props for {@link SetList}. */
 export interface SetListProps {
@@ -23,6 +23,12 @@ export interface SetListProps {
    * usually disappear together).
    */
   goalsByExercise: Readonly<Record<string, ExerciseGoal | undefined>>
+  /**
+   * Catalog slug → label lookup (#384). Preferred over the goal's joined
+   * label, because a set outlives its goal by design — deleting a goal keeps
+   * the sets, and only the catalog still knows what the movement is called.
+   */
+  labels?: ExerciseLabels
   /**
    * Per-row delete handler. Omit to render the list read-only — non-
    * admin viewers don't see the trash icon. Resolves clear the
@@ -57,6 +63,7 @@ export interface SetListProps {
 export function SetList({
   setsToday,
   goalsByExercise,
+  labels,
   onDelete,
   busy = false,
   dayLabel = 'Today',
@@ -142,7 +149,7 @@ export function SetList({
                   className="text-[10px] font-semibold uppercase tracking-[0.18em]"
                   style={{ color }}
                 >
-                  {slugLabel(exercise, goal)}
+                  {slugLabel(exercise, goal, labels)}
                 </span>
                 <span className="text-sm font-semibold tabular-nums text-white">
                   {total}
@@ -178,7 +185,7 @@ export function SetList({
                 className="min-w-[80px] font-mono text-sm font-semibold uppercase tracking-[0.18em]"
                 style={{ color }}
               >
-                {slugLabel(s.exercise, goalsByExercise[s.exercise])}
+                {slugLabel(s.exercise, goalsByExercise[s.exercise], labels)}
               </span>
               <span className="font-mono text-base font-semibold tabular-nums text-white">
                 {s.reps}
@@ -197,7 +204,7 @@ export function SetList({
               {onDelete ? (
                 <button
                   type="button"
-                  aria-label={`Delete set of ${s.reps} ${slugLabel(s.exercise, goalsByExercise[s.exercise])}`}
+                  aria-label={`Delete set of ${s.reps} ${slugLabel(s.exercise, goalsByExercise[s.exercise], labels)}`}
                   disabled={busy || isPending}
                   onClick={() => void handleDelete(s)}
                   className="rounded-full border border-rose-300/25 bg-rose-300/5 px-3 py-1 font-mono text-[10px] uppercase tracking-[0.22em] text-rose-200 transition hover:bg-rose-300/15 disabled:cursor-not-allowed disabled:opacity-40"

--- a/components/training-facility/weight-room/StreakBadge.tsx
+++ b/components/training-facility/weight-room/StreakBadge.tsx
@@ -4,7 +4,11 @@ import type { StrengthStreakResult } from '@/lib/training-facility/strength-stre
 
 /** Props for {@link StreakBadge}. */
 export interface StreakBadgeProps {
-  /** Display name for the exercise (e.g. `pushups`). Rendered uppercased. */
+  /**
+   * Label to render, uppercased by CSS. Callers pass the catalog's
+   * `display_name` when there is one (#384) and the slug otherwise — this is
+   * display text, never an identity.
+   */
   exercise: string
   /** Active and longest streak counts, from `computeStrengthStreaks`. */
   streak: StrengthStreakResult

--- a/components/training-facility/weight-room/StrengthHeatmap.tsx
+++ b/components/training-facility/weight-room/StrengthHeatmap.tsx
@@ -12,6 +12,7 @@ import {
 import type { ExerciseGoal, StrengthSet } from '@/types/weight-room'
 
 import { GoalChangeMarker } from './GoalChangeMarker'
+import { exerciseLabel } from '@/lib/training-facility/exercise-labels'
 
 /** Props for {@link StrengthHeatmap}. */
 export interface StrengthHeatmapProps {
@@ -126,7 +127,7 @@ export function StrengthHeatmap({
 
   const totalWidth = DAY_LABEL_WIDTH + gridWidth + monthOverhang
   const totalHeight = MONTH_LABEL_HEIGHT + gridHeight + LEGEND_HEIGHT
-  const label = ariaLabel ?? `${goal.exercise} heatmap`
+  const label = ariaLabel ?? `${exerciseLabel(goal)} heatmap`
 
   // Boundary markers for target changes (#362), dropped to whichever column
   // holds the effective date. Changes outside the visible window resolve to
@@ -275,7 +276,7 @@ function describeCell(cell: StrengthHeatmapCell, goal: ExerciseGoal): string {
   if (cell.reps === 0) return dateLabel
   const setNoun = cell.setCount === 1 ? 'set' : 'sets'
   const pctLabel = `${Math.round(cell.pct * 100)}%`
-  return `${dateLabel}: ${cell.reps} reps (${cell.setCount} ${setNoun}, ${pctLabel} of ${cell.dailyTarget} ${goal.exercise} goal)`
+  return `${dateLabel}: ${cell.reps} reps (${cell.setCount} ${setNoun}, ${pctLabel} of ${cell.dailyTarget} ${exerciseLabel(goal)} goal)`
 }
 
 /**

--- a/components/training-facility/weight-room/StrengthSettings.tsx
+++ b/components/training-facility/weight-room/StrengthSettings.tsx
@@ -4,6 +4,7 @@ import { useRouter } from 'next/navigation'
 import { useState, useTransition, type FormEvent, type JSX } from 'react'
 
 import type { ExerciseGoal } from '@/types/weight-room'
+import { exerciseLabel } from '@/lib/training-facility/exercise-labels'
 
 /** Props for {@link StrengthSettings}. */
 export interface StrengthSettingsProps {
@@ -56,12 +57,12 @@ export function StrengthSettings({ initialGoals }: StrengthSettingsProps): JSX.E
     refresh()
   }
 
-  async function deleteGoal(exercise: string): Promise<void> {
+  async function deleteGoal(exercise: string, label: string = exercise): Promise<void> {
     setError(null)
     // Sets FK into the movement catalog, not into goals (#373), so this drops
     // the daily ring and its target history and leaves the training log alone.
     const ok = window.confirm(
-      `Remove the daily goal for "${exercise}"? Its logged sets are kept — this only stops the daily ring and clears its target history.`,
+      `Remove the daily goal for "${label}"? Its logged sets are kept — this only stops the daily ring and clears its target history.`,
     )
     if (!ok) return
     const res = await fetch(
@@ -124,7 +125,7 @@ interface GoalRowProps {
   goal: ExerciseGoal
   disabled: boolean
   onSave: (goal: ExerciseGoal) => Promise<void>
-  onDelete: (exercise: string) => Promise<void>
+  onDelete: (exercise: string, label: string) => Promise<void>
 }
 
 function GoalRow({ goal, disabled, onSave, onDelete }: GoalRowProps): JSX.Element {
@@ -145,7 +146,7 @@ function GoalRow({ goal, disabled, onSave, onDelete }: GoalRowProps): JSX.Elemen
         className="flex flex-wrap items-center gap-3 sm:gap-4"
       >
         <span className="font-mono text-sm font-semibold uppercase tracking-[0.18em] text-white">
-          {goal.exercise}
+          {exerciseLabel(goal)}
         </span>
         <label className="flex items-center gap-2 text-xs text-white/70">
           <span className="font-mono uppercase tracking-[0.18em]">target</span>
@@ -177,7 +178,7 @@ function GoalRow({ goal, disabled, onSave, onDelete }: GoalRowProps): JSX.Elemen
           <button
             type="button"
             disabled={disabled}
-            onClick={() => onDelete(goal.exercise)}
+            onClick={() => onDelete(goal.exercise, exerciseLabel(goal))}
             className="rounded-full border border-rose-300/25 bg-rose-300/5 px-4 py-1.5 font-mono text-[11px] uppercase tracking-[0.22em] text-rose-200 transition hover:bg-rose-300/15 disabled:cursor-not-allowed disabled:opacity-40"
           >
             Delete

--- a/components/training-facility/weight-room/StrengthStats.test.tsx
+++ b/components/training-facility/weight-room/StrengthStats.test.tsx
@@ -248,3 +248,32 @@ describe('StrengthStats — upcoming rotations (#367 review)', () => {
     )
   })
 })
+
+describe('StrengthStats — catalog labels (#384)', () => {
+  it('renders the catalog display name instead of the slug', () => {
+    const { getByText, queryByText } = render(
+      <StrengthStats
+        stats={[{ ...PUSHUP_STATS, exercise: 'barbell-bench-press', displayName: 'Barbell Bench Press' }]}
+      />,
+    )
+    expect(getByText('Barbell Bench Press')).toBeInTheDocument()
+    expect(queryByText('barbell-bench-press')).toBeNull()
+  })
+
+  it('keys the card off the slug, not the label', () => {
+    // Identity stays the slug so test hooks, URLs, and React keys are stable
+    // across a rename in the catalog.
+    const { getByTestId } = render(
+      <StrengthStats
+        stats={[{ ...PUSHUP_STATS, exercise: 'barbell-bench-press', displayName: 'Barbell Bench Press' }]}
+      />,
+    )
+    expect(getByTestId('strength-stat-card-barbell-bench-press')).toBeInTheDocument()
+  })
+
+  it('falls back to the slug when the catalog has no label', () => {
+    const { getByText } = render(<StrengthStats stats={[PUSHUP_STATS]} />)
+    expect(getByText('pushups')).toBeInTheDocument()
+  })
+})
+

--- a/components/training-facility/weight-room/StrengthStats.tsx
+++ b/components/training-facility/weight-room/StrengthStats.tsx
@@ -89,7 +89,7 @@ export function ExerciseStatCard({ stat }: ExerciseStatCardProps): JSX.Element {
           className="flex items-baseline gap-2 font-mono text-sm font-bold uppercase tracking-[0.2em]"
           style={{ color: stat.color }}
         >
-          {stat.exercise}
+          {stat.displayName ?? stat.exercise}
           {stat.focus ? (
             <span
               data-testid={`strength-stat-focus-badge-${stat.exercise}`}

--- a/components/training-facility/weight-room/StrengthVsBodyweightChart.tsx
+++ b/components/training-facility/weight-room/StrengthVsBodyweightChart.tsx
@@ -7,6 +7,7 @@ import { buildWeeklyVolume } from '@/lib/training-facility/weight-room-history'
 import type { CardioTimePoint } from '@/types/cardio'
 import type { Benchmark } from '@/types/movement'
 import type { ExerciseGoal, StrengthSet } from '@/types/weight-room'
+import { exerciseLabel } from '@/lib/training-facility/exercise-labels'
 
 /** Cream axis ink that reads on the Weight Room's dark card surface. */
 const AXIS_COLOR = 'rgba(247, 234, 217, 0.6)'
@@ -95,8 +96,8 @@ export function StrengthVsBodyweightChart({
         width={width}
         height={height}
         axisColor={AXIS_COLOR}
-        emptyMessage={`Not enough completed weeks of ${goal.exercise} yet`}
-        ariaLabel={`${goal.exercise} weekly volume — not enough completed weeks yet`}
+        emptyMessage={`Not enough completed weeks of ${exerciseLabel(goal)} yet`}
+        ariaLabel={`${exerciseLabel(goal)} weekly volume — not enough completed weeks yet`}
       />
     )
   }
@@ -119,7 +120,7 @@ export function StrengthVsBodyweightChart({
         height={height}
         stroke={BODYWEIGHT_STROKE}
         axisColor={AXIS_COLOR}
-        ariaLabel={`Morning bodyweight in pounds overlaid on weekly ${goal.exercise} volume`}
+        ariaLabel={`Morning bodyweight in pounds overlaid on weekly ${exerciseLabel(goal)} volume`}
       >
         <RoughLine
           data={points}
@@ -129,11 +130,11 @@ export function StrengthVsBodyweightChart({
           height={height}
           stroke={goal.color}
           axisColor={AXIS_COLOR}
-          yLabel={`${goal.exercise}/wk`}
-          ariaLabel={`Weekly ${goal.exercise} volume over ${points.length} weeks`}
+          yLabel={`${exerciseLabel(goal)}/wk`}
+          ariaLabel={`Weekly ${exerciseLabel(goal)} volume over ${points.length} weeks`}
         />
       </BodyweightOverlay>
-      <ChartLegend exercise={goal.exercise} exerciseColor={goal.color} />
+      <ChartLegend exercise={exerciseLabel(goal)} exerciseColor={goal.color} />
     </div>
   )
 }

--- a/components/training-facility/weight-room/TrophyRoom.tsx
+++ b/components/training-facility/weight-room/TrophyRoom.tsx
@@ -375,7 +375,7 @@ function ChaseCard({ entry }: { entry: ResolvedAchievement }): JSX.Element {
   const color = achievement.color ?? DEFAULT_ACCENT
   const pct = Math.round(progress * 100)
   const unit = achievementUnit(achievement)
-  const scopeOwner = achievement.exercise ?? 'all movements'
+  const scopeOwner = entry.displayName ?? achievement.exercise ?? 'all movements'
 
   return (
     <div

--- a/components/training-facility/weight-room/UpcomingFocusStrip.tsx
+++ b/components/training-facility/weight-room/UpcomingFocusStrip.tsx
@@ -2,6 +2,7 @@ import type { JSX } from 'react'
 
 import { formatFocusWindow } from '@/lib/training-facility/monthly-focus'
 import type { MonthlyFocus } from '@/types/weight-room'
+import { exerciseLabel } from '@/lib/training-facility/exercise-labels'
 
 /** Props for {@link UpcomingFocusStrip}. */
 export interface UpcomingFocusStripProps {
@@ -37,7 +38,7 @@ export function UpcomingFocusStrip({ focuses }: UpcomingFocusStripProps): JSX.El
         >
           <span aria-hidden="true" className="h-2 w-2 rounded-full" style={{ background: focus.color }} />
           <span className="font-mono text-[11px] font-semibold uppercase tracking-[0.14em] text-white/80">
-            {focus.exercise}
+            {exerciseLabel(focus)}
           </span>
           <span
             data-testid={`upcoming-focus-${focus.exercise}-category`}

--- a/components/training-facility/weight-room/VariantBreakdown.tsx
+++ b/components/training-facility/weight-room/VariantBreakdown.tsx
@@ -2,6 +2,7 @@ import type { JSX } from 'react'
 
 import { variantBreakdown, type VariantSlice } from '@/lib/training-facility/strength-today'
 import type { ExerciseGoal, StrengthSet } from '@/types/weight-room'
+import { exerciseLabel } from '@/lib/training-facility/exercise-labels'
 
 /** Props for {@link VariantBreakdown}. */
 export interface VariantBreakdownProps {
@@ -64,7 +65,7 @@ export function VariantBreakdown({ sets, goal }: VariantBreakdownProps): JSX.Ele
   return (
     <section
       data-testid={`variant-breakdown-${goal.exercise}`}
-      aria-label={`${goal.exercise} variant breakdown`}
+      aria-label={`${exerciseLabel(goal)} variant breakdown`}
       className="mt-5 border-t border-white/10 pt-4"
     >
       <p className="mb-2 font-mono text-[10px] uppercase tracking-[0.22em] text-[#e8d5be]/60">
@@ -73,7 +74,7 @@ export function VariantBreakdown({ sets, goal }: VariantBreakdownProps): JSX.Ele
 
       <div
         role="img"
-        aria-label={`${goal.exercise} by variant: ${summary}`}
+        aria-label={`${exerciseLabel(goal)} by variant: ${summary}`}
         className="flex h-3 w-full overflow-hidden rounded-full bg-black/30"
       >
         {slices.map((slice, i) => (

--- a/components/training-facility/weight-room/WeeklyVolumeChart.tsx
+++ b/components/training-facility/weight-room/WeeklyVolumeChart.tsx
@@ -3,6 +3,7 @@ import type { JSX } from 'react'
 import { RoughBar } from '@/components/training-facility/shared/charts'
 import { buildWeeklyVolume } from '@/lib/training-facility/weight-room-history'
 import type { ExerciseGoal, StrengthSet } from '@/types/weight-room'
+import { exerciseLabel } from '@/lib/training-facility/exercise-labels'
 
 /** Cream axis ink that reads on the Weight Room's dark card surface. */
 const AXIS_COLOR = 'rgba(247, 234, 217, 0.55)'
@@ -62,7 +63,7 @@ export function WeeklyVolumeChart({
       stroke={goal.color}
       axisColor={AXIS_COLOR}
       yLabel="reps"
-      ariaLabel={`${goal.exercise} weekly volume over the last ${points.length} weeks (weekly goal ${weeklyGoal} reps)`}
+      ariaLabel={`${exerciseLabel(goal)} weekly volume over the last ${points.length} weeks (weekly goal ${weeklyGoal} reps)`}
       emptyMessage="No sets logged yet"
     />
   )

--- a/constants/weight-room-demo-fixture.ts
+++ b/constants/weight-room-demo-fixture.ts
@@ -22,10 +22,16 @@
 
 import type { ExerciseGoal, StrengthSet, WeightRoomData } from '@/types/weight-room'
 
-/** Default goals seeded by the migration; the demo mirrors them. */
+/**
+ * Default goals seeded by the migration; the demo mirrors them.
+ *
+ * `display_name` is set here for the same reason the live read joins it (#384):
+ * preview mode substitutes this fixture wholesale, so without it the demo would
+ * be the one surface still rendering raw slugs.
+ */
 const DEMO_GOALS: ExerciseGoal[] = [
-  { exercise: 'pushups', daily_target: 100, color: '#EA580C' },
-  { exercise: 'pullups', daily_target: 30, color: '#0EA5A1' },
+  { exercise: 'pushups', display_name: 'Pushups', daily_target: 100, color: '#EA580C' },
+  { exercise: 'pullups', display_name: 'Pullups', daily_target: 30, color: '#0EA5A1' },
 ]
 
 /**

--- a/lib/data/weight-room-shared.ts
+++ b/lib/data/weight-room-shared.ts
@@ -17,6 +17,7 @@ import {
 import type {
   ExerciseGoal,
   GoalTargetPoint,
+  MonthlyFocus,
   WeightRoomAchievement,
   WeightRoomData,
   WeightRoomExercise,
@@ -111,33 +112,62 @@ function parseExerciseRows(
 }
 
 /**
- * Attach each goal's `load_multiplier` from the catalog (#373).
+ * Attach each goal's `load_multiplier` and `display_name` from the catalog
+ * (#373, #384).
  *
- * The column moved to `weight_room_exercises` so movements without a daily goal
- * could carry it, but the tonnage math in `achievements.ts`, `monthly-focus.ts`,
- * and `LogDataIsland` all read it off {@link ExerciseGoal} — joining it here
- * keeps every one of those call sites unchanged.
+ * `load_multiplier` moved to `weight_room_exercises` so movements without a
+ * daily goal could carry it, but the tonnage math in `achievements.ts`,
+ * `monthly-focus.ts`, and `LogDataIsland` all read it off {@link ExerciseGoal}
+ * — joining it here keeps every one of those call sites unchanged.
+ * `display_name` rides the same join for the same reason: the ~10 surfaces that
+ * render a goal's name would otherwise each need the roster threaded to them.
  *
  * A multiplier of 1 is omitted rather than attached: it's the documented
  * default at every read site, so leaving it off keeps the pre-#373 shape for
- * the movements where nothing changed.
+ * the movements where nothing changed. A `display_name` equal to the slug is
+ * omitted on the same principle.
  *
  * @param goals Converted goals, in read order.
  * @param exercises The full roster, used to build the lookup.
  */
-function attachLoadMultipliers(
+function attachCatalogFields(
   goals: readonly ExerciseGoal[],
   exercises: readonly WeightRoomExercise[],
 ): ExerciseGoal[] {
-  const multiplierBySlug = new Map(
-    exercises.map((exercise) => [exercise.slug, exercise.load_multiplier ?? 1]),
-  )
+  const bySlug = new Map(exercises.map((exercise) => [exercise.slug, exercise]))
   return goals.map((goal) => {
     // A goal with no catalog row is impossible — the FK guarantees one — but
     // defaulting rather than asserting keeps a partially-migrated project
     // rendering instead of throwing.
-    const multiplier = multiplierBySlug.get(goal.exercise) ?? 1
-    return multiplier === 1 ? goal : { ...goal, load_multiplier: multiplier }
+    const entry = bySlug.get(goal.exercise)
+    const multiplier = entry?.load_multiplier ?? 1
+    const label = entry?.display_name
+
+    const next: ExerciseGoal = { ...goal }
+    if (multiplier !== 1) next.load_multiplier = multiplier
+    if (label !== undefined && label !== goal.exercise) next.display_name = label
+    return next
+  })
+}
+
+/**
+ * Attach each focus's `display_name` from the catalog (#384), mirroring
+ * {@link attachCatalogFields}. The rotation cards, the upcoming strip, and the
+ * lane heatmap legend all render {@link MonthlyFocus.exercise} directly.
+ *
+ * @param focuses Converted focuses, in read order.
+ * @param exercises The full roster, used to build the lookup.
+ */
+function attachFocusDisplayNames(
+  focuses: readonly MonthlyFocus[],
+  exercises: readonly WeightRoomExercise[],
+): MonthlyFocus[] {
+  const labelBySlug = new Map(exercises.map((e) => [e.slug, e.display_name]))
+  return focuses.map((focus) => {
+    const label = labelBySlug.get(focus.exercise)
+    return label === undefined || label === focus.exercise
+      ? focus
+      : { ...focus, display_name: label }
   })
 }
 
@@ -355,8 +385,11 @@ export async function assembleWeightRoomData(
   return {
     imported_at: importedAt,
     sets: setsParsed.data.map(setRowToStrengthSet),
-    goals: attachLoadMultipliers(goals, exercises),
-    monthly_focus: focusParsed.data.map(focusRowToMonthlyFocus),
+    goals: attachCatalogFields(goals, exercises),
+    monthly_focus: attachFocusDisplayNames(
+      focusParsed.data.map(focusRowToMonthlyFocus),
+      exercises,
+    ),
     exercises,
   }
 }

--- a/lib/data/weight-room.test.ts
+++ b/lib/data/weight-room.test.ts
@@ -368,6 +368,67 @@ describe('getWeightRoomData — exercise catalog (#373)', () => {
     expect(data?.goals[0]).not.toHaveProperty('load_multiplier')
   })
 
+  it('joins display_name from the catalog onto the goal', async () => {
+    stubTable('weight_room_sets', [])
+    stubTable('weight_room_goals', [goalRow('barbell-bench-press')])
+    stubTable('weight_room_exercises', [
+      catalogRow('barbell-bench-press', { display_name: 'Barbell Bench Press' }),
+    ])
+
+    const data = await getWeightRoomData()
+
+    // The ~10 surfaces that render a goal's name read it off the goal (#384),
+    // so the join is what keeps them from each needing the roster threaded in.
+    expect(data?.goals[0]).toMatchObject({
+      exercise: 'barbell-bench-press',
+      display_name: 'Barbell Bench Press',
+    })
+  })
+
+  it('omits display_name when the catalog label is just the slug', async () => {
+    stubTable('weight_room_sets', [])
+    stubTable('weight_room_goals', [goalRow('pushups')])
+    stubTable('weight_room_exercises', [catalogRow('pushups', { display_name: 'pushups' })])
+
+    const data = await getWeightRoomData()
+
+    // Same principle as load_multiplier: every render site falls back to the
+    // slug, so an identical label is noise on the wire.
+    expect(data?.goals[0]).not.toHaveProperty('display_name')
+  })
+
+  it('joins display_name onto a monthly focus too', async () => {
+    stubTable('weight_room_sets', [])
+    // The focus's anchor goal — a focus can't exist without one (FK), and the
+    // assembler's null contract treats sets+goals empty as "no data at all".
+    stubTable('weight_room_goals', [goalRow('farmers-carry')])
+    stubTable('weight_room_monthly_focus', [
+      {
+        id: '44444444-4444-4444-8444-444444444444',
+        exercise: 'farmers-carry',
+        daily_target: 50,
+        target_kind: 'reps',
+        color: '#C9A268',
+        category: 'upper',
+        start_date: '2026-07-01',
+        end_date: '2026-07-31',
+        updated_at: '2026-07-31T08:00:00Z',
+      },
+    ])
+    stubTable('weight_room_exercises', [
+      catalogRow('farmers-carry', { display_name: "Farmer's Carry" }),
+    ])
+
+    const data = await getWeightRoomData()
+
+    // Not derivable from the slug — an apostrophe is exactly the case that
+    // rules out detokenizing the slug at render time.
+    expect(data?.monthly_focus[0]).toMatchObject({
+      exercise: 'farmers-carry',
+      display_name: "Farmer's Carry",
+    })
+  })
+
   it('defaults to a single implement when a goal has no catalog row', async () => {
     stubTable('weight_room_sets', [])
     stubTable('weight_room_goals', [goalRow('orphaned')])

--- a/lib/training-facility/achievements.test.ts
+++ b/lib/training-facility/achievements.test.ts
@@ -556,6 +556,22 @@ describe('buildTrophyRoomView', () => {
     set('2026-07-15', 'pushups', 120),
   ]
 
+  it('labels groups from the catalog, including movements whose goal is gone', () => {
+    // Tiers are deliberately not FK'd to goals — deleting a goal keeps its
+    // badges — so a goals-only lookup would render the raw slug here (#384).
+    const catalog = [
+      { slug: 'pushups', display_name: 'Pushups', equipment: 'bodyweight' as const, muscle_group: 'chest' as const },
+      { slug: 'pullups', display_name: 'Pullups', equipment: 'bodyweight' as const, muscle_group: 'back' as const },
+    ]
+    const view = buildTrophyRoomView(SETS, [], LADDER, catalog)
+    expect(view.groups.map((g) => g.label)).toEqual([POOLED_LABEL, 'Pullups', 'Pushups'])
+  })
+
+  it('falls back to the slug with no catalog', () => {
+    const view = buildTrophyRoomView(SETS, [], LADDER)
+    expect(view.groups.map((g) => g.label)).toEqual([POOLED_LABEL, 'pullups', 'pushups'])
+  })
+
   it('puts the pooled ladder first, then exercises alphabetically', () => {
     const view = buildTrophyRoomView(SETS, GOALS, LADDER)
     expect(view.groups.map((g) => g.label)).toEqual([POOLED_LABEL, 'pullups', 'pushups'])

--- a/lib/training-facility/achievements.ts
+++ b/lib/training-facility/achievements.ts
@@ -126,6 +126,12 @@ interface MovementMetrics {
 export interface ResolvedAchievement {
   /** The tier being resolved. */
   achievement: WeightRoomAchievement
+  /**
+   * Human label for {@link WeightRoomAchievement.exercise} (#384), from the
+   * catalog via the matching goal. Absent for pooled tiers (which own no
+   * single movement) and for movements with no goal.
+   */
+  displayName?: string
   /** Whether {@link best} has reached the tier's threshold. */
   earned: boolean
   /**
@@ -539,11 +545,22 @@ export function buildTrophyRoomView(
   goals: readonly ExerciseGoal[],
   achievements: readonly WeightRoomAchievement[],
 ): TrophyRoomView {
-  const resolved = resolveAchievements(sets, goals, achievements)
   const colorByExercise = new Map(goals.map((g) => [g.exercise, g.color]))
+  // Catalog labels ride in on the goals (#384). A movement with tiers but no
+  // goal falls back to its slug — the catalog-only case is what #377's pooled
+  // decision has to settle before it can be reached anyway.
+  const labelByExercise = new Map(goals.map((g) => [g.exercise, g.display_name]))
   const multiplierByExercise = new Map(
     goals.map((g) => [g.exercise, Math.max(1, g.load_multiplier ?? 1)]),
   )
+
+  // Attached once here rather than inside `resolveAchievements` so the groups
+  // and both strips read the same label off the same objects.
+  const resolved = resolveAchievements(sets, goals, achievements).map((entry) => {
+    const slug = entry.achievement.exercise
+    const label = slug === null || slug === undefined ? undefined : labelByExercise.get(slug)
+    return label === undefined ? entry : { ...entry, displayName: label }
+  })
 
   const byExercise = new Map<string | null, ResolvedAchievement[]>()
   for (const entry of resolved) {
@@ -578,7 +595,7 @@ export function buildTrophyRoomView(
       })
       return {
         exercise: isPooled ? null : key,
-        label: isPooled ? POOLED_LABEL : key,
+        label: isPooled ? POOLED_LABEL : (labelByExercise.get(key) ?? key),
         color: isPooled ? null : (colorByExercise.get(key) ?? null),
         // The pooled ladder spans movements with different multipliers, so it
         // has no single one of its own — its tonnage already has each set's

--- a/lib/training-facility/achievements.ts
+++ b/lib/training-facility/achievements.ts
@@ -4,6 +4,7 @@ import type {
   ExerciseGoal,
   StrengthSet,
   WeightRoomAchievement,
+  WeightRoomExercise,
 } from '@/types/weight-room'
 
 import { targetResolverFor } from './goal-targets'
@@ -539,17 +540,26 @@ const STRIP_SIZE = 6
  * @param goals Configured exercises; supplies streak targets and group accents.
  * @param achievements The ladder from `weight_room_achievements`; may be empty
  *   (yields an empty view, which the page renders as its empty state).
+ * @param exercises The movement roster, for display labels (#384). Tiers are
+ *   deliberately not FK'd to goals — deleting a goal keeps its badges — so the
+ *   label has to come from the catalog, not from `goals`, or a movement with
+ *   tiers and no goal renders its raw slug.
  */
 export function buildTrophyRoomView(
   sets: readonly StrengthSet[],
   goals: readonly ExerciseGoal[],
   achievements: readonly WeightRoomAchievement[],
+  exercises: readonly WeightRoomExercise[] = [],
 ): TrophyRoomView {
   const colorByExercise = new Map(goals.map((g) => [g.exercise, g.color]))
-  // Catalog labels ride in on the goals (#384). A movement with tiers but no
-  // goal falls back to its slug — the catalog-only case is what #377's pooled
-  // decision has to settle before it can be reached anyway.
-  const labelByExercise = new Map(goals.map((g) => [g.exercise, g.display_name]))
+  // Catalog first, goal-joined label second (#384). Achievements outlive their
+  // goal, so a goals-only lookup would drop back to the slug for exactly the
+  // movements whose badges were deliberately preserved.
+  const labelByExercise = new Map<string, string>()
+  for (const g of goals) {
+    if (g.display_name !== undefined) labelByExercise.set(g.exercise, g.display_name)
+  }
+  for (const e of exercises) labelByExercise.set(e.slug, e.display_name)
   const multiplierByExercise = new Map(
     goals.map((g) => [g.exercise, Math.max(1, g.load_multiplier ?? 1)]),
   )

--- a/lib/training-facility/exercise-labels.test.ts
+++ b/lib/training-facility/exercise-labels.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { exerciseLabel, slugLabel } from './exercise-labels'
+import { buildExerciseLabels, exerciseLabel, slugLabel } from './exercise-labels'
 
 describe('exerciseLabel (#384)', () => {
   it('prefers the catalog label', () => {
@@ -43,3 +43,35 @@ describe('slugLabel (#384)', () => {
     expect(slugLabel('barbell-row', { exercise: 'barbell-row' })).toBe('barbell-row')
   })
 })
+
+describe('buildExerciseLabels (#384)', () => {
+  it('maps slugs to catalog labels', () => {
+    const labels = buildExerciseLabels([
+      { slug: 'farmers-carry', display_name: "Farmer's Carry" },
+      { slug: 'pushups', display_name: 'Pushups' },
+    ])
+    expect(labels.get('farmers-carry')).toBe("Farmer's Carry")
+    expect(labels.size).toBe(2)
+  })
+
+  it('is empty when the roster is absent, so callers fall back to slugs', () => {
+    expect(buildExerciseLabels(undefined).size).toBe(0)
+    expect(slugLabel('pushups', undefined, buildExerciseLabels(undefined))).toBe('pushups')
+  })
+
+  it('lets the catalog win over a goal-joined label', () => {
+    // The catalog owns the name; the goal's copy is a read-time convenience,
+    // and it's the catalog that survives the goal being deleted.
+    const labels = buildExerciseLabels([{ slug: 'dips', display_name: 'Dips' }])
+    expect(slugLabel('dips', { exercise: 'dips', display_name: 'Stale' }, labels)).toBe('Dips')
+  })
+
+  it('resolves a movement whose goal was deleted', () => {
+    // The case codex caught: sets and achievement tiers outlive their goal.
+    const labels = buildExerciseLabels([
+      { slug: 'barbell-row', display_name: 'Barbell Row' },
+    ])
+    expect(slugLabel('barbell-row', undefined, labels)).toBe('Barbell Row')
+  })
+})
+

--- a/lib/training-facility/exercise-labels.test.ts
+++ b/lib/training-facility/exercise-labels.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+
+import { exerciseLabel, slugLabel } from './exercise-labels'
+
+describe('exerciseLabel (#384)', () => {
+  it('prefers the catalog label', () => {
+    expect(
+      exerciseLabel({ exercise: 'barbell-bench-press', display_name: 'Barbell Bench Press' }),
+    ).toBe('Barbell Bench Press')
+  })
+
+  it('falls back to the slug when the catalog has no row', () => {
+    // The pre-#384 behavior — a partially-migrated project still renders.
+    expect(exerciseLabel({ exercise: 'pushups' })).toBe('pushups')
+  })
+
+  it('keeps a label the slug could never produce', () => {
+    // The reason this reads the catalog rather than detokenizing the slug.
+    expect(exerciseLabel({ exercise: 'farmers-carry', display_name: "Farmer's Carry" })).toBe(
+      "Farmer's Carry",
+    )
+  })
+
+  it('does not treat an empty label as a fallback trigger', () => {
+    // The column is `check (btrim(display_name) <> '')`, so an empty string
+    // can't come from the catalog — but if it ever did, surfacing it is more
+    // honest than silently swapping in the slug and hiding the bad row.
+    expect(exerciseLabel({ exercise: 'pushups', display_name: '' })).toBe('')
+  })
+})
+
+describe('slugLabel (#384)', () => {
+  it('reads the label off the matching record', () => {
+    expect(
+      slugLabel('barbell-row', { exercise: 'barbell-row', display_name: 'Barbell Row' }),
+    ).toBe('Barbell Row')
+  })
+
+  it('falls back to the slug with no record', () => {
+    // A set whose goal was deleted still renders — the sets outlive the goal
+    // by design (#373), so this path is reachable, not theoretical.
+    expect(slugLabel('barbell-row')).toBe('barbell-row')
+    expect(slugLabel('barbell-row', { exercise: 'barbell-row' })).toBe('barbell-row')
+  })
+})

--- a/lib/training-facility/exercise-labels.ts
+++ b/lib/training-facility/exercise-labels.ts
@@ -35,15 +35,42 @@ export function exerciseLabel(named: ExerciseNamed): string {
   return named.display_name ?? named.exercise
 }
 
+/** Slug → catalog label, for surfaces that iterate slugs rather than goals. */
+export type ExerciseLabels = ReadonlyMap<string, string>
+
 /**
- * Label for a bare slug, given the catalog-joined record for it if one exists.
+ * Build a slug → label lookup straight from the roster.
  *
- * For surfaces that iterate raw slugs — a day's sets, the filter chips — rather
- * than goal objects.
+ * Needed wherever a movement can outlive its daily goal, which is a supported
+ * state rather than an edge case: deleting a goal deliberately keeps its logged
+ * sets (#373) and its achievement tiers, and the catalog row survives both. A
+ * lookup built from `goals` alone would drop back to the slug for exactly those
+ * movements — which is the bug codex caught on this PR.
+ *
+ * @param exercises `WeightRoomData.exercises`; absent yields an empty map, and
+ *   every caller then falls back to the slug.
+ */
+export function buildExerciseLabels(
+  exercises: readonly { slug: string; display_name: string }[] | undefined,
+): ExerciseLabels {
+  return new Map((exercises ?? []).map((e) => [e.slug, e.display_name]))
+}
+
+/**
+ * Label for a bare slug.
+ *
+ * Prefers the catalog, then a goal/focus that carries the joined label, then
+ * the slug itself. The catalog wins because it's the surface that still has a
+ * row when the goal is gone.
  *
  * @param slug The movement slug to label.
  * @param named The goal/focus for that slug, if the caller has one.
+ * @param labels Catalog lookup from {@link buildExerciseLabels}, if available.
  */
-export function slugLabel(slug: string, named?: ExerciseNamed): string {
-  return named?.display_name ?? slug
+export function slugLabel(
+  slug: string,
+  named?: ExerciseNamed,
+  labels?: ExerciseLabels,
+): string {
+  return labels?.get(slug) ?? named?.display_name ?? slug
 }

--- a/lib/training-facility/exercise-labels.ts
+++ b/lib/training-facility/exercise-labels.ts
@@ -1,0 +1,49 @@
+/**
+ * Human-readable movement labels (#384).
+ *
+ * The Weight Room stores movements by slug — `barbell-bench-press` — because
+ * the slug is the primary key and the FK target for every set. The catalog
+ * (`weight_room_exercises`) owns the label that should be *shown*, and the data
+ * layer joins it onto {@link ExerciseGoal} and {@link MonthlyFocus} on read, so
+ * render sites resolve it from the object they already hold rather than
+ * carrying the roster around.
+ *
+ * These helpers exist so the fallback is written once. Every surface degrades
+ * to the slug when the catalog has no row — the pre-#384 behavior — rather than
+ * rendering an empty name.
+ */
+
+/**
+ * Anything carrying a movement slug and an optionally-joined catalog label —
+ * {@link import('@/types/weight-room').ExerciseGoal} and
+ * {@link import('@/types/weight-room').MonthlyFocus} both satisfy it.
+ */
+export interface ExerciseNamed {
+  /** Movement slug; the stored identity. */
+  exercise: string
+  /** Catalog label, joined on read. Absent falls back to {@link exercise}. */
+  display_name?: string
+}
+
+/**
+ * Label to render for a goal or focus.
+ *
+ * Identity (test IDs, React keys, URL tokens, `data-*` attributes) must keep
+ * using `.exercise` — this is for human-facing text and accessible names only.
+ */
+export function exerciseLabel(named: ExerciseNamed): string {
+  return named.display_name ?? named.exercise
+}
+
+/**
+ * Label for a bare slug, given the catalog-joined record for it if one exists.
+ *
+ * For surfaces that iterate raw slugs — a day's sets, the filter chips — rather
+ * than goal objects.
+ *
+ * @param slug The movement slug to label.
+ * @param named The goal/focus for that slug, if the caller has one.
+ */
+export function slugLabel(slug: string, named?: ExerciseNamed): string {
+  return named?.display_name ?? slug
+}

--- a/lib/training-facility/load-management.ts
+++ b/lib/training-facility/load-management.ts
@@ -74,6 +74,11 @@ export interface DailyVolumePoint {
 export interface MovementLoad {
   /** Exercise name, verbatim from the set rows (e.g. `pullups`). */
   movement: string
+  /**
+   * Human label for {@link movement}, from the catalog's `display_name`
+   * (#384). Absent falls back to the slug at the render site.
+   */
+  displayName?: string
   /** Hex display color from the matching {@link ExerciseGoal}, or a default. */
   color: string
   /** Which volume the ramp math is computed on. */
@@ -191,6 +196,7 @@ export function buildMovementLoads(
   const todayKey = pacificDayKey(now)
   const colorByExercise = new Map(goals.map(g => [g.exercise, g.color]))
   const equipmentByExercise = new Map(exercises.map(e => [e.slug, e.equipment]))
+  const labelByExercise = new Map(exercises.map(e => [e.slug, e.display_name]))
 
   // Precompute the trailing chronic-window day keys once — they're shared
   // by every movement. Index 0 is today; index CHRONIC_DAYS-1 is the
@@ -282,6 +288,7 @@ export function buildMovementLoads(
 
     loads.push({
       movement,
+      displayName: labelByExercise.get(movement),
       color: colorByExercise.get(movement) ?? DEFAULT_MOVEMENT_COLOR,
       metric: loaded ? 'load' : 'reps',
       unitLabel: loaded ? 'lb' : 'reps',

--- a/lib/training-facility/weight-room-history.ts
+++ b/lib/training-facility/weight-room-history.ts
@@ -109,6 +109,12 @@ export interface WeeklyVolumePoint {
 export interface StrengthExerciseStats {
   /** Exercise name (matches {@link ExerciseGoal.exercise}). */
   exercise: string
+  /**
+   * Human label for {@link exercise}, carried through from the goal's
+   * catalog-joined {@link ExerciseGoal.display_name} (#384). Absent falls back
+   * to the slug at the render site.
+   */
+  displayName?: string
   /** Hex color from the matching {@link ExerciseGoal.color}. */
   color: string
    /**
@@ -446,6 +452,7 @@ export function computeStrengthStats(
 
     return {
       exercise: goal.exercise,
+      displayName: goal.display_name,
       color: goal.color,
       // Resolved through `scoringGoal` so the label and the streak agree. For
       // a permanent goal this is just today's target; for a focus it's the

--- a/types/weight-room.ts
+++ b/types/weight-room.ts
@@ -183,6 +183,20 @@ export interface ExerciseGoal {
   /** Exercise name; primary key on `weight_room_goals`. */
   exercise: string
   /**
+   * Human-readable label for {@link exercise} — `Barbell Bench Press` for
+   * `barbell-bench-press`.
+   *
+   * **Joined from {@link WeightRoomExercise.display_name}** by the data layer
+   * on read, the same way {@link load_multiplier} is, so the surfaces that
+   * render a goal don't have to carry the catalog alongside it.
+   *
+   * Absent means "no catalog row" — every render site falls back to
+   * {@link exercise}, which is the pre-#384 behavior. Not derivable from the
+   * slug: the catalog holds `Farmer's Carry` for `farmers-carry`, and an
+   * apostrophe is not something slug-detokenizing produces.
+   */
+  display_name?: string
+  /**
    * Target reps per day for the "grease the groove" goal. Activity
    * rings fill toward this number; the heatmap colors by % of target.
    *
@@ -259,6 +273,12 @@ export interface MonthlyFocus {
    * `kind: 'focus'` {@link ExerciseGoal.exercise} that anchors logging.
    */
   exercise: string
+  /**
+   * Human-readable label for {@link exercise}, joined from
+   * {@link WeightRoomExercise.display_name} on read — see
+   * {@link ExerciseGoal.display_name}. Absent falls back to the slug.
+   */
+  display_name?: string
   /**
    * Target for the daily ring during the focus window. Interpreted per
    * {@link MonthlyFocus.target_kind}: reps/day or distinct sets/day.


### PR DESCRIPTION
Refs #384 — the `display_name` rollout item. The other three remaining items on that issue stay open; see the bottom for why.

The catalog has stored and edited `display_name` since #373, but every read surface still rendered the slug. Production already holds a **37-movement gym roster**, so the moment a set is logged against one it would read `barbell-bench-press`.

## Approach: join it, don't thread it

`ExerciseGoal.load_multiplier` set the precedent in #373 — the column lives on the catalog, and the data layer attaches it to the goal on read so the tonnage math doesn't have to carry the roster around. Its doc says exactly that. `display_name` rides the same join, onto `ExerciseGoal` and `MonthlyFocus`, so the ~15 surfaces that render a name resolve it from the object they already hold.

The alternative — a `labels` prop or a context — was rejected: the codebase has **no** context provider anywhere, and these components are a mix of server and client, so a provider would only cover half of them while a prop would touch every render call and every test.

**The label is deliberately not derived from the slug.** The catalog holds `Farmer's Carry` for `farmers-carry`. No amount of detokenizing produces an apostrophe.

## Identity vs. display

Everything that is an *identity* keeps the slug — `data-testid`, React keys, URL filter tokens, API paths. Only visible text, accessible names, tooltips, and confirm dialogs move to the label. A rename in the catalog therefore can't break a test hook or a shared filtered link.

There's a test asserting exactly that split: the chip renders `Barbell Bench Press` while its `href` still carries `barbell-bench-press`.

## Why the existing tests didn't need touching

Every new field is optional and every read site falls back to the slug — the pre-#384 behavior. The existing 1849 tests passed **unchanged**, because their fixtures carry no `display_name`. That's the design working, but it also meant the new behavior was initially uncovered, so the new tests supply a label and assert both halves.

Worth knowing for review: under the `uppercase` CSS these surfaces already use, `pushups` → `Pushups` is **visually identical**. The change that matters is `barbell-bench-press` → `Barbell Bench Press`, and the DOM text (which is what testing-library matches) changes in both cases.

## Surfaces covered

Today rings, streak badges, quick log, set list · History heatmaps, stats cards, filter chips, load panel, weekly volume, variant breakdown · Trophy Room groups and chase strip · focus cards, upcoming strip, lane heatmap · settings editors · **the weight-room scene's wall tallies**.

That last one wasn't on the issue's list. It draws the day's totals inside the lobby SVG and I found it by loading the page, not by grepping — the issue's "~10 components" estimate missed it.

Also covers the `?preview=demo` fixture, which substitutes its own data wholesale and would otherwise have been the one surface still showing slugs.

## Note on the diff

The repo has **mixed line endings per file** — no `.gitattributes`, `core.autocrlf=false`, and 5 of the files here are CRLF while the rest are LF. My first pass normalized 28 files the wrong way and produced a 6131-line diff. Each file is now byte-matched to whatever its parent used, so the diff is only the real changes. Worth a `.gitattributes` at some point; not this PR.

## Test plan

- [ ] **Today** (`/training-facility/weight-room`) — wall tallies read `Pushups 120/100`, not `pushups`; rings, streak badges, quick log, and the set list all show labels.
- [ ] **History** — per-exercise heatmap headings, stats cards, load panel, and filter chips all show labels.
- [ ] Toggle a filter chip — the URL still carries the **slug**, and a shared filtered link still resolves.
- [ ] **Trophy Room** — group headings and the "closest to earning" strip show labels; the pooled ladder still reads "all movements".
- [ ] **Settings → Exercises** — deleting a goal names the movement by its label in the confirm dialog.
- [ ] `?preview=demo` on a fresh/empty environment — demo rings read `Pushups` / `Pullups`.
- [ ] Nothing renders a bare `some-slug-with-hyphens` anywhere.

## Verification

- Unit: **146 files / 1867 tests** green (18 new).
- E2E: **65 passed**, including the `mobile-webkit` project.
- `tsc --noEmit`, `eslint`, `next build` all clean.
- Checked against production data on a flag-enabled dev server: scene tallies read `Pushups 120/100` with `data-testid="wall-tally-pushups"` intact; History and Trophy Room render no lowercase slug in any text position; no hydration warnings.

## Still open on #384

- **Achievements multiplier** — blocked on the pooled-tier decision #377 owns, and #377 is a large unstarted feature depending on workout sessions and live recording (#376). Fixing the multiplier alone would bake in an answer to a question nobody has decided.
- **Monthly-focus settings UI** and **the goal-delete atomicity fix** — the issue sequences the latter behind the former (or #330). Both are their own piece of work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
