### PR TITLE
feat(weight-room): workout templates — prescriptions, alternates, and within-set sequences (#375)

### DIFF
--- a/app/api/admin/weight-room/templates/[id]/route.ts
+++ b/app/api/admin/weight-room/templates/[id]/route.ts
@@ -1,0 +1,151 @@
+/**
+ * Admin-only item endpoints for a workout template (#375) — rename / recolour /
+ * recategorize / reorder / archive, and delete.
+ *
+ * DELETE cascades to the template's slots, and through them to steps and
+ * alternates. That cascade is safe in a way the roster's isn't: a slot carries
+ * no training history of its own. Logged sets reference a slot via
+ * `template_slot_id` with `on delete set null` (#376), so deleting a template
+ * degrades past sessions to "untemplated" rather than destroying anything.
+ *
+ * Archiving is still the better move for a template you've actually run —
+ * it keeps the prescription readable so a past session's adherence resolves.
+ */
+
+import { NextResponse, type NextRequest } from 'next/server'
+import { ZodError } from 'zod'
+
+import { requireAdmin } from '@/lib/auth/require-admin'
+import { WeightRoomTemplateUpdateSchema } from '@/lib/schemas/weight-room'
+import { createAdminSupabaseClient } from '@/lib/supabase/admin'
+import { withTelemetry } from '@/lib/telemetry/with-telemetry'
+
+interface Context {
+  params: Promise<{ id: string }>
+}
+
+/** Columns echoed by both handlers, matching `WeightRoomWorkoutTemplateRowSchema`. */
+const TEMPLATE_COLUMNS = 'id, name, description, color, category, position, archived'
+
+/** Postgres `invalid_text_representation` — a route segment that isn't a UUID. */
+const INVALID_UUID = '22P02'
+
+/**
+ * Update a template's metadata. Body must conform to
+ * {@link WeightRoomTemplateUpdateSchema} — every field optional, at least one
+ * required. Slots are edited through `slots/`, never here.
+ *
+ * Status codes: 200 · 400 · 401 / 403 · 404 · 500.
+ *
+ * @param request Incoming JSON request matching {@link WeightRoomTemplateUpdateSchema}.
+ * @param ctx Next.js route context; `ctx.params.id` is the template UUID.
+ * @throws when Supabase env vars are missing (misconfigured deploy).
+ */
+async function handlePATCH(request: NextRequest, ctx: Context): Promise<NextResponse> {
+  const auth = await requireAdmin()
+  if (!auth.ok) return auth.response
+
+  const { id } = await ctx.params
+  const templateId = id.trim()
+  if (templateId.length === 0) {
+    return NextResponse.json({ error: 'id must be non-empty.' }, { status: 400 })
+  }
+
+  let payload: unknown
+  try {
+    payload = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Body must be valid JSON.' }, { status: 400 })
+  }
+
+  let patch
+  try {
+    patch = WeightRoomTemplateUpdateSchema.parse(payload)
+  } catch (err) {
+    if (err instanceof ZodError) {
+      return NextResponse.json(
+        { error: 'Validation failed.', issues: err.flatten() },
+        { status: 400 }
+      )
+    }
+    throw err
+  }
+
+  // Zod's field transforms materialize every key, so an omitted field arrives
+  // as `undefined` rather than absent. Strip those or "leave alone" becomes
+  // indistinguishable from "clear" — same reasoning as the workouts PATCH.
+  const changes: Record<string, unknown> = { updated_at: new Date().toISOString() }
+  for (const [key, value] of Object.entries(patch)) {
+    if (value !== undefined) changes[key] = value
+  }
+
+  const supabase = createAdminSupabaseClient()
+  const { data, error } = await supabase
+    .from('weight_room_workout_templates')
+    .update(changes)
+    .eq('id', templateId)
+    .select(TEMPLATE_COLUMNS)
+    .maybeSingle()
+
+  if (error) {
+    if (error.code === INVALID_UUID) {
+      return NextResponse.json({ error: `No template for '${templateId}'.` }, { status: 404 })
+    }
+    return NextResponse.json(
+      { error: `Failed to update template: ${error.message}` },
+      { status: 500 }
+    )
+  }
+  if (!data) {
+    return NextResponse.json({ error: `No template for '${templateId}'.` }, { status: 404 })
+  }
+  return NextResponse.json(data, { status: 200 })
+}
+
+/**
+ * Delete a template and, by cascade, its slots / steps / alternates.
+ *
+ * Status codes: 200 · 400 · 401 / 403 · 404 · 500.
+ *
+ * @param _request Unused — DELETE has no body.
+ * @param ctx Next.js route context; `ctx.params.id` is the template UUID.
+ * @throws when Supabase env vars are missing (misconfigured deploy).
+ */
+async function handleDELETE(_request: NextRequest, ctx: Context): Promise<NextResponse> {
+  const auth = await requireAdmin()
+  if (!auth.ok) return auth.response
+
+  const { id } = await ctx.params
+  const templateId = id.trim()
+  if (templateId.length === 0) {
+    return NextResponse.json({ error: 'id must be non-empty.' }, { status: 400 })
+  }
+
+  const supabase = createAdminSupabaseClient()
+  const { data, error } = await supabase
+    .from('weight_room_workout_templates')
+    .delete()
+    .eq('id', templateId)
+    .select(TEMPLATE_COLUMNS)
+    .maybeSingle()
+
+  if (error) {
+    if (error.code === INVALID_UUID) {
+      return NextResponse.json({ error: `No template for '${templateId}'.` }, { status: 404 })
+    }
+    return NextResponse.json(
+      { error: `Failed to delete template: ${error.message}` },
+      { status: 500 }
+    )
+  }
+  if (!data) {
+    return NextResponse.json({ error: `No template for '${templateId}'.` }, { status: 404 })
+  }
+  return NextResponse.json(data, { status: 200 })
+}
+
+/** `handlePATCH` wrapped with one-event-per-request telemetry (#220). */
+export const PATCH = withTelemetry('PATCH /api/admin/weight-room/templates/[id]', handlePATCH)
+
+/** `handleDELETE` wrapped with one-event-per-request telemetry (#220). */
+export const DELETE = withTelemetry('DELETE /api/admin/weight-room/templates/[id]', handleDELETE)

--- a/app/api/admin/weight-room/templates/[id]/slots/[slotId]/route.ts
+++ b/app/api/admin/weight-room/templates/[id]/slots/[slotId]/route.ts
@@ -1,0 +1,182 @@
+/**
+ * Admin-only item endpoints for a single template slot (#375) — edit it, and
+ * remove it.
+ *
+ * PATCH edits the slot **in place**, preserving its id. That is deliberate and
+ * load-bearing: #376 links each logged set to the slot it was performed for via
+ * `weight_room_sets.template_slot_id`, so a save that deleted and recreated
+ * slots would null out that link on every past session and silently destroy
+ * adherence history. Steps and alternates *are* replaced wholesale, because
+ * nothing outside a slot references them.
+ */
+
+import { NextResponse, type NextRequest } from 'next/server'
+import { ZodError } from 'zod'
+
+import { requireAdmin } from '@/lib/auth/require-admin'
+import { replaceSlotChildren } from '@/lib/data/template-slot-children'
+import { WeightRoomTemplateSlotUpdateSchema } from '@/lib/schemas/weight-room'
+import { createAdminSupabaseClient } from '@/lib/supabase/admin'
+import { withTelemetry } from '@/lib/telemetry/with-telemetry'
+
+interface Context {
+  params: Promise<{ id: string; slotId: string }>
+}
+
+/** Postgres FK violation — an exercise slug that isn't in the catalog. */
+const FK_VIOLATION = '23503'
+/** Postgres `invalid_text_representation` — a segment that isn't a UUID. */
+const INVALID_UUID = '22P02'
+
+/** Slot columns echoed back, matching `WeightRoomTemplateSlotRowSchema`. */
+const SLOT_COLUMNS =
+  'id, template_id, position, exercise, target_sets, target_sets_max, target_reps, target_reps_max, target_weight_lbs, rest_seconds, notes'
+
+/**
+ * Edit a slot. Body must conform to {@link WeightRoomTemplateSlotUpdateSchema} —
+ * every field optional, at least one required.
+ *
+ * `steps` / `alternates` replace those lists wholesale when supplied and leave
+ * them untouched when omitted, so renaming a slot never wipes its swaps.
+ *
+ * Status codes:
+ * - 200 — updated (response echoes the slot row)
+ * - 400 — invalid JSON, failed validation, or an inverted range
+ * - 401 / 403 — not signed in / not on the allowlist
+ * - 404 — no such slot on this template
+ * - 409 — an exercise slug isn't in the catalog
+ * - 500 — unexpected Supabase error
+ *
+ * @param request Incoming JSON request matching {@link WeightRoomTemplateSlotUpdateSchema}.
+ * @param ctx Next.js route context; `id` is the template, `slotId` the slot.
+ * @throws when Supabase env vars are missing (misconfigured deploy).
+ */
+async function handlePATCH(request: NextRequest, ctx: Context): Promise<NextResponse> {
+  const auth = await requireAdmin()
+  if (!auth.ok) return auth.response
+
+  const { id, slotId } = await ctx.params
+  const templateId = id.trim()
+  const slot = slotId.trim()
+  if (templateId.length === 0 || slot.length === 0) {
+    return NextResponse.json({ error: 'id and slotId must be non-empty.' }, { status: 400 })
+  }
+
+  let payload: unknown
+  try {
+    payload = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Body must be valid JSON.' }, { status: 400 })
+  }
+
+  let patch
+  try {
+    patch = WeightRoomTemplateSlotUpdateSchema.parse(payload)
+  } catch (err) {
+    if (err instanceof ZodError) {
+      return NextResponse.json(
+        { error: 'Validation failed.', issues: err.flatten() },
+        { status: 400 }
+      )
+    }
+    throw err
+  }
+
+  const supabase = createAdminSupabaseClient()
+
+  // Scope the write by template as well as slot id, so a slot can't be edited
+  // through the wrong template's URL.
+  const { steps, alternates, ...scalars } = patch
+  const changes: Record<string, unknown> = { updated_at: new Date().toISOString() }
+  for (const [key, value] of Object.entries(scalars)) {
+    if (value !== undefined) changes[key] = value
+  }
+
+  const { data, error } = await supabase
+    .from('weight_room_template_slots')
+    .update(changes)
+    .eq('id', slot)
+    .eq('template_id', templateId)
+    .select(SLOT_COLUMNS)
+    .maybeSingle()
+
+  if (error) {
+    if (error.code === INVALID_UUID) {
+      return NextResponse.json({ error: `No slot '${slot}' on this template.` }, { status: 404 })
+    }
+    if (error.code === FK_VIOLATION) {
+      return NextResponse.json(
+        { error: 'That exercise is not in the movement catalog.' },
+        { status: 409 }
+      )
+    }
+    return NextResponse.json({ error: `Failed to update slot: ${error.message}` }, { status: 500 })
+  }
+  if (!data) {
+    return NextResponse.json({ error: `No slot '${slot}' on this template.` }, { status: 404 })
+  }
+
+  const childFailure = await replaceSlotChildren(supabase, slot, steps, alternates)
+  if (childFailure !== null) {
+    return NextResponse.json({ error: childFailure.message }, { status: childFailure.status })
+  }
+
+  return NextResponse.json(data, { status: 200 })
+}
+
+/**
+ * Remove a slot. Its steps and alternates cascade; logged sets that referenced
+ * it fall back to `template_slot_id = null` rather than being deleted.
+ *
+ * Leaves a gap in the remaining positions, which is fine — ordering is by
+ * `position`, and nothing requires it to be contiguous.
+ *
+ * Status codes: 200 · 400 · 401 / 403 · 404 · 500.
+ *
+ * @param _request Unused — DELETE has no body.
+ * @param ctx Next.js route context; `id` is the template, `slotId` the slot.
+ * @throws when Supabase env vars are missing (misconfigured deploy).
+ */
+async function handleDELETE(_request: NextRequest, ctx: Context): Promise<NextResponse> {
+  const auth = await requireAdmin()
+  if (!auth.ok) return auth.response
+
+  const { id, slotId } = await ctx.params
+  const templateId = id.trim()
+  const slot = slotId.trim()
+  if (templateId.length === 0 || slot.length === 0) {
+    return NextResponse.json({ error: 'id and slotId must be non-empty.' }, { status: 400 })
+  }
+
+  const supabase = createAdminSupabaseClient()
+  const { data, error } = await supabase
+    .from('weight_room_template_slots')
+    .delete()
+    .eq('id', slot)
+    .eq('template_id', templateId)
+    .select(SLOT_COLUMNS)
+    .maybeSingle()
+
+  if (error) {
+    if (error.code === INVALID_UUID) {
+      return NextResponse.json({ error: `No slot '${slot}' on this template.` }, { status: 404 })
+    }
+    return NextResponse.json({ error: `Failed to delete slot: ${error.message}` }, { status: 500 })
+  }
+  if (!data) {
+    return NextResponse.json({ error: `No slot '${slot}' on this template.` }, { status: 404 })
+  }
+  return NextResponse.json(data, { status: 200 })
+}
+
+/** `handlePATCH` wrapped with one-event-per-request telemetry (#220). */
+export const PATCH = withTelemetry(
+  'PATCH /api/admin/weight-room/templates/[id]/slots/[slotId]',
+  handlePATCH
+)
+
+/** `handleDELETE` wrapped with one-event-per-request telemetry (#220). */
+export const DELETE = withTelemetry(
+  'DELETE /api/admin/weight-room/templates/[id]/slots/[slotId]',
+  handleDELETE
+)

--- a/app/api/admin/weight-room/templates/[id]/slots/route.test.ts
+++ b/app/api/admin/weight-room/templates/[id]/slots/route.test.ts
@@ -106,7 +106,7 @@ describe('PATCH /api/admin/weight-room/templates/[id]/slots — reorder', () => 
 
   it('applies the requested positions, not the stored ones', async () => {
     await PATCH(reorderRequest(swap) as never, ctx('t1'))
-    const byId = Object.fromEntries((upserted ?? []).map((r) => [r.id, r.position]))
+    const byId = Object.fromEntries((upserted ?? []).map(r => [r.id, r.position]))
     expect(byId['11111111-1111-4111-8111-111111111111']).toBe(1)
     expect(byId['22222222-2222-4222-8222-222222222222']).toBe(0)
   })
@@ -116,7 +116,7 @@ describe('PATCH /api/admin/weight-room/templates/[id]/slots — reorder', () => 
       reorderRequest({
         order: [{ id: '33333333-3333-4333-8333-333333333333', position: 0 }],
       }) as never,
-      ctx('t1'),
+      ctx('t1')
     )
     expect(res.status).toBe(400)
     const body = await res.json()

--- a/app/api/admin/weight-room/templates/[id]/slots/route.test.ts
+++ b/app/api/admin/weight-room/templates/[id]/slots/route.test.ts
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextResponse } from 'next/server'
+
+import { PATCH } from './route'
+
+/**
+ * Tests for the slot collection endpoints (#375), concentrated on **reorder**.
+ *
+ * The reorder path shipped broken in the first cut and no test caught it:
+ * `upsert` is `INSERT ... ON CONFLICT`, and Postgres validates NOT NULL on the
+ * candidate row *before* resolving the conflict — so a payload carrying only
+ * `{id, position}` raises a not-null violation on `exercise` / `target_sets`
+ * and the position never moves. These pin the payload shape that fixes it.
+ */
+
+const requireAdminMock = vi.fn()
+vi.mock('@/lib/auth/require-admin', () => ({
+  requireAdmin: () => requireAdminMock(),
+}))
+
+/** Rows the "which slots belong to this template" read returns. */
+let ownedSlots: { id: string; exercise: string; target_sets: number }[]
+/** Error the ownership read resolves with, if any. */
+let ownedError: { code?: string; message: string } | null
+/** Payload captured from the upsert. */
+let upserted: Record<string, unknown>[] | null
+/** Error the upsert resolves with, if any. */
+let upsertError: { message: string } | null
+
+function makeChain() {
+  const chain: Record<string, unknown> = {
+    select: vi.fn(() => chain),
+    eq: vi.fn(() => Promise.resolve({ data: ownedSlots, error: ownedError })),
+    upsert: vi.fn((rows: Record<string, unknown>[]) => {
+      upserted = rows
+      return Promise.resolve({ error: upsertError })
+    }),
+  }
+  return chain
+}
+
+vi.mock('@/lib/supabase/admin', () => ({
+  createAdminSupabaseClient: () => ({ from: vi.fn(() => makeChain()) }),
+}))
+
+beforeEach(() => {
+  requireAdminMock.mockReset()
+  requireAdminMock.mockResolvedValue({ ok: true, email: 'a@b.com' })
+  ownedSlots = [
+    { id: '11111111-1111-4111-8111-111111111111', exercise: 'barbell-bench-press', target_sets: 4 },
+    { id: '22222222-2222-4222-8222-222222222222', exercise: 'barbell-row', target_sets: 3 },
+  ]
+  ownedError = null
+  upserted = null
+  upsertError = null
+})
+
+const ctx = (id: string) => ({ params: Promise.resolve({ id }) })
+
+function reorderRequest(body: unknown): Request {
+  return new Request('http://localhost/api/admin/weight-room/templates/t1/slots', {
+    method: 'PATCH',
+    headers: { 'content-type': 'application/json' },
+    body: typeof body === 'string' ? body : JSON.stringify(body),
+  })
+}
+
+/** A swap of the two seeded slots. */
+const swap = {
+  order: [
+    { id: '11111111-1111-4111-8111-111111111111', position: 1 },
+    { id: '22222222-2222-4222-8222-222222222222', position: 0 },
+  ],
+}
+
+describe('PATCH /api/admin/weight-room/templates/[id]/slots — reorder', () => {
+  it('returns 401 when not signed in', async () => {
+    requireAdminMock.mockResolvedValueOnce({
+      ok: false,
+      response: NextResponse.json({ error: 'Sign in required.' }, { status: 401 }),
+    })
+    const res = await PATCH(reorderRequest(swap) as never, ctx('t1'))
+    expect(res.status).toBe(401)
+  })
+
+  it('carries each slot’s NOT NULL columns into the upsert candidate', async () => {
+    // The bug: without exercise/target_sets, Postgres raises a not-null
+    // violation on the INSERT candidate before it ever resolves the conflict,
+    // so no position moves.
+    const res = await PATCH(reorderRequest(swap) as never, ctx('t1'))
+    expect(res.status).toBe(200)
+
+    expect(upserted).not.toBeNull()
+    for (const row of upserted ?? []) {
+      expect(row.exercise).toBeDefined()
+      expect(row.target_sets).toBeDefined()
+    }
+  })
+
+  it('sends both slots in one statement so the deferred constraint holds', async () => {
+    // A swap transiently duplicates a position. The unique constraint is
+    // DEFERRABLE, so one statement is legal — two sequential ones are not.
+    await PATCH(reorderRequest(swap) as never, ctx('t1'))
+    expect(upserted).toHaveLength(2)
+  })
+
+  it('applies the requested positions, not the stored ones', async () => {
+    await PATCH(reorderRequest(swap) as never, ctx('t1'))
+    const byId = Object.fromEntries((upserted ?? []).map((r) => [r.id, r.position]))
+    expect(byId['11111111-1111-4111-8111-111111111111']).toBe(1)
+    expect(byId['22222222-2222-4222-8222-222222222222']).toBe(0)
+  })
+
+  it('rejects a slot that belongs to another template', async () => {
+    const res = await PATCH(
+      reorderRequest({
+        order: [{ id: '33333333-3333-4333-8333-333333333333', position: 0 }],
+      }) as never,
+      ctx('t1'),
+    )
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.error).toMatch(/do not belong/i)
+    // Nothing written — an unknown id would otherwise attempt an INSERT and
+    // fail opaquely on the NOT NULL columns.
+    expect(upserted).toBeNull()
+  })
+
+  it('rejects an empty order list', async () => {
+    const res = await PATCH(reorderRequest({ order: [] }) as never, ctx('t1'))
+    expect(res.status).toBe(400)
+  })
+
+  it('maps a malformed template uuid to 404', async () => {
+    ownedError = { code: '22P02', message: 'invalid input syntax' }
+    const res = await PATCH(reorderRequest(swap) as never, ctx('not-a-uuid'))
+    expect(res.status).toBe(404)
+  })
+
+  it('surfaces an upsert failure as 500', async () => {
+    upsertError = { message: 'deadlock detected' }
+    const res = await PATCH(reorderRequest(swap) as never, ctx('t1'))
+    expect(res.status).toBe(500)
+  })
+})

--- a/app/api/admin/weight-room/templates/[id]/slots/route.ts
+++ b/app/api/admin/weight-room/templates/[id]/slots/route.ts
@@ -148,12 +148,7 @@ async function handlePOST(request: NextRequest, ctx: Context): Promise<NextRespo
     return NextResponse.json({ error: `Failed to add slot: ${error.message}` }, { status: 500 })
   }
 
-  const childFailure = await replaceSlotChildren(
-    supabase,
-    slot.id,
-    entry.steps,
-    entry.alternates
-  )
+  const childFailure = await replaceSlotChildren(supabase, slot.id, entry.steps, entry.alternates)
   if (childFailure !== null) {
     // The slot insert already committed in its own transaction. Reporting the
     // add as failed while leaving it behind means a retry adds a second slot
@@ -232,8 +227,8 @@ async function handlePATCH(request: NextRequest, ctx: Context): Promise<NextResp
     )
   }
 
-  const ownedById = new Map((owned ?? []).map((row) => [row.id, row]))
-  const strays = entry.order.filter((row) => !ownedById.has(row.id)).map((row) => row.id)
+  const ownedById = new Map((owned ?? []).map(row => [row.id, row]))
+  const strays = entry.order.filter(row => !ownedById.has(row.id)).map(row => row.id)
   if (strays.length > 0) {
     return NextResponse.json(
       { error: `These slots do not belong to this template: ${strays.join(', ')}` },
@@ -245,7 +240,7 @@ async function handlePATCH(request: NextRequest, ctx: Context): Promise<NextResp
   // One statement, so the DEFERRABLE unique constraint is checked at commit —
   // a swap that transiently duplicates a position passes through legally.
   const { error } = await supabase.from('weight_room_template_slots').upsert(
-    entry.order.map((row) => {
+    entry.order.map(row => {
       const existing = ownedById.get(row.id)
       return {
         id: row.id,
@@ -269,13 +264,7 @@ async function handlePATCH(request: NextRequest, ctx: Context): Promise<NextResp
 }
 
 /** `handlePOST` wrapped with one-event-per-request telemetry (#220). */
-export const POST = withTelemetry(
-  'POST /api/admin/weight-room/templates/[id]/slots',
-  handlePOST
-)
+export const POST = withTelemetry('POST /api/admin/weight-room/templates/[id]/slots', handlePOST)
 
 /** `handlePATCH` wrapped with one-event-per-request telemetry (#220). */
-export const PATCH = withTelemetry(
-  'PATCH /api/admin/weight-room/templates/[id]/slots',
-  handlePATCH
-)
+export const PATCH = withTelemetry('PATCH /api/admin/weight-room/templates/[id]/slots', handlePATCH)

--- a/app/api/admin/weight-room/templates/[id]/slots/route.ts
+++ b/app/api/admin/weight-room/templates/[id]/slots/route.ts
@@ -155,6 +155,11 @@ async function handlePOST(request: NextRequest, ctx: Context): Promise<NextRespo
     entry.alternates
   )
   if (childFailure !== null) {
+    // The slot insert already committed in its own transaction. Reporting the
+    // add as failed while leaving it behind means a retry adds a second slot
+    // and the incomplete first one stays in the template — so undo it. The
+    // slot has no children worth keeping at this point by definition.
+    await supabase.from('weight_room_template_slots').delete().eq('id', slot.id)
     return NextResponse.json({ error: childFailure.message }, { status: childFailure.status })
   }
 
@@ -206,14 +211,15 @@ async function handlePATCH(request: NextRequest, ctx: Context): Promise<NextResp
 
   const supabase = createAdminSupabaseClient()
 
-  // Verify every id belongs to this template before upserting. An upsert on a
-  // non-existent id doesn't no-op — it attempts an INSERT, which fails on the
-  // NOT NULL `exercise` / `target_sets` columns and surfaces as an opaque 500.
-  // Checking first turns that into a clear 400, and stops a body from being
-  // used to drag a slot out of someone else's template.
+  // Read the required columns, not just the ids. `upsert` is
+  // `INSERT ... ON CONFLICT`, and Postgres validates NOT NULL on the candidate
+  // row *before* resolving the conflict — so a row carrying only
+  // `{id, position}` raises a not-null violation on `exercise` / `target_sets`
+  // and the update never happens. Carrying the stored values through makes the
+  // insert candidate valid; the DO UPDATE still only moves `position`.
   const { data: owned, error: ownedError } = await supabase
     .from('weight_room_template_slots')
-    .select('id')
+    .select('id, exercise, target_sets')
     .eq('template_id', templateId)
 
   if (ownedError) {
@@ -226,8 +232,8 @@ async function handlePATCH(request: NextRequest, ctx: Context): Promise<NextResp
     )
   }
 
-  const ownedIds = new Set((owned ?? []).map((row) => row.id))
-  const strays = entry.order.filter((row) => !ownedIds.has(row.id)).map((row) => row.id)
+  const ownedById = new Map((owned ?? []).map((row) => [row.id, row]))
+  const strays = entry.order.filter((row) => !ownedById.has(row.id)).map((row) => row.id)
   if (strays.length > 0) {
     return NextResponse.json(
       { error: `These slots do not belong to this template: ${strays.join(', ')}` },
@@ -239,12 +245,17 @@ async function handlePATCH(request: NextRequest, ctx: Context): Promise<NextResp
   // One statement, so the DEFERRABLE unique constraint is checked at commit —
   // a swap that transiently duplicates a position passes through legally.
   const { error } = await supabase.from('weight_room_template_slots').upsert(
-    entry.order.map((row) => ({
-      id: row.id,
-      template_id: templateId,
-      position: row.position,
-      updated_at: nowIso,
-    })),
+    entry.order.map((row) => {
+      const existing = ownedById.get(row.id)
+      return {
+        id: row.id,
+        template_id: templateId,
+        position: row.position,
+        exercise: existing?.exercise,
+        target_sets: existing?.target_sets,
+        updated_at: nowIso,
+      }
+    }),
     { onConflict: 'id' }
   )
 

--- a/app/api/admin/weight-room/templates/[id]/slots/route.ts
+++ b/app/api/admin/weight-room/templates/[id]/slots/route.ts
@@ -1,0 +1,270 @@
+/**
+ * Admin-only collection endpoints for a template's slots (#375) — add one, and
+ * reorder the lot.
+ *
+ * Reordering is its own endpoint rather than a series of item PATCHes because
+ * it has to be **one statement**: swapping two slots transiently duplicates a
+ * position, and `(template_id, position)` is unique. The constraint is
+ * `DEFERRABLE INITIALLY DEFERRED` precisely so a single multi-row upsert can
+ * pass through that invalid intermediate state and be checked at commit.
+ * Sequential per-slot updates would fail on the first write.
+ */
+
+import { NextResponse, type NextRequest } from 'next/server'
+import { ZodError } from 'zod'
+
+import { requireAdmin } from '@/lib/auth/require-admin'
+import { replaceSlotChildren } from '@/lib/data/template-slot-children'
+import {
+  WeightRoomTemplateSlotCreateSchema,
+  WeightRoomTemplateSlotReorderSchema,
+} from '@/lib/schemas/weight-room'
+import { createAdminSupabaseClient } from '@/lib/supabase/admin'
+import { withTelemetry } from '@/lib/telemetry/with-telemetry'
+
+interface Context {
+  params: Promise<{ id: string }>
+}
+
+/** Postgres FK violation — an exercise slug that isn't in the catalog. */
+const FK_VIOLATION = '23503'
+/** Postgres `invalid_text_representation` — a segment that isn't a UUID. */
+const INVALID_UUID = '22P02'
+
+/**
+ * Append a slot to a template. Body must conform to
+ * {@link WeightRoomTemplateSlotCreateSchema}.
+ *
+ * Position is assigned server-side as `max(position) + 1` rather than taken
+ * from the client — the builder shouldn't have to know the current length, and
+ * a stale client value would collide with the unique constraint.
+ *
+ * Status codes:
+ * - 201 — created (response echoes the slot with its steps and alternates)
+ * - 400 — invalid JSON, failed validation, or an inverted range
+ * - 401 / 403 — not signed in / not on the allowlist
+ * - 404 — no such template
+ * - 409 — an exercise slug isn't in the catalog
+ * - 500 — unexpected Supabase error
+ *
+ * @param request Incoming JSON request matching {@link WeightRoomTemplateSlotCreateSchema}.
+ * @param ctx Next.js route context; `ctx.params.id` is the template UUID.
+ * @throws when Supabase env vars are missing (misconfigured deploy).
+ */
+async function handlePOST(request: NextRequest, ctx: Context): Promise<NextResponse> {
+  const auth = await requireAdmin()
+  if (!auth.ok) return auth.response
+
+  const { id } = await ctx.params
+  const templateId = id.trim()
+  if (templateId.length === 0) {
+    return NextResponse.json({ error: 'id must be non-empty.' }, { status: 400 })
+  }
+
+  let payload: unknown
+  try {
+    payload = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Body must be valid JSON.' }, { status: 400 })
+  }
+
+  let entry
+  try {
+    entry = WeightRoomTemplateSlotCreateSchema.parse(payload)
+  } catch (err) {
+    if (err instanceof ZodError) {
+      return NextResponse.json(
+        { error: 'Validation failed.', issues: err.flatten() },
+        { status: 400 }
+      )
+    }
+    throw err
+  }
+
+  const supabase = createAdminSupabaseClient()
+
+  const { data: template, error: templateError } = await supabase
+    .from('weight_room_workout_templates')
+    .select('id')
+    .eq('id', templateId)
+    .maybeSingle()
+
+  if (templateError) {
+    if (templateError.code === INVALID_UUID) {
+      return NextResponse.json({ error: `No template for '${templateId}'.` }, { status: 404 })
+    }
+    return NextResponse.json(
+      { error: `Failed to read template: ${templateError.message}` },
+      { status: 500 }
+    )
+  }
+  if (!template) {
+    return NextResponse.json({ error: `No template for '${templateId}'.` }, { status: 404 })
+  }
+
+  const { data: last, error: lastError } = await supabase
+    .from('weight_room_template_slots')
+    .select('position')
+    .eq('template_id', templateId)
+    .order('position', { ascending: false })
+    .limit(1)
+    .maybeSingle()
+
+  if (lastError) {
+    return NextResponse.json(
+      { error: `Failed to read slot order: ${lastError.message}` },
+      { status: 500 }
+    )
+  }
+
+  const nowIso = new Date().toISOString()
+  const slotRow: Record<string, unknown> = {
+    template_id: templateId,
+    position: last ? last.position + 1 : 0,
+    exercise: entry.exercise,
+    target_sets: entry.target_sets,
+    updated_at: nowIso,
+  }
+  if (entry.target_sets_max != null) slotRow.target_sets_max = entry.target_sets_max
+  if (entry.target_reps != null) slotRow.target_reps = entry.target_reps
+  if (entry.target_reps_max != null) slotRow.target_reps_max = entry.target_reps_max
+  if (entry.target_weight_lbs != null) slotRow.target_weight_lbs = entry.target_weight_lbs
+  if (entry.rest_seconds != null) slotRow.rest_seconds = entry.rest_seconds
+  if (entry.notes != null) slotRow.notes = entry.notes
+
+  const { data: slot, error } = await supabase
+    .from('weight_room_template_slots')
+    .insert(slotRow)
+    .select('id')
+    .single()
+
+  if (error) {
+    if (error.code === FK_VIOLATION) {
+      return NextResponse.json(
+        { error: `Exercise '${entry.exercise}' is not in the movement catalog.` },
+        { status: 409 }
+      )
+    }
+    return NextResponse.json({ error: `Failed to add slot: ${error.message}` }, { status: 500 })
+  }
+
+  const childFailure = await replaceSlotChildren(
+    supabase,
+    slot.id,
+    entry.steps,
+    entry.alternates
+  )
+  if (childFailure !== null) {
+    return NextResponse.json({ error: childFailure.message }, { status: childFailure.status })
+  }
+
+  return NextResponse.json({ id: slot.id }, { status: 201 })
+}
+
+/**
+ * Reorder a template's slots in one upsert. Body must conform to
+ * {@link WeightRoomTemplateSlotReorderSchema}.
+ *
+ * One statement, deliberately — see the module docs for why sequential updates
+ * can't work against the unique position constraint.
+ *
+ * Status codes: 200 · 400 · 401 / 403 · 500.
+ *
+ * @param request Incoming JSON request matching {@link WeightRoomTemplateSlotReorderSchema}.
+ * @param ctx Next.js route context; `ctx.params.id` is the template UUID.
+ * @throws when Supabase env vars are missing (misconfigured deploy).
+ */
+async function handlePATCH(request: NextRequest, ctx: Context): Promise<NextResponse> {
+  const auth = await requireAdmin()
+  if (!auth.ok) return auth.response
+
+  const { id } = await ctx.params
+  const templateId = id.trim()
+  if (templateId.length === 0) {
+    return NextResponse.json({ error: 'id must be non-empty.' }, { status: 400 })
+  }
+
+  let payload: unknown
+  try {
+    payload = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Body must be valid JSON.' }, { status: 400 })
+  }
+
+  let entry
+  try {
+    entry = WeightRoomTemplateSlotReorderSchema.parse(payload)
+  } catch (err) {
+    if (err instanceof ZodError) {
+      return NextResponse.json(
+        { error: 'Validation failed.', issues: err.flatten() },
+        { status: 400 }
+      )
+    }
+    throw err
+  }
+
+  const supabase = createAdminSupabaseClient()
+
+  // Verify every id belongs to this template before upserting. An upsert on a
+  // non-existent id doesn't no-op — it attempts an INSERT, which fails on the
+  // NOT NULL `exercise` / `target_sets` columns and surfaces as an opaque 500.
+  // Checking first turns that into a clear 400, and stops a body from being
+  // used to drag a slot out of someone else's template.
+  const { data: owned, error: ownedError } = await supabase
+    .from('weight_room_template_slots')
+    .select('id')
+    .eq('template_id', templateId)
+
+  if (ownedError) {
+    if (ownedError.code === INVALID_UUID) {
+      return NextResponse.json({ error: `No template for '${templateId}'.` }, { status: 404 })
+    }
+    return NextResponse.json(
+      { error: `Failed to read slot order: ${ownedError.message}` },
+      { status: 500 }
+    )
+  }
+
+  const ownedIds = new Set((owned ?? []).map((row) => row.id))
+  const strays = entry.order.filter((row) => !ownedIds.has(row.id)).map((row) => row.id)
+  if (strays.length > 0) {
+    return NextResponse.json(
+      { error: `These slots do not belong to this template: ${strays.join(', ')}` },
+      { status: 400 }
+    )
+  }
+
+  const nowIso = new Date().toISOString()
+  // One statement, so the DEFERRABLE unique constraint is checked at commit —
+  // a swap that transiently duplicates a position passes through legally.
+  const { error } = await supabase.from('weight_room_template_slots').upsert(
+    entry.order.map((row) => ({
+      id: row.id,
+      template_id: templateId,
+      position: row.position,
+      updated_at: nowIso,
+    })),
+    { onConflict: 'id' }
+  )
+
+  if (error) {
+    return NextResponse.json(
+      { error: `Failed to reorder slots: ${error.message}` },
+      { status: 500 }
+    )
+  }
+  return NextResponse.json({ ok: true }, { status: 200 })
+}
+
+/** `handlePOST` wrapped with one-event-per-request telemetry (#220). */
+export const POST = withTelemetry(
+  'POST /api/admin/weight-room/templates/[id]/slots',
+  handlePOST
+)
+
+/** `handlePATCH` wrapped with one-event-per-request telemetry (#220). */
+export const PATCH = withTelemetry(
+  'PATCH /api/admin/weight-room/templates/[id]/slots',
+  handlePATCH
+)

--- a/app/api/admin/weight-room/templates/route.ts
+++ b/app/api/admin/weight-room/templates/route.ts
@@ -1,0 +1,118 @@
+/**
+ * Admin-only collection endpoints for workout templates (#375).
+ *
+ * `GET` returns every template with its slots, steps, and alternates attached —
+ * the shape the builder hydrates from. `POST` creates an empty template; slots
+ * are added through `[id]/slots`.
+ *
+ * Pair with `[id]/route.ts` for PATCH / DELETE.
+ */
+
+import { NextResponse, type NextRequest } from 'next/server'
+import { ZodError } from 'zod'
+
+import { requireAdmin } from '@/lib/auth/require-admin'
+import { assembleWorkoutTemplates } from '@/lib/data/weight-room-shared'
+import { WeightRoomTemplateCreateSchema } from '@/lib/schemas/weight-room'
+import { createAdminSupabaseClient } from '@/lib/supabase/admin'
+import { withTelemetry } from '@/lib/telemetry/with-telemetry'
+
+/**
+ * List every template, nested, ordered by position at each level.
+ *
+ * Includes archived templates — the builder needs them to un-archive; pickers
+ * filter for themselves.
+ *
+ * Status codes: 200 · 401 / 403 · 500.
+ *
+ * @param _request Unused; the route takes no query params.
+ * @throws when Supabase env vars are missing (misconfigured deploy).
+ */
+async function handleGET(_request: NextRequest): Promise<NextResponse> {
+  const auth = await requireAdmin()
+  if (!auth.ok) return auth.response
+
+  try {
+    const templates = await assembleWorkoutTemplates(createAdminSupabaseClient())
+    return NextResponse.json(templates, { status: 200 })
+  } catch (err) {
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : 'Failed to load templates.' },
+      { status: 500 }
+    )
+  }
+}
+
+/**
+ * Create a template. Body must conform to
+ * {@link WeightRoomTemplateCreateSchema} — only `name` is required.
+ *
+ * Created empty: slots are added through `[id]/slots` so each one gets a
+ * durable id from the moment it exists. #376 links logged sets to those ids,
+ * so an editing flow that recreated slots would orphan adherence history.
+ *
+ * Status codes:
+ * - 201 — created (response echoes the row, with an empty `slots`)
+ * - 400 — invalid JSON or failed Zod validation
+ * - 401 / 403 — not signed in / not on the allowlist
+ * - 500 — unexpected Supabase error
+ *
+ * @param request Incoming JSON request matching {@link WeightRoomTemplateCreateSchema}.
+ * @throws when Supabase env vars are missing (misconfigured deploy).
+ */
+async function handlePOST(request: NextRequest): Promise<NextResponse> {
+  const auth = await requireAdmin()
+  if (!auth.ok) return auth.response
+
+  let payload: unknown
+  try {
+    payload = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Body must be valid JSON.' }, { status: 400 })
+  }
+
+  let entry
+  try {
+    entry = WeightRoomTemplateCreateSchema.parse(payload)
+  } catch (err) {
+    if (err instanceof ZodError) {
+      return NextResponse.json(
+        { error: 'Validation failed.', issues: err.flatten() },
+        { status: 400 }
+      )
+    }
+    throw err
+  }
+
+  const supabase = createAdminSupabaseClient()
+  const insertRow: Record<string, unknown> = {
+    name: entry.name,
+    position: entry.position,
+    archived: entry.archived,
+    updated_at: new Date().toISOString(),
+  }
+  if (entry.description != null) insertRow.description = entry.description
+  if (entry.color != null) insertRow.color = entry.color
+  if (entry.category != null) insertRow.category = entry.category
+
+  const { data, error } = await supabase
+    .from('weight_room_workout_templates')
+    .insert(insertRow)
+    .select('id, name, description, color, category, position, archived')
+    .single()
+
+  if (error) {
+    return NextResponse.json(
+      { error: `Failed to create template: ${error.message}` },
+      { status: 500 }
+    )
+  }
+
+  return NextResponse.json({ ...data, slots: [] }, { status: 201 })
+}
+
+/** `handleGET` wrapped with one-event-per-request telemetry (#220). */
+export const GET = withTelemetry('GET /api/admin/weight-room/templates', handleGET)
+
+/** `handlePOST` wrapped with one-event-per-request telemetry (#220). */
+export const POST = withTelemetry('POST /api/admin/weight-room/templates', handlePOST)

--- a/app/training-facility/weight-room/settings/page.tsx
+++ b/app/training-facility/weight-room/settings/page.tsx
@@ -9,10 +9,12 @@ import { ExerciseCatalogSettings } from '@/components/training-facility/weight-r
 import { StrengthSettings } from '@/components/training-facility/weight-room/StrengthSettings'
 import { WeightRoomSubNav } from '@/components/training-facility/weight-room/WeightRoomSubNav'
 import { requireAdminPage } from '@/lib/auth/require-admin-page'
+import { TemplateBuilder } from '@/components/training-facility/weight-room/TemplateBuilder'
 import {
   getWeightRoomAchievementsServer,
   getWeightRoomDataServer,
   getWeightRoomExercisesServer,
+  getWorkoutTemplatesServer,
 } from '@/lib/data/weight-room-server'
 import { isWeightRoomEnabled } from '@/lib/feature-flags'
 
@@ -40,12 +42,16 @@ export default async function WeightRoomSettingsPage(): Promise<JSX.Element> {
   // UI handles `goals: []` gracefully (renders the add-exercise form
   // without an existing-goal table). The achievement ladder read (#336)
   // degrades independently — a failed fetch just empties that editor.
-  const [data, achievements, exercises] = await Promise.all([
+  const [data, achievements, exercises, templates] = await Promise.all([
     getWeightRoomDataServer().catch(() => null),
     getWeightRoomAchievementsServer().catch(() => []),
     getWeightRoomExercisesServer().catch(() => []),
+    getWorkoutTemplatesServer().catch(() => []),
   ])
   const goals = data?.goals ?? []
+  // Pickers offer live movements only; an archived one stays rendered wherever
+  // it's already referenced, it just isn't selectable for something new.
+  const activeExercises = exercises.filter((exercise) => exercise.archived !== true)
 
   return (
     <div className="relative min-h-svh overflow-hidden bg-[#120d0a] text-[#f7ead9]">
@@ -76,6 +82,21 @@ export default async function WeightRoomSettingsPage(): Promise<JSX.Element> {
 
         <section className="mt-10">
           <StrengthSettings initialGoals={goals} />
+        </section>
+
+        <section className="mt-14 border-t border-white/10 pt-10">
+          <h2 className="font-mono text-[11px] uppercase tracking-[0.32em] text-amber-300/80">
+            Workout templates
+          </h2>
+          <p className="mt-2 max-w-xl text-sm leading-7 text-[#e8d5be]">
+            Named prescriptions — &ldquo;Chest Day 1&rdquo;, an ordered list of movements with
+            their sets and reps. A template is a <em>plan</em>: running one produces a workout
+            session, and editing it afterwards never changes what a past session says it
+            prescribed. Leave reps blank for a movement you take to failure.
+          </p>
+          <div className="mt-6">
+            <TemplateBuilder initialTemplates={templates} exercises={activeExercises} />
+          </div>
         </section>
 
         <section className="mt-14 border-t border-white/10 pt-10">

--- a/app/training-facility/weight-room/settings/page.tsx
+++ b/app/training-facility/weight-room/settings/page.tsx
@@ -51,7 +51,7 @@ export default async function WeightRoomSettingsPage(): Promise<JSX.Element> {
   const goals = data?.goals ?? []
   // Pickers offer live movements only; an archived one stays rendered wherever
   // it's already referenced, it just isn't selectable for something new.
-  const activeExercises = exercises.filter((exercise) => exercise.archived !== true)
+  const activeExercises = exercises.filter(exercise => exercise.archived !== true)
 
   return (
     <div className="relative min-h-svh overflow-hidden bg-[#120d0a] text-[#f7ead9]">
@@ -89,10 +89,10 @@ export default async function WeightRoomSettingsPage(): Promise<JSX.Element> {
             Workout templates
           </h2>
           <p className="mt-2 max-w-xl text-sm leading-7 text-[#e8d5be]">
-            Named prescriptions — &ldquo;Chest Day 1&rdquo;, an ordered list of movements with
-            their sets and reps. A template is a <em>plan</em>: running one produces a workout
-            session, and editing it afterwards never changes what a past session says it
-            prescribed. Leave reps blank for a movement you take to failure.
+            Named prescriptions — &ldquo;Chest Day 1&rdquo;, an ordered list of movements with their
+            sets and reps. A template is a <em>plan</em>: running one produces a workout session,
+            and editing it afterwards never changes what a past session says it prescribed. Leave
+            reps blank for a movement you take to failure.
           </p>
           <div className="mt-6">
             <TemplateBuilder initialTemplates={templates} exercises={activeExercises} />

--- a/components/training-facility/weight-room/TemplateBuilder.tsx
+++ b/components/training-facility/weight-room/TemplateBuilder.tsx
@@ -62,12 +62,12 @@ export function TemplateBuilder({
   const [isPending, startTransition] = useTransition()
 
   const visible = useMemo(
-    () => initialTemplates.filter((t) => showArchived || t.archived !== true),
-    [initialTemplates, showArchived],
+    () => initialTemplates.filter(t => showArchived || t.archived !== true),
+    [initialTemplates, showArchived]
   )
   const archivedCount = useMemo(
-    () => initialTemplates.filter((t) => t.archived === true).length,
-    [initialTemplates],
+    () => initialTemplates.filter(t => t.archived === true).length,
+    [initialTemplates]
   )
 
   function refresh(): void {
@@ -106,7 +106,7 @@ export function TemplateBuilder({
           <input
             type="checkbox"
             checked={showArchived}
-            onChange={(e) => setShowArchived(e.target.checked)}
+            onChange={e => setShowArchived(e.target.checked)}
             className="h-4 w-4 accent-amber-300"
           />
           Show archived ({archivedCount})
@@ -119,7 +119,7 @@ export function TemplateBuilder({
             No templates yet — add one below, then add the movements it prescribes.
           </p>
         ) : (
-          visible.map((template) => (
+          visible.map(template => (
             <TemplateCard
               key={template.id}
               template={template}
@@ -137,7 +137,7 @@ export function TemplateBuilder({
         </h3>
         <AddTemplateForm
           disabled={isPending}
-          existingNames={initialTemplates.map((t) => t.name.toLowerCase())}
+          existingNames={initialTemplates.map(t => t.name.toLowerCase())}
           nextPosition={initialTemplates.length}
           onMutate={mutate}
         />
@@ -156,18 +156,13 @@ interface TemplateCardProps {
   onMutate: Mutate
 }
 
-function TemplateCard({
-  template,
-  exercises,
-  disabled,
-  onMutate,
-}: TemplateCardProps): JSX.Element {
+function TemplateCard({ template, exercises, disabled, onMutate }: TemplateCardProps): JSX.Element {
   const archived = template.archived === true
   const base = `/api/admin/weight-room/templates/${template.id}`
 
   async function move(slot: TemplateSlot, direction: -1 | 1): Promise<void> {
     const ordered = [...template.slots].sort((a, b) => a.position - b.position)
-    const index = ordered.findIndex((s) => s.id === slot.id)
+    const index = ordered.findIndex(s => s.id === slot.id)
     const target = index + direction
     if (index < 0 || target < 0 || target >= ordered.length) return
 
@@ -186,7 +181,7 @@ function TemplateCard({
           ],
         }),
       },
-      'Reorder failed',
+      'Reorder failed'
     )
   }
 
@@ -216,11 +211,7 @@ function TemplateCard({
         </summary>
 
         <div className="space-y-4 border-t border-white/10 p-4">
-          <TemplateMetaForm
-            template={template}
-            disabled={disabled}
-            onMutate={onMutate}
-          />
+          <TemplateMetaForm template={template} disabled={disabled} onMutate={onMutate} />
 
           <div>
             <h4 className="font-mono text-[11px] uppercase tracking-[0.22em] text-amber-300/70">
@@ -266,7 +257,7 @@ function TemplateCard({
                 onMutate(
                   base,
                   { method: 'PATCH', body: JSON.stringify({ archived: !archived }) },
-                  'Save failed',
+                  'Save failed'
                 )
               }
               className="rounded-full border border-white/20 bg-white/5 px-4 py-1.5 font-mono text-[11px] uppercase tracking-[0.22em] text-white/80 transition hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-40"
@@ -278,7 +269,7 @@ function TemplateCard({
               disabled={disabled}
               onClick={() => {
                 const ok = window.confirm(
-                  `Delete "${template.name}"? Its movements go with it. Sets you already logged against it are kept — they just stop being linked to a prescription. Archive instead if you may run it again.`,
+                  `Delete "${template.name}"? Its movements go with it. Sets you already logged against it are kept — they just stop being linked to a prescription. Archive instead if you may run it again.`
                 )
                 if (ok) void onMutate(base, { method: 'DELETE' }, 'Delete failed')
               }}
@@ -299,11 +290,7 @@ interface TemplateMetaFormProps {
   onMutate: Mutate
 }
 
-function TemplateMetaForm({
-  template,
-  disabled,
-  onMutate,
-}: TemplateMetaFormProps): JSX.Element {
+function TemplateMetaForm({ template, disabled, onMutate }: TemplateMetaFormProps): JSX.Element {
   const [name, setName] = useState(template.name)
   const [category, setCategory] = useState<TemplateCategory | ''>(template.category ?? '')
   const [color, setColor] = useState(template.color ?? DEFAULT_TEMPLATE_COLOR)
@@ -329,7 +316,7 @@ function TemplateMetaForm({
           category: category === '' ? null : category,
         }),
       },
-      'Save failed',
+      'Save failed'
     )
   }
 
@@ -342,7 +329,7 @@ function TemplateMetaForm({
           required
           maxLength={80}
           value={name}
-          onChange={(e) => setName(e.target.value)}
+          onChange={e => setName(e.target.value)}
           className="rounded border border-white/15 bg-black/40 px-2 py-1.5 text-sm text-white focus:border-amber-300/60 focus:outline-none"
         />
       </label>
@@ -350,13 +337,13 @@ function TemplateMetaForm({
         <span className="font-mono uppercase tracking-[0.18em]">category</span>
         <select
           value={category}
-          onChange={(e) => setCategory(e.target.value as TemplateCategory | '')}
+          onChange={e => setCategory(e.target.value as TemplateCategory | '')}
           className="rounded border border-white/15 bg-black/40 px-2 py-1.5 font-mono text-sm text-white focus:border-amber-300/60 focus:outline-none"
         >
           <option value="" className="bg-[#120d0a]">
             — none —
           </option>
-          {CATEGORIES.map((c) => (
+          {CATEGORIES.map(c => (
             <option key={c} value={c} className="bg-[#120d0a]">
               {c}
             </option>
@@ -369,7 +356,7 @@ function TemplateMetaForm({
           type="text"
           maxLength={2000}
           value={description}
-          onChange={(e) => setDescription(e.target.value)}
+          onChange={e => setDescription(e.target.value)}
           placeholder="Target pace: 35 min"
           className="rounded border border-white/15 bg-black/40 px-2 py-1.5 text-sm text-white focus:border-amber-300/60 focus:outline-none"
         />
@@ -380,7 +367,7 @@ function TemplateMetaForm({
           <input
             type="color"
             value={color}
-            onChange={(e) => setColor(e.target.value)}
+            onChange={e => setColor(e.target.value)}
             className="h-9 w-16 cursor-pointer rounded border border-white/15 bg-black/40"
           />
         </label>
@@ -417,8 +404,7 @@ function SlotRow({
   onMove,
   onMutate,
 }: SlotRowProps): JSX.Element {
-  const label =
-    exercises.find((e) => e.slug === slot.exercise)?.display_name ?? slot.exercise
+  const label = exercises.find(e => e.slug === slot.exercise)?.display_name ?? slot.exercise
   const sequenceLabel = slot.steps.length === 0 ? null : isSuperset(slot) ? 'superset' : 'drop set'
 
   return (
@@ -505,15 +491,13 @@ function SlotEditor({
   const [weight, setWeight] = useState(slot.target_weight_lbs?.toString() ?? '')
   const [rest, setRest] = useState(slot.rest_seconds?.toString() ?? '')
   const [notes, setNotes] = useState(slot.notes ?? '')
-  const [alternates, setAlternates] = useState<string[]>(
-    slot.alternates.map((a) => a.exercise),
-  )
+  const [alternates, setAlternates] = useState<string[]>(slot.alternates.map(a => a.exercise))
   const [steps, setSteps] = useState<StepDraft[]>(
-    slot.steps.map((s) => ({
+    slot.steps.map(s => ({
       exercise: s.exercise ?? '',
       target_reps: s.target_reps?.toString() ?? '',
       target_weight_lbs: s.target_weight_lbs?.toString() ?? '',
-    })),
+    }))
   )
 
   const slotUrl = `${templateBase}/slots/${slot.id}`
@@ -545,8 +529,8 @@ function SlotEditor({
           notes,
           alternates,
           steps: steps
-            .filter((s) => s.exercise !== '' || s.target_reps !== '' || s.target_weight_lbs !== '')
-            .map((s) => ({
+            .filter(s => s.exercise !== '' || s.target_reps !== '' || s.target_weight_lbs !== '')
+            .map(s => ({
               ...(s.exercise !== '' ? { exercise: s.exercise } : {}),
               ...(num(s.target_reps) !== null ? { target_reps: num(s.target_reps) } : {}),
               ...(num(s.target_weight_lbs) !== null
@@ -555,7 +539,7 @@ function SlotEditor({
             })),
         }),
       },
-      'Save failed',
+      'Save failed'
     )
   }
 
@@ -570,8 +554,8 @@ function SlotEditor({
         <NumberField label="rest (s)" value={rest} onChange={setRest} min={0} />
       </div>
       <p className="text-[11px] leading-5 text-white/40">
-        Leave reps blank for <strong>{AMRAP_LABEL}</strong>. Reps are totals, not per side.
-        Weight is per implement — a pair of 35s is 35.
+        Leave reps blank for <strong>{AMRAP_LABEL}</strong>. Reps are totals, not per side. Weight
+        is per implement — a pair of 35s is 35.
       </p>
 
       <label className="flex flex-col gap-1 text-xs text-white/70">
@@ -580,7 +564,7 @@ function SlotEditor({
           type="text"
           maxLength={500}
           value={notes}
-          onChange={(e) => setNotes(e.target.value)}
+          onChange={e => setNotes(e.target.value)}
           placeholder="Rack run — descending down the rack"
           className="rounded border border-white/15 bg-black/40 px-2 py-1.5 text-sm text-white focus:border-amber-300/60 focus:outline-none"
         />
@@ -601,9 +585,9 @@ function SlotEditor({
               <span className="font-mono uppercase tracking-[0.14em]">movement</span>
               <select
                 value={step.exercise}
-                onChange={(e) =>
+                onChange={e =>
                   setSteps(
-                    steps.map((s, i) => (i === index ? { ...s, exercise: e.target.value } : s)),
+                    steps.map((s, i) => (i === index ? { ...s, exercise: e.target.value } : s))
                   )
                 }
                 className="rounded border border-white/15 bg-black/40 px-2 py-1 font-mono text-xs text-white focus:border-amber-300/60 focus:outline-none"
@@ -611,7 +595,7 @@ function SlotEditor({
                 <option value="" className="bg-[#120d0a]">
                   — same as slot —
                 </option>
-                {exercises.map((e) => (
+                {exercises.map(e => (
                   <option key={e.slug} value={e.slug} className="bg-[#120d0a]">
                     {e.display_name}
                   </option>
@@ -621,7 +605,7 @@ function SlotEditor({
             <NumberField
               label="reps"
               value={step.target_reps}
-              onChange={(v) =>
+              onChange={v =>
                 setSteps(steps.map((s, i) => (i === index ? { ...s, target_reps: v } : s)))
               }
               min={1}
@@ -630,10 +614,8 @@ function SlotEditor({
             <NumberField
               label="lb"
               value={step.target_weight_lbs}
-              onChange={(v) =>
-                setSteps(
-                  steps.map((s, i) => (i === index ? { ...s, target_weight_lbs: v } : s)),
-                )
+              onChange={v =>
+                setSteps(steps.map((s, i) => (i === index ? { ...s, target_weight_lbs: v } : s)))
               }
               min={0}
               compact
@@ -671,12 +653,12 @@ function SlotEditor({
           <div key={index} className="mb-2 flex items-center gap-2">
             <select
               value={alt}
-              onChange={(e) =>
+              onChange={e =>
                 setAlternates(alternates.map((a, i) => (i === index ? e.target.value : a)))
               }
               className="min-w-0 flex-1 rounded border border-white/15 bg-black/40 px-2 py-1 font-mono text-xs text-white focus:border-amber-300/60 focus:outline-none"
             >
-              {exercises.map((e) => (
+              {exercises.map(e => (
                 <option key={e.slug} value={e.slug} className="bg-[#120d0a]">
                   {e.display_name}
                 </option>
@@ -743,7 +725,7 @@ function NumberField({ label, value, onChange, min, compact }: NumberFieldProps)
         inputMode="numeric"
         min={min}
         value={value}
-        onChange={(e) => onChange(e.target.value)}
+        onChange={e => onChange(e.target.value)}
         className={`rounded border border-white/15 bg-black/40 px-2 py-1 text-right font-mono text-xs text-white focus:border-amber-300/60 focus:outline-none ${compact ? 'w-16' : ''}`}
       />
     </label>
@@ -783,7 +765,7 @@ function AddSlotForm({
           ...(reps.trim() !== '' ? { target_reps: Number(reps) } : {}),
         }),
       },
-      'Add failed',
+      'Add failed'
     )
     if (created) setReps('')
   }
@@ -797,10 +779,10 @@ function AddSlotForm({
         <span className="font-mono uppercase tracking-[0.14em]">add movement</span>
         <select
           value={exercise}
-          onChange={(e) => setExercise(e.target.value)}
+          onChange={e => setExercise(e.target.value)}
           className="rounded border border-white/15 bg-black/40 px-2 py-1.5 font-mono text-xs text-white focus:border-amber-300/60 focus:outline-none"
         >
-          {exercises.map((e) => (
+          {exercises.map(e => (
             <option key={e.slug} value={e.slug} className="bg-[#120d0a]">
               {e.display_name}
             </option>
@@ -853,7 +835,7 @@ function AddTemplateForm({
           ...(category !== '' ? { category } : {}),
         }),
       },
-      'Add failed',
+      'Add failed'
     )
     if (created) setName('')
   }
@@ -870,7 +852,7 @@ function AddTemplateForm({
           required
           maxLength={80}
           value={name}
-          onChange={(e) => setName(e.target.value)}
+          onChange={e => setName(e.target.value)}
           placeholder="Chest Day 1"
           className="rounded border border-white/15 bg-black/40 px-2 py-1.5 text-sm text-white focus:border-amber-300/60 focus:outline-none"
         />
@@ -884,13 +866,13 @@ function AddTemplateForm({
         <span className="font-mono uppercase tracking-[0.18em]">category</span>
         <select
           value={category}
-          onChange={(e) => setCategory(e.target.value as TemplateCategory | '')}
+          onChange={e => setCategory(e.target.value as TemplateCategory | '')}
           className="rounded border border-white/15 bg-black/40 px-2 py-1.5 font-mono text-sm text-white focus:border-amber-300/60 focus:outline-none"
         >
           <option value="" className="bg-[#120d0a]">
             — none —
           </option>
-          {CATEGORIES.map((c) => (
+          {CATEGORIES.map(c => (
             <option key={c} value={c} className="bg-[#120d0a]">
               {c}
             </option>
@@ -902,7 +884,7 @@ function AddTemplateForm({
         <input
           type="color"
           value={color}
-          onChange={(e) => setColor(e.target.value)}
+          onChange={e => setColor(e.target.value)}
           className="h-9 w-16 cursor-pointer rounded border border-white/15 bg-black/40"
         />
       </label>

--- a/components/training-facility/weight-room/TemplateBuilder.tsx
+++ b/components/training-facility/weight-room/TemplateBuilder.tsx
@@ -1,0 +1,918 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import { useMemo, useState, useTransition, type FormEvent, type JSX } from 'react'
+
+import {
+  AMRAP_LABEL,
+  formatSlotPrescription,
+  isSuperset,
+} from '@/lib/training-facility/template-format'
+import type {
+  TemplateCategory,
+  TemplateSlot,
+  WeightRoomExercise,
+  WorkoutTemplate,
+} from '@/types/weight-room'
+
+/** Props for {@link TemplateBuilder}. */
+export interface TemplateBuilderProps {
+  /**
+   * Templates as read by the server component, archived ones included, with
+   * slots / steps / alternates attached. Mutations refresh via
+   * `router.refresh()` so the next render comes from a fresh server fetch.
+   */
+  initialTemplates: readonly WorkoutTemplate[]
+  /** The movement catalog, for the exercise pickers. Archived entries filtered by the caller. */
+  exercises: readonly WeightRoomExercise[]
+}
+
+/** Selectable template categories, matching the DB check constraint. */
+const CATEGORIES: readonly TemplateCategory[] = [
+  'push',
+  'pull',
+  'legs',
+  'upper',
+  'lower',
+  'full-body',
+  'other',
+]
+
+const DEFAULT_TEMPLATE_COLOR = '#DC2626'
+
+/**
+ * Admin-only workout-template builder (#375).
+ *
+ * A template is a named, ordered prescription — the "plan" half of the gym
+ * workouts arc. Slots are edited **in place** rather than replaced on save,
+ * because #376 links each logged set to the slot it was performed for; a
+ * save that recreated slots would orphan that history on every edit.
+ *
+ * Mobile-first like its Settings siblings: templates and slots both collapse to
+ * a summary line and expand into their editor, so six templates of seven
+ * movements each stay navigable on a phone.
+ */
+export function TemplateBuilder({
+  initialTemplates,
+  exercises,
+}: TemplateBuilderProps): JSX.Element {
+  const router = useRouter()
+  const [error, setError] = useState<string | null>(null)
+  const [showArchived, setShowArchived] = useState(false)
+  const [isPending, startTransition] = useTransition()
+
+  const visible = useMemo(
+    () => initialTemplates.filter((t) => showArchived || t.archived !== true),
+    [initialTemplates, showArchived],
+  )
+  const archivedCount = useMemo(
+    () => initialTemplates.filter((t) => t.archived === true).length,
+    [initialTemplates],
+  )
+
+  function refresh(): void {
+    startTransition(() => router.refresh())
+  }
+
+  /** Issue a mutation, surface `{ error }` on failure, refresh on success. */
+  async function mutate(url: string, init: RequestInit, fallback: string): Promise<boolean> {
+    setError(null)
+    const res = await fetch(url, {
+      ...init,
+      headers: { 'Content-Type': 'application/json', ...(init.headers ?? {}) },
+    })
+    if (!res.ok) {
+      const body = (await res.json().catch(() => ({}))) as { error?: string }
+      setError(body.error ?? `${fallback} (${res.status})`)
+      return false
+    }
+    refresh()
+    return true
+  }
+
+  return (
+    <div className="space-y-6">
+      {error ? (
+        <p
+          role="alert"
+          className="rounded border border-rose-400/30 bg-rose-950/40 px-3 py-2 font-mono text-[12px] text-rose-200"
+        >
+          {error}
+        </p>
+      ) : null}
+
+      {archivedCount > 0 ? (
+        <label className="flex items-center gap-2 font-mono text-[11px] uppercase tracking-[0.18em] text-white/60">
+          <input
+            type="checkbox"
+            checked={showArchived}
+            onChange={(e) => setShowArchived(e.target.checked)}
+            className="h-4 w-4 accent-amber-300"
+          />
+          Show archived ({archivedCount})
+        </label>
+      ) : null}
+
+      <section aria-label="Workout templates" className="space-y-3">
+        {visible.length === 0 ? (
+          <p className="text-sm text-[#e8d5be]/70">
+            No templates yet — add one below, then add the movements it prescribes.
+          </p>
+        ) : (
+          visible.map((template) => (
+            <TemplateCard
+              key={template.id}
+              template={template}
+              exercises={exercises}
+              disabled={isPending}
+              onMutate={mutate}
+            />
+          ))
+        )}
+      </section>
+
+      <section aria-label="Add a template">
+        <h3 className="font-mono text-[11px] uppercase tracking-[0.32em] text-amber-300/80">
+          Add template
+        </h3>
+        <AddTemplateForm
+          disabled={isPending}
+          existingNames={initialTemplates.map((t) => t.name.toLowerCase())}
+          nextPosition={initialTemplates.length}
+          onMutate={mutate}
+        />
+      </section>
+    </div>
+  )
+}
+
+/** Shared mutation signature threaded down from {@link TemplateBuilder}. */
+type Mutate = (url: string, init: RequestInit, fallback: string) => Promise<boolean>
+
+interface TemplateCardProps {
+  template: WorkoutTemplate
+  exercises: readonly WeightRoomExercise[]
+  disabled: boolean
+  onMutate: Mutate
+}
+
+function TemplateCard({
+  template,
+  exercises,
+  disabled,
+  onMutate,
+}: TemplateCardProps): JSX.Element {
+  const archived = template.archived === true
+  const base = `/api/admin/weight-room/templates/${template.id}`
+
+  async function move(slot: TemplateSlot, direction: -1 | 1): Promise<void> {
+    const ordered = [...template.slots].sort((a, b) => a.position - b.position)
+    const index = ordered.findIndex((s) => s.id === slot.id)
+    const target = index + direction
+    if (index < 0 || target < 0 || target >= ordered.length) return
+
+    // Swap the two positions and send both in one request — the unique
+    // constraint is deferrable precisely so this transient duplicate is legal.
+    const a = ordered[index]
+    const b = ordered[target]
+    await onMutate(
+      `${base}/slots`,
+      {
+        method: 'PATCH',
+        body: JSON.stringify({
+          order: [
+            { id: a.id, position: b.position },
+            { id: b.id, position: a.position },
+          ],
+        }),
+      },
+      'Reorder failed',
+    )
+  }
+
+  return (
+    <div
+      className={`rounded-[1.1rem] border border-white/10 bg-white/5 ${archived ? 'opacity-50' : ''}`}
+    >
+      <details>
+        <summary className="cursor-pointer list-none px-4 py-3">
+          <span className="flex flex-wrap items-center gap-x-3 gap-y-1">
+            <span
+              aria-hidden="true"
+              className="h-2.5 w-2.5 rounded-full"
+              style={{ backgroundColor: template.color ?? '#666' }}
+            />
+            <span className="text-sm font-semibold text-white">{template.name}</span>
+            {template.category ? (
+              <span className="rounded-full border border-white/10 bg-white/5 px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.14em] text-white/50">
+                {template.category}
+              </span>
+            ) : null}
+            <span className="ml-auto font-mono text-[11px] text-white/40">
+              {template.slots.length} {template.slots.length === 1 ? 'movement' : 'movements'}
+              {archived ? ' · archived' : ''}
+            </span>
+          </span>
+        </summary>
+
+        <div className="space-y-4 border-t border-white/10 p-4">
+          <TemplateMetaForm
+            template={template}
+            disabled={disabled}
+            onMutate={onMutate}
+          />
+
+          <div>
+            <h4 className="font-mono text-[11px] uppercase tracking-[0.22em] text-amber-300/70">
+              Movements
+            </h4>
+            {template.slots.length === 0 ? (
+              <p className="mt-2 text-sm text-white/50">
+                No movements yet — add the first one below.
+              </p>
+            ) : (
+              <ul className="mt-2 space-y-2">
+                {[...template.slots]
+                  .sort((a, b) => a.position - b.position)
+                  .map((slot, index, all) => (
+                    <SlotRow
+                      key={slot.id}
+                      slot={slot}
+                      exercises={exercises}
+                      templateBase={base}
+                      disabled={disabled}
+                      isFirst={index === 0}
+                      isLast={index === all.length - 1}
+                      onMove={move}
+                      onMutate={onMutate}
+                    />
+                  ))}
+              </ul>
+            )}
+          </div>
+
+          <AddSlotForm
+            templateBase={base}
+            exercises={exercises}
+            disabled={disabled}
+            onMutate={onMutate}
+          />
+
+          <div className="flex flex-wrap gap-2 border-t border-white/10 pt-3">
+            <button
+              type="button"
+              disabled={disabled}
+              onClick={() =>
+                onMutate(
+                  base,
+                  { method: 'PATCH', body: JSON.stringify({ archived: !archived }) },
+                  'Save failed',
+                )
+              }
+              className="rounded-full border border-white/20 bg-white/5 px-4 py-1.5 font-mono text-[11px] uppercase tracking-[0.22em] text-white/80 transition hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              {archived ? 'Unarchive' : 'Archive'}
+            </button>
+            <button
+              type="button"
+              disabled={disabled}
+              onClick={() => {
+                const ok = window.confirm(
+                  `Delete "${template.name}"? Its movements go with it. Sets you already logged against it are kept — they just stop being linked to a prescription. Archive instead if you may run it again.`,
+                )
+                if (ok) void onMutate(base, { method: 'DELETE' }, 'Delete failed')
+              }}
+              className="ml-auto rounded-full border border-rose-300/25 bg-rose-300/5 px-4 py-1.5 font-mono text-[11px] uppercase tracking-[0.22em] text-rose-200 transition hover:bg-rose-300/15 disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              Delete
+            </button>
+          </div>
+        </div>
+      </details>
+    </div>
+  )
+}
+
+interface TemplateMetaFormProps {
+  template: WorkoutTemplate
+  disabled: boolean
+  onMutate: Mutate
+}
+
+function TemplateMetaForm({
+  template,
+  disabled,
+  onMutate,
+}: TemplateMetaFormProps): JSX.Element {
+  const [name, setName] = useState(template.name)
+  const [category, setCategory] = useState<TemplateCategory | ''>(template.category ?? '')
+  const [color, setColor] = useState(template.color ?? DEFAULT_TEMPLATE_COLOR)
+  const [description, setDescription] = useState(template.description ?? '')
+
+  const dirty =
+    name !== template.name ||
+    category !== (template.category ?? '') ||
+    color !== (template.color ?? DEFAULT_TEMPLATE_COLOR) ||
+    description !== (template.description ?? '')
+
+  async function handleSubmit(e: FormEvent<HTMLFormElement>): Promise<void> {
+    e.preventDefault()
+    if (!dirty) return
+    await onMutate(
+      `/api/admin/weight-room/templates/${template.id}`,
+      {
+        method: 'PATCH',
+        body: JSON.stringify({
+          name,
+          color,
+          description,
+          category: category === '' ? null : category,
+        }),
+      },
+      'Save failed',
+    )
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="grid gap-3 sm:grid-cols-2">
+      <label className="flex flex-col gap-1 text-xs text-white/70">
+        <span className="font-mono uppercase tracking-[0.18em]">name</span>
+        <input
+          type="text"
+          required
+          maxLength={80}
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className="rounded border border-white/15 bg-black/40 px-2 py-1.5 text-sm text-white focus:border-amber-300/60 focus:outline-none"
+        />
+      </label>
+      <label className="flex flex-col gap-1 text-xs text-white/70">
+        <span className="font-mono uppercase tracking-[0.18em]">category</span>
+        <select
+          value={category}
+          onChange={(e) => setCategory(e.target.value as TemplateCategory | '')}
+          className="rounded border border-white/15 bg-black/40 px-2 py-1.5 font-mono text-sm text-white focus:border-amber-300/60 focus:outline-none"
+        >
+          <option value="" className="bg-[#120d0a]">
+            — none —
+          </option>
+          {CATEGORIES.map((c) => (
+            <option key={c} value={c} className="bg-[#120d0a]">
+              {c}
+            </option>
+          ))}
+        </select>
+      </label>
+      <label className="flex flex-col gap-1 text-xs text-white/70 sm:col-span-2">
+        <span className="font-mono uppercase tracking-[0.18em]">description</span>
+        <input
+          type="text"
+          maxLength={2000}
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          placeholder="Target pace: 35 min"
+          className="rounded border border-white/15 bg-black/40 px-2 py-1.5 text-sm text-white focus:border-amber-300/60 focus:outline-none"
+        />
+      </label>
+      <div className="flex items-end gap-3">
+        <label className="flex flex-col gap-1 text-xs text-white/70">
+          <span className="font-mono uppercase tracking-[0.18em]">color</span>
+          <input
+            type="color"
+            value={color}
+            onChange={(e) => setColor(e.target.value)}
+            className="h-9 w-16 cursor-pointer rounded border border-white/15 bg-black/40"
+          />
+        </label>
+        <button
+          type="submit"
+          disabled={disabled || !dirty}
+          className="mb-0.5 rounded-full border border-amber-200/30 bg-amber-200/10 px-4 py-1.5 font-mono text-[11px] uppercase tracking-[0.22em] text-amber-100 transition hover:bg-amber-200/20 disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          Save
+        </button>
+      </div>
+    </form>
+  )
+}
+
+interface SlotRowProps {
+  slot: TemplateSlot
+  exercises: readonly WeightRoomExercise[]
+  templateBase: string
+  disabled: boolean
+  isFirst: boolean
+  isLast: boolean
+  onMove: (slot: TemplateSlot, direction: -1 | 1) => Promise<void>
+  onMutate: Mutate
+}
+
+function SlotRow({
+  slot,
+  exercises,
+  templateBase,
+  disabled,
+  isFirst,
+  isLast,
+  onMove,
+  onMutate,
+}: SlotRowProps): JSX.Element {
+  const label =
+    exercises.find((e) => e.slug === slot.exercise)?.display_name ?? slot.exercise
+  const sequenceLabel = slot.steps.length === 0 ? null : isSuperset(slot) ? 'superset' : 'drop set'
+
+  return (
+    <li className="rounded-[0.9rem] border border-white/10 bg-black/20">
+      <div className="flex items-center gap-2 px-3 py-2">
+        <div className="flex flex-col">
+          <button
+            type="button"
+            aria-label={`Move ${label} up`}
+            disabled={disabled || isFirst}
+            onClick={() => void onMove(slot, -1)}
+            className="px-1 text-[10px] leading-none text-white/50 transition hover:text-white disabled:opacity-20"
+          >
+            ▲
+          </button>
+          <button
+            type="button"
+            aria-label={`Move ${label} down`}
+            disabled={disabled || isLast}
+            onClick={() => void onMove(slot, 1)}
+            className="px-1 text-[10px] leading-none text-white/50 transition hover:text-white disabled:opacity-20"
+          >
+            ▼
+          </button>
+        </div>
+        <details className="min-w-0 flex-1">
+          <summary className="cursor-pointer list-none">
+            <span className="flex flex-wrap items-baseline gap-x-2">
+              <span className="text-sm text-white">{label}</span>
+              <span className="font-mono text-[11px] text-white/50">
+                {formatSlotPrescription(slot)}
+              </span>
+              {sequenceLabel ? (
+                <span className="rounded-full border border-white/10 bg-white/5 px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.12em] text-white/50">
+                  {sequenceLabel}
+                </span>
+              ) : null}
+              {slot.alternates.length > 0 ? (
+                <span className="font-mono text-[10px] text-white/35">
+                  {slot.alternates.length} alt
+                </span>
+              ) : null}
+            </span>
+          </summary>
+          <SlotEditor
+            slot={slot}
+            exercises={exercises}
+            templateBase={templateBase}
+            disabled={disabled}
+            onMutate={onMutate}
+          />
+        </details>
+      </div>
+    </li>
+  )
+}
+
+interface SlotEditorProps {
+  slot: TemplateSlot
+  exercises: readonly WeightRoomExercise[]
+  templateBase: string
+  disabled: boolean
+  onMutate: Mutate
+}
+
+/** A step row as edited locally; empty strings mean "not set". */
+interface StepDraft {
+  exercise: string
+  target_reps: string
+  target_weight_lbs: string
+}
+
+function SlotEditor({
+  slot,
+  exercises,
+  templateBase,
+  disabled,
+  onMutate,
+}: SlotEditorProps): JSX.Element {
+  const [sets, setSets] = useState(String(slot.target_sets))
+  const [setsMax, setSetsMax] = useState(slot.target_sets_max?.toString() ?? '')
+  const [reps, setReps] = useState(slot.target_reps?.toString() ?? '')
+  const [repsMax, setRepsMax] = useState(slot.target_reps_max?.toString() ?? '')
+  const [weight, setWeight] = useState(slot.target_weight_lbs?.toString() ?? '')
+  const [rest, setRest] = useState(slot.rest_seconds?.toString() ?? '')
+  const [notes, setNotes] = useState(slot.notes ?? '')
+  const [alternates, setAlternates] = useState<string[]>(
+    slot.alternates.map((a) => a.exercise),
+  )
+  const [steps, setSteps] = useState<StepDraft[]>(
+    slot.steps.map((s) => ({
+      exercise: s.exercise ?? '',
+      target_reps: s.target_reps?.toString() ?? '',
+      target_weight_lbs: s.target_weight_lbs?.toString() ?? '',
+    })),
+  )
+
+  const slotUrl = `${templateBase}/slots/${slot.id}`
+
+  /** Parse a numeric field; empty string becomes null (an explicit clear). */
+  function num(value: string): number | null {
+    const trimmed = value.trim()
+    if (trimmed === '') return null
+    const parsed = Number(trimmed)
+    return Number.isFinite(parsed) ? parsed : null
+  }
+
+  async function handleSubmit(e: FormEvent<HTMLFormElement>): Promise<void> {
+    e.preventDefault()
+    const setsValue = num(sets)
+    if (setsValue === null || setsValue < 1) return
+
+    await onMutate(
+      slotUrl,
+      {
+        method: 'PATCH',
+        body: JSON.stringify({
+          target_sets: setsValue,
+          target_sets_max: num(setsMax),
+          target_reps: num(reps),
+          target_reps_max: num(repsMax),
+          target_weight_lbs: num(weight),
+          rest_seconds: num(rest),
+          notes,
+          alternates,
+          steps: steps
+            .filter((s) => s.exercise !== '' || s.target_reps !== '' || s.target_weight_lbs !== '')
+            .map((s) => ({
+              ...(s.exercise !== '' ? { exercise: s.exercise } : {}),
+              ...(num(s.target_reps) !== null ? { target_reps: num(s.target_reps) } : {}),
+              ...(num(s.target_weight_lbs) !== null
+                ? { target_weight_lbs: num(s.target_weight_lbs) }
+                : {}),
+            })),
+        }),
+      },
+      'Save failed',
+    )
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="mt-3 grid gap-3 border-t border-white/10 pt-3">
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        <NumberField label="sets" value={sets} onChange={setSets} min={1} />
+        <NumberField label="sets max" value={setsMax} onChange={setSetsMax} min={1} />
+        <NumberField label="reps" value={reps} onChange={setReps} min={1} />
+        <NumberField label="reps max" value={repsMax} onChange={setRepsMax} min={1} />
+        <NumberField label="lb / implement" value={weight} onChange={setWeight} min={0} />
+        <NumberField label="rest (s)" value={rest} onChange={setRest} min={0} />
+      </div>
+      <p className="text-[11px] leading-5 text-white/40">
+        Leave reps blank for <strong>{AMRAP_LABEL}</strong>. Reps are totals, not per side.
+        Weight is per implement — a pair of 35s is 35.
+      </p>
+
+      <label className="flex flex-col gap-1 text-xs text-white/70">
+        <span className="font-mono uppercase tracking-[0.18em]">notes</span>
+        <input
+          type="text"
+          maxLength={500}
+          value={notes}
+          onChange={(e) => setNotes(e.target.value)}
+          placeholder="Rack run — descending down the rack"
+          className="rounded border border-white/15 bg-black/40 px-2 py-1.5 text-sm text-white focus:border-amber-300/60 focus:outline-none"
+        />
+      </label>
+
+      <fieldset className="rounded border border-white/10 p-3">
+        <legend className="px-1 font-mono text-[10px] uppercase tracking-[0.18em] text-white/50">
+          within-set sequence
+        </legend>
+        <p className="mb-2 text-[11px] leading-5 text-white/40">
+          Leave empty for an ordinary straight set. Same movement at descending loads is a{' '}
+          <strong>drop set</strong>; naming a different movement makes it a{' '}
+          <strong>superset</strong>.
+        </p>
+        {steps.map((step, index) => (
+          <div key={index} className="mb-2 grid grid-cols-[1fr_auto_auto_auto] items-end gap-2">
+            <label className="flex flex-col gap-1 text-[11px] text-white/60">
+              <span className="font-mono uppercase tracking-[0.14em]">movement</span>
+              <select
+                value={step.exercise}
+                onChange={(e) =>
+                  setSteps(
+                    steps.map((s, i) => (i === index ? { ...s, exercise: e.target.value } : s)),
+                  )
+                }
+                className="rounded border border-white/15 bg-black/40 px-2 py-1 font-mono text-xs text-white focus:border-amber-300/60 focus:outline-none"
+              >
+                <option value="" className="bg-[#120d0a]">
+                  — same as slot —
+                </option>
+                {exercises.map((e) => (
+                  <option key={e.slug} value={e.slug} className="bg-[#120d0a]">
+                    {e.display_name}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <NumberField
+              label="reps"
+              value={step.target_reps}
+              onChange={(v) =>
+                setSteps(steps.map((s, i) => (i === index ? { ...s, target_reps: v } : s)))
+              }
+              min={1}
+              compact
+            />
+            <NumberField
+              label="lb"
+              value={step.target_weight_lbs}
+              onChange={(v) =>
+                setSteps(
+                  steps.map((s, i) => (i === index ? { ...s, target_weight_lbs: v } : s)),
+                )
+              }
+              min={0}
+              compact
+            />
+            <button
+              type="button"
+              aria-label={`Remove step ${index + 1}`}
+              onClick={() => setSteps(steps.filter((_, i) => i !== index))}
+              className="mb-1 rounded border border-white/15 px-2 py-1 text-[11px] text-white/60 transition hover:border-rose-300/40 hover:text-rose-200"
+            >
+              ✕
+            </button>
+          </div>
+        ))}
+        <button
+          type="button"
+          onClick={() =>
+            setSteps([...steps, { exercise: '', target_reps: '', target_weight_lbs: '' }])
+          }
+          className="rounded-full border border-white/20 px-3 py-1 font-mono text-[10px] uppercase tracking-[0.18em] text-white/70 transition hover:bg-white/10"
+        >
+          + step
+        </button>
+      </fieldset>
+
+      <fieldset className="rounded border border-white/10 p-3">
+        <legend className="px-1 font-mono text-[10px] uppercase tracking-[0.18em] text-white/50">
+          alternates
+        </legend>
+        <p className="mb-2 text-[11px] leading-5 text-white/40">
+          Swaps offered first when the rack is taken, in order. Anything in the catalog stays
+          reachable during a workout — this is only the shortcut.
+        </p>
+        {alternates.map((alt, index) => (
+          <div key={index} className="mb-2 flex items-center gap-2">
+            <select
+              value={alt}
+              onChange={(e) =>
+                setAlternates(alternates.map((a, i) => (i === index ? e.target.value : a)))
+              }
+              className="min-w-0 flex-1 rounded border border-white/15 bg-black/40 px-2 py-1 font-mono text-xs text-white focus:border-amber-300/60 focus:outline-none"
+            >
+              {exercises.map((e) => (
+                <option key={e.slug} value={e.slug} className="bg-[#120d0a]">
+                  {e.display_name}
+                </option>
+              ))}
+            </select>
+            <button
+              type="button"
+              aria-label={`Remove alternate ${index + 1}`}
+              onClick={() => setAlternates(alternates.filter((_, i) => i !== index))}
+              className="rounded border border-white/15 px-2 py-1 text-[11px] text-white/60 transition hover:border-rose-300/40 hover:text-rose-200"
+            >
+              ✕
+            </button>
+          </div>
+        ))}
+        <button
+          type="button"
+          disabled={exercises.length === 0}
+          onClick={() => setAlternates([...alternates, exercises[0]?.slug ?? ''])}
+          className="rounded-full border border-white/20 px-3 py-1 font-mono text-[10px] uppercase tracking-[0.18em] text-white/70 transition hover:bg-white/10 disabled:opacity-40"
+        >
+          + alternate
+        </button>
+      </fieldset>
+
+      <div className="flex flex-wrap gap-2">
+        <button
+          type="submit"
+          disabled={disabled}
+          className="rounded-full border border-amber-200/30 bg-amber-200/10 px-4 py-1.5 font-mono text-[11px] uppercase tracking-[0.22em] text-amber-100 transition hover:bg-amber-200/20 disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          Save movement
+        </button>
+        <button
+          type="button"
+          disabled={disabled}
+          onClick={() => {
+            const ok = window.confirm('Remove this movement from the template?')
+            if (ok) void onMutate(slotUrl, { method: 'DELETE' }, 'Delete failed')
+          }}
+          className="ml-auto rounded-full border border-rose-300/25 bg-rose-300/5 px-4 py-1.5 font-mono text-[11px] uppercase tracking-[0.22em] text-rose-200 transition hover:bg-rose-300/15 disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          Remove
+        </button>
+      </div>
+    </form>
+  )
+}
+
+interface NumberFieldProps {
+  label: string
+  value: string
+  onChange: (value: string) => void
+  min: number
+  compact?: boolean
+}
+
+function NumberField({ label, value, onChange, min, compact }: NumberFieldProps): JSX.Element {
+  return (
+    <label className="flex flex-col gap-1 text-[11px] text-white/60">
+      <span className="font-mono uppercase tracking-[0.14em]">{label}</span>
+      <input
+        type="number"
+        inputMode="numeric"
+        min={min}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className={`rounded border border-white/15 bg-black/40 px-2 py-1 text-right font-mono text-xs text-white focus:border-amber-300/60 focus:outline-none ${compact ? 'w-16' : ''}`}
+      />
+    </label>
+  )
+}
+
+interface AddSlotFormProps {
+  templateBase: string
+  exercises: readonly WeightRoomExercise[]
+  disabled: boolean
+  onMutate: Mutate
+}
+
+function AddSlotForm({
+  templateBase,
+  exercises,
+  disabled,
+  onMutate,
+}: AddSlotFormProps): JSX.Element {
+  const [exercise, setExercise] = useState(exercises[0]?.slug ?? '')
+  const [sets, setSets] = useState('4')
+  const [reps, setReps] = useState('')
+
+  async function handleSubmit(e: FormEvent<HTMLFormElement>): Promise<void> {
+    e.preventDefault()
+    if (exercise === '') return
+    const setsValue = Number(sets)
+    if (!Number.isFinite(setsValue) || setsValue < 1) return
+
+    const created = await onMutate(
+      `${templateBase}/slots`,
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          exercise,
+          target_sets: setsValue,
+          ...(reps.trim() !== '' ? { target_reps: Number(reps) } : {}),
+        }),
+      },
+      'Add failed',
+    )
+    if (created) setReps('')
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="grid gap-2 rounded border border-white/10 bg-white/5 p-3 sm:grid-cols-[1fr_auto_auto_auto] sm:items-end"
+    >
+      <label className="flex flex-col gap-1 text-[11px] text-white/60">
+        <span className="font-mono uppercase tracking-[0.14em]">add movement</span>
+        <select
+          value={exercise}
+          onChange={(e) => setExercise(e.target.value)}
+          className="rounded border border-white/15 bg-black/40 px-2 py-1.5 font-mono text-xs text-white focus:border-amber-300/60 focus:outline-none"
+        >
+          {exercises.map((e) => (
+            <option key={e.slug} value={e.slug} className="bg-[#120d0a]">
+              {e.display_name}
+            </option>
+          ))}
+        </select>
+      </label>
+      <NumberField label="sets" value={sets} onChange={setSets} min={1} compact />
+      <NumberField label="reps" value={reps} onChange={setReps} min={1} compact />
+      <button
+        type="submit"
+        disabled={disabled || exercise === ''}
+        className="rounded-full border border-amber-200/30 bg-amber-200/10 px-4 py-1.5 font-mono text-[11px] uppercase tracking-[0.22em] text-amber-100 transition hover:bg-amber-200/20 disabled:cursor-not-allowed disabled:opacity-40"
+      >
+        Add
+      </button>
+    </form>
+  )
+}
+
+interface AddTemplateFormProps {
+  disabled: boolean
+  existingNames: readonly string[]
+  nextPosition: number
+  onMutate: Mutate
+}
+
+function AddTemplateForm({
+  disabled,
+  existingNames,
+  nextPosition,
+  onMutate,
+}: AddTemplateFormProps): JSX.Element {
+  const [name, setName] = useState('')
+  const [category, setCategory] = useState<TemplateCategory | ''>('')
+  const [color, setColor] = useState(DEFAULT_TEMPLATE_COLOR)
+
+  const taken = name.trim() !== '' && existingNames.includes(name.trim().toLowerCase())
+
+  async function handleSubmit(e: FormEvent<HTMLFormElement>): Promise<void> {
+    e.preventDefault()
+    if (name.trim() === '' || taken) return
+    const created = await onMutate(
+      '/api/admin/weight-room/templates',
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          name: name.trim(),
+          color,
+          position: nextPosition,
+          ...(category !== '' ? { category } : {}),
+        }),
+      },
+      'Add failed',
+    )
+    if (created) setName('')
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="mt-3 grid gap-3 rounded-[1.1rem] border border-white/10 bg-white/5 p-4 sm:grid-cols-[1fr_auto_auto_auto] sm:items-end"
+    >
+      <label className="flex flex-col gap-1 text-xs text-white/70">
+        <span className="font-mono uppercase tracking-[0.18em]">name</span>
+        <input
+          type="text"
+          required
+          maxLength={80}
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Chest Day 1"
+          className="rounded border border-white/15 bg-black/40 px-2 py-1.5 text-sm text-white focus:border-amber-300/60 focus:outline-none"
+        />
+        {taken ? (
+          <span role="alert" className="font-mono text-[11px] text-rose-300">
+            A template with that name already exists.
+          </span>
+        ) : null}
+      </label>
+      <label className="flex flex-col gap-1 text-xs text-white/70">
+        <span className="font-mono uppercase tracking-[0.18em]">category</span>
+        <select
+          value={category}
+          onChange={(e) => setCategory(e.target.value as TemplateCategory | '')}
+          className="rounded border border-white/15 bg-black/40 px-2 py-1.5 font-mono text-sm text-white focus:border-amber-300/60 focus:outline-none"
+        >
+          <option value="" className="bg-[#120d0a]">
+            — none —
+          </option>
+          {CATEGORIES.map((c) => (
+            <option key={c} value={c} className="bg-[#120d0a]">
+              {c}
+            </option>
+          ))}
+        </select>
+      </label>
+      <label className="flex flex-col gap-1 text-xs text-white/70">
+        <span className="font-mono uppercase tracking-[0.18em]">color</span>
+        <input
+          type="color"
+          value={color}
+          onChange={(e) => setColor(e.target.value)}
+          className="h-9 w-16 cursor-pointer rounded border border-white/15 bg-black/40"
+        />
+      </label>
+      <button
+        type="submit"
+        disabled={disabled || name.trim() === '' || taken}
+        className="rounded-full border border-amber-200/30 bg-amber-200/10 px-5 py-2 font-mono text-[11px] uppercase tracking-[0.22em] text-amber-100 transition hover:bg-amber-200/20 disabled:cursor-not-allowed disabled:opacity-40"
+      >
+        Add
+      </button>
+    </form>
+  )
+}

--- a/lib/data/template-slot-children.ts
+++ b/lib/data/template-slot-children.ts
@@ -1,0 +1,132 @@
+import 'server-only'
+
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+/**
+ * Write-side helper for a template slot's children — its within-set steps and
+ * its pre-declared alternates (#375).
+ *
+ * Both are replaced **wholesale** rather than edited in place, which is safe
+ * precisely because neither is referenced from outside its slot: recreating
+ * their rows loses nothing. Slot ids are the opposite case — `#376` links
+ * logged sets to them via `weight_room_sets.template_slot_id`, so slots are
+ * edited in place and never recreated, or adherence history would be orphaned
+ * every time a template was touched.
+ *
+ * Lives outside the route files because a Next.js route module should export
+ * only its handlers.
+ */
+
+/** Postgres FK violation — an exercise slug that isn't in the catalog. */
+const FK_VIOLATION = '23503'
+
+/** One step in a slot write body, post-validation. */
+export interface SlotStepInput {
+  /** Absent/null inherits the slot's movement (drop set); set makes it a superset. */
+  exercise?: string | null
+  /** Reps for this step; absent inherits the slot's. */
+  target_reps?: number
+  /** Load on one implement for this step. */
+  target_weight_lbs?: number
+  /** Free-text cue. */
+  notes?: string | null
+}
+
+/** Outcome of a child write: `null` on success, else a message and status. */
+export interface ChildWriteFailure {
+  /** Human-readable message, safe to return to the caller. */
+  message: string
+  /** HTTP status the route should answer with. */
+  status: number
+}
+
+/**
+ * Replace a slot's steps and alternates.
+ *
+ * Each list is only touched when supplied — passing `undefined` leaves that
+ * child list exactly as it was, so a PATCH that renames a slot doesn't wipe its
+ * alternates.
+ *
+ * @param supabase Service-role client.
+ * @param slotId Slot whose children are being replaced.
+ * @param steps New within-set sequence, in array order; `undefined` leaves it alone.
+ * @param alternates New swap slugs in preference order; `undefined` leaves it alone.
+ * @returns `null` on success, or a {@link ChildWriteFailure} to surface.
+ */
+export async function replaceSlotChildren(
+  supabase: SupabaseClient,
+  slotId: string,
+  steps: readonly SlotStepInput[] | undefined,
+  alternates: readonly string[] | undefined,
+): Promise<ChildWriteFailure | null> {
+  const nowIso = new Date().toISOString()
+
+  if (steps !== undefined) {
+    const { error: clearError } = await supabase
+      .from('weight_room_template_slot_steps')
+      .delete()
+      .eq('slot_id', slotId)
+    if (clearError) {
+      return { message: `Failed to clear steps: ${clearError.message}`, status: 500 }
+    }
+
+    if (steps.length > 0) {
+      const rows = steps.map((step, index) => {
+        const row: Record<string, unknown> = {
+          slot_id: slotId,
+          position: index,
+          updated_at: nowIso,
+        }
+        if (step.exercise != null) row.exercise = step.exercise
+        if (step.target_reps != null) row.target_reps = step.target_reps
+        if (step.target_weight_lbs != null) row.target_weight_lbs = step.target_weight_lbs
+        if (step.notes != null) row.notes = step.notes
+        return row
+      })
+      const { error } = await supabase.from('weight_room_template_slot_steps').insert(rows)
+      if (error) {
+        if (error.code === FK_VIOLATION) {
+          return {
+            message: 'A step names an exercise that is not in the movement catalog.',
+            status: 409,
+          }
+        }
+        return { message: `Failed to write steps: ${error.message}`, status: 500 }
+      }
+    }
+  }
+
+  if (alternates !== undefined) {
+    const { error: clearError } = await supabase
+      .from('weight_room_template_alternates')
+      .delete()
+      .eq('slot_id', slotId)
+    if (clearError) {
+      return { message: `Failed to clear alternates: ${clearError.message}`, status: 500 }
+    }
+
+    // De-duplicated because `(slot_id, exercise)` is unique — a builder that
+    // listed the same swap twice should get one row, not a 409.
+    const unique = [...new Set(alternates)]
+    if (unique.length > 0) {
+      const rows = unique.map((exercise, index) => ({
+        slot_id: slotId,
+        exercise,
+        position: index,
+        updated_at: nowIso,
+      }))
+      const { error } = await supabase.from('weight_room_template_alternates').insert(rows)
+      if (error) {
+        if (error.code === FK_VIOLATION) {
+          return {
+            message: 'An alternate names an exercise that is not in the movement catalog.',
+            status: 409,
+          }
+        }
+        return { message: `Failed to write alternates: ${error.message}`, status: 500 }
+      }
+    }
+  }
+
+  return null
+}

--- a/lib/data/template-slot-children.ts
+++ b/lib/data/template-slot-children.ts
@@ -31,7 +31,7 @@ const FK_VIOLATION = '23503'
  */
 async function findUnknownExercises(
   supabase: SupabaseClient,
-  slugs: readonly string[],
+  slugs: readonly string[]
 ): Promise<string[] | null> {
   const { data, error } = await supabase
     .from('weight_room_exercises')
@@ -39,8 +39,8 @@ async function findUnknownExercises(
     .in('slug', slugs as string[])
 
   if (error) return null
-  const known = new Set((data ?? []).map((row) => row.slug))
-  return slugs.filter((slug) => !known.has(slug))
+  const known = new Set((data ?? []).map(row => row.slug))
+  return slugs.filter(slug => !known.has(slug))
 }
 
 /** One step in a slot write body, post-validation. */
@@ -80,7 +80,7 @@ export async function replaceSlotChildren(
   supabase: SupabaseClient,
   slotId: string,
   steps: readonly SlotStepInput[] | undefined,
-  alternates: readonly string[] | undefined,
+  alternates: readonly string[] | undefined
 ): Promise<ChildWriteFailure | null> {
   const nowIso = new Date().toISOString()
 
@@ -91,7 +91,7 @@ export async function replaceSlotChildren(
   // is the realistic way that happens. Checking first turns the common failure
   // into a clean 409 with nothing destroyed.
   const referenced = [
-    ...(steps ?? []).map((step) => step.exercise).filter((s): s is string => s != null),
+    ...(steps ?? []).map(step => step.exercise).filter((s): s is string => s != null),
     ...(alternates ?? []),
   ]
   if (referenced.length > 0) {

--- a/lib/data/template-slot-children.ts
+++ b/lib/data/template-slot-children.ts
@@ -20,6 +20,29 @@ import type { SupabaseClient } from '@supabase/supabase-js'
 /** Postgres FK violation — an exercise slug that isn't in the catalog. */
 const FK_VIOLATION = '23503'
 
+/**
+ * Which of `slugs` are missing from the movement catalog.
+ *
+ * @param supabase Service-role client.
+ * @param slugs Distinct slugs to check.
+ * @returns The missing slugs (empty when all exist), or `null` if the lookup
+ *   itself failed — which the caller must treat as "don't proceed", not as
+ *   "everything is fine".
+ */
+async function findUnknownExercises(
+  supabase: SupabaseClient,
+  slugs: readonly string[],
+): Promise<string[] | null> {
+  const { data, error } = await supabase
+    .from('weight_room_exercises')
+    .select('slug')
+    .in('slug', slugs as string[])
+
+  if (error) return null
+  const known = new Set((data ?? []).map((row) => row.slug))
+  return slugs.filter((slug) => !known.has(slug))
+}
+
 /** One step in a slot write body, post-validation. */
 export interface SlotStepInput {
   /** Absent/null inherits the slot's movement (drop set); set makes it a superset. */
@@ -60,6 +83,29 @@ export async function replaceSlotChildren(
   alternates: readonly string[] | undefined,
 ): Promise<ChildWriteFailure | null> {
   const nowIso = new Date().toISOString()
+
+  // Validate every slug BEFORE deleting anything. Each delete and insert is
+  // its own PostgREST transaction, so a delete that succeeds followed by an
+  // insert that fails leaves the slot's children permanently gone — and a
+  // stale builder submitting a movement that was archived out of the catalog
+  // is the realistic way that happens. Checking first turns the common failure
+  // into a clean 409 with nothing destroyed.
+  const referenced = [
+    ...(steps ?? []).map((step) => step.exercise).filter((s): s is string => s != null),
+    ...(alternates ?? []),
+  ]
+  if (referenced.length > 0) {
+    const unknown = await findUnknownExercises(supabase, [...new Set(referenced)])
+    if (unknown === null) {
+      return { message: 'Failed to verify exercises against the catalog.', status: 500 }
+    }
+    if (unknown.length > 0) {
+      return {
+        message: `Not in the movement catalog: ${unknown.join(', ')}.`,
+        status: 409,
+      }
+    }
+  }
 
   if (steps !== undefined) {
     const { error: clearError } = await supabase

--- a/lib/data/weight-room-server.ts
+++ b/lib/data/weight-room-server.ts
@@ -1,12 +1,18 @@
 import 'server-only'
 
 import { createServerSupabaseClient } from '@/lib/supabase/server'
-import type { WeightRoomAchievement, WeightRoomData, WeightRoomExercise } from '@/types/weight-room'
+import type {
+  WeightRoomAchievement,
+  WeightRoomData,
+  WeightRoomExercise,
+  WorkoutTemplate,
+} from '@/types/weight-room'
 
 import {
   assembleWeightRoomAchievements,
   assembleWeightRoomData,
   assembleWeightRoomExercises,
+  assembleWorkoutTemplates,
 } from './weight-room-shared'
 
 /**
@@ -64,4 +70,20 @@ export async function getWeightRoomAchievementsServer(): Promise<WeightRoomAchie
 export async function getWeightRoomExercisesServer(): Promise<WeightRoomExercise[]> {
   const supabase = await createServerSupabaseClient()
   return assembleWeightRoomExercises(supabase)
+}
+
+/**
+ * Server-side reader for workout templates (#375) with their slots, steps, and
+ * alternates attached — used by the Settings builder and, later, the recording
+ * surface's template picker.
+ *
+ * Returns an empty array (never `null`) when none are configured, and includes
+ * archived templates so the builder can un-archive them.
+ *
+ * @throws See {@link assembleWorkoutTemplates}. Call sites downgrade this to an
+ *   empty list rather than failing the page.
+ */
+export async function getWorkoutTemplatesServer(): Promise<WorkoutTemplate[]> {
+  const supabase = await createServerSupabaseClient()
+  return assembleWorkoutTemplates(supabase)
 }

--- a/lib/data/weight-room-shared.ts
+++ b/lib/data/weight-room-shared.ts
@@ -4,6 +4,11 @@ import { z } from 'zod'
 import {
   WeightRoomAchievementRowSchema,
   WeightRoomExerciseRowSchema,
+  WeightRoomTemplateAlternateRowSchema,
+  WeightRoomTemplateSlotRowSchema,
+  WeightRoomTemplateSlotStepRowSchema,
+  WeightRoomWorkoutTemplateRowSchema,
+  assembleWorkoutTemplates as assembleTemplateShape,
   WeightRoomGoalRowSchema,
   WeightRoomGoalTargetRowSchema,
   WeightRoomMonthlyFocusRowSchema,
@@ -21,6 +26,7 @@ import type {
   WeightRoomAchievement,
   WeightRoomData,
   WeightRoomExercise,
+  WorkoutTemplate,
 } from '@/types/weight-room'
 
 import { fetchAllRows } from './paged-read'
@@ -101,6 +107,118 @@ export async function assembleWeightRoomExercises(
   }
 
   return parseExerciseRows((res.data ?? []) as unknown as Array<Record<string, unknown>>)
+}
+
+/** Workout-template tables (#375). */
+const TEMPLATES_TABLE = 'weight_room_workout_templates'
+const TEMPLATE_SLOTS_TABLE = 'weight_room_template_slots'
+const TEMPLATE_STEPS_TABLE = 'weight_room_template_slot_steps'
+const TEMPLATE_ALTERNATES_TABLE = 'weight_room_template_alternates'
+
+/** Whitelisted columns for `weight_room_workout_templates`, in sync with its row schema. */
+const TEMPLATES_COLUMNS = 'id, name, description, color, category, position, archived'
+/** Whitelisted columns for `weight_room_template_slots`. */
+const TEMPLATE_SLOTS_COLUMNS =
+  'id, template_id, position, exercise, target_sets, target_sets_max, target_reps, target_reps_max, target_weight_lbs, rest_seconds, notes'
+/** Whitelisted columns for `weight_room_template_slot_steps`. */
+const TEMPLATE_STEPS_COLUMNS =
+  'id, slot_id, position, exercise, target_reps, target_weight_lbs, notes'
+/** Whitelisted columns for `weight_room_template_alternates`. */
+const TEMPLATE_ALTERNATES_COLUMNS = 'id, slot_id, position, exercise'
+
+const WeightRoomWorkoutTemplateRowsSchema = z.array(WeightRoomWorkoutTemplateRowSchema)
+const WeightRoomTemplateSlotRowsSchema = z.array(WeightRoomTemplateSlotRowSchema)
+const WeightRoomTemplateSlotStepRowsSchema = z.array(WeightRoomTemplateSlotStepRowSchema)
+const WeightRoomTemplateAlternateRowsSchema = z.array(WeightRoomTemplateAlternateRowSchema)
+
+/**
+ * Fetch every workout template (#375) with its slots, steps, and alternates
+ * attached, ordered by `position` at every level.
+ *
+ * Reads the four tables in parallel and assembles in memory rather than using a
+ * PostgREST embedded select. An embed returns a nested object that no single
+ * `.strict()` row schema can validate — which is exactly how a column added to
+ * one of these tables would slip past validation unnoticed, the failure mode
+ * the whitelist-plus-strict-schema convention exists to prevent.
+ *
+ * Returns an empty array (never `null`) when nothing is configured, matching
+ * {@link assembleWeightRoomExercises}. Includes archived templates so the
+ * builder can un-archive them; pickers filter.
+ *
+ * @param supabase Browser or server SSR client (both anon role; RLS allows
+ *   anon SELECT on all four tables).
+ * @throws when any query fails or any row-shape validation fails.
+ */
+export async function assembleWorkoutTemplates(
+  supabase: SupabaseClient,
+): Promise<WorkoutTemplate[]> {
+  const [templatesRes, slotsRes, stepsRes, alternatesRes] = await Promise.all([
+    supabase.from(TEMPLATES_TABLE).select(TEMPLATES_COLUMNS).order('position', { ascending: true }),
+    supabase
+      .from(TEMPLATE_SLOTS_TABLE)
+      .select(TEMPLATE_SLOTS_COLUMNS)
+      .order('position', { ascending: true }),
+    supabase
+      .from(TEMPLATE_STEPS_TABLE)
+      .select(TEMPLATE_STEPS_COLUMNS)
+      .order('position', { ascending: true }),
+    supabase
+      .from(TEMPLATE_ALTERNATES_TABLE)
+      .select(TEMPLATE_ALTERNATES_COLUMNS)
+      .order('position', { ascending: true }),
+  ])
+
+  if (templatesRes.error) {
+    throw new Error(`Failed to load workout templates: ${templatesRes.error.message}`)
+  }
+  if (slotsRes.error) {
+    throw new Error(`Failed to load template slots: ${slotsRes.error.message}`)
+  }
+  if (stepsRes.error) {
+    throw new Error(`Failed to load template slot steps: ${stepsRes.error.message}`)
+  }
+  if (alternatesRes.error) {
+    throw new Error(`Failed to load template alternates: ${alternatesRes.error.message}`)
+  }
+
+  const templates = parseRows(
+    WeightRoomWorkoutTemplateRowsSchema,
+    templatesRes.data,
+    TEMPLATES_TABLE,
+  )
+  const slots = parseRows(WeightRoomTemplateSlotRowsSchema, slotsRes.data, TEMPLATE_SLOTS_TABLE)
+  const steps = parseRows(
+    WeightRoomTemplateSlotStepRowsSchema,
+    stepsRes.data,
+    TEMPLATE_STEPS_TABLE,
+  )
+  const alternates = parseRows(
+    WeightRoomTemplateAlternateRowsSchema,
+    alternatesRes.data,
+    TEMPLATE_ALTERNATES_TABLE,
+  )
+
+  return assembleTemplateShape(templates, slots, steps, alternates)
+}
+
+/**
+ * Validate one table's rows, or throw naming the table.
+ *
+ * @param schema Array schema for the table.
+ * @param data Raw PostgREST rows.
+ * @param table Table name, for the error message.
+ */
+function parseRows<T>(
+  schema: z.ZodType<T[]>,
+  data: unknown,
+  table: string,
+): T[] {
+  const raw = (data ?? []) as Array<Record<string, unknown>>
+  const parsed = schema.safeParse(raw)
+  if (!parsed.success) {
+    throw new Error(`${table} failed schema validation: ${parsed.error.message}`)
+  }
+  return parsed.data
 }
 
 /**

--- a/lib/data/weight-room-shared.ts
+++ b/lib/data/weight-room-shared.ts
@@ -150,7 +150,7 @@ const WeightRoomTemplateAlternateRowsSchema = z.array(WeightRoomTemplateAlternat
  * @throws when any query fails or any row-shape validation fails.
  */
 export async function assembleWorkoutTemplates(
-  supabase: SupabaseClient,
+  supabase: SupabaseClient
 ): Promise<WorkoutTemplate[]> {
   const [templatesRes, slotsRes, stepsRes, alternatesRes] = await Promise.all([
     supabase.from(TEMPLATES_TABLE).select(TEMPLATES_COLUMNS).order('position', { ascending: true }),
@@ -184,18 +184,14 @@ export async function assembleWorkoutTemplates(
   const templates = parseRows(
     WeightRoomWorkoutTemplateRowsSchema,
     templatesRes.data,
-    TEMPLATES_TABLE,
+    TEMPLATES_TABLE
   )
   const slots = parseRows(WeightRoomTemplateSlotRowsSchema, slotsRes.data, TEMPLATE_SLOTS_TABLE)
-  const steps = parseRows(
-    WeightRoomTemplateSlotStepRowsSchema,
-    stepsRes.data,
-    TEMPLATE_STEPS_TABLE,
-  )
+  const steps = parseRows(WeightRoomTemplateSlotStepRowsSchema, stepsRes.data, TEMPLATE_STEPS_TABLE)
   const alternates = parseRows(
     WeightRoomTemplateAlternateRowsSchema,
     alternatesRes.data,
-    TEMPLATE_ALTERNATES_TABLE,
+    TEMPLATE_ALTERNATES_TABLE
   )
 
   return assembleTemplateShape(templates, slots, steps, alternates)
@@ -208,11 +204,7 @@ export async function assembleWorkoutTemplates(
  * @param data Raw PostgREST rows.
  * @param table Table name, for the error message.
  */
-function parseRows<T>(
-  schema: z.ZodType<T[]>,
-  data: unknown,
-  table: string,
-): T[] {
+function parseRows<T>(schema: z.ZodType<T[]>, data: unknown, table: string): T[] {
   const raw = (data ?? []) as Array<Record<string, unknown>>
   const parsed = schema.safeParse(raw)
   if (!parsed.success) {

--- a/lib/schemas/weight-room.ts
+++ b/lib/schemas/weight-room.ts
@@ -20,10 +20,15 @@ import type {
   ExerciseMuscleGroup,
   MonthlyFocus,
   StrengthSet,
+  TemplateAlternate,
+  TemplateCategory,
+  TemplateSlot,
+  TemplateSlotStep,
   WeightRoomAchievement,
   WeightRoomExercise,
   WeightRoomWorkout,
   WorkoutLocation,
+  WorkoutTemplate,
 } from '@/types/weight-room'
 
 /**
@@ -399,6 +404,343 @@ export const WeightRoomWorkoutUpdateSchema = z
 
 /** Validated body of `PATCH /api/admin/weight-room/workouts/[id]`. */
 export type WeightRoomWorkoutUpdate = z.infer<typeof WeightRoomWorkoutUpdateSchema>
+
+/** The seven template categories, as a Zod enum reused by the row + write schemas (#375). */
+const templateCategory = (): z.ZodType<TemplateCategory> =>
+  z.enum(['push', 'pull', 'legs', 'upper', 'lower', 'full-body', 'other'])
+
+/**
+ * Zod schema for one row of `public.weight_room_workout_templates` (#375).
+ * Mirrors `supabase/migrations/20260803120000_weight_room_workout_templates.sql`.
+ */
+export const WeightRoomWorkoutTemplateRowSchema = z
+  .object({
+    id: z.string().uuid(),
+    name: z.string().min(1),
+    description: z.string().nullable().optional(),
+    color: z.string().nullable().optional(),
+    category: templateCategory().nullable().optional(),
+    position: nonNegativeInt(),
+    archived: z.boolean().nullable().optional(),
+  })
+  .strict()
+
+/** Validated `weight_room_workout_templates` row. */
+export type WeightRoomWorkoutTemplateRow = z.infer<typeof WeightRoomWorkoutTemplateRowSchema>
+
+/**
+ * Zod schema for one row of `public.weight_room_template_slots` (#375).
+ *
+ * `target_reps` absent is meaningful — AMRAP, or "sets prescribed, reps not" —
+ * so it is never defaulted to a number.
+ */
+export const WeightRoomTemplateSlotRowSchema = z
+  .object({
+    id: z.string().uuid(),
+    template_id: z.string().uuid(),
+    position: nonNegativeInt(),
+    exercise: z.string().min(1),
+    target_sets: positiveInt(),
+    target_sets_max: positiveInt().nullable().optional(),
+    target_reps: positiveInt().nullable().optional(),
+    target_reps_max: positiveInt().nullable().optional(),
+    target_weight_lbs: z.number().nonnegative().nullable().optional(),
+    rest_seconds: nonNegativeInt().nullable().optional(),
+    notes: z.string().nullable().optional(),
+  })
+  .strict()
+
+/** Validated `weight_room_template_slots` row. */
+export type WeightRoomTemplateSlotRow = z.infer<typeof WeightRoomTemplateSlotRowSchema>
+
+/**
+ * Zod schema for one row of `public.weight_room_template_slot_steps` (#375).
+ * `exercise` nullable is the drop-set / superset distinction — see
+ * {@link import('@/types/weight-room').TemplateSlotStep}.
+ */
+export const WeightRoomTemplateSlotStepRowSchema = z
+  .object({
+    id: z.string().uuid(),
+    slot_id: z.string().uuid(),
+    position: nonNegativeInt(),
+    exercise: z.string().min(1).nullable().optional(),
+    target_reps: positiveInt().nullable().optional(),
+    target_weight_lbs: z.number().nonnegative().nullable().optional(),
+    notes: z.string().nullable().optional(),
+  })
+  .strict()
+
+/** Validated `weight_room_template_slot_steps` row. */
+export type WeightRoomTemplateSlotStepRow = z.infer<typeof WeightRoomTemplateSlotStepRowSchema>
+
+/** Zod schema for one row of `public.weight_room_template_alternates` (#375). */
+export const WeightRoomTemplateAlternateRowSchema = z
+  .object({
+    id: z.string().uuid(),
+    slot_id: z.string().uuid(),
+    position: nonNegativeInt(),
+    exercise: z.string().min(1),
+  })
+  .strict()
+
+/** Validated `weight_room_template_alternates` row. */
+export type WeightRoomTemplateAlternateRow = z.infer<typeof WeightRoomTemplateAlternateRowSchema>
+
+/**
+ * Assemble validated template / slot / step / alternate rows into the nested
+ * {@link WorkoutTemplate} shape, ordered by `position` at every level.
+ *
+ * Done here rather than with a PostgREST embedded select so the four row
+ * schemas stay flat and independently `.strict()` — an embed returns a nested
+ * object that no single row schema can validate, which is how a column added
+ * to one of these tables would slip past validation unnoticed.
+ *
+ * @param templates Template rows.
+ * @param slots Slot rows across all templates.
+ * @param steps Step rows across all slots.
+ * @param alternates Alternate rows across all slots.
+ */
+export function assembleWorkoutTemplates(
+  templates: readonly WeightRoomWorkoutTemplateRow[],
+  slots: readonly WeightRoomTemplateSlotRow[],
+  steps: readonly WeightRoomTemplateSlotStepRow[],
+  alternates: readonly WeightRoomTemplateAlternateRow[],
+): WorkoutTemplate[] {
+  const stepsBySlot = new Map<string, TemplateSlotStep[]>()
+  for (const row of [...steps].sort((a, b) => a.position - b.position)) {
+    const list = stepsBySlot.get(row.slot_id) ?? []
+    list.push({
+      id: row.id,
+      position: row.position,
+      ...(row.exercise != null ? { exercise: row.exercise } : {}),
+      ...(row.target_reps != null ? { target_reps: row.target_reps } : {}),
+      ...(row.target_weight_lbs != null
+        ? { target_weight_lbs: row.target_weight_lbs }
+        : {}),
+      ...(row.notes != null && row.notes !== '' ? { notes: row.notes } : {}),
+    })
+    stepsBySlot.set(row.slot_id, list)
+  }
+
+  const alternatesBySlot = new Map<string, TemplateAlternate[]>()
+  for (const row of [...alternates].sort((a, b) => a.position - b.position)) {
+    const list = alternatesBySlot.get(row.slot_id) ?? []
+    list.push({ id: row.id, exercise: row.exercise, position: row.position })
+    alternatesBySlot.set(row.slot_id, list)
+  }
+
+  const slotsByTemplate = new Map<string, TemplateSlot[]>()
+  for (const row of [...slots].sort((a, b) => a.position - b.position)) {
+    const list = slotsByTemplate.get(row.template_id) ?? []
+    list.push({
+      id: row.id,
+      position: row.position,
+      exercise: row.exercise,
+      target_sets: row.target_sets,
+      ...(row.target_sets_max != null ? { target_sets_max: row.target_sets_max } : {}),
+      ...(row.target_reps != null ? { target_reps: row.target_reps } : {}),
+      ...(row.target_reps_max != null ? { target_reps_max: row.target_reps_max } : {}),
+      ...(row.target_weight_lbs != null
+        ? { target_weight_lbs: row.target_weight_lbs }
+        : {}),
+      ...(row.rest_seconds != null ? { rest_seconds: row.rest_seconds } : {}),
+      ...(row.notes != null && row.notes !== '' ? { notes: row.notes } : {}),
+      steps: stepsBySlot.get(row.id) ?? [],
+      alternates: alternatesBySlot.get(row.id) ?? [],
+    })
+    slotsByTemplate.set(row.template_id, list)
+  }
+
+  return [...templates]
+    .sort((a, b) => a.position - b.position || a.name.localeCompare(b.name))
+    .map((row) => ({
+      id: row.id,
+      name: row.name,
+      position: row.position,
+      ...(row.description != null && row.description !== ''
+        ? { description: row.description }
+        : {}),
+      ...(row.color != null ? { color: row.color } : {}),
+      ...(row.category != null ? { category: row.category } : {}),
+      ...(row.archived != null ? { archived: row.archived } : {}),
+      slots: slotsByTemplate.get(row.id) ?? [],
+    }))
+}
+
+/**
+ * The template write fields, without any `.default()` — see
+ * {@link achievementWriteFields} for why deriving a PATCH schema from a
+ * defaulted create schema silently resets omitted keys.
+ */
+const templateWriteFields = {
+  name: z.string().trim().min(1, 'name is required').max(80, 'name is too long'),
+  description: clearableTextField(2000),
+  color: z.string().regex(HEX_COLOR_REGEX, 'color must be a hex string like #DC2626').nullable(),
+  category: templateCategory().nullable(),
+  position: nonNegativeInt(),
+  archived: z.boolean(),
+}
+
+/** Request-body schema for `POST /api/admin/weight-room/templates` (#375). */
+export const WeightRoomTemplateCreateSchema = z
+  .object({
+    ...templateWriteFields,
+    description: templateWriteFields.description,
+    color: templateWriteFields.color.optional(),
+    category: templateWriteFields.category.optional(),
+    position: templateWriteFields.position.default(0),
+    archived: templateWriteFields.archived.default(false),
+  })
+  .strict()
+
+/** Validated body of `POST /api/admin/weight-room/templates`. */
+export type WeightRoomTemplateCreate = z.infer<typeof WeightRoomTemplateCreateSchema>
+
+/**
+ * Request-body schema for `PATCH /api/admin/weight-room/templates/[id]` (#375).
+ * Every field optional, at least one required.
+ */
+export const WeightRoomTemplateUpdateSchema = z
+  .object(templateWriteFields)
+  .strict()
+  .partial()
+  .refine((patch) => Object.values(patch).some((v) => v !== undefined), {
+    message: 'At least one field is required.',
+  })
+
+/** Validated body of `PATCH /api/admin/weight-room/templates/[id]`. */
+export type WeightRoomTemplateUpdate = z.infer<typeof WeightRoomTemplateUpdateSchema>
+
+/**
+ * One step in a slot write body. Steps carry no external references, so a slot
+ * write replaces them wholesale rather than editing them individually — unlike
+ * slots themselves, whose ids #376 links logged sets to.
+ */
+const slotStepWriteSchema = z
+  .object({
+    exercise: exerciseWriteField().nullable().optional(),
+    target_reps: positiveInt().optional(),
+    target_weight_lbs: z.number().nonnegative().optional(),
+    notes: clearableTextField(200),
+  })
+  .strict()
+
+/** The slot write fields, default-free for the same reason as the template ones. */
+const slotWriteFields = {
+  exercise: exerciseWriteField(),
+  target_sets: positiveInt(),
+  target_sets_max: positiveInt().nullable(),
+  target_reps: positiveInt().nullable(),
+  target_reps_max: positiveInt().nullable(),
+  target_weight_lbs: z.number().nonnegative().nullable(),
+  rest_seconds: nonNegativeInt().nullable(),
+  notes: clearableTextField(500),
+  /** Full replacement of this slot's within-set sequence. */
+  steps: z.array(slotStepWriteSchema).max(20),
+  /** Full replacement of this slot's pre-declared swaps, in array order. */
+  alternates: z.array(exerciseWriteField()).max(20),
+}
+
+/**
+ * Shape the two range refinements inspect. Both schemas below are `.partial()`
+ * or optional-heavy, so every field may be absent.
+ */
+interface SlotRangeFields {
+  target_sets?: number | null
+  target_sets_max?: number | null
+  target_reps?: number | null
+  target_reps_max?: number | null
+}
+
+/**
+ * A set range's top must not sit below its floor.
+ *
+ * On a partial patch `target_sets` may be absent while `target_sets_max` is
+ * supplied; that can't be validated in isolation, so it passes here and the
+ * table's CHECK backstops it against the stored floor.
+ */
+function setRangeIsOrdered(v: SlotRangeFields): boolean {
+  return v.target_sets_max == null || v.target_sets == null || v.target_sets_max >= v.target_sets
+}
+
+/**
+ * A rep-range top is meaningless without a floor to range from, and must not
+ * sit below it. Unlike sets, `target_reps` absent *with* a max supplied is
+ * always wrong — absent reps means AMRAP, which has no range.
+ */
+function repRangeIsOrdered(v: SlotRangeFields): boolean {
+  return v.target_reps_max == null || (v.target_reps != null && v.target_reps_max >= v.target_reps)
+}
+
+/** Request-body schema for `POST /api/admin/weight-room/templates/[id]/slots` (#375). */
+export const WeightRoomTemplateSlotCreateSchema = z
+  .object({
+    ...slotWriteFields,
+    target_sets_max: slotWriteFields.target_sets_max.optional(),
+    target_reps: slotWriteFields.target_reps.optional(),
+    target_reps_max: slotWriteFields.target_reps_max.optional(),
+    target_weight_lbs: slotWriteFields.target_weight_lbs.optional(),
+    rest_seconds: slotWriteFields.rest_seconds.optional(),
+    steps: slotWriteFields.steps.default([]),
+    alternates: slotWriteFields.alternates.default([]),
+  })
+  .strict()
+  .refine(setRangeIsOrdered, {
+    message: 'target_sets_max must be at least target_sets',
+    path: ['target_sets_max'],
+  })
+  .refine(repRangeIsOrdered, {
+    message: 'target_reps_max requires target_reps and must be at least it',
+    path: ['target_reps_max'],
+  })
+
+/** Validated body of the slot-create route. */
+export type WeightRoomTemplateSlotCreate = z.infer<typeof WeightRoomTemplateSlotCreateSchema>
+
+/**
+ * Request-body schema for
+ * `PATCH /api/admin/weight-room/templates/[id]/slots/[slotId]` (#375).
+ *
+ * Omitting `steps` or `alternates` leaves them untouched; supplying either
+ * replaces that slot's list wholesale.
+ */
+export const WeightRoomTemplateSlotUpdateSchema = z
+  .object(slotWriteFields)
+  .strict()
+  .partial()
+  .refine((patch) => Object.values(patch).some((v) => v !== undefined), {
+    message: 'At least one field is required.',
+  })
+  .refine(setRangeIsOrdered, {
+    message: 'target_sets_max must be at least target_sets',
+    path: ['target_sets_max'],
+  })
+  .refine(repRangeIsOrdered, {
+    message: 'target_reps_max requires target_reps and must be at least it',
+    path: ['target_reps_max'],
+  })
+
+/** Validated body of the slot-update route. */
+export type WeightRoomTemplateSlotUpdate = z.infer<typeof WeightRoomTemplateSlotUpdateSchema>
+
+/**
+ * Request-body schema for reordering a template's slots — an array of
+ * `{ id, position }` applied in one upsert.
+ *
+ * The table's `(template_id, position)` unique constraint is DEFERRABLE, so a
+ * swap that transiently duplicates a position is legal until commit. An
+ * immediate constraint would reject the first half of every swap.
+ */
+export const WeightRoomTemplateSlotReorderSchema = z
+  .object({
+    order: z
+      .array(z.object({ id: z.string().uuid(), position: nonNegativeInt() }).strict())
+      .min(1, 'order must list at least one slot'),
+  })
+  .strict()
+
+/** Validated body of the slot-reorder route. */
+export type WeightRoomTemplateSlotReorder = z.infer<typeof WeightRoomTemplateSlotReorderSchema>
 
 /**
  * Translate a validated `weight_room_goals` row into the public

--- a/lib/schemas/weight-room.ts
+++ b/lib/schemas/weight-room.ts
@@ -504,7 +504,7 @@ export function assembleWorkoutTemplates(
   templates: readonly WeightRoomWorkoutTemplateRow[],
   slots: readonly WeightRoomTemplateSlotRow[],
   steps: readonly WeightRoomTemplateSlotStepRow[],
-  alternates: readonly WeightRoomTemplateAlternateRow[],
+  alternates: readonly WeightRoomTemplateAlternateRow[]
 ): WorkoutTemplate[] {
   const stepsBySlot = new Map<string, TemplateSlotStep[]>()
   for (const row of [...steps].sort((a, b) => a.position - b.position)) {
@@ -514,9 +514,7 @@ export function assembleWorkoutTemplates(
       position: row.position,
       ...(row.exercise != null ? { exercise: row.exercise } : {}),
       ...(row.target_reps != null ? { target_reps: row.target_reps } : {}),
-      ...(row.target_weight_lbs != null
-        ? { target_weight_lbs: row.target_weight_lbs }
-        : {}),
+      ...(row.target_weight_lbs != null ? { target_weight_lbs: row.target_weight_lbs } : {}),
       ...(row.notes != null && row.notes !== '' ? { notes: row.notes } : {}),
     })
     stepsBySlot.set(row.slot_id, list)
@@ -540,9 +538,7 @@ export function assembleWorkoutTemplates(
       ...(row.target_sets_max != null ? { target_sets_max: row.target_sets_max } : {}),
       ...(row.target_reps != null ? { target_reps: row.target_reps } : {}),
       ...(row.target_reps_max != null ? { target_reps_max: row.target_reps_max } : {}),
-      ...(row.target_weight_lbs != null
-        ? { target_weight_lbs: row.target_weight_lbs }
-        : {}),
+      ...(row.target_weight_lbs != null ? { target_weight_lbs: row.target_weight_lbs } : {}),
       ...(row.rest_seconds != null ? { rest_seconds: row.rest_seconds } : {}),
       ...(row.notes != null && row.notes !== '' ? { notes: row.notes } : {}),
       steps: stepsBySlot.get(row.id) ?? [],
@@ -553,7 +549,7 @@ export function assembleWorkoutTemplates(
 
   return [...templates]
     .sort((a, b) => a.position - b.position || a.name.localeCompare(b.name))
-    .map((row) => ({
+    .map(row => ({
       id: row.id,
       name: row.name,
       position: row.position,
@@ -604,7 +600,7 @@ export const WeightRoomTemplateUpdateSchema = z
   .object(templateWriteFields)
   .strict()
   .partial()
-  .refine((patch) => Object.values(patch).some((v) => v !== undefined), {
+  .refine(patch => Object.values(patch).some(v => v !== undefined), {
     message: 'At least one field is required.',
   })
 
@@ -708,7 +704,7 @@ export const WeightRoomTemplateSlotUpdateSchema = z
   .object(slotWriteFields)
   .strict()
   .partial()
-  .refine((patch) => Object.values(patch).some((v) => v !== undefined), {
+  .refine(patch => Object.values(patch).some(v => v !== undefined), {
     message: 'At least one field is required.',
   })
   .refine(setRangeIsOrdered, {

--- a/lib/training-facility/template-format.test.ts
+++ b/lib/training-facility/template-format.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest'
+
+import type { TemplateSlot } from '@/types/weight-room'
+
+import {
+  AMRAP_LABEL,
+  formatRepRange,
+  formatSetCount,
+  formatSlotPrescription,
+  isSuperset,
+} from './template-format'
+
+/**
+ * Coverage for template prescription formatting (#375) — mostly the awkward
+ * cases the six seeded templates actually contain: set ranges, absent rep
+ * targets, and a drop set's descending loads.
+ */
+
+/** A slot with sensible defaults; override what the case is about. */
+function slot(overrides: Partial<TemplateSlot> = {}): TemplateSlot {
+  return {
+    id: 's1',
+    position: 0,
+    exercise: 'barbell-bench-press',
+    target_sets: 4,
+    steps: [],
+    alternates: [],
+    ...overrides,
+  }
+}
+
+describe('formatSetCount', () => {
+  it('shows a single count when there is no range', () => {
+    expect(formatSetCount(slot())).toBe('4')
+  })
+
+  it('shows a range when target_sets_max differs — "Skull Crushers 4-5 sets"', () => {
+    expect(formatSetCount(slot({ target_sets_max: 5 }))).toBe('4-5')
+  })
+
+  it('collapses a range whose ends are equal', () => {
+    expect(formatSetCount(slot({ target_sets_max: 4 }))).toBe('4')
+  })
+})
+
+describe('formatRepRange', () => {
+  it('returns null when there is no rep target', () => {
+    // Not zero, and not an omission — it means AMRAP, and is also how a
+    // transcribed template that only recorded set counts arrives.
+    expect(formatRepRange(slot())).toBeNull()
+  })
+
+  it('formats an exact prescription', () => {
+    expect(formatRepRange(slot({ target_reps: 5 }))).toBe('5')
+  })
+
+  it('formats a range', () => {
+    expect(formatRepRange(slot({ target_reps: 8, target_reps_max: 12 }))).toBe('8-12')
+  })
+})
+
+describe('formatSlotPrescription', () => {
+  it('formats the ordinary case', () => {
+    expect(formatSlotPrescription(slot({ target_reps: 5 }))).toBe('4 × 5')
+  })
+
+  it('renders an absent rep target as "to failure" rather than a blank or a zero', () => {
+    expect(formatSlotPrescription(slot())).toBe(`4 × ${AMRAP_LABEL}`)
+  })
+
+  it('combines ranges on both axes', () => {
+    expect(
+      formatSlotPrescription(slot({ target_sets_max: 5, target_reps: 8, target_reps_max: 12 })),
+    ).toBe('4-5 × 8-12')
+  })
+
+  it('appends a prescribed load', () => {
+    expect(formatSlotPrescription(slot({ target_reps: 5, target_weight_lbs: 185 }))).toBe(
+      '4 × 5 @ 185 lb',
+    )
+  })
+
+  it('surfaces a drop set’s descending loads from its steps', () => {
+    // The rack run on Back Day 1: the loads live on the steps, not on the slot.
+    const rackRun = slot({
+      exercise: 'dumbbell-curl',
+      target_sets: 2,
+      steps: [
+        { id: 'a', position: 0, target_weight_lbs: 35 },
+        { id: 'b', position: 1, target_weight_lbs: 30 },
+        { id: 'c', position: 2, target_weight_lbs: 25 },
+        { id: 'd', position: 3, target_weight_lbs: 20 },
+      ],
+    })
+    expect(formatSlotPrescription(rackRun)).toBe(
+      `2 × ${AMRAP_LABEL} · 35 → 30 → 25 → 20 lb`,
+    )
+  })
+})
+
+describe('isSuperset', () => {
+  it('is false for a plain straight set', () => {
+    expect(isSuperset(slot())).toBe(false)
+  })
+
+  it('is false for a drop set — same movement, descending load', () => {
+    expect(
+      isSuperset(slot({ steps: [{ id: 'a', position: 0, target_weight_lbs: 35 }] })),
+    ).toBe(false)
+  })
+
+  it('is true once a step names its own movement', () => {
+    expect(
+      isSuperset(slot({ steps: [{ id: 'a', position: 0, exercise: 'dumbbell-row' }] })),
+    ).toBe(true)
+  })
+})

--- a/lib/training-facility/template-format.test.ts
+++ b/lib/training-facility/template-format.test.ts
@@ -70,13 +70,13 @@ describe('formatSlotPrescription', () => {
 
   it('combines ranges on both axes', () => {
     expect(
-      formatSlotPrescription(slot({ target_sets_max: 5, target_reps: 8, target_reps_max: 12 })),
+      formatSlotPrescription(slot({ target_sets_max: 5, target_reps: 8, target_reps_max: 12 }))
     ).toBe('4-5 × 8-12')
   })
 
   it('appends a prescribed load', () => {
     expect(formatSlotPrescription(slot({ target_reps: 5, target_weight_lbs: 185 }))).toBe(
-      '4 × 5 @ 185 lb',
+      '4 × 5 @ 185 lb'
     )
   })
 
@@ -92,9 +92,7 @@ describe('formatSlotPrescription', () => {
         { id: 'd', position: 3, target_weight_lbs: 20 },
       ],
     })
-    expect(formatSlotPrescription(rackRun)).toBe(
-      `2 × ${AMRAP_LABEL} · 35 → 30 → 25 → 20 lb`,
-    )
+    expect(formatSlotPrescription(rackRun)).toBe(`2 × ${AMRAP_LABEL} · 35 → 30 → 25 → 20 lb`)
   })
 })
 
@@ -104,14 +102,14 @@ describe('isSuperset', () => {
   })
 
   it('is false for a drop set — same movement, descending load', () => {
-    expect(
-      isSuperset(slot({ steps: [{ id: 'a', position: 0, target_weight_lbs: 35 }] })),
-    ).toBe(false)
+    expect(isSuperset(slot({ steps: [{ id: 'a', position: 0, target_weight_lbs: 35 }] }))).toBe(
+      false
+    )
   })
 
   it('is true once a step names its own movement', () => {
-    expect(
-      isSuperset(slot({ steps: [{ id: 'a', position: 0, exercise: 'dumbbell-row' }] })),
-    ).toBe(true)
+    expect(isSuperset(slot({ steps: [{ id: 'a', position: 0, exercise: 'dumbbell-row' }] }))).toBe(
+      true
+    )
   })
 })

--- a/lib/training-facility/template-format.ts
+++ b/lib/training-facility/template-format.ts
@@ -1,0 +1,102 @@
+import type { TemplateSlot } from '@/types/weight-room'
+
+/**
+ * Display helpers for workout-template prescriptions (#375).
+ *
+ * Pure string formatting, kept out of the components so the awkward cases —
+ * AMRAP, ranges on either axis, a drop set's descending loads — are
+ * unit-testable rather than only visible by clicking through the builder.
+ */
+
+/**
+ * Format a slot's set count: `4`, or `4-5` when it's a range.
+ *
+ * @param slot The slot to describe.
+ */
+export function formatSetCount(slot: Pick<TemplateSlot, 'target_sets' | 'target_sets_max'>): string {
+  const max = slot.target_sets_max
+  return max != null && max !== slot.target_sets ? `${slot.target_sets}-${max}` : `${slot.target_sets}`
+}
+
+/**
+ * Format a slot's rep prescription, or `null` when there isn't one.
+ *
+ * Absent `target_reps` is **not** zero and not an omission to paper over — it
+ * means the prescription is "as many as you can", which is a real instruction
+ * for dips and pullups, and also how a transcribed template that only recorded
+ * set counts arrives. Callers render {@link AMRAP_LABEL} for the null.
+ *
+ * @param slot The slot to describe.
+ */
+export function formatRepRange(
+  slot: Pick<TemplateSlot, 'target_reps' | 'target_reps_max'>,
+): string | null {
+  if (slot.target_reps == null) return null
+  const max = slot.target_reps_max
+  return max != null && max !== slot.target_reps
+    ? `${slot.target_reps}-${max}`
+    : `${slot.target_reps}`
+}
+
+/** What a slot with no rep target reads as. */
+export const AMRAP_LABEL = 'to failure'
+
+/**
+ * One-line prescription for a slot — the string the builder and the recording
+ * surface both show under a movement name.
+ *
+ * Shapes it produces:
+ * - `4 × 5` — the ordinary case
+ * - `4-5 × 8-12` — ranges on either axis
+ * - `4 × to failure` — no rep target
+ * - `4 × 5 @ 185 lb` — with a prescribed load
+ * - `2 × to failure · 35 → 30 → 25 → 20 lb` — a drop set, loads from its steps
+ *
+ * Load is per implement, matching `weight_room_sets.weight_lbs`, so this is
+ * deliberately *not* multiplied by the movement's `load_multiplier` — the
+ * number shown is the one read off the dumbbell.
+ *
+ * @param slot The slot to describe, including its steps.
+ */
+export function formatSlotPrescription(slot: TemplateSlot): string {
+  const reps = formatRepRange(slot) ?? AMRAP_LABEL
+  let line = `${formatSetCount(slot)} × ${reps}`
+
+  if (slot.target_weight_lbs != null) {
+    line += ` @ ${formatWeight(slot.target_weight_lbs)} lb`
+  }
+
+  // A drop set's loads live on its steps, so surface them instead of the
+  // slot's single (usually absent) weight.
+  const stepLoads = slot.steps
+    .map((step) => step.target_weight_lbs)
+    .filter((w): w is number => w != null)
+  if (stepLoads.length > 0) {
+    line += ` · ${stepLoads.map(formatWeight).join(' → ')} lb`
+  }
+
+  return line
+}
+
+/**
+ * Trim a trailing `.0` off a numeric load so `35` doesn't render as `35.0`,
+ * while `2.5` keeps its half.
+ *
+ * @param weight Pounds on one implement.
+ */
+function formatWeight(weight: number): string {
+  return Number.isInteger(weight) ? `${weight}` : `${weight}`.replace(/0+$/, '')
+}
+
+/**
+ * Whether a slot's within-set sequence is a **superset** rather than a drop
+ * set — true when any step names its own movement.
+ *
+ * The two share a table and a shape but are different training intents, so
+ * surfaces should label them differently rather than calling both "steps".
+ *
+ * @param slot The slot to classify.
+ */
+export function isSuperset(slot: Pick<TemplateSlot, 'steps'>): boolean {
+  return slot.steps.some((step) => step.exercise != null)
+}

--- a/lib/training-facility/template-format.ts
+++ b/lib/training-facility/template-format.ts
@@ -13,9 +13,13 @@ import type { TemplateSlot } from '@/types/weight-room'
  *
  * @param slot The slot to describe.
  */
-export function formatSetCount(slot: Pick<TemplateSlot, 'target_sets' | 'target_sets_max'>): string {
+export function formatSetCount(
+  slot: Pick<TemplateSlot, 'target_sets' | 'target_sets_max'>
+): string {
   const max = slot.target_sets_max
-  return max != null && max !== slot.target_sets ? `${slot.target_sets}-${max}` : `${slot.target_sets}`
+  return max != null && max !== slot.target_sets
+    ? `${slot.target_sets}-${max}`
+    : `${slot.target_sets}`
 }
 
 /**
@@ -29,7 +33,7 @@ export function formatSetCount(slot: Pick<TemplateSlot, 'target_sets' | 'target_
  * @param slot The slot to describe.
  */
 export function formatRepRange(
-  slot: Pick<TemplateSlot, 'target_reps' | 'target_reps_max'>,
+  slot: Pick<TemplateSlot, 'target_reps' | 'target_reps_max'>
 ): string | null {
   if (slot.target_reps == null) return null
   const max = slot.target_reps_max
@@ -69,7 +73,7 @@ export function formatSlotPrescription(slot: TemplateSlot): string {
   // A drop set's loads live on its steps, so surface them instead of the
   // slot's single (usually absent) weight.
   const stepLoads = slot.steps
-    .map((step) => step.target_weight_lbs)
+    .map(step => step.target_weight_lbs)
     .filter((w): w is number => w != null)
   if (stepLoads.length > 0) {
     line += ` · ${stepLoads.map(formatWeight).join(' → ')} lb`
@@ -98,5 +102,5 @@ function formatWeight(weight: number): string {
  * @param slot The slot to classify.
  */
 export function isSuperset(slot: Pick<TemplateSlot, 'steps'>): boolean {
-  return slot.steps.some((step) => step.exercise != null)
+  return slot.steps.some(step => step.exercise != null)
 }

--- a/supabase/migrations/20260803120000_weight_room_workout_templates.sql
+++ b/supabase/migrations/20260803120000_weight_room_workout_templates.sql
@@ -1,0 +1,160 @@
+-- Workout templates (#375) — the "plan" half of the gym-workouts arc (#372).
+--
+-- A template is a named, ordered prescription: "Push Day — 5x5 bench, 3x8
+-- overhead press, 3x12 lateral raise". Nothing in the Weight Room could express
+-- that. `weight_room_goals` prescribes a *daily rep total* for a single
+-- movement — no set structure, no ordering, no grouping across movements — and
+-- `weight_room_monthly_focus` is a time-boxed campaign for one movement.
+-- Neither composes into a workout.
+--
+-- Three tables:
+--
+--   * weight_room_workout_templates   — the named plan
+--   * weight_room_template_slots      — its ordered prescriptions, one per movement
+--   * weight_room_template_alternates — per-slot swaps, in preference order
+--
+-- Alternates are a child table rather than a `text[]` on the slot: an array can
+-- hold a slug the catalog no longer has, and #373 exists precisely to make the
+-- roster referentially real. Both `exercise` FKs are `on delete restrict`, so
+-- archiving is how a movement retires — consistent with sets.
+--
+-- Reps are **totals**, never per-side, matching `weight_room_sets.reps` and the
+-- daily goals (the August lunges target is 100/day, described as 50 per side).
+-- Keeping one convention means the recording surface (#376) never converts
+-- between a prescription and a logged set. `weight_room_exercises.is_unilateral`
+-- already flags which movements that nuance applies to.
+--
+-- RLS mirrors every sibling table: anon + authenticated SELECT only; writes go
+-- through the service-role key via `app/api/admin/weight-room/*`.
+--
+-- All DDL is idempotent.
+
+create table if not exists public.weight_room_workout_templates (
+  id uuid primary key default gen_random_uuid(),
+  name text not null check (btrim(name) <> ''),
+  description text null,
+  color text null,
+  category text null check (
+    category is null or category in
+      ('push', 'pull', 'legs', 'upper', 'lower', 'full-body', 'other')
+  ),
+  position integer not null default 0,
+  archived boolean not null default false,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+comment on table public.weight_room_workout_templates is
+  'Named workout prescriptions for the Weight Room (#375) — "Push Day", "Legs A". A template is a plan, not a record: running one produces a weight_room_workouts session (#374), and editing a template never changes what a past session says it prescribed.';
+
+create index if not exists weight_room_workout_templates_active_idx
+  on public.weight_room_workout_templates (position, name)
+  where archived = false;
+
+alter table public.weight_room_workout_templates enable row level security;
+
+do $$
+begin
+  create policy "anon and authenticated can read weight room workout templates"
+    on public.weight_room_workout_templates
+    for select
+    to anon, authenticated
+    using (true);
+exception when duplicate_object then null;
+end $$;
+
+-- ---------------------------------------------------------------------------
+-- Slots — the ordered prescriptions
+-- ---------------------------------------------------------------------------
+
+create table if not exists public.weight_room_template_slots (
+  id uuid primary key default gen_random_uuid(),
+  template_id uuid not null
+    references public.weight_room_workout_templates(id) on delete cascade,
+  position integer not null check (position >= 0),
+  exercise text not null
+    references public.weight_room_exercises(slug) on delete restrict on update cascade,
+  target_sets integer not null check (target_sets > 0),
+  target_reps integer null check (target_reps is null or target_reps > 0),
+  target_reps_max integer null,
+  target_weight_lbs numeric null check (target_weight_lbs is null or target_weight_lbs >= 0),
+  rest_seconds integer null check (rest_seconds is null or rest_seconds >= 0),
+  notes text null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint weight_room_template_slots_rep_range_check check (
+    target_reps_max is null
+    or (target_reps is not null and target_reps_max >= target_reps)
+  )
+);
+
+-- DEFERRABLE is load-bearing, not decoration. Reordering slots means swapping
+-- positions, and an immediate unique check fires the moment the first row is
+-- written — before the second half of the swap has happened. Deferring to
+-- commit lets one multi-row upsert reorder a whole template atomically, which
+-- is exactly how the builder saves an order change.
+do $$
+begin
+  alter table public.weight_room_template_slots
+    add constraint weight_room_template_slots_position_key
+    unique (template_id, position) deferrable initially deferred;
+exception when duplicate_table or duplicate_object then null;
+end $$;
+
+comment on table public.weight_room_template_slots is
+  'One prescribed movement within a workout template (#375), ordered by `position`. Reps are TOTALS, never per-side — same convention as weight_room_sets.reps.';
+
+comment on column public.weight_room_template_slots.target_reps is
+  'Prescribed reps per set, or NULL for AMRAP / to failure — a real prescription for dips and pullups, so it is deliberately not forced to a number. Set target_reps_max alongside it for a range (8-12).';
+
+comment on column public.weight_room_template_slots.target_weight_lbs is
+  'Prescribed load on ONE implement, matching weight_room_sets.weight_lbs. Effective load is this x weight_room_exercises.load_multiplier, so a two-dumbbell prescription stores the per-hand number. This is the field most likely to be double-counted.';
+
+create index if not exists weight_room_template_slots_template_idx
+  on public.weight_room_template_slots (template_id, position);
+
+alter table public.weight_room_template_slots enable row level security;
+
+do $$
+begin
+  create policy "anon and authenticated can read weight room template slots"
+    on public.weight_room_template_slots
+    for select
+    to anon, authenticated
+    using (true);
+exception when duplicate_object then null;
+end $$;
+
+-- ---------------------------------------------------------------------------
+-- Alternates — the pre-declared swaps
+-- ---------------------------------------------------------------------------
+
+create table if not exists public.weight_room_template_alternates (
+  id uuid primary key default gen_random_uuid(),
+  slot_id uuid not null
+    references public.weight_room_template_slots(id) on delete cascade,
+  exercise text not null
+    references public.weight_room_exercises(slug) on delete restrict on update cascade,
+  position integer not null check (position >= 0),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (slot_id, exercise)
+);
+
+comment on table public.weight_room_template_alternates is
+  'Pre-declared swaps for a template slot (#375), in preference order: barbell bench -> dumbbell bench -> machine press. Exists so the common "rack is taken" substitution is one tap during recording (#376) rather than a catalog search. Uniqueness is on (slot_id, exercise), so position may repeat without harm.';
+
+create index if not exists weight_room_template_alternates_slot_idx
+  on public.weight_room_template_alternates (slot_id, position);
+
+alter table public.weight_room_template_alternates enable row level security;
+
+do $$
+begin
+  create policy "anon and authenticated can read weight room template alternates"
+    on public.weight_room_template_alternates
+    for select
+    to anon, authenticated
+    using (true);
+exception when duplicate_object then null;
+end $$;

--- a/supabase/migrations/20260803120100_weight_room_template_slot_steps.sql
+++ b/supabase/migrations/20260803120100_weight_room_template_slot_steps.sql
@@ -1,0 +1,92 @@
+-- Set ranges and within-set sequences for workout templates (#375).
+--
+-- Both came out of transcribing six real templates rather than imagined ones,
+-- and neither fits the shape the first migration created:
+--
+--   * "Skull Crushers 4-5 sets" is a range on *sets*. The slot had a range on
+--     reps but a single `target_sets`, so the top of the range had nowhere to
+--     live and a 5th set would have scored as exceeding the prescription
+--     rather than hitting it.
+--   * "Rack Run 35,30,25,20 2 sets" is a drop set — one set is really four
+--     mini-sets at descending load, run twice. A slot carries one
+--     `target_weight_lbs`, so it could not be expressed at all.
+--
+-- `weight_room_template_slot_steps` models the second as an ordered sequence
+-- performed *inside* one set. A slot with no steps is an ordinary straight-set
+-- prescription and behaves exactly as before — steps are strictly additive.
+--
+-- Each step's `exercise` is nullable, and that nullability is the whole design:
+--
+--   * NULL  → the step is the slot's own movement at a different load or rep
+--             count. That is a **drop set** (the rack run).
+--   * set   → the step is a *different* movement performed back-to-back. That
+--             is a **superset**.
+--
+-- One mechanism, both structures, no second migration when supersets turn up.
+-- They are not the same thing and shouldn't be presented as one in UI, but they
+-- are the same shape, and modelling the shape once is what makes the second
+-- free.
+--
+-- All DDL is idempotent.
+
+alter table public.weight_room_template_slots
+  add column if not exists target_sets_max integer null;
+
+do $$
+begin
+  alter table public.weight_room_template_slots
+    add constraint weight_room_template_slots_set_range_check
+    check (target_sets_max is null or target_sets_max >= target_sets);
+exception when duplicate_object then null;
+end $$;
+
+comment on column public.weight_room_template_slots.target_sets_max is
+  'Top of a set range — "4-5 sets" is target_sets 4, target_sets_max 5. NULL means target_sets is exact. Scoring in #377 should treat anything within the range as hitting the prescription, not exceeding it.';
+
+create table if not exists public.weight_room_template_slot_steps (
+  id uuid primary key default gen_random_uuid(),
+  slot_id uuid not null
+    references public.weight_room_template_slots(id) on delete cascade,
+  position integer not null check (position >= 0),
+  exercise text null
+    references public.weight_room_exercises(slug) on delete restrict on update cascade,
+  target_reps integer null check (target_reps is null or target_reps > 0),
+  target_weight_lbs numeric null check (target_weight_lbs is null or target_weight_lbs >= 0),
+  notes text null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+-- Deferrable for the same reason the slot ordering is: reordering steps swaps
+-- positions, and an immediate check fires halfway through the swap.
+do $$
+begin
+  alter table public.weight_room_template_slot_steps
+    add constraint weight_room_template_slot_steps_position_key
+    unique (slot_id, position) deferrable initially deferred;
+exception when duplicate_table or duplicate_object then null;
+end $$;
+
+comment on table public.weight_room_template_slot_steps is
+  'An ordered sequence performed inside ONE set of a template slot (#375). A slot with no steps is an ordinary straight set. Steps with a NULL exercise are the slot''s own movement at a different load — a drop set. Steps naming a different exercise are a superset. Same shape, different training intent; surfaces should label them distinctly.';
+
+comment on column public.weight_room_template_slot_steps.exercise is
+  'NULL inherits the slot''s movement (drop set). A catalog slug makes this step a different movement performed back-to-back (superset).';
+
+comment on column public.weight_room_template_slot_steps.target_weight_lbs is
+  'Load on ONE implement for this step, same convention as weight_room_sets.weight_lbs — a 35 lb rack-run step is 35 per hand, and effective load is this x the movement''s load_multiplier.';
+
+create index if not exists weight_room_template_slot_steps_slot_idx
+  on public.weight_room_template_slot_steps (slot_id, position);
+
+alter table public.weight_room_template_slot_steps enable row level security;
+
+do $$
+begin
+  create policy "anon and authenticated can read weight room template slot steps"
+    on public.weight_room_template_slot_steps
+    for select
+    to anon, authenticated
+    using (true);
+exception when duplicate_object then null;
+end $$;

--- a/supabase/migrations/20260803120200_seed_workout_templates.sql
+++ b/supabase/migrations/20260803120200_seed_workout_templates.sql
@@ -1,0 +1,157 @@
+-- Seed the six workout templates and the movements they need (#375).
+--
+-- The catalog seed in `20260731120000_weight_room_exercises_catalog.sql` set the
+-- precedent that movements are migration data, so the eighteen this adds belong
+-- here rather than in a one-off script — otherwise a fresh project builds the
+-- template tables and cannot populate them, and rebuilding after a restore
+-- means re-transcribing six templates by hand.
+--
+-- The templates themselves were transcribed from phone notes. Two mapping
+-- decisions in here are the kind that go wrong quietly and are worth stating:
+--
+--   * "Squats" on a legs day is `barbell-back-squat`, NOT the bodyweight
+--     `squats` movement. `squats` is a 100/day grease-the-groove ring; pointing
+--     five sets of loaded squats at it would dump gym volume into that ring and
+--     corrupt the streak it measures.
+--   * "Military press" is `barbell-overhead-press` — the same movement, kept on
+--     one slug so its history doesn't split in two.
+--
+-- Bare rep lists in the source notes (pull-ups `8/8/7/6`, push-ups `10x10`) are
+-- deliberately absent: those were grease-the-groove volume that happened to be
+-- written under a workout, not part of its prescription. The two that carried
+-- explicit set counts — Chest Day 2's push-ups, Back Day 1's pull-ups — are
+-- slots, because they were prescribed.
+--
+-- Idempotent twice over: `on conflict do nothing` on the movements, and an
+-- early return if any template already exists. Re-applying never duplicates,
+-- and never overwrites a template edited since.
+
+insert into public.weight_room_exercises
+  (slug, display_name, equipment, muscle_group, load_multiplier, is_unilateral)
+values
+  -- Referenced by the August lower-body focus rather than a template; included
+  -- so a rebuilt project has the movement its focus points at.
+  ('lunges',                       'Lunges',                       'bodyweight', 'legs',      1, true),
+  ('barbell-decline-press',        'Barbell Decline Press',        'barbell',    'chest',     1, false),
+  ('skull-crushers',               'Skull Crushers',               'barbell',    'arms',      1, false),
+  ('close-grip-bench-press',       'Close Grip Bench Press',       'barbell',    'arms',      1, false),
+  ('rope-overhead-extension',      'Rope Overhead Extension',      'cable',      'arms',      1, false),
+  ('upright-row',                  'Upright Row',                  'barbell',    'shoulders', 1, false),
+  ('ez-bar-curl',                  'EZ Bar Curl',                  'barbell',    'arms',      1, false),
+  ('preacher-curl',                'Preacher Curl',                'barbell',    'arms',      1, false),
+  ('rope-curl',                    'Rope Curl',                    'cable',      'arms',      1, false),
+  ('back-extension',               'Back Extension',               'bodyweight', 'back',      1, false),
+  ('walking-lunges',               'Walking Lunges',               'bodyweight', 'legs',      1, true),
+  ('single-leg-romanian-deadlift', 'Single Leg Romanian Deadlift', 'dumbbell',   'legs',      1, true),
+  ('step-ups',                     'Step Ups',                     'bodyweight', 'legs',      1, true),
+  ('calf-press-machine',           'Calf Press (Machine)',         'machine',    'legs',      1, false),
+  ('seated-calf-raise',            'Seated Calf Raise',            'machine',    'legs',      1, false),
+  ('sled-push',                    'Sled Push',                    'other',      'full-body', 1, false),
+  ('knee-tucks',                   'Knee Tucks',                   'bodyweight', 'core',      1, false),
+  ('russian-twist',                'Russian Twist',                'other',      'core',      1, false),
+  ('decline-crunch',               'Decline Crunch',               'bodyweight', 'core',      1, false)
+on conflict (slug) do nothing;
+
+do $$
+declare
+  t uuid;
+  s uuid;
+begin
+  -- Any existing template means this has run (or the templates were built by
+  -- hand); leave them alone rather than duplicating or clobbering.
+  if exists (select 1 from public.weight_room_workout_templates) then
+    return;
+  end if;
+
+  -- ---- Chest Day 1 -------------------------------------------------------
+  insert into public.weight_room_workout_templates (name, category, color, position)
+  values ('Chest Day 1', 'push', '#DC2626', 0) returning id into t;
+  insert into public.weight_room_template_slots
+    (template_id, position, exercise, target_sets, target_sets_max)
+  values
+    (t, 0, 'barbell-bench-press',    4, null),
+    (t, 1, 'barbell-incline-press',  4, null),
+    (t, 2, 'barbell-decline-press',  4, null),
+    (t, 3, 'skull-crushers',         4, 5),
+    (t, 4, 'cable-tricep-pushdown',  4, 5);
+
+  -- ---- Chest Day 2 -------------------------------------------------------
+  insert into public.weight_room_workout_templates (name, category, color, position)
+  values ('Chest Day 2', 'push', '#F97316', 1) returning id into t;
+  insert into public.weight_room_template_slots (template_id, position, exercise, target_sets)
+  values
+    (t, 0, 'barbell-overhead-press',   4),
+    (t, 1, 'dumbbell-bench-press',     4),
+    (t, 2, 'barbell-incline-press',    4),
+    (t, 3, 'pushups',                  4),
+    (t, 4, 'dips',                     4),
+    (t, 5, 'close-grip-bench-press',   4),
+    (t, 6, 'rope-overhead-extension',  4);
+
+  -- ---- Back Day 1 --------------------------------------------------------
+  insert into public.weight_room_workout_templates (name, category, color, position)
+  values ('Back Day 1', 'pull', '#0891B2', 2) returning id into t;
+  insert into public.weight_room_template_slots (template_id, position, exercise, target_sets)
+  values
+    (t, 0, 'pullups',          4),
+    (t, 1, 'seated-cable-row', 4),
+    (t, 2, 'dumbbell-row',     4),
+    (t, 3, 'upright-row',      4),
+    (t, 4, 'ez-bar-curl',      5);
+  insert into public.weight_room_template_slots
+    (template_id, position, exercise, target_sets, notes)
+  values (t, 5, 'dumbbell-curl', 5, 'Seated, alternating');
+
+  -- The rack run: one set is four mini-sets down the rack, run twice.
+  insert into public.weight_room_template_slots
+    (template_id, position, exercise, target_sets, notes)
+  values (t, 6, 'dumbbell-curl', 2, 'Rack run — descending down the rack')
+  returning id into s;
+  insert into public.weight_room_template_slot_steps
+    (slot_id, position, target_weight_lbs)
+  values (s, 0, 35), (s, 1, 30), (s, 2, 25), (s, 3, 20);
+
+  -- ---- Back Day 2 --------------------------------------------------------
+  insert into public.weight_room_workout_templates
+    (name, category, color, position, description)
+  values ('Back Day 2', 'pull', '#0E7490', 3, 'Target pace: 35 min') returning id into t;
+  insert into public.weight_room_template_slots (template_id, position, exercise, target_sets)
+  values
+    (t, 0, 'barbell-row',    4),
+    (t, 1, 'lat-pulldown',   4),
+    (t, 2, 'back-extension', 4),
+    (t, 3, 'shrugs',         4),
+    (t, 4, 'preacher-curl',  5),
+    (t, 5, 'rope-curl',      5);
+  insert into public.weight_room_template_slots
+    (template_id, position, exercise, target_sets, notes)
+  values (t, 6, 'dumbbell-curl', 2, '21s — 7 bottom half / 7 top half / 7 full');
+
+  -- ---- Legs Day 1 --------------------------------------------------------
+  insert into public.weight_room_workout_templates (name, category, color, position)
+  values ('Legs Day 1', 'legs', '#4F46E5', 4) returning id into t;
+  insert into public.weight_room_template_slots (template_id, position, exercise, target_sets)
+  values
+    (t, 0, 'barbell-back-squat',            5),
+    (t, 1, 'walking-lunges',                4),
+    (t, 2, 'single-leg-romanian-deadlift',  3),
+    (t, 3, 'leg-press',                     3),
+    (t, 4, 'calf-press-machine',            3),
+    (t, 5, 'plank',                         4),
+    (t, 6, 'knee-tucks',                    4);
+
+  -- ---- Legs Day 2 --------------------------------------------------------
+  -- "Sled Push 2 sets" in the source listed four blank set lines; the header
+  -- wins until corrected in the builder.
+  insert into public.weight_room_workout_templates (name, category, color, position)
+  values ('Legs Day 2', 'legs', '#7E22CE', 5) returning id into t;
+  insert into public.weight_room_template_slots (template_id, position, exercise, target_sets)
+  values
+    (t, 0, 'barbell-back-squat',         4),
+    (t, 1, 'barbell-romanian-deadlift',  4),
+    (t, 2, 'step-ups',                   4),
+    (t, 3, 'sled-push',                  2),
+    (t, 4, 'seated-calf-raise',          5),
+    (t, 5, 'russian-twist',              5),
+    (t, 6, 'decline-crunch',             5);
+end $$;

--- a/types/weight-room.ts
+++ b/types/weight-room.ts
@@ -120,6 +120,172 @@ export interface WeightRoomWorkout {
 }
 
 /**
+ * Broad split a {@link WorkoutTemplate} belongs to (#375) — how the plan is
+ * filed, not what it prescribes. Nullable on purpose: a template that doesn't
+ * fit a split shouldn't be forced into one.
+ */
+export type TemplateCategory =
+  | 'push'
+  | 'pull'
+  | 'legs'
+  | 'upper'
+  | 'lower'
+  | 'full-body'
+  | 'other'
+
+/**
+ * One step in a {@link TemplateSlot}'s within-set sequence (#375) — mirrors a
+ * row of `public.weight_room_template_slot_steps`.
+ *
+ * {@link exercise} is what distinguishes the two structures this models:
+ *
+ * - **absent** — the slot's own movement at a different load or rep count, i.e.
+ *   a **drop set**. A "rack run" down the dumbbells is four steps at 35 / 30 /
+ *   25 / 20.
+ * - **set** — a *different* movement performed back-to-back, i.e. a
+ *   **superset**.
+ *
+ * The two are the same shape and genuinely different training intents; UI
+ * should label them distinctly rather than calling both "steps".
+ */
+export interface TemplateSlotStep {
+  /** UUID primary key, generated server-side. */
+  id: string
+  /** Order within the set, lowest first. */
+  position: number
+  /**
+   * Catalog slug for this step's movement, or absent to inherit the slot's —
+   * see the interface docs; this field is what makes a sequence a superset
+   * rather than a drop set.
+   */
+  exercise?: string
+  /** Reps for this step. Absent inherits {@link TemplateSlot.target_reps}. */
+  target_reps?: number
+  /**
+   * Load on **one implement** for this step, in pounds — same convention as
+   * {@link StrengthSet.weight_lbs}, so a 35 lb rack-run step is 35 per hand.
+   */
+  target_weight_lbs?: number
+  /** Free-text cue for this step. Absent when none. */
+  notes?: string
+}
+
+/**
+ * One pre-declared swap for a {@link TemplateSlot} (#375) — mirrors a row of
+ * `public.weight_room_template_alternates`.
+ *
+ * Exists so the common "the rack is taken" substitution is one tap while
+ * recording (#376) rather than a search through the whole catalog. Declaring
+ * alternates never *restricts* substitution — anything in the catalog stays
+ * reachable; this is only the shortcut.
+ */
+export interface TemplateAlternate {
+  /** UUID primary key, generated server-side. */
+  id: string
+  /** Catalog slug of the substitute movement. */
+  exercise: string
+  /**
+   * Preference order, lowest first — the first alternate is the one to reach
+   * for. Only `(slot_id, exercise)` is unique, so positions may repeat.
+   */
+  position: number
+}
+
+/**
+ * One prescribed movement inside a {@link WorkoutTemplate} (#375) — mirrors a
+ * row of `public.weight_room_template_slots`.
+ *
+ * **Reps are totals, never per-side.** `3 × 34` lunges means 34 reps in a set
+ * however they're split between legs — matching {@link StrengthSet.reps} and
+ * the daily goals, so the recording surface never converts between a
+ * prescription and a logged set. {@link WeightRoomExercise.is_unilateral} flags
+ * the movements where that distinction matters.
+ */
+export interface TemplateSlot {
+  /** UUID primary key, generated server-side. */
+  id: string
+  /** Order within the template, lowest first. */
+  position: number
+  /** Catalog slug of the prescribed movement. */
+  exercise: string
+  /** How many sets to perform; the floor when {@link target_sets_max} is set. */
+  target_sets: number
+  /**
+   * Top of a set range — "4–5 sets" is `target_sets: 4, target_sets_max: 5`.
+   * Absent means {@link target_sets} is exact. Adherence should treat anything
+   * inside the range as hitting the prescription, not exceeding it.
+   */
+  target_sets_max?: number
+  /**
+   * Reps per set, or absent for **AMRAP / to failure** — a real prescription
+   * for dips and pullups, so it's deliberately not forced to a number. Absent
+   * also covers "sets prescribed, reps unspecified", which is how most
+   * transcribed templates arrive.
+   */
+  target_reps?: number
+  /**
+   * Top of a rep range (`8–12` is `target_reps: 8, target_reps_max: 12`).
+   * Never set without {@link target_reps}.
+   */
+  target_reps_max?: number
+  /**
+   * Prescribed load on **one implement**, in pounds — matching
+   * {@link StrengthSet.weight_lbs}. Effective load is this ×
+   * {@link WeightRoomExercise.load_multiplier}, so a two-dumbbell prescription
+   * stores the per-hand number. Absent for bodyweight or "whatever's loaded".
+   */
+  target_weight_lbs?: number
+  /** Prescribed rest between sets, in seconds. Absent when unspecified. */
+  rest_seconds?: number
+  /** Free-text cue — "pause at the bottom", "seated, alternating". */
+  notes?: string
+  /**
+   * Within-set sequence, ordered. **Empty for an ordinary straight set**, which
+   * is the overwhelming majority — see {@link TemplateSlotStep} for what a
+   * populated one means.
+   */
+  steps: TemplateSlotStep[]
+  /**
+   * Pre-declared swaps, in preference order. Empty when none — recording can
+   * still substitute anything in the catalog.
+   */
+  alternates: TemplateAlternate[]
+}
+
+/**
+ * A named, ordered workout prescription (#375) — mirrors a row of
+ * `public.weight_room_workout_templates` with its slots attached.
+ *
+ * A template is a **plan, not a record**. Running one produces a
+ * {@link WeightRoomWorkout}; editing the template afterwards never changes what
+ * a past session says it prescribed, which is why recording links each set to
+ * the slot it was performed for rather than recomputing adherence against the
+ * live template.
+ */
+export interface WorkoutTemplate {
+  /** UUID primary key, generated server-side. */
+  id: string
+  /** Display name, e.g. `Chest Day 1`. */
+  name: string
+  /** Longer free-text description — "Target pace: 35 min". Absent when none. */
+  description?: string
+  /** Hex color for the template's chip, matching the goal/focus convention. */
+  color?: string
+  /** Broad split. Absent when the template doesn't fit one. */
+  category?: TemplateCategory
+  /** Display order among templates, lowest first. */
+  position: number
+  /**
+   * Soft-retire flag. An archived template drops out of the "start a workout"
+   * picker but stays readable, so a past session that ran it still resolves.
+   * Absent is treated as `false`.
+   */
+  archived?: boolean
+  /** Prescribed movements, ordered by {@link TemplateSlot.position}. */
+  slots: TemplateSlot[]
+}
+
+/**
  * How a movement is loaded (#373). Drives the catalog's equipment filter and,
  * once templates land, "what can I swap this for when the rack is taken".
  *

--- a/types/weight-room.ts
+++ b/types/weight-room.ts
@@ -124,14 +124,7 @@ export interface WeightRoomWorkout {
  * filed, not what it prescribes. Nullable on purpose: a template that doesn't
  * fit a split shouldn't be forced into one.
  */
-export type TemplateCategory =
-  | 'push'
-  | 'pull'
-  | 'legs'
-  | 'upper'
-  | 'lower'
-  | 'full-body'
-  | 'other'
+export type TemplateCategory = 'push' | 'pull' | 'legs' | 'upper' | 'lower' | 'full-body' | 'other'
 
 /**
  * One step in a {@link TemplateSlot}'s within-set sequence (#375) — mirrors a


### PR DESCRIPTION
The **plan** half of #372, and the last backend-shaped link before #376 makes it usable at the gym.

## Why

A template is a named, ordered prescription — "Chest Day 1: 4 sets bench, 4 sets incline, 4–5 sets skull crushers". Nothing in the Weight Room could express that. `weight_room_goals` prescribes a *daily rep total* for one movement; `weight_room_monthly_focus` is a time-boxed campaign for one movement. Neither composes into a workout.

## Two things the real templates forced

The six templates seeded here were transcribed from actual phone notes, not invented — and two of them broke the schema I'd designed from imagination:

- **"Skull Crushers 4-5 sets"** is a range on *sets*. There was a range on reps but `target_sets` was a single number, so the top had nowhere to live and a 5th set would have scored as *exceeding* the prescription rather than hitting it. → `target_sets_max`.
- **"Rack Run 35,30,25,20 2 sets"** is a drop set — one set is four mini-sets down the rack, run twice. A slot carries one `target_weight_lbs`, so it couldn't be expressed at all. → a step sequence.

Steps model **drop sets and supersets with one mechanism**: a step with no `exercise` is the slot's own movement at a different load (drop set); a step naming a movement is a different one performed back-to-back (superset). Same shape, genuinely different training intents — the UI labels them distinctly — and no second migration when supersets turn up.

## Slots are edited in place, never recreated

The load-bearing constraint. #376 links each logged set to the slot it was performed for via `weight_room_sets.template_slot_id`. A "save the whole template" endpoint that deleted and reinserted slots would null those links and **silently destroy adherence history on every edit**. So slots have their own item endpoint and keep their ids.

Steps and alternates *are* replaced wholesale, which is safe precisely because nothing outside a slot references them.

## Reordering

One upsert against a `DEFERRABLE INITIALLY DEFERRED` unique constraint on `(template_id, position)`. Swapping two slots transiently duplicates a position; an immediate check rejects the first half of every swap. Rehearsed on staging before building anything on it:

```
REHEARSAL: order after swap = [barbell-overhead-press > barbell-bench-press > dumbbell-lateral-raise];
duplicate position blocked = t; alternates left after slot delete = 0 (want 0)
```

The reorder endpoint also verifies every id belongs to the template first — an upsert on an unknown id doesn't no-op, it attempts an INSERT and fails on the NOT NULL columns as an opaque 500.

## Seeded

Six templates (40 slots, 4 steps) on **both** projects, plus the 18 movements they needed — decline press, skull crushers, close-grip bench, rope overhead ext, upright row, EZ bar curl, preacher curl, rope curl, back extension, walking lunges, single-leg RDL, step ups, calf press, seated calf raise, sled push, knee tucks, russian twist, decline crunch.

Mapping decisions worth reviewing, since guessing wrong here is quiet:

| note said | seeded as | why |
|---|---|---|
| `Squats` (legs day) | `barbell-back-squat` | **not** the bodyweight `squats` GTG movement — that would have dumped gym volume into the 100/day ring |
| `Military press` | `barbell-overhead-press` | same movement, history stays together |
| `Rack Run 35,30,25,20` | `dumbbell-curl`, 2 sets, 4 steps | per your call |
| `DB Flat Press` | `dumbbell-bench-press` | |
| `One arm DB Row` | `dumbbell-row` | already `is_unilateral` |

Bare rep lists (pull ups `8/8/7/6`, push ups `10×10`) are **excluded** — those were 100-a-day grease-the-groove volume, not workout prescriptions. The two that carried explicit set counts (Chest Day 2's push ups, Back Day 1's pull ups) *are* slots.

`Military press` on Chest Day 1 is excluded per the same rule, even though it reads like a transcription gap — your call, and it's one click to add back.

## Migrations

`20260803120000` + `20260803120100`, both applied to production and staging. `migrations:check` clean (30 committed, 30 applied).

## Test plan

Everything is at **Settings → Workout templates** (admin-only).

- [ ] All six templates render with their movements and prescriptions.
- [ ] **Chest Day 1** shows skull crushers and pressdowns as `4-5 × to failure` — the set range and the AMRAP label.
- [ ] **Back Day 1**'s last slot shows `2 × to failure · 35 → 30 → 25 → 20 lb` and a `drop set` chip.
- [ ] Reorder a movement with ▲/▼ — the order persists after refresh.
- [ ] Edit a slot's sets/reps/weight; add an alternate; save; refresh.
- [ ] Add a step naming a *different* movement — the chip flips to `superset`.
- [ ] Add a movement, then remove it.
- [ ] Add a template; try a duplicate name → blocked before submit.
- [ ] Archive a template → hidden behind the toggle; unarchive.
- [ ] `/training-facility/weight-room` and `/history` unchanged.
- [ ] Non-admin still 404s on `/settings`.

Verified locally: `tsc --noEmit` clean, `next build` compiles (all four routes registered), 1969 unit tests, 65/65 Playwright, `migrations:check` clean.

**Note:** rebased through #397's tree-wide LF normalization with `-Xrenormalize`; the diff is 15 files, no line-ending noise.

Closes #375.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
