### PR TITLE
chore(worktree): let the bootstrap isolate node_modules before a dep change (#404)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,13 @@ Supabase script fails on missing env. See `scripts/README.md`.
 it writes through the link into the main checkout's install and every other
 worktree sharing it. The bootstrap avoids this by giving dependency-changing
 branches a real isolated `npm ci` instead of a junction; if you need to change
-dependencies in a worktree that's already linked, re-run the bootstrap.
+dependencies in a worktree that's already linked, re-run the bootstrap — it
+detects the uncommitted `package.json` edit and reinstalls in isolation.
+
+If you know up front that you're adding a dependency, pass **`-Isolate`** on the
+first run and skip the junction entirely. The automatic detection can only see
+changes that already exist, so on a branch where you haven't made the edit yet
+there is nothing for it to find.
 
 Prefer `git worktree add` + `EnterWorktree({ path })` over
 `EnterWorktree({ name })`: the latter has crashed here mid-create, leaving an

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -22,9 +22,34 @@ When the branch changes `package.json` or `package-lock.json` it does a real `np
 
 `-Link` forces the junction anyway, for when you know the dependency delta is irrelevant to what you're running. Know what it shares before reaching for it.
 
-Safe to re-run: an existing junction, an existing real install, and an existing `.env.local` are all left alone (`-Force` overwrites the env file). So a re-run is a no-op on a normal branch, but **does** repeat `npm ci` on a dependency branch — slow, and the only way to stay correct about a lockfile that may have moved.
+### Adding a dependency: `-Isolate`
 
-Refuses to run in the main checkout, where `node_modules` is real. Exits `0` when ready, `1` if run from the wrong place, the main checkout has no install to link, or `npm ci` fails.
+The check above reads the *committed* diff, so it can only see a dependency change that already exists. On a branch where you're **about to** add one, there's nothing to detect yet — you get a junction, and the `npm install` you run next writes through it into the main checkout. That's the trap, and it's easy to walk into because nothing looks wrong until something else breaks.
+
+Two ways out, depending on when you notice:
+
+```
+powershell -File scripts/worktree-init.ps1 -Isolate   # before: skip the junction entirely
+powershell -File scripts/worktree-init.ps1            # after:  re-run, it detects the edit
+```
+
+`-Isolate` forces a real install up front. And because the working tree is now checked too, simply **re-running the bootstrap** after editing `package.json` repairs a worktree that was already junctioned — it unlinks and installs for real. That's what `CLAUDE.md`'s "re-run the bootstrap" instruction has always promised; before this it did nothing.
+
+`-Isolate` and `-Link` contradict each other, so passing both is an error rather than a silent precedence rule.
+
+Which install command runs depends on whether the lockfile can be trusted:
+
+| situation | command | why |
+|---|---|---|
+| committed dependency change | `npm ci` | branch carries a coherent `package.json` + lock |
+| uncommitted `package.json` edit | `npm install` | lock hasn't caught up; `ci` **refuses** outright |
+| `-Isolate`, clean tree | `npm ci` | nothing has changed yet — install the lock, then add your package |
+
+That middle row is the whole reason the distinction exists. `npm ci` fails with *"can only install packages when your package.json and package-lock.json are in sync"* — so on the exact state this feature is for, a plain `ci` would leave the worktree with **no** `node_modules`, which is worse than where it started.
+
+Safe to re-run: an existing junction, an existing real install, and an existing `.env.local` are all left alone (`-Force` overwrites the env file). So a re-run is a no-op on a normal branch, but **does** repeat the install on a dependency branch — slow, and the only way to stay correct about a lockfile that may have moved.
+
+Refuses to run in the main checkout, where `node_modules` is real. Exits `0` when ready, `1` if run from the wrong place, the main checkout has no install to link, `-Isolate` and `-Link` are combined, or the install fails.
 
 Without this, the first thing a new worktree shows you is a wall of red tests — which is how a worktree convention dies. See `CLAUDE.md` § Work in a worktree.
 

--- a/scripts/worktree-init.ps1
+++ b/scripts/worktree-init.ps1
@@ -90,6 +90,14 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
+# Argument validation before anything that can fail for other reasons, so a
+# contradictory invocation reports itself rather than surfacing as whatever
+# git happens to complain about first.
+if ($Isolate -and $Link) {
+  Write-Error '-Isolate and -Link are contradictory: one forces a real install, the other forces the shared junction. Pass at most one.'
+  exit 1
+}
+
 # In a worktree, --git-common-dir points at the MAIN checkout's .git, while
 # --git-dir points at .git/worktrees/<name>. Equal values mean we're in the
 # main checkout, where node_modules is real and this script has no business
@@ -142,6 +150,13 @@ $committedDepChange = [bool]$changedDepFiles
 # CLAUDE.md's documented recovery ("re-run the bootstrap if you need to change
 # dependencies in a worktree that's already linked") a silent no-op: the re-run
 # saw no committed change and happily re-confirmed the junction.
+#
+# Any touch of package.json counts, including one that changes no dependency at
+# all -- a version bump, an edited script. That is a deliberate false positive
+# and matches how the committed check has always behaved: the cost of guessing
+# wrong is a slower-but-correct isolated install, whereas parsing the diff to
+# decide would be both fiddly and wrong the first time someone writes their
+# dependencies in a shape the parser didn't expect.
 $dirtyDepFiles = git status --porcelain -- package.json package-lock.json
 if ($LASTEXITCODE -ne 0) {
   Write-Error 'git status on package.json failed - cannot determine whether this worktree has uncommitted dependency edits.'
@@ -150,11 +165,6 @@ if ($LASTEXITCODE -ne 0) {
 $uncommittedDepChange = [bool]$dirtyDepFiles
 
 $depsChanged = $committedDepChange -or $uncommittedDepChange
-
-if ($Isolate -and $Link) {
-  Write-Error '-Isolate and -Link are contradictory: one forces a real install, the other forces the shared junction. Pass at most one.'
-  exit 1
-}
 
 if (($depsChanged -or $Isolate) -and -not $Link) {
   # Name the trigger: three different conditions land here, and "why is this

--- a/scripts/worktree-init.ps1
+++ b/scripts/worktree-init.ps1
@@ -51,6 +51,22 @@
   you know the dependency delta is irrelevant to what you're running and don't
   want to wait for `npm ci`. Understand what it shares before using it.
 
+.PARAMETER Isolate
+  Force a real, isolated `node_modules` even when nothing has changed yet.
+
+  For the case the automatic detection cannot see: you are *about* to add a
+  dependency. Both checks look at what already exists -- committed diff and
+  working tree -- so on a branch where neither has happened, the script
+  junctions, and the `npm install` that follows writes THROUGH the junction
+  into the main checkout's install. Passing `-Isolate` up front skips that
+  whole trap.
+
+  If you only realise afterwards, re-running the script now works too: an
+  uncommitted `package.json` edit is detected and triggers isolation (#404).
+
+  Contradicts `-Link`; passing both is an error rather than a silent
+  precedence rule.
+
 .EXAMPLE
   powershell -File scripts/worktree-init.ps1
 
@@ -68,7 +84,8 @@
 [CmdletBinding()]
 param(
   [switch]$Force,
-  [switch]$Link
+  [switch]$Link,
+  [switch]$Isolate
 )
 
 $ErrorActionPreference = 'Stop'
@@ -116,19 +133,67 @@ if ($LASTEXITCODE -ne 0) {
   Write-Error 'git diff against origin/main failed - cannot determine whether this branch changes dependencies.'
   exit 1
 }
-$depsChanged = [bool]$changedDepFiles
+$committedDepChange = [bool]$changedDepFiles
 
-if ($depsChanged -and -not $Link) {
-  Write-Host 'node_modules  branch changes dependencies - installing in isolation'
+# Uncommitted dependency edits count too (#404). The committed check above only
+# sees `origin/main...HEAD`, so it is blind for the whole window between
+# editing package.json and committing it -- which is exactly when the risk is
+# live, because that is when you reach for `npm install`. It also made
+# CLAUDE.md's documented recovery ("re-run the bootstrap if you need to change
+# dependencies in a worktree that's already linked") a silent no-op: the re-run
+# saw no committed change and happily re-confirmed the junction.
+$dirtyDepFiles = git status --porcelain -- package.json package-lock.json
+if ($LASTEXITCODE -ne 0) {
+  Write-Error 'git status on package.json failed - cannot determine whether this worktree has uncommitted dependency edits.'
+  exit 1
+}
+$uncommittedDepChange = [bool]$dirtyDepFiles
+
+$depsChanged = $committedDepChange -or $uncommittedDepChange
+
+if ($Isolate -and $Link) {
+  Write-Error '-Isolate and -Link are contradictory: one forces a real install, the other forces the shared junction. Pass at most one.'
+  exit 1
+}
+
+if (($depsChanged -or $Isolate) -and -not $Link) {
+  # Name the trigger: three different conditions land here, and "why is this
+  # taking two minutes" is the first question when it fires unexpectedly.
+  $reason =
+    if ($Isolate) { '-Isolate requested' }
+    elseif ($committedDepChange) { 'branch changes dependencies' }
+    else { 'uncommitted dependency edits' }
+  Write-Host "node_modules  $reason - installing in isolation"
   $existing = if (Test-Path $dstModules) { Get-Item $dstModules -Force } else { $null }
   if ($existing -and $existing.LinkType -eq 'Junction') {
     # Never Remove-Item -Recurse a junction: it deletes the TARGET.
     cmd /c rmdir "$dstModules" | Out-Null
   }
-  # `ci` not `install`: honours the lockfile the branch is actually changing.
-  npm ci --prefix "$worktreeRoot"
+  # `ci` or `install`, depending on whether the lockfile can be trusted (#404).
+  #
+  # `npm ci` honours the lockfile exactly, which is right for a *committed*
+  # dependency change: the branch carries a coherent package.json + lock pair.
+  # But `ci` refuses outright when the two disagree, and mid-authoring they
+  # always do -- you have just added a dependency to package.json and the lock
+  # has not caught up. Running `ci` there fails with "package.json and
+  # package-lock.json are not in sync", leaving the worktree with no
+  # node_modules at all, which is a worse place than it started.
+  #
+  # So an uncommitted edit gets `install`, which updates the lock and is the
+  # command you actually wanted. It is safe here specifically because the
+  # junction has already been removed above -- that is the whole hazard this
+  # branch exists to avoid.
+  if ($uncommittedDepChange) {
+    Write-Host 'node_modules  uncommitted package.json - using `npm install` so the lockfile updates'
+    npm install --prefix "$worktreeRoot"
+    $installCmd = 'npm install'
+  }
+  else {
+    npm ci --prefix "$worktreeRoot"
+    $installCmd = 'npm ci'
+  }
   if ($LASTEXITCODE -ne 0) {
-    Write-Error 'npm ci failed - the worktree has no usable node_modules.'
+    Write-Error "$installCmd failed - the worktree has no usable node_modules."
     exit 1
   }
 }


### PR DESCRIPTION
## The problem

`worktree-init.ps1` decided junction-vs-real-install from the **committed** `package.json` diff. So on a branch that was *about* to add a dependency, there was nothing to detect — it junctioned, and the `npm install` that followed wrote **through** the link into the main checkout's `node_modules`.

That's not theoretical: it happened on #398, and the junction had to be unlinked by hand with `cmd /c rmdir` mid-task.

It also meant `CLAUDE.md`'s documented recovery — "if you need to change dependencies in a worktree that's already linked, re-run the bootstrap" — did nothing at all. Re-running saw the same clean committed diff and re-junctioned.

## Two triggers, because they cover different moments

**`-Isolate`** — you know up front you're adding a dependency. Skips the junction entirely.

**Working-tree detection** — you only realised afterwards. An uncommitted `package.json` / `package-lock.json` edit now unlinks and installs for real, which is what re-running the bootstrap was always supposed to do.

`-Isolate` and `-Link` contradict each other, so passing both is an error rather than a silent precedence rule.

## The part the issue didn't anticipate: `ci` vs `install`

The issue said "run `npm ci`". That would have failed on the exact case this exists for.

`npm ci` **refuses** when `package.json` and the lockfile disagree — and mid-authoring they always do, because you've just added a dependency and the lock hasn't caught up. Verified rather than assumed:

```
npm error `npm ci` can only install packages when your package.json and
npm error package-lock.json or npm-shrinkwrap.json are in sync.
```

A plain `ci` there would unlink the junction and then fail, leaving the worktree with **no `node_modules` at all** — worse than where it started. So the command matches the situation:

| situation | command | why |
|---|---|---|
| committed dependency change | `npm ci` | branch carries a coherent `package.json` + lock |
| uncommitted `package.json` edit | `npm install` | lock hasn't caught up; `ci` refuses |
| `-Isolate`, clean tree | `npm ci` | nothing changed yet — install the lock, then add your package |

`npm install` is safe here specifically because the junction is already removed by that point — that's the entire hazard, and it's gone before npm runs.

## Verified by running all four paths

In a throwaway worktree off `origin/main`, checking the main checkout's install after each (**474 top-level dirs**, constant throughout):

| path | result |
|---|---|
| clean tree, no flags | `Junction` → `C:\Users\lucas\git\personal_website\node_modules` |
| `-Isolate`, clean tree | `-Isolate requested` → `npm ci`, 669 packages, **real directory** |
| uncommitted dep edit | `uncommitted dependency edits` → `npm install`, 672 packages, **real directory** |
| `-Isolate -Link` | refused: *"-Isolate and -Link are contradictory"* |

The third is the #398 scenario end to end. The junction was replaced with a real install, the new package landed **in the worktree**, the lockfile updated, and — the thing that actually matters:

```
main intact  : 474 (was 474)
main is-odd  : False   <- no bleed into the shared install
```

## Scope

Three files, no TypeScript: `scripts/worktree-init.ps1`, `scripts/README.md`, `CLAUDE.md`. The README gains an "Adding a dependency" section with the decision table; `CLAUDE.md`'s recovery sentence is now true.

Gates still run: `tsc` clean, `eslint` clean, `format:check` clean, **1977 unit tests (152 files)** — re-run after rebasing onto #402, so its 22 new tests are included.

## Test plan

- [ ] `git worktree add /tmp/probe -b probe origin/main`, then `powershell -File scripts/worktree-init.ps1` — `node_modules` is a **junction**
- [ ] Add any dependency to that worktree's `package.json`, don't touch the lock, re-run the bootstrap — it reports `uncommitted dependency edits`, uses `npm install`, and `node_modules` becomes a **real directory**
- [ ] Confirm the new package is in the worktree and **not** in the main checkout's `node_modules`
- [ ] `powershell -File scripts/worktree-init.ps1 -Isolate -Link` — errors out
- [ ] After each, the main checkout's `node_modules` still has its full install (`npm ls server-only` resolves)
- [ ] Clean up with `scripts/worktree-remove.ps1`

Note for cleanup: a worktree with a *real* `node_modules` can exceed MAX_PATH on removal. `robocopy <empty-dir> <worktree>\node_modules /MIR` clears it first — that's how the probes here were torn down.

Closes #404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
