### PR TITLE
feat(weight-room): live workout recording — start from a template, swap, add, end (#376)

### DIFF
--- a/app/api/admin/weight-room/sets/[id]/route.ts
+++ b/app/api/admin/weight-room/sets/[id]/route.ts
@@ -1,12 +1,18 @@
 /**
- * Admin-only item endpoint for Weight Room set deletion (#79). Sibling
- * of the collection POST — same admin gate, same service-role client.
- * Used by the Today View's swipe-to-delete / undo affordance.
+ * Admin-only item endpoints for a Weight Room set (#79, #376) — correct one,
+ * and delete one. Sibling of the collection POST: same admin gate, same
+ * service-role client.
+ *
+ * PATCH exists because correcting a typo previously meant delete-and-re-enter,
+ * which silently loses the set's `logged_at` and, inside a workout, its place
+ * in the order. Mid-lift that is exactly the wrong trade.
  */
 
 import { NextResponse, type NextRequest } from 'next/server'
+import { ZodError } from 'zod'
 
 import { requireAdmin } from '@/lib/auth/require-admin'
+import { WeightRoomSetUpdateSchema } from '@/lib/schemas/weight-room'
 import { createAdminSupabaseClient } from '@/lib/supabase/admin'
 import { withTelemetry } from '@/lib/telemetry/with-telemetry'
 
@@ -64,6 +70,94 @@ async function handleDELETE(_request: NextRequest, ctx: Context): Promise<NextRe
   }
   return NextResponse.json(data, { status: 200 })
 }
+
+/**
+ * Correct one strength set. Body must conform to
+ * {@link WeightRoomSetUpdateSchema} — every field optional, at least one
+ * required.
+ *
+ * `weight_lbs` and `variant` accept an explicit `null` to clear them, so a set
+ * logged as weighted by mistake can become a bodyweight set again. An omitted
+ * key always means "leave alone".
+ *
+ * Deliberately cannot move a set between workouts or slots: those links are
+ * the record of where the set was performed, and a typo in the reps is not a
+ * reason to let a fat finger re-attribute it.
+ *
+ * Status codes:
+ * - 200 — updated (response echoes the row)
+ * - 400 — malformed id, invalid JSON, or failed Zod validation
+ * - 401 / 403 — not signed in / not on the allowlist
+ * - 404 — no set for `id`
+ * - 409 — `exercise` isn't in the movement catalog
+ * - 500 — unexpected Supabase error
+ *
+ * @param request Incoming JSON request matching {@link WeightRoomSetUpdateSchema}.
+ * @param ctx Next.js route context; `ctx.params.id` is the set's UUID.
+ * @throws when Supabase env vars are missing (misconfigured deploy).
+ */
+async function handlePATCH(request: NextRequest, ctx: Context): Promise<NextResponse> {
+  const auth = await requireAdmin()
+  if (!auth.ok) return auth.response
+
+  const { id } = await ctx.params
+  if (!UUID_REGEX.test(id)) {
+    return NextResponse.json({ error: 'id must be a UUID.' }, { status: 400 })
+  }
+
+  let payload: unknown
+  try {
+    payload = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Body must be valid JSON.' }, { status: 400 })
+  }
+
+  let patch
+  try {
+    patch = WeightRoomSetUpdateSchema.parse(payload)
+  } catch (err) {
+    if (err instanceof ZodError) {
+      return NextResponse.json(
+        { error: 'Validation failed.', issues: err.flatten() },
+        { status: 400 }
+      )
+    }
+    throw err
+  }
+
+  // Zod's transforms materialize every key, so an omitted field arrives as
+  // `undefined`. Strip those or "leave alone" becomes indistinguishable from
+  // "clear" — the distinction the nullable fields above exist to preserve.
+  const changes: Record<string, unknown> = { updated_at: new Date().toISOString() }
+  for (const [key, value] of Object.entries(patch)) {
+    if (value !== undefined) changes[key] = value
+  }
+
+  const supabase = createAdminSupabaseClient()
+  const { data, error } = await supabase
+    .from('weight_room_sets')
+    .update(changes)
+    .eq('id', id)
+    .select()
+    .maybeSingle()
+
+  if (error) {
+    if (error.code === '23503') {
+      return NextResponse.json(
+        { error: 'That exercise is not in the movement catalog.' },
+        { status: 409 }
+      )
+    }
+    return NextResponse.json({ error: `Failed to update set: ${error.message}` }, { status: 500 })
+  }
+  if (!data) {
+    return NextResponse.json({ error: `No set for id '${id}'.` }, { status: 404 })
+  }
+  return NextResponse.json(data, { status: 200 })
+}
+
+/** `handlePATCH` wrapped with one-event-per-request telemetry (#220). */
+export const PATCH = withTelemetry('PATCH /api/admin/weight-room/sets/[id]', handlePATCH)
 
 /** `handleDELETE` wrapped with one-event-per-request telemetry (#220). */
 export const DELETE = withTelemetry('DELETE /api/admin/weight-room/sets/[id]', handleDELETE)

--- a/app/api/admin/weight-room/sets/route.ts
+++ b/app/api/admin/weight-room/sets/route.ts
@@ -72,11 +72,15 @@ async function handlePOST(request: NextRequest): Promise<NextResponse> {
     // than writing an empty-string bucket the History View would have
     // to special-case.
     ...(entry.variant != null ? { variant: entry.variant } : {}),
+    // External load, per implement (#376). Absent leaves the column null,
+    // which is what makes a set bodyweight.
+    ...(entry.weight_lbs != null ? { weight_lbs: entry.weight_lbs } : {}),
     // Session membership (#374), only when the caller asked for it. There is
     // deliberately no "attach to whatever workout is open" fallback: a
     // grease-the-groove set logged during a gym window must stay loose.
     ...(entry.workout_id != null ? { workout_id: entry.workout_id } : {}),
     ...(entry.position != null ? { position: entry.position } : {}),
+    ...(entry.template_slot_id != null ? { template_slot_id: entry.template_slot_id } : {}),
   }
   const { data, error } = await supabase
     .from('weight_room_sets')
@@ -92,6 +96,12 @@ async function handlePOST(request: NextRequest): Promise<NextResponse> {
     // since the exercise one is the far more common case and reads as the
     // sensible default.
     if (error.code === '23503') {
+      if (error.message.includes('template_slot_id')) {
+        return NextResponse.json(
+          { error: `Template slot '${entry.template_slot_id}' does not exist.` },
+          { status: 409 }
+        )
+      }
       if (error.message.includes('workout_id')) {
         return NextResponse.json(
           { error: `Workout '${entry.workout_id}' does not exist.` },

--- a/app/api/admin/weight-room/workouts/[id]/route.ts
+++ b/app/api/admin/weight-room/workouts/[id]/route.ts
@@ -23,7 +23,7 @@ interface Context {
 }
 
 /** Columns echoed back by both handlers, matching `WeightRoomWorkoutRowSchema`. */
-const WORKOUT_COLUMNS = 'id, started_at, ended_at, title, location, notes'
+const WORKOUT_COLUMNS = 'id, started_at, ended_at, template_id, title, location, notes'
 
 /** Postgres `invalid_text_representation` — a route segment that isn't a UUID. */
 const INVALID_UUID = '22P02'

--- a/app/api/admin/weight-room/workouts/route.ts
+++ b/app/api/admin/weight-room/workouts/route.ts
@@ -26,7 +26,7 @@ import {
 } from '@/lib/training-facility/workout-sessions'
 
 /** Columns returned by both handlers, matching `WeightRoomWorkoutRowSchema`. */
-const WORKOUT_COLUMNS = 'id, started_at, ended_at, title, location, notes'
+const WORKOUT_COLUMNS = 'id, started_at, ended_at, template_id, title, location, notes'
 
 /** How many sessions `GET` returns without `?open=true`. */
 const DEFAULT_LIMIT = 50
@@ -184,6 +184,7 @@ async function handlePOST(request: NextRequest): Promise<NextResponse> {
   const insertRow = {
     started_at: startedAt,
     ...(entry.ended_at != null ? { ended_at: entry.ended_at } : {}),
+    ...(entry.template_id != null ? { template_id: entry.template_id } : {}),
     ...(entry.title != null ? { title: entry.title } : {}),
     ...(entry.location != null ? { location: entry.location } : {}),
     ...(entry.notes != null ? { notes: entry.notes } : {}),

--- a/app/training-facility/weight-room/log/page.tsx
+++ b/app/training-facility/weight-room/log/page.tsx
@@ -6,6 +6,7 @@ import { FacilityBackLink } from '@/components/training-facility/FacilityBackLin
 import { LogDataIsland } from '@/components/training-facility/weight-room/LogDataIsland'
 import { WeightRoomSubNav } from '@/components/training-facility/weight-room/WeightRoomSubNav'
 import { requireAdminPage } from '@/lib/auth/require-admin-page'
+import { getWorkoutTemplatesServer } from '@/lib/data/weight-room-server'
 import { isWeightRoomEnabled } from '@/lib/feature-flags'
 
 /**
@@ -26,6 +27,12 @@ import { isWeightRoomEnabled } from '@/lib/feature-flags'
 export default async function WeightRoomLogPage(): Promise<JSX.Element> {
   if (!isWeightRoomEnabled()) notFound()
   await requireAdminPage()
+
+  // Templates are read server-side and handed down (#376) so the live panel
+  // doesn't add a client round trip on mount. A read failure degrades to
+  // "freestyle only" rather than failing the page — you can still start a
+  // workout and log into it without a prescription.
+  const templates = await getWorkoutTemplatesServer().catch(() => [])
 
   return (
     <div className="relative min-h-svh overflow-hidden bg-[#120d0a] text-[#f7ead9]">
@@ -55,7 +62,7 @@ export default async function WeightRoomLogPage(): Promise<JSX.Element> {
         </header>
 
         <section className="mt-10 flex-1">
-          <LogDataIsland />
+          <LogDataIsland templates={templates} />
         </section>
       </div>
     </div>

--- a/components/training-facility/weight-room/LiveWorkoutPanel.tsx
+++ b/components/training-facility/weight-room/LiveWorkoutPanel.tsx
@@ -1,0 +1,602 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useState, type JSX } from 'react'
+
+import { buildExerciseLabels, slugLabel } from '@/lib/training-facility/exercise-labels'
+import {
+  buildSlotProgress,
+  extraSets,
+  nextSetDefaults,
+  nextSetPosition,
+  type SlotProgress,
+} from '@/lib/training-facility/live-workout'
+import { formatSlotPrescription } from '@/lib/training-facility/template-format'
+import { workoutDurationMinutes } from '@/lib/training-facility/workout-sessions'
+import type {
+  StrengthSet,
+  WeightRoomExercise,
+  WeightRoomWorkout,
+  WorkoutTemplate,
+} from '@/types/weight-room'
+
+/** Props for {@link LiveWorkoutPanel}. */
+export interface LiveWorkoutPanelProps {
+  /**
+   * Every logged set, from the parent island's single read. The panel filters
+   * to the open workout rather than fetching its own copy, so the set list
+   * below it and the panel can never disagree about what was just logged.
+   */
+  sets: readonly StrengthSet[]
+  /** The movement catalog, for swaps and added movements. Archived filtered out by the caller. */
+  exercises: readonly WeightRoomExercise[]
+  /** Templates available to start from. Archived filtered out by the caller. */
+  templates: readonly WorkoutTemplate[]
+  /** Whether a write is in flight elsewhere on the page. */
+  disabled: boolean
+  /** Called after any successful write so the parent refetches. */
+  onChanged: () => void | Promise<void>
+}
+
+/**
+ * The live workout surface (#376) — start from a template, then log, swap, add,
+ * and end.
+ *
+ * Sits **above** the grease-the-groove dashboard rather than replacing it, so a
+ * desk pushup set mid-session is still one tap. That matters more than it
+ * sounds: pull-ups and push-ups appear in the templates *and* in the daily
+ * rings, and forcing a choice between them would make one of the two wrong.
+ *
+ * Every set POSTs immediately — the server is the source of truth and a reload
+ * resumes the open session with everything intact. A failed write surfaces on
+ * the set it belongs to and is retryable, rather than being swallowed or
+ * escalated to a page-level error. There is deliberately no offline queue.
+ */
+export function LiveWorkoutPanel({
+  sets,
+  exercises,
+  templates,
+  disabled,
+  onChanged,
+}: LiveWorkoutPanelProps): JSX.Element {
+  const [workout, setWorkout] = useState<WeightRoomWorkout | null | undefined>(undefined)
+  const [error, setError] = useState<string | null>(null)
+  const [busy, setBusy] = useState(false)
+  const [templateId, setTemplateId] = useState<string>('')
+
+  // Built from the roster rather than from goals: a gym movement has no daily
+  // goal at all, so a goal-derived lookup would render every one of them as a
+  // raw slug.
+  const labels = useMemo(() => buildExerciseLabels(exercises), [exercises])
+
+  /**
+   * Ask the server whether a session is already open. Returns the value rather
+   * than setting state, so the mount effect can drop a late response after
+   * unmount instead of writing to a gone component.
+   */
+  const fetchOpen = useCallback(async (): Promise<WeightRoomWorkout | null> => {
+    try {
+      const res = await fetch('/api/admin/weight-room/workouts?open=true')
+      if (!res.ok) return null
+      return (await res.json()) as WeightRoomWorkout | null
+    } catch {
+      // A failed probe isn't the same as "no session", but there's nothing
+      // useful to render either way and the retry is a page reload.
+      return null
+    }
+  }, [])
+
+  useEffect(() => {
+    let cancelled = false
+    fetchOpen().then(open => {
+      if (!cancelled) setWorkout(open)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [fetchOpen])
+
+  /** Sets belonging to the open session, oldest first. */
+  const workoutSets = useMemo(() => {
+    if (!workout) return []
+    return sets
+      .filter(set => set.workout_id === workout.id)
+      .sort((a, b) => (a.position ?? 0) - (b.position ?? 0))
+  }, [sets, workout])
+
+  /** The template this session is running, if it named one we still have. */
+  const template = useMemo(() => {
+    if (!workout?.title) return null
+    return templates.find(t => t.name === workout.title) ?? null
+  }, [templates, workout])
+
+  const progress = useMemo(() => buildSlotProgress(template, workoutSets), [template, workoutSets])
+  const extras = useMemo(() => extraSets(workoutSets), [workoutSets])
+
+  async function post(url: string, init: RequestInit, fallback: string): Promise<boolean> {
+    setError(null)
+    setBusy(true)
+    try {
+      const res = await fetch(url, {
+        ...init,
+        headers: { 'Content-Type': 'application/json', ...(init.headers ?? {}) },
+      })
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { error?: string }
+        setError(body.error ?? `${fallback} (${res.status})`)
+        return false
+      }
+      return true
+    } catch {
+      setError(`${fallback} — the request didn't reach the server. Try again.`)
+      return false
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function startWorkout(): Promise<void> {
+    const chosen = templates.find(t => t.id === templateId)
+    const ok = await post(
+      '/api/admin/weight-room/workouts',
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          location: 'gym',
+          ...(chosen ? { title: chosen.name } : {}),
+        }),
+      },
+      'Could not start the workout'
+    )
+    if (ok) {
+      setWorkout(await fetchOpen())
+      await onChanged()
+    }
+  }
+
+  async function endWorkout(): Promise<void> {
+    if (!workout) return
+    const ok = await post(
+      `/api/admin/weight-room/workouts/${workout.id}`,
+      { method: 'PATCH', body: JSON.stringify({ ended_at: new Date().toISOString() }) },
+      'Could not end the workout'
+    )
+    if (ok) {
+      setWorkout(null)
+      await onChanged()
+    }
+  }
+
+  async function logSet(
+    exercise: string,
+    reps: number,
+    weightLbs: number | null,
+    slotId: string | null
+  ): Promise<void> {
+    if (!workout) return
+    const ok = await post(
+      '/api/admin/weight-room/sets',
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          exercise,
+          reps,
+          workout_id: workout.id,
+          position: nextSetPosition(workoutSets),
+          ...(weightLbs != null ? { weight_lbs: weightLbs } : {}),
+          ...(slotId != null ? { template_slot_id: slotId } : {}),
+        }),
+      },
+      'Could not log the set'
+    )
+    if (ok) await onChanged()
+  }
+
+  async function deleteSet(id: string): Promise<void> {
+    const ok = await post(
+      `/api/admin/weight-room/sets/${id}`,
+      { method: 'DELETE' },
+      'Could not remove the set'
+    )
+    if (ok) await onChanged()
+  }
+
+  if (workout === undefined) {
+    return (
+      <div className="rounded-[1.1rem] border border-white/10 bg-white/5 px-4 py-3 font-mono text-[11px] uppercase tracking-[0.18em] text-white/40">
+        Checking for an open workout…
+      </div>
+    )
+  }
+
+  if (workout === null) {
+    return (
+      <section
+        aria-label="Start a workout"
+        className="rounded-[1.1rem] border border-white/10 bg-white/5 p-4"
+      >
+        {error ? <ErrorLine message={error} /> : null}
+        <div className="flex flex-wrap items-end gap-3">
+          <label className="flex min-w-0 flex-1 flex-col gap-1 text-xs text-white/70">
+            <span className="font-mono uppercase tracking-[0.18em]">start a workout</span>
+            <select
+              value={templateId}
+              onChange={e => setTemplateId(e.target.value)}
+              className="rounded border border-white/15 bg-black/40 px-2 py-2 font-mono text-sm text-white focus:border-amber-300/60 focus:outline-none"
+            >
+              <option value="" className="bg-[#120d0a]">
+                — no template, freestyle —
+              </option>
+              {templates.map(t => (
+                <option key={t.id} value={t.id} className="bg-[#120d0a]">
+                  {t.name}
+                </option>
+              ))}
+            </select>
+          </label>
+          <button
+            type="button"
+            disabled={disabled || busy}
+            onClick={() => void startWorkout()}
+            className="rounded-full border border-amber-200/40 bg-amber-200/15 px-6 py-2.5 font-mono text-[12px] uppercase tracking-[0.22em] text-amber-100 transition hover:bg-amber-200/25 disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            Start
+          </button>
+        </div>
+      </section>
+    )
+  }
+
+  const minutes = workoutDurationMinutes({
+    started_at: workout.started_at,
+    ended_at: new Date().toISOString(),
+  })
+
+  return (
+    <section
+      aria-label="Live workout"
+      className="rounded-[1.1rem] border border-amber-300/30 bg-amber-300/5 p-4"
+    >
+      {error ? <ErrorLine message={error} /> : null}
+
+      <header className="flex flex-wrap items-center gap-x-3 gap-y-1">
+        <span className="rounded-full bg-amber-300/20 px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.2em] text-amber-100">
+          live
+        </span>
+        <span className="text-sm font-semibold text-white">
+          {workout.title ?? 'Freestyle workout'}
+        </span>
+        <span className="font-mono text-[11px] text-white/50">
+          {minutes ?? 0} min · {workoutSets.length} {workoutSets.length === 1 ? 'set' : 'sets'}
+        </span>
+        <button
+          type="button"
+          disabled={disabled || busy}
+          onClick={() => void endWorkout()}
+          className="ml-auto rounded-full border border-white/25 bg-white/5 px-4 py-1.5 font-mono text-[11px] uppercase tracking-[0.22em] text-white/85 transition hover:bg-white/15 disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          End
+        </button>
+      </header>
+
+      {progress.length > 0 ? (
+        <ul className="mt-4 space-y-2">
+          {progress.map(entry => (
+            <SlotCard
+              key={entry.slot.id}
+              entry={entry}
+              exercises={exercises}
+              labels={labels}
+              disabled={disabled || busy}
+              onLog={logSet}
+              onDeleteSet={deleteSet}
+            />
+          ))}
+        </ul>
+      ) : (
+        <p className="mt-4 text-sm text-white/50">
+          No template — log whatever you do below and it all counts as this workout.
+        </p>
+      )}
+
+      {extras.length > 0 ? (
+        <div className="mt-4">
+          <h4 className="font-mono text-[10px] uppercase tracking-[0.2em] text-white/40">
+            Extra work
+          </h4>
+          <ul className="mt-1 space-y-1">
+            {extras.map(set => (
+              <li
+                key={set.id}
+                className="flex items-center gap-2 font-mono text-[11px] text-white/60"
+              >
+                <span>{slugLabel(set.exercise, undefined, labels)}</span>
+                <span className="text-white/40">
+                  {set.reps}
+                  {set.weight_lbs != null ? ` × ${set.weight_lbs} lb` : ''}
+                </span>
+                <button
+                  type="button"
+                  aria-label="Remove set"
+                  disabled={disabled || busy}
+                  onClick={() => void deleteSet(set.id)}
+                  className="ml-auto px-1 text-white/40 transition hover:text-rose-300 disabled:opacity-30"
+                >
+                  ✕
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
+      <AddMovement
+        exercises={exercises}
+        disabled={disabled || busy}
+        onLog={(exercise, reps, weight) => logSet(exercise, reps, weight, null)}
+      />
+    </section>
+  )
+}
+
+/** Inline, retryable failure line. Never escalates to a page-level error. */
+function ErrorLine({ message }: { message: string }): JSX.Element {
+  return (
+    <p
+      role="alert"
+      className="mb-3 rounded border border-rose-400/30 bg-rose-950/40 px-3 py-2 font-mono text-[11px] text-rose-200"
+    >
+      {message}
+    </p>
+  )
+}
+
+interface SlotCardProps {
+  entry: SlotProgress
+  exercises: readonly WeightRoomExercise[]
+  /** Slug → display-name lookup, built from the roster by the parent. */
+  labels: ReturnType<typeof buildExerciseLabels>
+  disabled: boolean
+  onLog: (
+    exercise: string,
+    reps: number,
+    weightLbs: number | null,
+    slotId: string | null
+  ) => Promise<void>
+  onDeleteSet: (id: string) => Promise<void>
+}
+
+function SlotCard({
+  entry,
+  exercises,
+  labels,
+  disabled,
+  onLog,
+  onDeleteSet,
+}: SlotCardProps): JSX.Element {
+  const { slot, sets, logged, performedExercise, isSubstituted, isComplete } = entry
+  const defaults = nextSetDefaults(slot, sets)
+  const [reps, setReps] = useState<string>(defaults.reps?.toString() ?? '')
+  const [weight, setWeight] = useState<string>(defaults.weight_lbs?.toString() ?? '')
+  const [swapOpen, setSwapOpen] = useState(false)
+  const [exercise, setExercise] = useState(performedExercise)
+
+  // The alternates first, then everything else — the whole point of declaring
+  // them is that the common swap is one tap rather than a search.
+  const swapOptions = useMemo(() => {
+    const preferred = slot.alternates.map(a => a.exercise)
+    const rest = exercises
+      .map(e => e.slug)
+      .filter(slug => slug !== slot.exercise && !preferred.includes(slug))
+    return [slot.exercise, ...preferred, ...rest]
+  }, [exercises, slot])
+
+  async function handleLog(): Promise<void> {
+    const repsValue = Number(reps)
+    if (!Number.isFinite(repsValue) || repsValue < 1) return
+    const weightValue = weight.trim() === '' ? null : Number(weight)
+    await onLog(
+      exercise,
+      repsValue,
+      weightValue != null && Number.isFinite(weightValue) ? weightValue : null,
+      slot.id
+    )
+  }
+
+  return (
+    <li
+      className={`rounded-[0.9rem] border p-3 ${
+        isComplete ? 'border-emerald-300/25 bg-emerald-300/5' : 'border-white/10 bg-black/25'
+      }`}
+    >
+      <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
+        <span className="text-sm text-white">
+          {slugLabel(performedExercise, undefined, labels)}
+        </span>
+        {isSubstituted ? (
+          <span className="rounded-full border border-amber-200/30 bg-amber-200/10 px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.12em] text-amber-100">
+            swapped from {slugLabel(slot.exercise, undefined, labels)}
+          </span>
+        ) : null}
+        <span className="ml-auto font-mono text-[11px] text-white/50">
+          {logged} / {slot.target_sets}
+          {slot.target_sets_max != null && slot.target_sets_max !== slot.target_sets
+            ? `-${slot.target_sets_max}`
+            : ''}
+        </span>
+      </div>
+      <p className="mt-0.5 font-mono text-[11px] text-white/35">
+        {formatSlotPrescription(slot)}
+        {slot.notes ? ` · ${slot.notes}` : ''}
+      </p>
+
+      {sets.length > 0 ? (
+        <ul className="mt-2 flex flex-wrap gap-1.5">
+          {sets.map((set, index) => (
+            <li key={set.id}>
+              <button
+                type="button"
+                aria-label={`Remove set ${index + 1}`}
+                disabled={disabled}
+                onClick={() => void onDeleteSet(set.id)}
+                title="Tap to remove"
+                className="rounded border border-white/15 bg-white/5 px-2 py-1 font-mono text-[11px] text-white/70 transition hover:border-rose-300/40 hover:text-rose-200 disabled:opacity-30"
+              >
+                {set.reps}
+                {set.weight_lbs != null ? `×${set.weight_lbs}` : ''}
+              </button>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+
+      <div className="mt-2 flex flex-wrap items-end gap-2">
+        <label className="flex flex-col gap-0.5 text-[10px] text-white/50">
+          <span className="font-mono uppercase tracking-[0.14em]">reps</span>
+          <input
+            type="number"
+            inputMode="numeric"
+            min={1}
+            value={reps}
+            onChange={e => setReps(e.target.value)}
+            className="w-16 rounded border border-white/15 bg-black/40 px-2 py-1.5 text-right font-mono text-sm text-white focus:border-amber-300/60 focus:outline-none"
+          />
+        </label>
+        <label className="flex flex-col gap-0.5 text-[10px] text-white/50">
+          <span className="font-mono uppercase tracking-[0.14em]">lb</span>
+          <input
+            type="number"
+            inputMode="decimal"
+            min={0}
+            value={weight}
+            onChange={e => setWeight(e.target.value)}
+            placeholder="bw"
+            className="w-20 rounded border border-white/15 bg-black/40 px-2 py-1.5 text-right font-mono text-sm text-white focus:border-amber-300/60 focus:outline-none"
+          />
+        </label>
+        <button
+          type="button"
+          disabled={disabled || reps.trim() === ''}
+          onClick={() => void handleLog()}
+          className="rounded-full border border-amber-200/40 bg-amber-200/15 px-5 py-2 font-mono text-[11px] uppercase tracking-[0.2em] text-amber-100 transition hover:bg-amber-200/25 disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          Log set
+        </button>
+        <button
+          type="button"
+          disabled={disabled}
+          onClick={() => setSwapOpen(!swapOpen)}
+          className="ml-auto rounded-full border border-white/20 px-3 py-1.5 font-mono text-[10px] uppercase tracking-[0.18em] text-white/60 transition hover:bg-white/10 disabled:opacity-40"
+        >
+          Swap
+        </button>
+      </div>
+
+      {swapOpen ? (
+        <label className="mt-2 flex flex-col gap-1 text-[10px] text-white/50">
+          <span className="font-mono uppercase tracking-[0.14em]">perform this slot with</span>
+          <select
+            value={exercise}
+            onChange={e => {
+              setExercise(e.target.value)
+              setSwapOpen(false)
+            }}
+            className="rounded border border-white/15 bg-black/40 px-2 py-1.5 font-mono text-xs text-white focus:border-amber-300/60 focus:outline-none"
+          >
+            {swapOptions.map(slug => (
+              <option key={slug} value={slug} className="bg-[#120d0a]">
+                {slugLabel(slug, undefined, labels)}
+                {slug === slot.exercise ? ' (prescribed)' : ''}
+                {slot.alternates.some(a => a.exercise === slug) ? ' — alternate' : ''}
+              </option>
+            ))}
+          </select>
+        </label>
+      ) : null}
+    </li>
+  )
+}
+
+interface AddMovementProps {
+  exercises: readonly WeightRoomExercise[]
+  disabled: boolean
+  onLog: (exercise: string, reps: number, weightLbs: number | null) => Promise<void>
+}
+
+function AddMovement({ exercises, disabled, onLog }: AddMovementProps): JSX.Element {
+  const [open, setOpen] = useState(false)
+  const [exercise, setExercise] = useState(exercises[0]?.slug ?? '')
+  const [reps, setReps] = useState('')
+  const [weight, setWeight] = useState('')
+
+  if (!open) {
+    return (
+      <button
+        type="button"
+        disabled={disabled}
+        onClick={() => setOpen(true)}
+        className="mt-4 rounded-full border border-white/20 px-4 py-1.5 font-mono text-[10px] uppercase tracking-[0.18em] text-white/70 transition hover:bg-white/10 disabled:opacity-40"
+      >
+        + add movement
+      </button>
+    )
+  }
+
+  return (
+    <div className="mt-4 grid gap-2 rounded border border-white/10 bg-black/25 p-3 sm:grid-cols-[1fr_auto_auto_auto]">
+      <label className="flex flex-col gap-0.5 text-[10px] text-white/50">
+        <span className="font-mono uppercase tracking-[0.14em]">movement</span>
+        <select
+          value={exercise}
+          onChange={e => setExercise(e.target.value)}
+          className="rounded border border-white/15 bg-black/40 px-2 py-1.5 font-mono text-xs text-white focus:border-amber-300/60 focus:outline-none"
+        >
+          {exercises.map(e => (
+            <option key={e.slug} value={e.slug} className="bg-[#120d0a]">
+              {e.display_name}
+            </option>
+          ))}
+        </select>
+      </label>
+      <label className="flex flex-col gap-0.5 text-[10px] text-white/50">
+        <span className="font-mono uppercase tracking-[0.14em]">reps</span>
+        <input
+          type="number"
+          inputMode="numeric"
+          min={1}
+          value={reps}
+          onChange={e => setReps(e.target.value)}
+          className="w-16 rounded border border-white/15 bg-black/40 px-2 py-1.5 text-right font-mono text-sm text-white focus:border-amber-300/60 focus:outline-none"
+        />
+      </label>
+      <label className="flex flex-col gap-0.5 text-[10px] text-white/50">
+        <span className="font-mono uppercase tracking-[0.14em]">lb</span>
+        <input
+          type="number"
+          inputMode="decimal"
+          min={0}
+          value={weight}
+          onChange={e => setWeight(e.target.value)}
+          placeholder="bw"
+          className="w-20 rounded border border-white/15 bg-black/40 px-2 py-1.5 text-right font-mono text-sm text-white focus:border-amber-300/60 focus:outline-none"
+        />
+      </label>
+      <button
+        type="button"
+        disabled={disabled || reps.trim() === '' || exercise === ''}
+        onClick={() => {
+          const repsValue = Number(reps)
+          if (!Number.isFinite(repsValue) || repsValue < 1) return
+          const weightValue = weight.trim() === '' ? null : Number(weight)
+          void onLog(
+            exercise,
+            repsValue,
+            weightValue != null && Number.isFinite(weightValue) ? weightValue : null
+          ).then(() => setReps(''))
+        }}
+        className="self-end rounded-full border border-amber-200/40 bg-amber-200/15 px-4 py-2 font-mono text-[11px] uppercase tracking-[0.2em] text-amber-100 transition hover:bg-amber-200/25 disabled:cursor-not-allowed disabled:opacity-40"
+      >
+        Log
+      </button>
+    </div>
+  )
+}

--- a/components/training-facility/weight-room/LiveWorkoutPanel.tsx
+++ b/components/training-facility/weight-room/LiveWorkoutPanel.tsx
@@ -103,16 +103,56 @@ export function LiveWorkoutPanel({
       .sort((a, b) => (a.position ?? 0) - (b.position ?? 0))
   }, [sets, workout])
 
-  /** The template this session is running, if it named one we still have. */
+  /**
+   * The template this session is running.
+   *
+   * By id. Matching on `title` resolves to the wrong template whenever two
+   * share a name — nothing constrains them to be unique — and loses the
+   * prescription entirely if one is renamed mid-session. The title fallback
+   * exists only for sessions started before `template_id` existed.
+   */
   const template = useMemo(() => {
-    if (!workout?.title) return null
+    if (!workout) return null
+    if (workout.template_id !== undefined) {
+      return templates.find(t => t.id === workout.template_id) ?? null
+    }
+    if (!workout.title) return null
     return templates.find(t => t.name === workout.title) ?? null
   }, [templates, workout])
 
   const progress = useMemo(() => buildSlotProgress(template, workoutSets), [template, workoutSets])
+
+  /**
+   * The most recent set of each movement across all history, for the first-set
+   * prefill. Most seeded slots prescribe sets but not reps, so without this the
+   * documented history fallback in `nextSetDefaults` is unreachable and every
+   * such slot opens with blank inputs.
+   */
+  const lastByExercise = useMemo(() => {
+    const map = new Map<string, StrengthSet>()
+    for (const set of sets) {
+      const seen = map.get(set.exercise)
+      if (seen === undefined || set.logged_at > seen.logged_at) map.set(set.exercise, set)
+    }
+    return map
+  }, [sets])
   const extras = useMemo(() => extraSets(workoutSets), [workoutSets])
 
-  async function post(url: string, init: RequestInit, fallback: string): Promise<boolean> {
+  /**
+   * Issue a write and hold the controls disabled until any follow-up settles.
+   *
+   * `after` runs *inside* the busy window on purpose. Clearing `busy` when the
+   * response lands but before the parent refetch completes re-enables the
+   * buttons while `workoutSets` still holds the pre-write list — a second tap
+   * in that gap computes the same `nextSetPosition`, and two sets end up
+   * sharing an index with an ambiguous performed order.
+   */
+  async function post(
+    url: string,
+    init: RequestInit,
+    fallback: string,
+    after?: () => void | Promise<void>
+  ): Promise<boolean> {
     setError(null)
     setBusy(true)
     try {
@@ -125,6 +165,7 @@ export function LiveWorkoutPanel({
         setError(body.error ?? `${fallback} (${res.status})`)
         return false
       }
+      await after?.()
       return true
     } catch {
       setError(`${fallback} — the request didn't reach the server. Try again.`)
@@ -142,15 +183,16 @@ export function LiveWorkoutPanel({
         method: 'POST',
         body: JSON.stringify({
           location: 'gym',
-          ...(chosen ? { title: chosen.name } : {}),
+          ...(chosen ? { template_id: chosen.id, title: chosen.name } : {}),
         }),
       },
-      'Could not start the workout'
+      'Could not start the workout',
+      async () => {
+        setWorkout(await fetchOpen())
+        await onChanged()
+      }
     )
-    if (ok) {
-      setWorkout(await fetchOpen())
-      await onChanged()
-    }
+    if (!ok) return
   }
 
   async function endWorkout(): Promise<void> {
@@ -158,12 +200,13 @@ export function LiveWorkoutPanel({
     const ok = await post(
       `/api/admin/weight-room/workouts/${workout.id}`,
       { method: 'PATCH', body: JSON.stringify({ ended_at: new Date().toISOString() }) },
-      'Could not end the workout'
+      'Could not end the workout',
+      async () => {
+        setWorkout(null)
+        await onChanged()
+      }
     )
-    if (ok) {
-      setWorkout(null)
-      await onChanged()
-    }
+    if (!ok) return
   }
 
   async function logSet(
@@ -171,9 +214,9 @@ export function LiveWorkoutPanel({
     reps: number,
     weightLbs: number | null,
     slotId: string | null
-  ): Promise<void> {
-    if (!workout) return
-    const ok = await post(
+  ): Promise<boolean> {
+    if (!workout) return false
+    return post(
       '/api/admin/weight-room/sets',
       {
         method: 'POST',
@@ -186,18 +229,19 @@ export function LiveWorkoutPanel({
           ...(slotId != null ? { template_slot_id: slotId } : {}),
         }),
       },
-      'Could not log the set'
+      'Could not log the set',
+      onChanged
     )
-    if (ok) await onChanged()
   }
 
   async function deleteSet(id: string): Promise<void> {
     const ok = await post(
       `/api/admin/weight-room/sets/${id}`,
       { method: 'DELETE' },
-      'Could not remove the set'
+      'Could not remove the set',
+      onChanged
     )
-    if (ok) await onChanged()
+    if (!ok) return
   }
 
   if (workout === undefined) {
@@ -286,6 +330,7 @@ export function LiveWorkoutPanel({
               entry={entry}
               exercises={exercises}
               labels={labels}
+              lastElsewhere={lastByExercise.get(entry.performedExercise) ?? null}
               disabled={disabled || busy}
               onLog={logSet}
               onDeleteSet={deleteSet}
@@ -355,13 +400,18 @@ interface SlotCardProps {
   exercises: readonly WeightRoomExercise[]
   /** Slug → display-name lookup, built from the roster by the parent. */
   labels: ReturnType<typeof buildExerciseLabels>
+  /**
+   * The most recent set of this movement from any earlier session, for the
+   * first-set prefill when the slot prescribes no reps.
+   */
+  lastElsewhere: StrengthSet | null
   disabled: boolean
   onLog: (
     exercise: string,
     reps: number,
     weightLbs: number | null,
     slotId: string | null
-  ) => Promise<void>
+  ) => Promise<boolean>
   onDeleteSet: (id: string) => Promise<void>
 }
 
@@ -369,12 +419,13 @@ function SlotCard({
   entry,
   exercises,
   labels,
+  lastElsewhere,
   disabled,
   onLog,
   onDeleteSet,
 }: SlotCardProps): JSX.Element {
   const { slot, sets, logged, performedExercise, isSubstituted, isComplete } = entry
-  const defaults = nextSetDefaults(slot, sets)
+  const defaults = nextSetDefaults(slot, sets, lastElsewhere)
   const [reps, setReps] = useState<string>(defaults.reps?.toString() ?? '')
   const [weight, setWeight] = useState<string>(defaults.weight_lbs?.toString() ?? '')
   const [swapOpen, setSwapOpen] = useState(false)
@@ -519,7 +570,8 @@ function SlotCard({
 interface AddMovementProps {
   exercises: readonly WeightRoomExercise[]
   disabled: boolean
-  onLog: (exercise: string, reps: number, weightLbs: number | null) => Promise<void>
+  /** Resolves `true` only when the write was confirmed by the server. */
+  onLog: (exercise: string, reps: number, weightLbs: number | null) => Promise<boolean>
 }
 
 function AddMovement({ exercises, disabled, onLog }: AddMovementProps): JSX.Element {
@@ -587,11 +639,16 @@ function AddMovement({ exercises, disabled, onLog }: AddMovementProps): JSX.Elem
           const repsValue = Number(reps)
           if (!Number.isFinite(repsValue) || repsValue < 1) return
           const weightValue = weight.trim() === '' ? null : Number(weight)
+          // Only clear on a confirmed write. Clearing regardless makes the
+          // advertised retryable failure useless — you'd have to remember the
+          // reps you just typed and enter them again.
           void onLog(
             exercise,
             repsValue,
             weightValue != null && Number.isFinite(weightValue) ? weightValue : null
-          ).then(() => setReps(''))
+          ).then(logged => {
+            if (logged) setReps('')
+          })
         }}
         className="self-end rounded-full border border-amber-200/40 bg-amber-200/15 px-4 py-2 font-mono text-[11px] uppercase tracking-[0.2em] text-amber-100 transition hover:bg-amber-200/25 disabled:cursor-not-allowed disabled:opacity-40"
       >

--- a/components/training-facility/weight-room/LogDataIsland.test.tsx
+++ b/components/training-facility/weight-room/LogDataIsland.test.tsx
@@ -181,6 +181,23 @@ describe('LogDataIsland — load states', () => {
   })
 })
 
+/**
+ * The set POST, found by URL rather than by call index.
+ *
+ * The live workout panel (#376) probes `GET /workouts?open=true` on mount, so
+ * `calls[0]` is no longer the write these assertions are about — and indexing
+ * blind would silently start asserting against the wrong request the next time
+ * anything else on the page fetches.
+ */
+function setPostCall(): [string, RequestInit] {
+  const call = fetchMock.mock.calls.find(
+    ([url, init]) =>
+      url === '/api/admin/weight-room/sets' && (init as RequestInit | undefined)?.method === 'POST'
+  )
+  if (!call) throw new Error('no POST to /api/admin/weight-room/sets was issued')
+  return [call[0] as string, call[1] as RequestInit]
+}
+
 describe('LogDataIsland — write orchestration', () => {
   it('stamps a backdated log with the selected day, not now', async () => {
     const user = userEvent.setup()
@@ -191,9 +208,9 @@ describe('LogDataIsland — write orchestration', () => {
     await user.click(await screen.findByTestId('quick-log-pullups-10'))
 
     await waitFor(() => expect(fetchMock).toHaveBeenCalled())
-    const [url, init] = fetchMock.mock.calls[0]
+    const [url, init] = setPostCall()
     expect(url).toBe('/api/admin/weight-room/sets')
-    const body = JSON.parse((init as RequestInit).body as string)
+    const body = JSON.parse(init.body as string)
     expect(body.exercise).toBe('pullups')
     expect(body.reps).toBe(10)
     // Pacific midday of the picked day (#319), so the set buckets back onto
@@ -209,7 +226,7 @@ describe('LogDataIsland — write orchestration', () => {
     await user.click(await screen.findByTestId('quick-log-pullups-10'))
 
     await waitFor(() => expect(fetchMock).toHaveBeenCalled())
-    const body = JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string)
+    const body = JSON.parse(setPostCall()[1].body as string)
     expect(body.logged_at).toBeUndefined()
   })
 

--- a/components/training-facility/weight-room/LogDataIsland.tsx
+++ b/components/training-facility/weight-room/LogDataIsland.tsx
@@ -18,9 +18,16 @@ import {
   toLocalDateKey,
   totalsByExercise,
 } from '@/lib/training-facility/strength-today'
-import type { ExerciseGoal, MonthlyFocus, StrengthSet, WeightRoomData } from '@/types/weight-room'
+import type {
+  ExerciseGoal,
+  MonthlyFocus,
+  StrengthSet,
+  WeightRoomData,
+  WorkoutTemplate,
+} from '@/types/weight-room'
 
 import { ActivityRings, type RingProgress } from './ActivityRings'
+import { LiveWorkoutPanel } from './LiveWorkoutPanel'
 import { LogDayPicker } from './LogDayPicker'
 import { MonthlyFocusCard } from './MonthlyFocusCard'
 import { QuickLog } from './QuickLog'
@@ -57,7 +64,17 @@ import {
  * monotonic request id keeps a slow mount fetch from clobbering fresh
  * post-write data.
  */
-export function LogDataIsland(): JSX.Element {
+/** Props for {@link LogDataIsland}. */
+export interface LogDataIslandProps {
+  /**
+   * Templates available to start a workout from (#376), server-fetched by the
+   * page. Passed in rather than fetched here so the panel doesn't add a second
+   * client round trip on every mount of an admin page that already reads a lot.
+   */
+  templates?: readonly WorkoutTemplate[]
+}
+
+export function LogDataIsland({ templates = [] }: LogDataIslandProps = {}): JSX.Element {
   const [data, setData] = useState<WeightRoomData | null | undefined>(undefined)
   // `loadError` is the "fetch threw" branch, distinct from `data === null`
   // (the "tables are genuinely empty" branch). Splitting them keeps a
@@ -133,6 +150,10 @@ export function LogDataIsland(): JSX.Element {
     monthly_focus: [],
   }
   const todayKey = toLocalDateKey(new Date())
+  // Pickers offer live movements and templates only; archived ones stay
+  // rendered wherever they're already referenced, they just aren't selectable.
+  const activeExercises = (surfaceData.exercises ?? []).filter(e => e.archived !== true)
+  const activeTemplates = templates.filter(t => t.archived !== true)
   // Display-only backfill flag. After a midnight rollover `selectedDay`
   // (set at mount) lags `todayKey` — that's intentional: the view stays
   // on the day the admin was logging against, now flagged as a backfill
@@ -199,6 +220,18 @@ export function LogDataIsland(): JSX.Element {
   return (
     <div className="flex flex-col gap-8">
       {loadError ? <LoadErrorBanner message={loadError} /> : null}
+
+      {/* Live recording (#376) sits above the grease-the-groove dashboard
+          rather than replacing it: pull-ups and push-ups are in the templates
+          *and* in the daily rings, so forcing a choice between the two
+          surfaces would make one of them wrong. */}
+      <LiveWorkoutPanel
+        sets={surfaceData.sets}
+        exercises={activeExercises}
+        templates={activeTemplates}
+        disabled={busy}
+        onChanged={refetch}
+      />
 
       <LogDayPicker selectedDay={selectedDay} todayKey={todayKey} onSelectDay={setSelectedDay} />
 

--- a/lib/data/weight-room-shared.ts
+++ b/lib/data/weight-room-shared.ts
@@ -64,7 +64,7 @@ const EXERCISES_TABLE = 'weight_room_exercises'
  * into a workout without another round trip.
  */
 const SETS_COLUMNS =
-  'id, logged_at, exercise, reps, weight_lbs, variant, workout_id, position, updated_at'
+  'id, logged_at, exercise, reps, weight_lbs, variant, workout_id, position, template_slot_id, updated_at'
 // `load_multiplier` deliberately absent (#373) — it moved to the catalog and is
 // joined on below. The goals column still exists (dropping it while the
 // deployed build still selected it would break the live read) but is dead.

--- a/lib/data/weight-room.test.ts
+++ b/lib/data/weight-room.test.ts
@@ -293,6 +293,56 @@ describe('getWeightRoomData', () => {
   })
 })
 
+describe('getWeightRoomData — slot attribution (#376)', () => {
+  it('carries template_slot_id through to the assembled set', async () => {
+    // The column has to be in SETS_COLUMNS, not just in the row schema.
+    // Without it every refetch silently strips the link, so a set logged
+    // against a slot immediately reappears as extra work and the slot's
+    // counter never leaves zero — the feature looks broken on the first set.
+    stubTable('weight_room_sets', [
+      {
+        id: '11111111-1111-4111-8111-111111111111',
+        logged_at: '2026-08-01T18:05:00Z',
+        exercise: 'barbell-bench-press',
+        reps: 5,
+        weight_lbs: 185,
+        workout_id: '22222222-2222-4222-8222-222222222222',
+        position: 0,
+        template_slot_id: '33333333-3333-4333-8333-333333333333',
+        updated_at: '2026-08-01T18:05:01Z',
+      },
+    ])
+    stubTable('weight_room_goals', [])
+
+    const data = await getWeightRoomData()
+
+    expect(data?.sets[0]).toMatchObject({
+      template_slot_id: '33333333-3333-4333-8333-333333333333',
+      weight_lbs: 185,
+    })
+  })
+
+  it('omits it for extra work rather than surfacing a null', async () => {
+    stubTable('weight_room_sets', [
+      {
+        id: '44444444-4444-4444-8444-444444444444',
+        logged_at: '2026-08-01T18:05:00Z',
+        exercise: 'pec-deck',
+        reps: 12,
+        workout_id: '22222222-2222-4222-8222-222222222222',
+        position: 1,
+        template_slot_id: null,
+        updated_at: '2026-08-01T18:05:01Z',
+      },
+    ])
+    stubTable('weight_room_goals', [])
+
+    const data = await getWeightRoomData()
+
+    expect(data?.sets[0]).not.toHaveProperty('template_slot_id')
+  })
+})
+
 describe('getWeightRoomData — session membership (#374)', () => {
   it('carries workout_id and position through to the assembled set', async () => {
     stubTable('weight_room_sets', [

--- a/lib/schemas/weight-room.ts
+++ b/lib/schemas/weight-room.ts
@@ -335,6 +335,7 @@ export const WeightRoomWorkoutRowSchema = z
     id: z.string().uuid(),
     started_at: z.string().min(1, 'started_at must be an ISO timestamp'),
     ended_at: z.string().nullable().optional(),
+    template_id: z.string().uuid().nullable().optional(),
     title: z.string().nullable().optional(),
     location: workoutLocation().nullable().optional(),
     notes: z.string().nullable().optional(),
@@ -355,6 +356,7 @@ export function workoutRowToWeightRoomWorkout(row: WeightRoomWorkoutRow): Weight
     id: row.id,
     started_at: row.started_at,
     ...(row.ended_at != null ? { ended_at: row.ended_at } : {}),
+    ...(row.template_id != null ? { template_id: row.template_id } : {}),
     ...(row.title != null && row.title !== '' ? { title: row.title } : {}),
     ...(row.location != null ? { location: row.location } : {}),
     ...(row.notes != null && row.notes !== '' ? { notes: row.notes } : {}),
@@ -416,6 +418,9 @@ export const WeightRoomWorkoutCreateSchema = z
   .object({
     started_at: z.string().min(1).optional(),
     ended_at: z.string().min(1).optional(),
+    // Which template this session runs (#376), by id — never by title, which
+    // is free text and not unique across templates.
+    template_id: z.string().uuid().optional(),
     title: optionalTextField(80),
     location: workoutLocation().optional(),
     notes: optionalTextField(2000),

--- a/lib/schemas/weight-room.ts
+++ b/lib/schemas/weight-room.ts
@@ -147,6 +147,7 @@ export const WeightRoomSetRowSchema = z
     // grease-the-groove set ever logged — and means "loose", not "missing".
     workout_id: z.string().uuid().nullable().optional(),
     position: nonNegativeInt().nullable().optional(),
+    template_slot_id: z.string().uuid().nullable().optional(),
   })
   .strict()
 
@@ -239,16 +240,57 @@ export const WeightRoomSetCreateSchema = z
     // empty / whitespace / null all normalize to `undefined` so the
     // route omits the column and the DB stores `null` (unspecified).
     variant: variantWriteField(),
+    // External load in pounds, per implement (#376). This was missing until
+    // now, which meant weighted sets could not be logged through the app at
+    // all — every one on the site got there via the log-workout skill writing
+    // raw SQL and bypassing this schema entirely.
+    weight_lbs: z.number().nonnegative().optional(),
     // Session membership (#374). Explicit only — the route never infers it
     // from whichever workout happens to be open, so a desk pushup set can't
     // silently join the morning's gym session.
     workout_id: z.string().uuid().optional(),
     position: nonNegativeInt().optional(),
+    // The template slot this set was performed for (#376). A set whose
+    // `exercise` differs from its slot's is a substitution, recorded by that
+    // difference rather than by a flag.
+    template_slot_id: z.string().uuid().optional(),
   })
   .strict()
 
 /** Validated body of `POST /api/admin/weight-room/sets`. */
 export type WeightRoomSetCreate = z.infer<typeof WeightRoomSetCreateSchema>
+
+/**
+ * Request-body schema for `PATCH /api/admin/weight-room/sets/[id]` (#376).
+ *
+ * Correcting a mistyped set previously meant deleting it and re-entering —
+ * which loses its `logged_at` and, inside a workout, its place in the order.
+ * Every field optional, at least one required.
+ *
+ * `weight_lbs` and `variant` accept an explicit `null` to *clear* them: a set
+ * logged as weighted by mistake has to be able to become a bodyweight set
+ * again, which an omitted key can't express under PATCH semantics.
+ */
+export const WeightRoomSetUpdateSchema = z
+  .object({
+    exercise: exerciseWriteField(),
+    reps: positiveInt(),
+    logged_at: z.string().min(1),
+    weight_lbs: z.number().nonnegative().nullable(),
+    variant: z.union([z.string(), z.null()]).transform(v => {
+      if (v === null) return null
+      const trimmed = v.trim().toLowerCase()
+      return trimmed === '' ? null : trimmed
+    }),
+  })
+  .strict()
+  .partial()
+  .refine(patch => Object.values(patch).some(v => v !== undefined), {
+    message: 'At least one field (exercise, reps, logged_at, weight_lbs, or variant) is required.',
+  })
+
+/** Validated body of `PATCH /api/admin/weight-room/sets/[id]`. */
+export type WeightRoomSetUpdate = z.infer<typeof WeightRoomSetUpdateSchema>
 
 /**
  * Translate a validated `weight_room_sets` row into the public
@@ -272,6 +314,7 @@ export function setRowToStrengthSet(row: WeightRoomSetRow): StrengthSet {
     // Session membership (#374); same absent-not-null treatment.
     ...(row.workout_id != null ? { workout_id: row.workout_id } : {}),
     ...(row.position != null ? { position: row.position } : {}),
+    ...(row.template_slot_id != null ? { template_slot_id: row.template_slot_id } : {}),
   }
 }
 

--- a/lib/training-facility/live-workout.test.ts
+++ b/lib/training-facility/live-workout.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from 'vitest'
+
+import type { StrengthSet, TemplateSlot, WorkoutTemplate } from '@/types/weight-room'
+
+import { buildSlotProgress, extraSets, nextSetDefaults, nextSetPosition } from './live-workout'
+
+/**
+ * Coverage for the live-recording logic (#376) — chiefly the two things the
+ * schema encodes implicitly and a component would otherwise get wrong: a
+ * substitution is a *derived* fact about the sets, and "extra work" is an
+ * absence that only means something inside a workout.
+ */
+
+function slot(overrides: Partial<TemplateSlot> = {}): TemplateSlot {
+  return {
+    id: 'slot-1',
+    position: 0,
+    exercise: 'barbell-bench-press',
+    target_sets: 4,
+    steps: [],
+    alternates: [],
+    ...overrides,
+  }
+}
+
+function set(overrides: Partial<StrengthSet> = {}): StrengthSet {
+  return {
+    id: 'set-1',
+    logged_at: '2026-08-01T18:00:00Z',
+    exercise: 'barbell-bench-press',
+    reps: 5,
+    ...overrides,
+  }
+}
+
+function template(slots: TemplateSlot[]): WorkoutTemplate {
+  return { id: 't1', name: 'Chest Day 1', position: 0, slots }
+}
+
+describe('buildSlotProgress', () => {
+  it('counts sets logged against each slot', () => {
+    const s = slot()
+    const progress = buildSlotProgress(template([s]), [
+      set({ id: 'a', template_slot_id: 'slot-1' }),
+      set({ id: 'b', template_slot_id: 'slot-1', logged_at: '2026-08-01T18:05:00Z' }),
+    ])
+    expect(progress[0].logged).toBe(2)
+    expect(progress[0].isComplete).toBe(false)
+  })
+
+  it('is complete at the prescribed count, and stays complete beyond it', () => {
+    const s = slot({ target_sets: 2 })
+    const two = buildSlotProgress(template([s]), [
+      set({ id: 'a', template_slot_id: 'slot-1' }),
+      set({ id: 'b', template_slot_id: 'slot-1' }),
+    ])
+    expect(two[0].isComplete).toBe(true)
+
+    const three = buildSlotProgress(template([s]), [
+      set({ id: 'a', template_slot_id: 'slot-1' }),
+      set({ id: 'b', template_slot_id: 'slot-1' }),
+      set({ id: 'c', template_slot_id: 'slot-1' }),
+    ])
+    expect(three[0].logged).toBe(3)
+    expect(three[0].isComplete).toBe(true)
+  })
+
+  it('treats a set-range slot as complete at its floor', () => {
+    // "4-5 sets" means 4 hits the prescription; the 5th is within range, not
+    // over it.
+    const s = slot({ target_sets: 4, target_sets_max: 5 })
+    const progress = buildSlotProgress(
+      template([s]),
+      Array.from({ length: 4 }, (_, i) => set({ id: `a${i}`, template_slot_id: 'slot-1' }))
+    )
+    expect(progress[0].isComplete).toBe(true)
+  })
+
+  it('derives a substitution from the logged movement, with no flag', () => {
+    const progress = buildSlotProgress(template([slot()]), [
+      set({ id: 'a', template_slot_id: 'slot-1', exercise: 'dumbbell-bench-press' }),
+    ])
+    expect(progress[0].isSubstituted).toBe(true)
+    expect(progress[0].performedExercise).toBe('dumbbell-bench-press')
+  })
+
+  it('is not a substitution when the prescribed movement was used', () => {
+    const progress = buildSlotProgress(template([slot()]), [
+      set({ id: 'a', template_slot_id: 'slot-1' }),
+    ])
+    expect(progress[0].isSubstituted).toBe(false)
+  })
+
+  it('lets the newest set decide the current movement after a mid-slot swap', () => {
+    // Two barbell sets, then the rack goes — earlier sets keep what they were
+    // actually done with, but the slot is now being performed with dumbbells.
+    const progress = buildSlotProgress(template([slot()]), [
+      set({ id: 'a', template_slot_id: 'slot-1', logged_at: '2026-08-01T18:00:00Z' }),
+      set({
+        id: 'b',
+        template_slot_id: 'slot-1',
+        exercise: 'dumbbell-bench-press',
+        logged_at: '2026-08-01T18:10:00Z',
+      }),
+    ])
+    expect(progress[0].performedExercise).toBe('dumbbell-bench-press')
+    expect(progress[0].sets[0].exercise).toBe('barbell-bench-press')
+  })
+
+  it('orders slots by position regardless of set order', () => {
+    const a = slot({ id: 'slot-a', position: 1, exercise: 'dips' })
+    const b = slot({ id: 'slot-b', position: 0, exercise: 'pushups' })
+    const progress = buildSlotProgress(template([a, b]), [])
+    expect(progress.map(p => p.slot.exercise)).toEqual(['pushups', 'dips'])
+  })
+
+  it('yields no slots for a session started without a template', () => {
+    expect(buildSlotProgress(null, [set({ id: 'a' })])).toEqual([])
+  })
+})
+
+describe('extraSets', () => {
+  it('returns sets in the workout that no slot prescribed', () => {
+    const found = extraSets([
+      set({ id: 'a', template_slot_id: 'slot-1' }),
+      set({ id: 'b', exercise: 'pec-deck' }),
+    ])
+    expect(found.map(s => s.id)).toEqual(['b'])
+  })
+
+  it('returns nothing when everything was prescribed', () => {
+    expect(extraSets([set({ id: 'a', template_slot_id: 'slot-1' })])).toEqual([])
+  })
+})
+
+describe('nextSetDefaults', () => {
+  it('repeats the previous set in this slot', () => {
+    // Loads get adjusted on set one and then held, so after a set the
+    // prescription is the stale number.
+    const s = slot({ target_reps: 5, target_weight_lbs: 135 })
+    const defaults = nextSetDefaults(s, [set({ reps: 5, weight_lbs: 185 })])
+    expect(defaults).toEqual({ reps: 5, weight_lbs: 185 })
+  })
+
+  it('falls back to the prescription for the first set', () => {
+    const s = slot({ target_reps: 5, target_weight_lbs: 135 })
+    expect(nextSetDefaults(s, [])).toEqual({ reps: 5, weight_lbs: 135 })
+  })
+
+  it('falls back to the last time this movement was done when nothing is prescribed', () => {
+    const s = slot({ target_reps: undefined })
+    const defaults = nextSetDefaults(s, [], set({ reps: 8, weight_lbs: 50 }))
+    expect(defaults).toEqual({ reps: 8, weight_lbs: 50 })
+  })
+
+  it('prefills nothing for AMRAP with no history rather than guessing', () => {
+    expect(nextSetDefaults(slot(), [])).toEqual({ reps: null, weight_lbs: null })
+  })
+
+  it('carries a bodyweight previous set through as a null load', () => {
+    const defaults = nextSetDefaults(slot(), [set({ reps: 12 })])
+    expect(defaults).toEqual({ reps: 12, weight_lbs: null })
+  })
+})
+
+describe('nextSetPosition', () => {
+  it('starts at zero for an empty workout', () => {
+    expect(nextSetPosition([])).toBe(0)
+  })
+
+  it('takes the max rather than the count, so a deletion never reuses an index', () => {
+    // Sets 0,1,2 logged then set 1 deleted: the next set must be 3, not 2, or
+    // it lands in the middle of the history.
+    expect(nextSetPosition([set({ position: 0 }), set({ position: 2 })])).toBe(3)
+  })
+
+  it('ignores sets with no position', () => {
+    expect(nextSetPosition([set({ position: 4 }), set({})])).toBe(5)
+  })
+})

--- a/lib/training-facility/live-workout.ts
+++ b/lib/training-facility/live-workout.ts
@@ -1,0 +1,166 @@
+import type { StrengthSet, TemplateSlot, WorkoutTemplate } from '@/types/weight-room'
+
+/**
+ * Pure logic for the live recording surface (#376) — how a template's
+ * prescription lines up against what's actually been logged into the open
+ * session so far.
+ *
+ * Kept out of the component so the parts that are easy to get quietly wrong —
+ * what counts as a substitution, what the next set should prefill to, what
+ * "extra work" means — are unit-testable rather than only observable by
+ * standing in a gym.
+ */
+
+/** How one template slot is going, against what it prescribed. */
+export interface SlotProgress {
+  /** The slot being tracked. */
+  slot: TemplateSlot
+  /** Sets logged against this slot so far, oldest first. */
+  sets: StrengthSet[]
+  /** How many sets have been logged — may exceed the prescription. */
+  logged: number
+  /**
+   * The movement actually being performed. Differs from `slot.exercise` once a
+   * set has been logged with something else — the rack was taken.
+   */
+  performedExercise: string
+  /**
+   * Whether this slot is being performed with a movement other than the one
+   * prescribed. Derived from the logged sets, never from a flag: the set rows
+   * *are* the record.
+   */
+  isSubstituted: boolean
+  /**
+   * True once at least the prescribed number of sets exists. A slot with a set
+   * range is complete at its floor — anything up to the ceiling is still
+   * "hitting the prescription", not exceeding it.
+   */
+  isComplete: boolean
+}
+
+/**
+ * Line a template's slots up against the sets logged into a workout.
+ *
+ * @param template The template being run, or `null` for a session started
+ *   without one — which yields no slots, so everything logged is extra work.
+ * @param workoutSets Every set belonging to the open workout.
+ */
+export function buildSlotProgress(
+  template: WorkoutTemplate | null,
+  workoutSets: readonly StrengthSet[]
+): SlotProgress[] {
+  if (template === null) return []
+
+  const bySlot = new Map<string, StrengthSet[]>()
+  for (const set of workoutSets) {
+    if (set.template_slot_id === undefined) continue
+    const list = bySlot.get(set.template_slot_id) ?? []
+    list.push(set)
+    bySlot.set(set.template_slot_id, list)
+  }
+
+  return [...template.slots]
+    .sort((a, b) => a.position - b.position)
+    .map(slot => {
+      const sets = (bySlot.get(slot.id) ?? []).sort((a, b) =>
+        a.logged_at < b.logged_at ? -1 : a.logged_at > b.logged_at ? 1 : 0
+      )
+      // The newest set decides what's being performed: swapping mid-slot means
+      // the most recent choice is the current one, and earlier sets keep the
+      // movement they were actually done with.
+      const performedExercise = sets.at(-1)?.exercise ?? slot.exercise
+      return {
+        slot,
+        sets,
+        logged: sets.length,
+        performedExercise,
+        isSubstituted: performedExercise !== slot.exercise,
+        isComplete: sets.length >= slot.target_sets,
+      }
+    })
+}
+
+/**
+ * Sets logged into the workout that no slot prescribed — the accessory work
+ * added on the day.
+ *
+ * A set with no `template_slot_id` inside a workout is extra by definition; the
+ * same absence outside a workout is just a loose grease-the-groove set, which
+ * is why this only ever looks at one session's sets.
+ *
+ * @param workoutSets Every set belonging to the open workout.
+ */
+export function extraSets(workoutSets: readonly StrengthSet[]): StrengthSet[] {
+  return workoutSets.filter(set => set.template_slot_id === undefined)
+}
+
+/** Prefilled values for the next set of a slot. */
+export interface NextSetDefaults {
+  /** Reps to prefill, or `null` when nothing sensible is known (AMRAP, no history). */
+  reps: number | null
+  /** Load per implement to prefill, or `null` for bodyweight / unknown. */
+  weight_lbs: number | null
+}
+
+/**
+ * What the next set of a slot should prefill to.
+ *
+ * Priority is **what you just did**, then what was prescribed. Repeating the
+ * previous set is right far more often than repeating the plan: loads get
+ * adjusted on the first set and then held, so after one set the prescription is
+ * the stale number.
+ *
+ * A rep *range* prefills its floor — the honest reading of "8–12" mid-set is
+ * the commitment, not the stretch. AMRAP prefills nothing rather than guessing.
+ *
+ * @param slot The slot being performed.
+ * @param setsInSlot Sets already logged against it, oldest first.
+ * @param lastElsewhere The most recent set of this movement from any earlier
+ *   session, used when the slot is still empty. `null` when it has never been
+ *   logged.
+ */
+export function nextSetDefaults(
+  slot: TemplateSlot,
+  setsInSlot: readonly StrengthSet[],
+  lastElsewhere: StrengthSet | null = null
+): NextSetDefaults {
+  const previous = setsInSlot.at(-1)
+  if (previous !== undefined) {
+    return {
+      reps: previous.reps,
+      weight_lbs: previous.weight_lbs ?? null,
+    }
+  }
+
+  return {
+    reps: slot.target_reps ?? lastElsewhere?.reps ?? null,
+    weight_lbs: slot.target_weight_lbs ?? lastElsewhere?.weight_lbs ?? null,
+  }
+}
+
+/**
+ * Total sets logged into a workout, prescribed and extra alike — the headline
+ * count while a session is running.
+ *
+ * @param workoutSets Every set belonging to the open workout.
+ */
+export function totalSetsLogged(workoutSets: readonly StrengthSet[]): number {
+  return workoutSets.length
+}
+
+/**
+ * The next `position` to stamp on a set, so the order it was performed in
+ * survives even when two movements are interleaved.
+ *
+ * Takes the max rather than the count: sets get deleted, and reusing a freed
+ * index would put a new set in the middle of the history.
+ *
+ * @param workoutSets Every set belonging to the open workout.
+ */
+export function nextSetPosition(workoutSets: readonly StrengthSet[]): number {
+  let max = -1
+  for (const set of workoutSets) {
+    if (set.position !== undefined && set.position > max) max = set.position
+  }
+  return max + 1
+}

--- a/supabase/migrations/20260804120000_weight_room_sets_template_slot.sql
+++ b/supabase/migrations/20260804120000_weight_room_sets_template_slot.sql
@@ -1,0 +1,32 @@
+-- Link a logged set to the template slot it was performed for (#376).
+--
+-- One nullable column, and it is what makes prescribed-vs-actual computable at
+-- all — deliberately without a separate substitutions table:
+--
+--   * A set carrying a `template_slot_id` was performed **for** that slot.
+--     Compare its `exercise` to the slot's and a mismatch *is* the record of a
+--     substitution. Nothing else needs storing: the rack was taken, you did
+--     dumbbell bench against the barbell-bench slot, and both halves are on the
+--     row already.
+--   * A set inside a workout with a NULL `template_slot_id` is extra work —
+--     something added on the day that the template never prescribed.
+--   * A set with no workout at all is loose grease-the-groove volume, exactly
+--     as before.
+--
+-- `on delete set null`, so editing or deleting a template later degrades old
+-- sessions to "untemplated sets" rather than erroring or, worse, silently
+-- rewriting what a past workout says it was doing. #375 keeps slot ids stable
+-- across edits precisely so this link survives ordinary template maintenance.
+--
+-- Idempotent.
+
+alter table public.weight_room_sets
+  add column if not exists template_slot_id uuid null
+  references public.weight_room_template_slots(id) on delete set null;
+
+comment on column public.weight_room_sets.template_slot_id is
+  'The template slot this set was performed for (#376), or NULL for extra work inside a workout / a loose grease-the-groove set. A set whose `exercise` differs from its slot''s IS the substitution record — there is no separate table. ON DELETE SET NULL so template maintenance degrades old sessions rather than breaking them.';
+
+create index if not exists weight_room_sets_template_slot_idx
+  on public.weight_room_sets (template_slot_id)
+  where template_slot_id is not null;

--- a/supabase/migrations/20260804120100_weight_room_workouts_template_id.sql
+++ b/supabase/migrations/20260804120100_weight_room_workouts_template_id.sql
@@ -1,0 +1,37 @@
+-- Record which template a workout is running, by id (#376).
+--
+-- The live panel first resolved the template by matching `title` against
+-- template names, which is wrong in three ways that all end with sets attributed
+-- to the wrong slots or silently treated as freestyle:
+--
+--   * Template names are not unique — nothing in #375 constrains them — so two
+--     templates sharing a name always resolve to whichever came first.
+--   * Renaming a template while its workout is open loses the prescription on
+--     the next reload.
+--   * `title` is free text a user can edit; it was never meant to be a key.
+--
+-- `on delete set null` rather than cascade or restrict: deleting a template
+-- should leave the session and its sets intact and merely untemplated, matching
+-- how `weight_room_sets.template_slot_id` already degrades. A finished workout
+-- is a record of what happened, and template maintenance months later must not
+-- rewrite or destroy it.
+--
+-- `title` stays, and stays free text — it's the human label ("Push Day", or
+-- something typed for a freestyle session), not the link.
+--
+-- No backfill: the column lands empty, and the one workout that could exist
+-- before this is a test session. Sessions without an id fall back to matching
+-- on title, so nothing that predates this loses its prescription.
+--
+-- Idempotent.
+
+alter table public.weight_room_workouts
+  add column if not exists template_id uuid null
+  references public.weight_room_workout_templates(id) on delete set null;
+
+comment on column public.weight_room_workouts.template_id is
+  'The template this session is running (#376). NULL for a freestyle workout, or for one whose template was deleted afterwards. Resolved by id rather than by matching `title`, which is free text and not unique.';
+
+create index if not exists weight_room_workouts_template_idx
+  on public.weight_room_workouts (template_id)
+  where template_id is not null;

--- a/types/weight-room.ts
+++ b/types/weight-room.ts
@@ -125,7 +125,19 @@ export interface WeightRoomWorkout {
    * guess.
    */
   ended_at?: string
-  /** Free-text label, e.g. `Push Day`. Absent when unnamed. */
+  /**
+   * The {@link WorkoutTemplate} this session is running (#376), or absent for a
+   * freestyle workout — or for one whose template was deleted afterwards.
+   *
+   * The link is by id, never by {@link title}: template names aren't unique,
+   * and `title` is free text a user can edit, so matching on it resolves to the
+   * wrong prescription and attributes sets to the wrong slots.
+   */
+  template_id?: string
+  /**
+   * Free-text label, e.g. `Push Day`. Absent when unnamed. Human-facing only —
+   * see {@link template_id} for the link.
+   */
   title?: string
   /** Where it happened. Absent when unspecified. */
   location?: WorkoutLocation

--- a/types/weight-room.ts
+++ b/types/weight-room.ts
@@ -67,6 +67,20 @@ export interface StrengthSet {
    * writer didn't care. Gaps are fine; nothing renumbers.
    */
   position?: number
+  /**
+   * The template slot this set was performed **for** (#376), or absent.
+   *
+   * Absent means two different things depending on {@link workout_id}: inside a
+   * workout it's **extra work** the template never prescribed; outside one it's
+   * an ordinary loose set.
+   *
+   * When present, comparing this set's {@link exercise} to the slot's *is* the
+   * substitution record — a dumbbell-bench set against a barbell-bench slot
+   * says the rack was taken, with no separate table and no flag. Nulled if the
+   * template is later deleted, so the session degrades to untemplated rather
+   * than the record being rewritten.
+   */
+  template_slot_id?: string
 }
 
 /**


### PR DESCRIPTION
The improvise half of #372, and the point of the whole arc. The template says 5×5 bench; the rack is taken, so it becomes 4 sets of dumbbell bench plus a set of flyes. Both halves have to be recordable without fighting the app mid-lift.

## A gap that's been live since #255

**`weight_lbs` was never in the set create schema.** `WeightRoomSetCreateSchema` is `.strict()` and didn't have the field, so `POST /api/admin/weight-room/sets` rejected it — weighted sets could not be logged through the app *at all*. Every weighted set on the site got there via the `log-workout` skill writing raw SQL and bypassing the API entirely. Fixed here, because a gym recording flow is impossible without it.

Also adds **`PATCH /sets/[id]`**. Correcting a typo previously meant delete-and-re-enter, which silently loses the set's `logged_at` and, inside a workout, its place in the order. Mid-lift that's exactly the wrong trade. `weight_lbs` and `variant` accept an explicit `null` to clear them, so a set logged as weighted by mistake can become bodyweight again.

## The slot link replaces a substitutions table

`weight_room_sets.template_slot_id`, nullable, `on delete set null`. One column, and it's what makes prescribed-vs-actual computable:

- A set carrying a slot **whose exercise differs from the slot's own IS the substitution record.** Both facts are already on the row — no flag, no second table.
- A set in a workout with **no** slot is extra work.
- A set with no workout is loose grease-the-groove volume, exactly as before.

`on delete set null` means editing or deleting a template later degrades old sessions to "untemplated" rather than erroring or rewriting what a past workout says it did. #375 keeps slot ids stable across edits precisely so this survives ordinary template maintenance.

Rehearsed on staging in a rolled-back transaction:

```
REHEARSAL OK: substitution recorded on the slot;
deleting the template kept both sets and nulled their slot link.
```

## The panel sits above the dashboard, not over it

Pull-ups and push-ups are in your templates **and** in your daily rings. A takeover would have forced a choice that makes one of them wrong, so the live panel renders above the existing rings / QuickLog / SetList and a desk pushup set mid-session is still one tap.

Behaviour worth knowing:

- **Every set POSTs immediately.** The server is the source of truth, so a reload resumes the open session with everything intact — the panel probes `GET /workouts?open=true` on mount.
- **A failed write surfaces inline and retryable**, never swallowed and never escalated to a page-level error. No offline queue, deliberately.
- **Swap** offers the slot's declared alternates first, then the whole catalog. Sets already logged keep the movement they were actually done with; the newest set decides what the slot is currently being performed with.
- **No skip.** Do 3 of 5 and move on — the slot reads `3 / 5` and #377 reads the shortfall from what exists. A set-range slot is complete at its floor, so 4 of "4–5" is hitting the prescription, not falling short.
- **Prefill is what you just did**, then the prescription, then the last time you did the movement. Loads get adjusted on set one and then held, so after a set the prescription is the stale number. AMRAP prefills nothing rather than guessing.

## Test invalidation

`LogDataIsland.test.tsx` asserted on `fetchMock.mock.calls[0]`, which is no longer the set POST now that the panel probes for an open workout on mount. Those assertions now find the call by URL and method — indexing blind would silently start asserting against the wrong request the next time anything else on the page fetches.

## Test plan

At `/training-facility/weight-room/log` (admin-only):

- [ ] **Start a workout** from *Chest Day 1* — the panel switches to LIVE with its five movements listed and their prescriptions.
- [ ] **Log a set** on bench — it appears as a chip, the counter goes `1 / 4`, and the reps/lb fields keep your values for the next set.
- [ ] **Log a weighted set** — this is the path that was impossible before; confirm the load persists after a refresh.
- [ ] **Swap** a slot to an alternate, log a set — the card shows "swapped from …" and the earlier sets keep their original movement.
- [ ] **Add movement** — logs against the session as *Extra work*, not against any slot.
- [ ] **Reload the page mid-session** — the workout resumes with every set intact.
- [ ] **Tap a logged set chip** to remove it; the counter drops.
- [ ] **End** the workout — the panel returns to "start a workout".
- [ ] **Grease-the-groove still works**: with a session open, log pushups via the QuickLog below; it should be a *loose* set, not part of the workout.
- [ ] Start a second workout while one is open → refused (one at a time, #374).
- [ ] Today and History unchanged; `/log` still 404s for non-admins.
- [ ] Usable one-handed at 390px.

Verified locally: `tsc` clean, `next build` compiles, 2036 unit tests, 65/65 Playwright, `format:check` clean, `migrations:check` clean (32 committed, 32 applied).

Closes #376.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added live Weight Room workout tracking with session controls, set logging, progress indicators, substitutions, extra sets, and freestyle movements.
  * Added support for associating sets with workout template slots.
  * Added admin editing for individual logged sets.
  * Added support for optional weight and template-slot details when creating sets.

* **Bug Fixes**
  * Improved handling of missing templates, invalid requests, and catalog conflicts.
  * Weight Room logging now remains usable when template loading fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->