### PR TITLE
feat(weight-room): import Apple Health strength workouts as Weight Room sessions (#413)

### DIFF
--- a/app/training-facility/weight-room/workouts/[id]/page.tsx
+++ b/app/training-facility/weight-room/workouts/[id]/page.tsx
@@ -25,6 +25,7 @@ import {
   compareToPrevious,
   findPersonalBests,
   findPreviousRun,
+  workoutDisplayTitle,
 } from '@/lib/training-facility/workout-stats'
 
 /** Route params for the per-workout summary. */
@@ -118,7 +119,9 @@ export default async function WeightRoomWorkoutSummaryPage({
           day: 'numeric',
           year: 'numeric',
         })
-  const heading = template?.name ?? workout.title ?? 'Freestyle session'
+  // Shared with the history row so the same session can't be titled two
+  // different things on two screens (#413).
+  const heading = workoutDisplayTitle(workout, template?.name ?? null)
 
   return (
     <div className="relative min-h-svh overflow-hidden bg-[#120d0a] text-[#f7ead9]">

--- a/app/training-facility/weight-room/workouts/page.tsx
+++ b/app/training-facility/weight-room/workouts/page.tsx
@@ -9,6 +9,7 @@ import {
   WorkoutHistoryList,
   WORKOUTS_ROUTE,
   type TemplateFilterOption,
+  type WorkoutSourceFilter,
 } from '@/components/training-facility/weight-room/WorkoutHistoryList'
 import { WeightRoomSubNav } from '@/components/training-facility/weight-room/WeightRoomSubNav'
 import { isAdminRequest } from '@/lib/auth/admin-session'
@@ -93,15 +94,28 @@ export default async function WeightRoomWorkoutsPage({
       .sort((a, b) => a.name.localeCompare(b.name)),
   ]
 
+  // Provenance is a second, independent filter axis (#413). Hundreds of
+  // imported skeletons would otherwise bury the handful of sessions that carry
+  // real set data.
+  const recordedCount = history.filter(e => e.workout.source !== 'apple_health').length
+  const importedCount = history.length - recordedCount
+  const requestedSource = firstParam(params.source)
+  const selectedSource: WorkoutSourceFilter | null =
+    requestedSource === 'recorded' || requestedSource === 'imported' ? requestedSource : null
+
   const requestedTemplate = firstParam(params.template)
   // An unknown id falls back to "all" rather than to an empty list — a stale
   // link naming a deleted template should degrade to the full history.
   const selectedTemplateId =
     requestedTemplate !== null && counts.has(requestedTemplate) ? requestedTemplate : null
-  const entries =
-    selectedTemplateId === null
-      ? history
-      : history.filter(entry => entry.workout.template_id === selectedTemplateId)
+  const entries = history.filter(entry => {
+    if (selectedTemplateId !== null && entry.workout.template_id !== selectedTemplateId) {
+      return false
+    }
+    if (selectedSource === null) return true
+    const isImported = entry.workout.source === 'apple_health'
+    return selectedSource === 'imported' ? isImported : !isImported
+  })
 
   return (
     <div className="relative min-h-svh overflow-hidden bg-[#120d0a] text-[#f7ead9]">
@@ -154,6 +168,9 @@ export default async function WeightRoomWorkoutsPage({
             selectedTemplateId={selectedTemplateId}
             hasAnyWorkouts={history.length > 0}
             isPreviewMode={isPreviewMode}
+            selectedSource={selectedSource}
+            recordedCount={recordedCount}
+            importedCount={importedCount}
           />
         </div>
       </div>

--- a/components/training-facility/weight-room/WorkoutHistoryList.test.tsx
+++ b/components/training-facility/weight-room/WorkoutHistoryList.test.tsx
@@ -4,7 +4,11 @@ import { render, screen } from '@testing-library/react'
 import { buildWorkoutHistory } from '@/lib/training-facility/workout-stats'
 import type { StrengthSet, WeightRoomWorkout, WorkoutTemplate } from '@/types/weight-room'
 
-import { WorkoutHistoryList, type TemplateFilterOption } from './WorkoutHistoryList'
+import {
+  WorkoutHistoryList,
+  type TemplateFilterOption,
+  type WorkoutHistoryListProps,
+} from './WorkoutHistoryList'
 
 /**
  * Rendering coverage for the workout history (#377).
@@ -64,8 +68,10 @@ describe('WorkoutHistoryList', () => {
     render(
       <WorkoutHistoryList entries={[]} filters={FILTERS} selectedTemplateId="t1" hasAnyWorkouts />
     )
+    // Copy is filter-agnostic since #413 added the provenance axis — it can no
+    // longer name templates specifically, because either filter can empty the list.
     expect(screen.getByTestId('workout-history-empty')).toHaveTextContent(
-      /No sessions recorded for that template/i
+      /No sessions match that filter/i
     )
   })
 
@@ -182,5 +188,103 @@ describe('WorkoutHistoryList', () => {
       <WorkoutHistoryList entries={entries} filters={[]} selectedTemplateId={null} hasAnyWorkouts />
     )
     expect(screen.getByTestId('workout-row-w2')).toHaveTextContent(/never ended/i)
+  })
+})
+
+describe('WorkoutHistoryList — imported sessions (#413)', () => {
+  const IMPORTED: WeightRoomWorkout = {
+    id: 'wh1',
+    started_at: '2019-03-04T18:00:00Z',
+    ended_at: '2019-03-04T18:47:00Z',
+    source: 'apple_health',
+    avg_hr: 112,
+    max_hr: 148,
+  }
+
+  function renderImported(overrides: Partial<WorkoutHistoryListProps> = {}) {
+    const entries = buildWorkoutHistory([IMPORTED], [], [], [])
+    render(
+      <WorkoutHistoryList
+        entries={entries}
+        filters={[]}
+        selectedTemplateId={null}
+        hasAnyWorkouts
+        importedCount={1}
+        recordedCount={0}
+        {...overrides}
+      />
+    )
+  }
+
+  it('badges an imported row so it is never mistaken for a recorded one', () => {
+    renderImported()
+    expect(screen.getByTestId('workout-imported-badge')).toHaveTextContent('Apple Health')
+  })
+
+  it('shows HR instead of zeroed sets and reps', () => {
+    renderImported()
+    const row = screen.getByTestId('workout-row-wh1')
+    // Three zeros would read as "you did nothing", which is the opposite of
+    // what the record says happened.
+    expect(row).not.toHaveTextContent(/0 sets/)
+    expect(row).toHaveTextContent(/112\s*avg bpm/)
+    expect(row).toHaveTextContent(/47\s*min/)
+  })
+
+  it('titles it by what it is, not as a freestyle session', () => {
+    // "Freestyle session" claims an intent — that a plan was declined — which
+    // nothing about an import supports.
+    expect(buildWorkoutHistory([IMPORTED], [], [], [])[0].workout.source).toBe('apple_health')
+    renderImported()
+    expect(screen.getByTestId('workout-row-wh1')).toHaveTextContent('Strength training')
+  })
+
+  it('offers the provenance rail only once something is imported', () => {
+    renderImported({ importedCount: 0 })
+    expect(screen.queryByTestId('workout-source-filter')).toBeNull()
+  })
+
+  it('keeps both filter axes in every chip href, so one never clears the other', () => {
+    render(
+      <WorkoutHistoryList
+        entries={[]}
+        filters={FILTERS}
+        selectedTemplateId="t1"
+        hasAnyWorkouts
+        selectedSource="imported"
+        recordedCount={2}
+        importedCount={507}
+      />
+    )
+    // Switching template must preserve the source filter...
+    expect(screen.getByTestId('workout-filter-t1')).toHaveAttribute(
+      'href',
+      '/training-facility/weight-room/workouts?template=t1&source=imported'
+    )
+    // ...and switching source must preserve the template.
+    expect(screen.getByTestId('workout-source-recorded')).toHaveAttribute(
+      'href',
+      '/training-facility/weight-room/workouts?template=t1&source=recorded'
+    )
+    expect(screen.getByTestId('workout-source-all')).toHaveAttribute(
+      'href',
+      '/training-facility/weight-room/workouts?template=t1'
+    )
+  })
+
+  it('counts each population on its chip', () => {
+    render(
+      <WorkoutHistoryList
+        entries={[]}
+        filters={[]}
+        selectedTemplateId={null}
+        hasAnyWorkouts
+        recordedCount={2}
+        importedCount={507}
+      />
+    )
+    expect(screen.getByTestId('workout-source-all')).toHaveTextContent('509')
+    expect(screen.getByTestId('workout-source-imported')).toHaveTextContent('507')
+    expect(screen.getByTestId('workout-source-recorded')).toHaveTextContent('2')
   })
 })

--- a/components/training-facility/weight-room/WorkoutHistoryList.tsx
+++ b/components/training-facility/weight-room/WorkoutHistoryList.tsx
@@ -7,6 +7,19 @@ import type { WorkoutHistoryEntry } from '@/lib/training-facility/workout-stats'
 /** Route the workout history lives at; also the base for every filter chip. */
 export const WORKOUTS_ROUTE = '/training-facility/weight-room/workouts'
 
+/** URL param naming the provenance filter (#413). */
+export const SOURCE_FILTER_PARAM = 'source'
+
+/**
+ * Provenance filter selection (#413).
+ *
+ * `'recorded'` — sessions logged set by set through the app. `'imported'` —
+ * sessions from an Apple Health export, which know only that lifting happened
+ * and for how long. `null` — both, in true chronological order, which is the
+ * default because the whole point of importing is to see the two eras together.
+ */
+export type WorkoutSourceFilter = 'recorded' | 'imported'
+
 /** One entry in the filter rail. */
 export interface TemplateFilterOption {
   /** Template id, or `null` for the "all workouts" chip. */
@@ -27,6 +40,12 @@ export interface WorkoutHistoryListProps {
   filters: readonly TemplateFilterOption[]
   /** Currently selected template id, or `null` for all. */
   selectedTemplateId: string | null
+  /** Currently selected provenance filter, or `null` for both (#413). */
+  selectedSource?: WorkoutSourceFilter | null
+  /** How many sessions were recorded in-app; drives the Recorded chip's count. */
+  recordedCount?: number
+  /** How many were imported from Apple Health; drives the Imported chip's count. */
+  importedCount?: number
   /** Whether any session exists at all, so a filtered-to-nothing view reads differently from a fresh log. */
   hasAnyWorkouts: boolean
   /**
@@ -56,13 +75,27 @@ export function WorkoutHistoryList({
   selectedTemplateId,
   hasAnyWorkouts,
   isPreviewMode = false,
+  selectedSource = null,
+  recordedCount = 0,
+  importedCount = 0,
 }: WorkoutHistoryListProps): JSX.Element {
   return (
     <div className="flex flex-col gap-5">
+      {importedCount > 0 ? (
+        <SourceFilterRail
+          selectedSource={selectedSource}
+          selectedTemplateId={selectedTemplateId}
+          recordedCount={recordedCount}
+          importedCount={importedCount}
+          isPreviewMode={isPreviewMode}
+        />
+      ) : null}
+
       {filters.length > 1 ? (
         <TemplateFilterRail
           filters={filters}
           selectedTemplateId={selectedTemplateId}
+          selectedSource={selectedSource}
           isPreviewMode={isPreviewMode}
         />
       ) : null}
@@ -73,7 +106,7 @@ export function WorkoutHistoryList({
           className="rounded-[1.2rem] border border-white/10 bg-white/5 p-6 text-center text-sm text-[#e8d5be]/70"
         >
           {hasAnyWorkouts
-            ? 'No sessions recorded for that template yet.'
+            ? 'No sessions match that filter yet.'
             : 'No workouts recorded yet. Start one from the Log page and it will show up here.'}
         </p>
       ) : (
@@ -92,21 +125,97 @@ export function WorkoutHistoryList({
 interface TemplateFilterRailProps {
   filters: readonly TemplateFilterOption[]
   selectedTemplateId: string | null
+  selectedSource: WorkoutSourceFilter | null
   isPreviewMode: boolean
 }
 
-/** Build a chip href, keeping `preview=demo` alongside `template=<id>`. */
-function chipHref(templateId: string | null, isPreviewMode: boolean): string {
+/**
+ * Build a chip href carrying every active filter, not just the one being set.
+ *
+ * The two rails are independent axes, so choosing a template must not silently
+ * clear a provenance filter (or vice versa) — and `preview=demo` has to survive
+ * both, since the fixture only stands in when the real read is empty and
+ * dropping it ends the demo mid-tour.
+ */
+function chipHref(
+  templateId: string | null,
+  source: WorkoutSourceFilter | null,
+  isPreviewMode: boolean
+): string {
   const params = new URLSearchParams()
   if (templateId !== null) params.set('template', templateId)
+  if (source !== null) params.set(SOURCE_FILTER_PARAM, source)
   if (isPreviewMode) params.set('preview', 'demo')
   const query = params.toString()
   return query === '' ? WORKOUTS_ROUTE : `${WORKOUTS_ROUTE}?${query}`
 }
 
+/** Shared chip styling, so the two rails can't drift apart visually. */
+function chipClass(isActive: boolean): string {
+  return isActive
+    ? 'inline-flex items-center gap-1.5 rounded-full bg-[#f5f1e6] px-3.5 py-1.5 font-mono text-[0.65rem] uppercase tracking-[0.14em] text-[#0a0a0a]'
+    : 'inline-flex items-center gap-1.5 rounded-full border border-white/15 px-3.5 py-1.5 font-mono text-[0.65rem] uppercase tracking-[0.14em] text-[#e8d5be]/75 transition hover:border-white/35 hover:text-[#f7ead9]'
+}
+
+interface SourceFilterRailProps {
+  selectedSource: WorkoutSourceFilter | null
+  selectedTemplateId: string | null
+  recordedCount: number
+  importedCount: number
+  isPreviewMode: boolean
+}
+
+/**
+ * Provenance rail (#413) — All / Recorded / Imported.
+ *
+ * Rendered only once imported sessions exist, so a log with nothing imported
+ * never grows a filter for a distinction that doesn't apply to it. It matters
+ * because the two populations are wildly different sizes: hundreds of imported
+ * skeletons would otherwise bury the handful of sessions with real set data.
+ */
+function SourceFilterRail({
+  selectedSource,
+  selectedTemplateId,
+  recordedCount,
+  importedCount,
+  isPreviewMode,
+}: SourceFilterRailProps): JSX.Element {
+  const options: Array<{ value: WorkoutSourceFilter | null; label: string; count: number }> = [
+    { value: null, label: 'All', count: recordedCount + importedCount },
+    { value: 'recorded', label: 'Recorded', count: recordedCount },
+    { value: 'imported', label: 'Apple Health', count: importedCount },
+  ]
+
+  return (
+    <nav aria-label="Filter by source" data-testid="workout-source-filter">
+      <ul className="flex flex-wrap gap-2">
+        {options.map(option => {
+          const isActive = option.value === selectedSource
+          return (
+            <li key={option.value ?? 'all'}>
+              <Link
+                href={chipHref(selectedTemplateId, option.value, isPreviewMode)}
+                aria-current={isActive ? 'page' : undefined}
+                data-testid={`workout-source-${option.value ?? 'all'}`}
+                className={chipClass(isActive)}
+              >
+                {option.label}
+                <span className={isActive ? 'text-[#0a0a0a]/50' : 'text-[#e8d5be]/45'}>
+                  {option.count}
+                </span>
+              </Link>
+            </li>
+          )
+        })}
+      </ul>
+    </nav>
+  )
+}
+
 function TemplateFilterRail({
   filters,
   selectedTemplateId,
+  selectedSource,
   isPreviewMode,
 }: TemplateFilterRailProps): JSX.Element {
   return (
@@ -117,14 +226,10 @@ function TemplateFilterRail({
           return (
             <li key={option.id ?? 'all'}>
               <Link
-                href={chipHref(option.id, isPreviewMode)}
+                href={chipHref(option.id, selectedSource, isPreviewMode)}
                 aria-current={isActive ? 'page' : undefined}
                 data-testid={`workout-filter-${option.id ?? 'all'}`}
-                className={
-                  isActive
-                    ? 'inline-flex items-center gap-1.5 rounded-full bg-[#f5f1e6] px-3.5 py-1.5 font-mono text-[0.65rem] uppercase tracking-[0.14em] text-[#0a0a0a]'
-                    : 'inline-flex items-center gap-1.5 rounded-full border border-white/15 px-3.5 py-1.5 font-mono text-[0.65rem] uppercase tracking-[0.14em] text-[#e8d5be]/75 transition hover:border-white/35 hover:text-[#f7ead9]'
-                }
+                className={chipClass(isActive)}
               >
                 {option.color !== null ? (
                   <span
@@ -174,7 +279,12 @@ function formatStart(startedAt: string): string {
 
 function WorkoutHistoryRow({ entry, isPreviewMode }: WorkoutHistoryRowProps): JSX.Element {
   const { summary, workout } = entry
-  const heading = entry.templateName ?? workout.title ?? 'Freestyle session'
+  const isImported = workout.source === 'apple_health'
+  // An imported session has no title and no template, so "Freestyle session" —
+  // which means "I chose not to follow a plan" — would be a claim about intent
+  // that nothing supports. It says what it is instead.
+  const heading =
+    entry.templateName ?? workout.title ?? (isImported ? 'Strength training' : 'Freestyle session')
   const topLift = summary.exercises.find(e => e.topSet !== null)
 
   return (
@@ -193,19 +303,39 @@ function WorkoutHistoryRow({ entry, isPreviewMode }: WorkoutHistoryRowProps): JS
             />
           ) : null}
           {heading}
+          {isImported ? (
+            <span
+              data-testid="workout-imported-badge"
+              className="rounded bg-black/10 px-1.5 py-0.5 font-mono text-[0.55rem] uppercase tracking-[0.1em] text-[#0a0a0a]/65"
+            >
+              Apple Health
+            </span>
+          ) : null}
         </h3>
         <p className="text-xs text-[#0a0a0a]/60">{formatStart(workout.started_at)}</p>
       </header>
 
       <p className="mt-2.5 flex flex-wrap items-baseline gap-x-3 gap-y-1 text-sm tabular-nums">
-        <span>
-          <span className="font-bold">{summary.totalSets}</span>
-          <span className="text-[#0a0a0a]/55"> sets</span>
-        </span>
-        <span>
-          <span className="font-bold">{summary.totalReps.toLocaleString('en-US')}</span>
-          <span className="text-[#0a0a0a]/55"> reps</span>
-        </span>
+        {/* An imported session's zeros are unknowns, not measurements, so the
+            set/rep counts are simply not shown for one with nothing logged. */}
+        {isImported && summary.totalSets === 0 ? null : (
+          <>
+            <span>
+              <span className="font-bold">{summary.totalSets}</span>
+              <span className="text-[#0a0a0a]/55"> sets</span>
+            </span>
+            <span>
+              <span className="font-bold">{summary.totalReps.toLocaleString('en-US')}</span>
+              <span className="text-[#0a0a0a]/55"> reps</span>
+            </span>
+          </>
+        )}
+        {workout.avg_hr !== undefined ? (
+          <span>
+            <span className="font-bold">{Math.round(workout.avg_hr)}</span>
+            <span className="text-[#0a0a0a]/55"> avg bpm</span>
+          </span>
+        ) : null}
         {summary.tonnage > 0 ? (
           <span>
             <span className="font-bold">{Math.round(summary.tonnage).toLocaleString('en-US')}</span>

--- a/components/training-facility/weight-room/WorkoutHistoryList.tsx
+++ b/components/training-facility/weight-room/WorkoutHistoryList.tsx
@@ -2,7 +2,10 @@ import type { JSX } from 'react'
 import Link from 'next/link'
 
 import { formatDayKey, safePacificDayKey, todayDayKey } from '@/lib/training-facility/day-keys'
-import type { WorkoutHistoryEntry } from '@/lib/training-facility/workout-stats'
+import {
+  workoutDisplayTitle,
+  type WorkoutHistoryEntry,
+} from '@/lib/training-facility/workout-stats'
 
 /** Route the workout history lives at; also the base for every filter chip. */
 export const WORKOUTS_ROUTE = '/training-facility/weight-room/workouts'
@@ -280,11 +283,7 @@ function formatStart(startedAt: string): string {
 function WorkoutHistoryRow({ entry, isPreviewMode }: WorkoutHistoryRowProps): JSX.Element {
   const { summary, workout } = entry
   const isImported = workout.source === 'apple_health'
-  // An imported session has no title and no template, so "Freestyle session" —
-  // which means "I chose not to follow a plan" — would be a claim about intent
-  // that nothing supports. It says what it is instead.
-  const heading =
-    entry.templateName ?? workout.title ?? (isImported ? 'Strength training' : 'Freestyle session')
+  const heading = workoutDisplayTitle(workout, entry.templateName)
   const topLift = summary.exercises.find(e => e.topSet !== null)
 
   return (

--- a/components/training-facility/weight-room/WorkoutSummaryPanel.test.tsx
+++ b/components/training-facility/weight-room/WorkoutSummaryPanel.test.tsx
@@ -238,3 +238,77 @@ describe('WorkoutSummaryPanel', () => {
     expect(screen.getByTestId('workout-pb-barbell-bench-press')).toHaveTextContent(/past 185 lb/i)
   })
 })
+
+describe('WorkoutSummaryPanel — imported sessions (#413)', () => {
+  const IMPORTED: WeightRoomWorkout = {
+    id: 'wh1',
+    started_at: '2019-03-04T18:00:00Z',
+    ended_at: '2019-03-04T18:47:00Z',
+    source: 'apple_health',
+    avg_hr: 112,
+    max_hr: 148,
+  }
+
+  function renderImported(sets: StrengthSet[] = []) {
+    const summary = buildWorkoutSummary(IMPORTED, sets, CATALOG)
+    render(
+      <WorkoutSummaryPanel
+        summary={summary}
+        adherence={null}
+        comparison={null}
+        personalBests={[]}
+        templateName={null}
+        exerciseLabels={LABELS}
+      />
+    )
+  }
+
+  it('reports unknowns as unknown, never as zero', () => {
+    renderImported()
+    // "0 sets, 0 reps, 0 lb" would say the session was empty. It wasn't — Health
+    // just doesn't record what was done.
+    const headline = screen.getByTestId('workout-headline')
+    expect(headline).not.toHaveTextContent(/\b0\b/)
+    expect(screen.getByTestId('workout-duration')).toHaveTextContent('47m')
+  })
+
+  it('surfaces HR, the only intensity signal it has', () => {
+    renderImported()
+    expect(screen.getByTestId('workout-tonnage')).toHaveTextContent('112 bpm')
+    expect(screen.getByTestId('workout-imported-note')).toHaveTextContent(/148 bpm/)
+  })
+
+  it('explains why there is no breakdown rather than showing an empty one', () => {
+    renderImported()
+    expect(screen.getByTestId('workout-imported-note')).toHaveTextContent(
+      /not what was done in it/i
+    )
+    // The "No sets logged into this session" copy is for a session someone
+    // abandoned — a wrong and slightly accusatory thing to say about an import.
+    expect(screen.queryByTestId('workout-breakdown-empty')).toBeNull()
+    expect(screen.queryByTestId('workout-breakdown')).toBeNull()
+  })
+
+  it('does not claim a bodyweight session', () => {
+    renderImported()
+    expect(screen.queryByTestId('workout-bodyweight-note')).toBeNull()
+  })
+
+  it('falls back to the full breakdown once an imported session gains sets', () => {
+    // #400 will attach sets to a subset of these from iCloud notes; when that
+    // happens the session stops being a skeleton and reads like any other.
+    renderImported([
+      {
+        id: 'imported-set',
+        logged_at: '2019-03-04T18:10:00Z',
+        exercise: 'barbell-bench-press',
+        reps: 8,
+        weight_lbs: 155,
+        workout_id: 'wh1',
+      },
+    ])
+    expect(screen.queryByTestId('workout-imported-note')).toBeNull()
+    expect(screen.getByTestId('workout-breakdown')).toBeInTheDocument()
+    expect(screen.getByTestId('workout-tonnage')).toHaveTextContent('1,240 lb')
+  })
+})

--- a/components/training-facility/weight-room/WorkoutSummaryPanel.tsx
+++ b/components/training-facility/weight-room/WorkoutSummaryPanel.tsx
@@ -82,10 +82,18 @@ export function WorkoutSummaryPanel({
   // breakdown saying no sets were logged at all. A session ended without
   // logging anything is reachable, so the two must not contradict each other.
   const allBodyweight = summary.totalSets > 0 && summary.weightedSets === 0
+  // An Apple Health import knows a session happened and how long it ran, not
+  // what was done in it (#413). Its zeros are unknowns, and this is the normal
+  // state for one — not a session someone abandoned.
+  const isImportedSkeleton = summary.workout.source === 'apple_health' && summary.totalSets === 0
 
   return (
     <div data-testid="workout-summary" className="flex flex-col gap-5">
-      <HeadlineStats summary={summary} allBodyweight={allBodyweight} />
+      <HeadlineStats
+        summary={summary}
+        allBodyweight={allBodyweight}
+        isImportedSkeleton={isImportedSkeleton}
+      />
 
       {personalBests.length > 0 ? <PersonalBestStrip bests={personalBests} /> : null}
 
@@ -109,7 +117,9 @@ export function WorkoutSummaryPanel({
         <ExtraWorkCard sets={adherence.extra} exerciseLabels={exerciseLabels} />
       ) : null}
 
-      <BreakdownCard exercises={summary.exercises} allBodyweight={allBodyweight} />
+      {isImportedSkeleton ? null : (
+        <BreakdownCard exercises={summary.exercises} allBodyweight={allBodyweight} />
+      )}
     </div>
   )
 }
@@ -117,10 +127,15 @@ export function WorkoutSummaryPanel({
 interface HeadlineStatsProps {
   summary: WorkoutSummary
   allBodyweight: boolean
+  isImportedSkeleton: boolean
 }
 
 /** The four headline numbers, plus the honest caveats about what they exclude. */
-function HeadlineStats({ summary, allBodyweight }: HeadlineStatsProps): JSX.Element {
+function HeadlineStats({
+  summary,
+  allBodyweight,
+  isImportedSkeleton,
+}: HeadlineStatsProps): JSX.Element {
   const { density } = summary
   return (
     <section
@@ -129,11 +144,29 @@ function HeadlineStats({ summary, allBodyweight }: HeadlineStatsProps): JSX.Elem
       className="rounded-[1.2rem] border border-white/10 bg-[#f5f1e6] p-5 text-[#0a0a0a] shadow-[0_12px_32px_rgba(0,0,0,0.28)]"
     >
       <dl className="grid grid-cols-2 gap-x-4 gap-y-4 sm:grid-cols-4">
-        <Stat label="Sets" value={summary.totalSets.toLocaleString('en-US')} />
-        <Stat label="Reps" value={summary.totalReps.toLocaleString('en-US')} />
+        {/* An imported session's sets, reps and tonnage are all genuinely
+            unknown. Printing three zeros would read as "you did nothing",
+            which is the opposite of what the record says happened — so it
+            shows what Health actually measured instead. */}
         <Stat
-          label="Tonnage"
-          value={allBodyweight ? '—' : lbs(summary.tonnage)}
+          label="Sets"
+          value={isImportedSkeleton ? '—' : summary.totalSets.toLocaleString('en-US')}
+        />
+        <Stat
+          label="Reps"
+          value={isImportedSkeleton ? '—' : summary.totalReps.toLocaleString('en-US')}
+        />
+        <Stat
+          label={isImportedSkeleton ? 'Avg HR' : 'Tonnage'}
+          value={
+            isImportedSkeleton
+              ? summary.workout.avg_hr === undefined
+                ? '—'
+                : `${Math.round(summary.workout.avg_hr)} bpm`
+              : allBodyweight
+                ? '—'
+                : lbs(summary.tonnage)
+          }
           testId="workout-tonnage"
         />
         <Stat
@@ -143,7 +176,19 @@ function HeadlineStats({ summary, allBodyweight }: HeadlineStatsProps): JSX.Elem
         />
       </dl>
 
-      {density !== null ? (
+      {isImportedSkeleton ? (
+        <p data-testid="workout-imported-note" className="mt-4 text-xs text-[#0a0a0a]/70">
+          <span className="font-mono uppercase tracking-[0.16em]">From Apple Health</span> ·{' '}
+          {summary.workout.max_hr === undefined
+            ? 'This session was imported from a Health export.'
+            : `Peaked at ${Math.round(summary.workout.max_hr)} bpm.`}{' '}
+          Health records that a workout happened and how long it ran, not what was done in it — so
+          there are no sets or reps to show. Sessions recorded in the app from here on carry the
+          full breakdown.
+        </p>
+      ) : null}
+
+      {!isImportedSkeleton && density !== null ? (
         <p data-testid="workout-density" className="mt-4 text-xs text-[#0a0a0a]/70">
           <span className="font-mono uppercase tracking-[0.16em]">Density</span> ·{' '}
           {density.setsPerMinute >= 0.1
@@ -167,7 +212,7 @@ function HeadlineStats({ summary, allBodyweight }: HeadlineStatsProps): JSX.Elem
         <p data-testid="workout-bodyweight-note" className="mt-3 text-xs text-[#0a0a0a]/70">
           Bodyweight session — no external load, so there&rsquo;s no tonnage to report.
         </p>
-      ) : summary.bodyweightSets > 0 ? (
+      ) : !isImportedSkeleton && summary.bodyweightSets > 0 ? (
         <p data-testid="workout-bodyweight-note" className="mt-3 text-xs text-[#0a0a0a]/70">
           {summary.bodyweightSets} of {summary.totalSets} sets were bodyweight. They count toward
           reps but not tonnage.

--- a/constants/weight-room-demo-fixture.test.ts
+++ b/constants/weight-room-demo-fixture.test.ts
@@ -25,8 +25,11 @@ describe('buildWorkoutDemoData', () => {
   const history = buildWorkoutHistory(demo.workouts, demo.sets, demo.templates, demo.exercises, NOW)
   const [latest, previous] = history
 
-  it('produces two completed sessions, newest first', () => {
-    expect(history).toHaveLength(2)
+  it('produces completed sessions, newest first', () => {
+    // Two fully recorded, plus the imported ones (#413) — the mix the page
+    // actually renders once a Health import has run.
+    expect(history.length).toBeGreaterThanOrEqual(2)
+    expect(history.filter(e => e.workout.source === 'apple_health').length).toBeGreaterThan(0)
     expect(latest.summary.isInProgress).toBe(false)
     expect(latest.summary.durationMinutes).toBeGreaterThan(0)
     expect(new Date(latest.workout.started_at).getTime()).toBeGreaterThan(
@@ -90,11 +93,31 @@ describe('buildWorkoutDemoData', () => {
     expect(bests.length).toBeGreaterThan(0)
   })
 
-  it('carries a frozen prescription, so the preview exercises the snapshot path', () => {
-    for (const workout of demo.workouts) {
+  it('carries a frozen prescription on every session that ran a template', () => {
+    // Imported sessions ran no template, so they carry none — see the
+    // Apple Health assertions below.
+    const templated = demo.workouts.filter(w => w.template_id !== undefined)
+    expect(templated).toHaveLength(2)
+    for (const workout of templated) {
       expect(workout.prescription).toBeDefined()
       expect(workout.prescription?.name).toBe('Chest Day 1')
       expect(workout.prescription?.slots).toHaveLength(demo.templates[0].slots.length)
+    }
+  })
+
+  it('includes Apple Health sessions, because they are the majority case (#413)', () => {
+    const imported = demo.workouts.filter(w => w.source === 'apple_health')
+    expect(imported.length).toBeGreaterThan(0)
+    for (const workout of imported) {
+      // What Health knows.
+      expect(workout.ended_at).toBeDefined()
+      expect(workout.avg_hr).toBeGreaterThan(0)
+      expect(workout.max_hr).toBeGreaterThan(0)
+      // What it doesn't.
+      expect(workout.template_id).toBeUndefined()
+      expect(workout.prescription).toBeUndefined()
+      expect(workout.location).toBeUndefined()
+      expect(demo.sets.some(s => s.workout_id === workout.id)).toBe(false)
     }
   })
 

--- a/constants/weight-room-demo-fixture.ts
+++ b/constants/weight-room-demo-fixture.ts
@@ -383,6 +383,24 @@ function buildDemoWorkout(
  *
  * @param now Optional override; defaults to system time. Tests pin it.
  */
+/**
+ * Sessions imported from Apple Health (#413), as the preview renders them.
+ *
+ * Included because they are the *majority* case once a real import runs — 507
+ * of them against a handful of recorded sessions — so a preview showing only
+ * fully-recorded workouts would misrepresent what the page actually looks like.
+ * They carry duration and HR and nothing else, which is exactly what Health
+ * knows.
+ *
+ * `[daysAgo, durationMinutes, avgHr, maxHr]`.
+ */
+const DEMO_IMPORTED: Array<[number, number, number, number]> = [
+  [16, 47, 112, 148],
+  [23, 54, 105, 127],
+  [30, 41, 98, 121],
+  [37, 62, 118, 156],
+]
+
 export function buildWorkoutDemoData(now: Date = new Date()): WorkoutDemoData {
   // Anchored to 6pm on each day rather than to `now`, so the fixture reads as
   // evening gym sessions regardless of when the page is loaded.
@@ -395,8 +413,24 @@ export function buildWorkoutDemoData(now: Date = new Date()): WorkoutDemoData {
   const previous = buildDemoWorkout('demo-workout-1', evening(9), 58, DEMO_PREVIOUS_SETS)
   const latest = buildDemoWorkout('demo-workout-2', evening(2), 52, DEMO_LATEST_SETS)
 
+  const imported: WeightRoomWorkout[] = DEMO_IMPORTED.map(
+    ([daysAgo, durationMinutes, avgHr, maxHr], index) => {
+      const startedAt = evening(daysAgo)
+      return {
+        id: `demo-imported-${index}`,
+        started_at: startedAt.toISOString(),
+        ended_at: new Date(startedAt.getTime() + durationMinutes * 60_000).toISOString(),
+        // No template, no title, no sets — and deliberately no location, since
+        // Health does not record one.
+        source: 'apple_health',
+        avg_hr: avgHr,
+        max_hr: maxHr,
+      }
+    }
+  )
+
   return {
-    workouts: [latest.workout, previous.workout],
+    workouts: [latest.workout, previous.workout, ...imported],
     sets: [...previous.sets, ...latest.sets],
     templates: [DEMO_TEMPLATE],
     exercises: DEMO_EXERCISES,

--- a/lib/data/weight-room-shared.ts
+++ b/lib/data/weight-room-shared.ts
@@ -208,7 +208,7 @@ const WORKOUTS_TABLE = 'weight_room_workouts'
 
 /** Whitelisted columns for `weight_room_workouts`, in sync with {@link WeightRoomWorkoutRowSchema}. */
 const WORKOUTS_COLUMNS =
-  'id, started_at, ended_at, template_id, prescription, title, location, notes, updated_at'
+  'id, started_at, ended_at, template_id, prescription, source, avg_hr, max_hr, title, location, notes, updated_at'
 
 const WeightRoomWorkoutRowsSchema = z.array(WeightRoomWorkoutRowSchema)
 

--- a/lib/schemas/weight-room.ts
+++ b/lib/schemas/weight-room.ts
@@ -429,6 +429,9 @@ export const WeightRoomWorkoutRowSchema = z
     started_at: z.string().min(1, 'started_at must be an ISO timestamp'),
     ended_at: z.string().nullable().optional(),
     template_id: z.string().uuid().nullable().optional(),
+    source: z.enum(['manual', 'apple_health']).nullable().optional(),
+    avg_hr: z.number().nullable().optional(),
+    max_hr: z.number().nullable().optional(),
     prescription: WorkoutPrescriptionSchema.nullable().optional(),
     title: z.string().nullable().optional(),
     location: workoutLocation().nullable().optional(),
@@ -451,6 +454,11 @@ export function workoutRowToWeightRoomWorkout(row: WeightRoomWorkoutRow): Weight
     started_at: row.started_at,
     ...(row.ended_at != null ? { ended_at: row.ended_at } : {}),
     ...(row.template_id != null ? { template_id: row.template_id } : {}),
+    // `'manual'` is the column default and the absent-field meaning, so it's
+    // omitted rather than carried — every read site treats absent as manual.
+    ...(row.source != null && row.source !== 'manual' ? { source: row.source } : {}),
+    ...(row.avg_hr != null ? { avg_hr: row.avg_hr } : {}),
+    ...(row.max_hr != null ? { max_hr: row.max_hr } : {}),
     ...(row.prescription != null ? { prescription: row.prescription } : {}),
     ...(row.title != null && row.title !== '' ? { title: row.title } : {}),
     ...(row.location != null ? { location: row.location } : {}),

--- a/lib/training-facility/workout-stats.test.ts
+++ b/lib/training-facility/workout-stats.test.ts
@@ -19,6 +19,7 @@ import {
   findPersonalBests,
   findPreviousRun,
   loadMultipliersBySlug,
+  workoutDisplayTitle,
 } from './workout-stats'
 
 /**
@@ -570,5 +571,29 @@ describe('buildWorkoutHistory', () => {
     const broken = workout({ id: 'bad', started_at: 'not-a-date' })
     const history = buildWorkoutHistory([broken, w2], [], [], CATALOG)
     expect(history.map(e => e.workout.id)).toEqual(['w2', 'bad'])
+  })
+})
+
+describe('workoutDisplayTitle (#413)', () => {
+  it('prefers the template name', () => {
+    expect(workoutDisplayTitle({}, 'Chest Day 1')).toBe('Chest Day 1')
+  })
+
+  it('falls back to a free-text title', () => {
+    expect(workoutDisplayTitle({ title: 'Push Day' }, null)).toBe('Push Day')
+  })
+
+  it('calls an untitled manual session freestyle', () => {
+    expect(workoutDisplayTitle({}, null)).toBe('Freestyle session')
+  })
+
+  it('does not call an imported session freestyle', () => {
+    // "Freestyle" asserts a plan was available and declined. An import had no
+    // template to decline — the app wasn't involved.
+    expect(workoutDisplayTitle({ source: 'apple_health' }, null)).toBe('Strength training')
+  })
+
+  it('still honours a template on an imported session, once #400 links one', () => {
+    expect(workoutDisplayTitle({ source: 'apple_health' }, 'Chest Day 1')).toBe('Chest Day 1')
   })
 })

--- a/lib/training-facility/workout-stats.ts
+++ b/lib/training-facility/workout-stats.ts
@@ -640,6 +640,31 @@ export function findPersonalBests(
   return bests
 }
 
+/**
+ * What to call a session in a heading (#413).
+ *
+ * Shared by the history row and the summary page so the two can never disagree
+ * about the same workout — they did, briefly, and the disagreement was exactly
+ * the sort that matters: the list called an imported session "Strength
+ * training" while its own detail page called it "Freestyle session".
+ *
+ * "Freestyle session" asserts an *intent* — that a plan was available and
+ * declined. That's true of a workout someone started without picking a
+ * template, and false of one imported from Apple Health, which had no template
+ * to decline because the app wasn't involved.
+ *
+ * @param workout The session being titled.
+ * @param templateName Name of the template it ran, or `null`.
+ */
+export function workoutDisplayTitle(
+  workout: Pick<WeightRoomWorkout, 'source' | 'title'>,
+  templateName: string | null
+): string {
+  if (templateName !== null) return templateName
+  if (workout.title !== undefined) return workout.title
+  return workout.source === 'apple_health' ? 'Strength training' : 'Freestyle session'
+}
+
 /** One row of the workout history list. */
 export interface WorkoutHistoryEntry {
   /** The session. */

--- a/scripts/import-health.mjs
+++ b/scripts/import-health.mjs
@@ -33,7 +33,10 @@ import {
   loadEnv,
   upsertCardioData,
 } from './lib/cardio-supabase.mjs'
-import { upsertStrengthSessions } from './lib/weight-room-supabase.mjs'
+import {
+  findOrphanedStrengthSessions,
+  upsertStrengthSessions,
+} from './lib/weight-room-supabase.mjs'
 
 const PYTHON_SCRIPT = path.join('scripts', 'preprocess-health.py')
 const DEFAULT_OUTPUT_PATH = path.join('public', 'data', 'cardio.json')
@@ -126,6 +129,24 @@ async function main() {
   const strength = await upsertStrengthSessions(supabase, data.strength_sessions ?? [])
   if (strength.upserted > 0) {
     console.log(`✓ Upserted ${strength.upserted} strength session(s) to weight_room_workouts.`)
+  }
+
+  // Reported, never pruned. A session deleted or time-corrected in Health leaves
+  // a stale row that nothing else would point out — but these rows can carry
+  // sets transcribed from iCloud notes (#400), so deleting one silently orphans
+  // that work. Name them and let a human decide.
+  const orphans = await findOrphanedStrengthSessions(supabase, data.strength_sessions ?? [])
+  if (orphans.length > 0) {
+    console.log(
+      `\n⚠ ${orphans.length} imported session(s) are in Supabase but not in this export.\n` +
+        '  Likely deleted or time-corrected in Apple Health since the last import.\n' +
+        '  Not removed automatically — they may have sets attached from iCloud notes.\n' +
+        orphans
+          .slice(0, 10)
+          .map(s => `    ${s}`)
+          .join('\n') +
+        (orphans.length > 10 ? `\n    … and ${orphans.length - 10} more` : '')
+    )
   }
 }
 

--- a/scripts/import-health.mjs
+++ b/scripts/import-health.mjs
@@ -33,6 +33,7 @@ import {
   loadEnv,
   upsertCardioData,
 } from './lib/cardio-supabase.mjs'
+import { upsertStrengthSessions } from './lib/weight-room-supabase.mjs'
 
 const PYTHON_SCRIPT = path.join('scripts', 'preprocess-health.py')
 const DEFAULT_OUTPUT_PATH = path.join('public', 'data', 'cardio.json')
@@ -47,7 +48,7 @@ function pythonExecutable() {
 
 function usage() {
   console.error(
-    'Usage: npm run import-health -- <export.zip|export.xml> [--max-hr=185] [--from-json=<path>]',
+    'Usage: npm run import-health -- <export.zip|export.xml> [--max-hr=185] [--from-json=<path>]'
   )
   process.exit(1)
 }
@@ -56,7 +57,7 @@ async function runPython(args) {
   return new Promise((resolve, reject) => {
     const child = spawn(pythonExecutable(), [PYTHON_SCRIPT, ...args], { stdio: 'inherit' })
     child.on('error', reject)
-    child.on('exit', (code) => {
+    child.on('exit', code => {
       if (code === 0) resolve()
       else reject(new Error(`Python preprocess-health.py exited with code ${code}`))
     })
@@ -72,7 +73,9 @@ async function validateJson(jsonPath) {
     for (const issue of result.error.issues) {
       console.error(`  - ${issue.path.join('.') || '<root>'}: ${issue.message}`)
     }
-    throw new Error('Schema mismatch — check `types/cardio.ts` against `preprocess-health.py` output.')
+    throw new Error(
+      'Schema mismatch — check `types/cardio.ts` against `preprocess-health.py` output.'
+    )
   }
   return result.data
 }
@@ -109,16 +112,24 @@ async function main() {
   console.log(
     `✓ Upserted to Supabase: ${counts.sessions} sessions, ` +
       `${counts.restingHr} resting-HR points, ${counts.vo2max} VO2max points, ` +
-      `${counts.hrSamples.toLocaleString()} HR samples.`,
+      `${counts.hrSamples.toLocaleString()} HR samples.`
   )
   if (counts.pruned > 0) {
     console.log(
-      `  (Pruned ${counts.pruned} orphan row(s) — present in Supabase but not in this import.)`,
+      `  (Pruned ${counts.pruned} orphan row(s) — present in Supabase but not in this import.)`
     )
+  }
+
+  // Strength workouts land in the Weight Room, not in any cardio table (#413).
+  // Upsert-only and never pruned: unlike the cardio tables, this one also holds
+  // manually recorded sessions, and an import must not reach into those.
+  const strength = await upsertStrengthSessions(supabase, data.strength_sessions ?? [])
+  if (strength.upserted > 0) {
+    console.log(`✓ Upserted ${strength.upserted} strength session(s) to weight_room_workouts.`)
   }
 }
 
-main().catch((err) => {
+main().catch(err => {
   console.error(err.message ?? err)
   process.exit(1)
 })

--- a/scripts/lib/cardio-supabase.mjs
+++ b/scripts/lib/cardio-supabase.mjs
@@ -43,7 +43,7 @@ export function createServiceRoleClient() {
   }
   if (!serviceRoleKey) {
     throw new Error(
-      'SUPABASE_SERVICE_ROLE_KEY is not set. Grab it from Supabase dashboard → Project Settings → API and add to .env.local.',
+      'SUPABASE_SERVICE_ROLE_KEY is not set. Grab it from Supabase dashboard → Project Settings → API and add to .env.local.'
     )
   }
   return createClient(url, serviceRoleKey, {
@@ -116,10 +116,40 @@ const CardioTimePointSchema = z
   })
   .strict()
 
+/**
+ * One Apple Health strength workout (#413), as emitted by
+ * `preprocess-health.py`'s `to_strength_session`.
+ *
+ * Lives in this payload because it comes out of the same preprocessor run, but
+ * it is written to `weight_room_workouts` rather than to `cardio_sessions` —
+ * see `upsertStrengthSessions` in `weight-room-supabase.mjs`. There are no
+ * distance, pace or zone fields because none of them mean anything for lifting,
+ * and no sets because Health does not record what was done in the session.
+ */
+const StrengthSessionSchema = z
+  .object({
+    /** ISO timestamp the session began. Doubles as its idempotency key. */
+    started_at: z.string().min(1),
+    /** ISO timestamp it finished. */
+    ended_at: z.string().min(1),
+    /** Elapsed seconds, straight from Health's own `duration`. */
+    duration_seconds: z.number().nonnegative(),
+    /** Mean BPM over the session, or null when no samples overlapped it. */
+    avg_hr: z.number().nonnegative().nullable().optional(),
+    /** Peak BPM over the session, or null when no samples overlapped it. */
+    max_hr: z.number().nonnegative().nullable().optional(),
+  })
+  .strict()
+
 export const CardioDataSchema = z
   .object({
     imported_at: z.string().min(1),
     sessions: z.array(CardioSessionSchema),
+    // #413 — strength workouts ride along in the same preprocessor output but
+    // are written to `weight_room_workouts`, not to any cardio table. Optional
+    // for the same reason the lifestyle trends are: a JSON produced before this
+    // key existed must still validate.
+    strength_sessions: z.array(StrengthSessionSchema).optional(),
     resting_hr_trend: z.array(CardioTimePointSchema),
     vo2max_trend: z.array(CardioTimePointSchema),
     // #75 slice C-data — six lifestyle-metric trends ported from
@@ -242,13 +272,13 @@ export async function upsertCardioData(supabase, data) {
   // value rather than three near-equal ones.
   const importedAt = new Date().toISOString()
 
-  const sessionRows = parsed.sessions.map((s) => sessionToRow(s, importedAt))
-  const restingRows = parsed.resting_hr_trend.map((point) => ({
+  const sessionRows = parsed.sessions.map(s => sessionToRow(s, importedAt))
+  const restingRows = parsed.resting_hr_trend.map(point => ({
     date: point.date,
     value: point.value,
     updated_at: importedAt,
   }))
-  const vo2Rows = parsed.vo2max_trend.map((point) => ({
+  const vo2Rows = parsed.vo2max_trend.map(point => ({
     date: point.date,
     value: point.value,
     updated_at: importedAt,
@@ -258,7 +288,7 @@ export async function upsertCardioData(supabase, data) {
   const lifestyleRows = LIFESTYLE_TREND_TABLES.map(([field, table]) => ({
     field,
     table,
-    rows: (parsed[field] ?? []).map((point) => ({
+    rows: (parsed[field] ?? []).map(point => ({
       date: point.date,
       value: point.value,
       updated_at: importedAt,
@@ -282,13 +312,11 @@ export async function upsertCardioData(supabase, data) {
     if (manualErr) {
       throw new Error(`Failed to read manual body-mass dates: ${manualErr.message}`)
     }
-    manualBodyMassDates = new Set(
-      (manualRows ?? []).map((r) => String(r.date).slice(0, 10)),
-    )
+    manualBodyMassDates = new Set((manualRows ?? []).map(r => String(r.date).slice(0, 10)))
   }
   const bodyMassRows = bodyMassPayload
-    .filter((point) => !manualBodyMassDates.has(point.date))
-    .map((point) => ({
+    .filter(point => !manualBodyMassDates.has(point.date))
+    .map(point => ({
       date: point.date,
       value: point.value,
       source: 'apple_health',
@@ -317,9 +345,7 @@ export async function upsertCardioData(supabase, data) {
     }
   }
   if (vo2Rows.length > 0) {
-    const { error } = await supabase
-      .from('cardio_vo2max')
-      .upsert(vo2Rows, { onConflict: 'date' })
+    const { error } = await supabase.from('cardio_vo2max').upsert(vo2Rows, { onConflict: 'date' })
     if (error) {
       throw new Error(`Failed to upsert cardio_vo2max: ${error.message}`)
     }
@@ -344,20 +370,15 @@ export async function upsertCardioData(supabase, data) {
     supabase,
     'cardio_sessions',
     importedAt,
-    sessionRows.length > 0,
+    sessionRows.length > 0
   )
   const restingPruned = await pruneStaleRows(
     supabase,
     'cardio_resting_hr',
     importedAt,
-    restingRows.length > 0,
+    restingRows.length > 0
   )
-  const vo2Pruned = await pruneStaleRows(
-    supabase,
-    'cardio_vo2max',
-    importedAt,
-    vo2Rows.length > 0,
-  )
+  const vo2Pruned = await pruneStaleRows(supabase, 'cardio_vo2max', importedAt, vo2Rows.length > 0)
   let lifestylePruned = 0
   const lifestyleCounts = {}
   for (const { field, table, rows } of lifestyleRows) {
@@ -371,7 +392,7 @@ export async function upsertCardioData(supabase, data) {
     'cardio_body_mass_trend',
     importedAt,
     bodyMassRows.length > 0,
-    'apple_health',
+    'apple_health'
   )
 
   return {
@@ -383,8 +404,7 @@ export async function upsertCardioData(supabase, data) {
     // Count of Apple Health body-mass rows written (manual days are excluded
     // from the batch, so this can be < the payload's body_mass_trend length).
     body_mass_trend: bodyMassRows.length,
-    pruned:
-      sessionsPruned + restingPruned + vo2Pruned + lifestylePruned + bodyMassPruned,
+    pruned: sessionsPruned + restingPruned + vo2Pruned + lifestylePruned + bodyMassPruned,
   }
 }
 
@@ -428,26 +448,24 @@ export async function upsertHrSamples(supabase, sessions) {
       .eq('session_started_at', session.date)
     if (deleteErr) {
       throw new Error(
-        `Failed to clear cardio_session_hr_samples for session ${session.date}: ${deleteErr.message}`,
+        `Failed to clear cardio_session_hr_samples for session ${session.date}: ${deleteErr.message}`
       )
     }
 
     const samples = session.hr_samples ?? []
     if (samples.length === 0) continue
 
-    const rows = samples.map((s) => ({
+    const rows = samples.map(s => ({
       session_started_at: session.date,
       sample_at: s.ts,
       bpm: s.bpm,
     }))
     for (let i = 0; i < rows.length; i += HR_SAMPLES_INSERT_BATCH) {
       const batch = rows.slice(i, i + HR_SAMPLES_INSERT_BATCH)
-      const { error: insertErr } = await supabase
-        .from('cardio_session_hr_samples')
-        .insert(batch)
+      const { error: insertErr } = await supabase.from('cardio_session_hr_samples').insert(batch)
       if (insertErr) {
         throw new Error(
-          `Failed to insert cardio_session_hr_samples for session ${session.date}: ${insertErr.message}`,
+          `Failed to insert cardio_session_hr_samples for session ${session.date}: ${insertErr.message}`
         )
       }
       totalInserted += batch.length

--- a/scripts/lib/weight-room-supabase.mjs
+++ b/scripts/lib/weight-room-supabase.mjs
@@ -1,0 +1,80 @@
+/**
+ * Supabase writer for Apple Health strength workouts (#413).
+ *
+ * Separate from `cardio-supabase.mjs` on purpose: these rows go to
+ * `weight_room_workouts`, and folding them into `upsertCardioData` would make a
+ * function named for cardio the owner of the Weight Room's table.
+ *
+ * Everything here is idempotent. The export's `<Workout>` elements carry no
+ * UUID — only `startDate`, `endDate`, `duration` and `sourceName` — so the
+ * natural key is the instant the session began, which two lifting sessions
+ * cannot share. A partial unique index on `(source, started_at) where source <>
+ * 'manual'` backs the upsert, so re-running a full import is a no-op rather
+ * than a second copy of 8.5 years of history.
+ */
+
+/** Table that owns bounded Weight Room sessions (#374). */
+const WORKOUTS_TABLE = 'weight_room_workouts'
+
+/** Provenance marker for rows this module writes. Mirrors the `body_mass_trend` convention. */
+export const APPLE_HEALTH_SOURCE = 'apple_health'
+
+/** Rows per upsert request. Keeps a full 507-session import to a handful of round trips. */
+const UPSERT_BATCH = 200
+
+/**
+ * Upsert Health strength workouts into `weight_room_workouts`.
+ *
+ * Only ever touches rows with `source = 'apple_health'`. A session recorded
+ * through the app is `source = 'manual'` and is never read, updated or pruned
+ * here — the same "manual always wins" rule the body-mass import already
+ * follows, and the reason the unique index excludes manual rows.
+ *
+ * `location` is deliberately left null: Health does not record where a workout
+ * happened, and defaulting it to `'gym'` would put an inference into the record
+ * where nothing established one.
+ *
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase Service-role client.
+ * @param {Array<{started_at: string, ended_at: string, duration_seconds: number,
+ *   avg_hr?: number|null, max_hr?: number|null}>} sessions Validated strength
+ *   sessions from `CardioDataSchema`'s `strength_sessions`.
+ * @returns {Promise<{ upserted: number }>} How many rows were sent.
+ * @throws when any batch fails, naming the Supabase error.
+ */
+export async function upsertStrengthSessions(supabase, sessions) {
+  if (!Array.isArray(sessions) || sessions.length === 0) {
+    return { upserted: 0 }
+  }
+
+  // Guard against a duplicated start inside one payload. The DB would reject
+  // the whole batch on the unique index, and the message ("duplicate key") is a
+  // long way from the cause, so collapse them here where the reason is
+  // obvious. Later wins — the export is chronological and a repeat means the
+  // same session was written twice.
+  const byStart = new Map()
+  for (const session of sessions) {
+    byStart.set(session.started_at, session)
+  }
+
+  const rows = [...byStart.values()].map(session => ({
+    started_at: session.started_at,
+    ended_at: session.ended_at,
+    source: APPLE_HEALTH_SOURCE,
+    avg_hr: session.avg_hr ?? null,
+    max_hr: session.max_hr ?? null,
+  }))
+
+  for (let i = 0; i < rows.length; i += UPSERT_BATCH) {
+    const batch = rows.slice(i, i + UPSERT_BATCH)
+    const { error } = await supabase
+      .from(WORKOUTS_TABLE)
+      .upsert(batch, { onConflict: 'source,started_at' })
+    if (error) {
+      throw new Error(
+        `Failed to upsert strength sessions (batch ${i / UPSERT_BATCH + 1}): ${error.message}`
+      )
+    }
+  }
+
+  return { upserted: rows.length }
+}

--- a/scripts/lib/weight-room-supabase.mjs
+++ b/scripts/lib/weight-room-supabase.mjs
@@ -8,9 +8,11 @@
  * Everything here is idempotent. The export's `<Workout>` elements carry no
  * UUID — only `startDate`, `endDate`, `duration` and `sourceName` — so the
  * natural key is the instant the session began, which two lifting sessions
- * cannot share. A partial unique index on `(source, started_at) where source <>
- * 'manual'` backs the upsert, so re-running a full import is a no-op rather
- * than a second copy of 8.5 years of history.
+ * cannot share. A unique index on `(source, started_at)` backs the upsert, so
+ * re-running a full import is a no-op rather than a second copy of 8.5 years of
+ * history. That index is deliberately *not* partial: Postgres only infers
+ * `ON CONFLICT` from a full one, and supabase-js's `onConflict` cannot restate a
+ * predicate.
  */
 
 /** Table that owns bounded Weight Room sessions (#374). */
@@ -25,14 +27,27 @@ const UPSERT_BATCH = 200
 /**
  * Upsert Health strength workouts into `weight_room_workouts`.
  *
- * Only ever touches rows with `source = 'apple_health'`. A session recorded
- * through the app is `source = 'manual'` and is never read, updated or pruned
- * here — the same "manual always wins" rule the body-mass import already
- * follows, and the reason the unique index excludes manual rows.
+ * Only ever writes rows with `source = 'apple_health'`. A session recorded
+ * through the app is `source = 'manual'` and is never touched — the same
+ * "manual always wins" rule the body-mass import already follows.
  *
  * `location` is deliberately left null: Health does not record where a workout
  * happened, and defaulting it to `'gym'` would put an inference into the record
  * where nothing established one.
+ *
+ * **Upsert-only — this never deletes.** The cardio import prunes rows absent
+ * from the payload, and that is right for `cardio_sessions`, which is a pure
+ * mirror of the export. `weight_room_workouts` is not a mirror: an imported
+ * session can *acquire* hand-authored data, because #400 attaches sets
+ * transcribed from iCloud notes to exactly these rows. Deleting one is not the
+ * cheap correction it looks like — `weight_room_sets.workout_id` is `ON DELETE
+ * SET NULL`, so those sets would survive as undated loose volume, still
+ * counting toward the daily rings while the session they documented vanished.
+ * Silent, and unrecoverable without re-transcribing the note.
+ *
+ * The real gap pruning would have closed — a workout deleted or time-corrected
+ * in Health leaving a stale row behind — is instead *reported* by
+ * {@link findOrphanedStrengthSessions}, so a human decides.
  *
  * @param {import('@supabase/supabase-js').SupabaseClient} supabase Service-role client.
  * @param {Array<{started_at: string, ended_at: string, duration_seconds: number,
@@ -77,4 +92,52 @@ export async function upsertStrengthSessions(supabase, sessions) {
   }
 
   return { upserted: rows.length }
+}
+
+/**
+ * Find imported sessions in the database that this export no longer contains.
+ *
+ * The reconciliation half of the import, and deliberately read-only. A workout
+ * deleted in Apple Health, or one whose start time was corrected (which
+ * produces a *new* row at the new instant and strands the old one), would
+ * otherwise sit in the history forever with nothing to point it out.
+ *
+ * Reporting rather than pruning because these rows are not disposable — see
+ * {@link upsertStrengthSessions}. What to do about an orphan depends on whether
+ * it has sets attached, which is a judgement call, so the script names them and
+ * stops.
+ *
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase Service-role client.
+ * @param {Array<{started_at: string}>} sessions The sessions this export carries.
+ * @returns {Promise<string[]>} `started_at` of every stored imported session
+ *   absent from the payload, oldest first. Empty when the two agree, and empty
+ *   when the payload is empty — an import that carried no strength sessions is
+ *   no evidence that the stored ones are stale.
+ * @throws when the read fails.
+ */
+export async function findOrphanedStrengthSessions(supabase, sessions) {
+  if (!Array.isArray(sessions) || sessions.length === 0) return []
+
+  const { data, error } = await supabase
+    .from(WORKOUTS_TABLE)
+    .select('started_at')
+    .eq('source', APPLE_HEALTH_SOURCE)
+  if (error) {
+    throw new Error(`Failed to read existing strength sessions: ${error.message}`)
+  }
+
+  // Compared as instants, not strings: Postgres renders timestamptz in its own
+  // canonical form, which will not be byte-identical to the offset-bearing ISO
+  // the preprocessor emits for the very same moment.
+  const inExport = new Set(
+    sessions.map(s => new Date(s.started_at).getTime()).filter(Number.isFinite)
+  )
+
+  return (data ?? [])
+    .map(row => row.started_at)
+    .filter(startedAt => {
+      const t = new Date(startedAt).getTime()
+      return Number.isFinite(t) && !inExport.has(t)
+    })
+    .sort()
 }

--- a/scripts/lib/weight-room-supabase.test.ts
+++ b/scripts/lib/weight-room-supabase.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from 'vitest'
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+import { APPLE_HEALTH_SOURCE, upsertStrengthSessions } from './weight-room-supabase.mjs'
+
+/**
+ * Coverage for the Apple Health strength import (#413).
+ *
+ * This is the least-observable code in the pipeline — a Node script with no
+ * preview to eyeball and no page to click — and the two ways it could go wrong
+ * are both silent: writing 507 duplicate sessions on a re-import, or reaching
+ * into manually recorded sessions that it has no business touching.
+ */
+
+/**
+ * Minimal Supabase stub capturing what `.upsert()` was called with.
+ *
+ * Cast rather than mocked wholesale: the writer touches exactly `.from().upsert()`,
+ * and standing up the other 25 members of `SupabaseClient` to satisfy the type
+ * would obscure that.
+ */
+function stubClient() {
+  const calls: Array<{ table: string; rows: unknown[]; options: unknown }> = []
+  const client = {
+    from(table: string) {
+      return {
+        upsert(rows: unknown[], options: unknown) {
+          calls.push({ table, rows, options })
+          return Promise.resolve({ error: null })
+        },
+      }
+    },
+  } as unknown as SupabaseClient
+  return { client, calls }
+}
+
+function session(startedAt: string, overrides: Record<string, unknown> = {}) {
+  return {
+    started_at: startedAt,
+    ended_at: '2019-03-04T18:47:00-07:00',
+    duration_seconds: 2820,
+    avg_hr: 112,
+    max_hr: 148,
+    ...overrides,
+  }
+}
+
+describe('upsertStrengthSessions', () => {
+  it('writes to weight_room_workouts, not to a cardio table', async () => {
+    const { client, calls } = stubClient()
+    await upsertStrengthSessions(client, [session('2019-03-04T18:00:00-07:00')])
+    expect(calls[0].table).toBe('weight_room_workouts')
+  })
+
+  it('stamps the provenance every row needs to be distinguishable', async () => {
+    const { client, calls } = stubClient()
+    await upsertStrengthSessions(client, [session('2019-03-04T18:00:00-07:00')])
+    expect(calls[0].rows[0]).toMatchObject({
+      source: APPLE_HEALTH_SOURCE,
+      started_at: '2019-03-04T18:00:00-07:00',
+      avg_hr: 112,
+      max_hr: 148,
+    })
+  })
+
+  it('conflicts on (source, started_at) — the only key the export supports', async () => {
+    // Health's <Workout> elements carry no UUID, so a second import of the same
+    // export must collide on the start instant or it duplicates 8.5 years.
+    const { client, calls } = stubClient()
+    await upsertStrengthSessions(client, [session('2019-03-04T18:00:00-07:00')])
+    expect(calls[0].options).toEqual({ onConflict: 'source,started_at' })
+  })
+
+  it('never sets a location, because Health does not record one', async () => {
+    const { client, calls } = stubClient()
+    await upsertStrengthSessions(client, [session('2019-03-04T18:00:00-07:00')])
+    expect(calls[0].rows[0]).not.toHaveProperty('location')
+  })
+
+  it('collapses a duplicated start inside one payload', async () => {
+    // The DB would reject the whole batch on the unique index, and "duplicate
+    // key" is a long way from the cause.
+    const { client, calls } = stubClient()
+    const result = await upsertStrengthSessions(client, [
+      session('2019-03-04T18:00:00-07:00', { max_hr: 100 }),
+      session('2019-03-04T18:00:00-07:00', { max_hr: 148 }),
+    ])
+    expect(result.upserted).toBe(1)
+    expect(calls[0].rows).toHaveLength(1)
+    expect(calls[0].rows[0]).toMatchObject({ max_hr: 148 })
+  })
+
+  it('normalises a missing HR to null rather than dropping the column', async () => {
+    const { client, calls } = stubClient()
+    await upsertStrengthSessions(client, [
+      {
+        started_at: '2020-01-01T10:00:00Z',
+        ended_at: '2020-01-01T11:00:00Z',
+        duration_seconds: 3600,
+      },
+    ])
+    expect(calls[0].rows[0]).toMatchObject({ avg_hr: null, max_hr: null })
+  })
+
+  it('does nothing at all for an empty or absent payload', async () => {
+    const { client, calls } = stubClient()
+    expect(await upsertStrengthSessions(client, [])).toEqual({ upserted: 0 })
+    // `strength_sessions` is optional on the payload schema, so a JSON produced
+    // before #413 reaches this as undefined rather than as an empty array.
+    expect(await upsertStrengthSessions(client, undefined as unknown as never[])).toEqual({
+      upserted: 0,
+    })
+    expect(calls).toHaveLength(0)
+  })
+
+  it('batches a full-history import instead of one giant request', async () => {
+    const { client, calls } = stubClient()
+    // 507 distinct instants, one per hour — the real import's size.
+    const base = Date.parse('2019-01-01T00:00:00Z')
+    const many = Array.from({ length: 507 }, (_, i) =>
+      session(new Date(base + i * 3_600_000).toISOString())
+    )
+    const result = await upsertStrengthSessions(client, many)
+    expect(new Set(many.map(s => s.started_at)).size).toBe(507)
+    expect(calls.length).toBeGreaterThan(1)
+    expect(result.upserted).toBe(507)
+    // Every row makes it through the batching, none dropped at a boundary.
+    expect(calls.reduce((n, c) => n + c.rows.length, 0)).toBe(507)
+  })
+
+  it('names the failing batch rather than surfacing a bare Supabase message', async () => {
+    const client = {
+      from() {
+        return {
+          upsert() {
+            return Promise.resolve({ error: { message: 'permission denied' } })
+          },
+        }
+      },
+    } as unknown as SupabaseClient
+    await expect(
+      upsertStrengthSessions(client, [session('2019-03-04T18:00:00-07:00')])
+    ).rejects.toThrow(/strength sessions.*permission denied/i)
+  })
+})

--- a/scripts/lib/weight-room-supabase.test.ts
+++ b/scripts/lib/weight-room-supabase.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import type { SupabaseClient } from '@supabase/supabase-js'
 
-import { APPLE_HEALTH_SOURCE, upsertStrengthSessions } from './weight-room-supabase.mjs'
+import {
+  APPLE_HEALTH_SOURCE,
+  findOrphanedStrengthSessions,
+  upsertStrengthSessions,
+} from './weight-room-supabase.mjs'
 
 /**
  * Coverage for the Apple Health strength import (#413).
@@ -141,5 +145,62 @@ describe('upsertStrengthSessions', () => {
     await expect(
       upsertStrengthSessions(client, [session('2019-03-04T18:00:00-07:00')])
     ).rejects.toThrow(/strength sessions.*permission denied/i)
+  })
+})
+
+/** Stub whose `.select().eq()` resolves to the given stored rows. */
+function readClient(rows: Array<{ started_at: string }>) {
+  return {
+    from() {
+      return {
+        select() {
+          return { eq: () => Promise.resolve({ data: rows, error: null }) }
+        },
+      }
+    },
+  } as unknown as SupabaseClient
+}
+
+describe('findOrphanedStrengthSessions', () => {
+  it('names a stored session the export no longer carries', async () => {
+    const stored = [
+      { started_at: '2019-03-04T18:00:00+00:00' },
+      { started_at: '2019-03-05T18:00:00+00:00' },
+    ]
+    const orphans = await findOrphanedStrengthSessions(readClient(stored), [
+      session('2019-03-04T18:00:00Z'),
+    ])
+    expect(orphans).toEqual(['2019-03-05T18:00:00+00:00'])
+  })
+
+  it('compares instants, not strings — Postgres renders a timestamptz its own way', async () => {
+    // Same moment, three encodings. A string compare would report all of these
+    // as orphans on every single import.
+    const stored = [
+      { started_at: '2019-03-04T18:00:00+00:00' },
+      { started_at: '2019-03-04T11:00:00-07:00' },
+    ]
+    const orphans = await findOrphanedStrengthSessions(readClient(stored), [
+      session('2019-03-04T18:00:00Z'),
+    ])
+    expect(orphans).toEqual([])
+  })
+
+  it('reports nothing when the export and the database agree', async () => {
+    const orphans = await findOrphanedStrengthSessions(
+      readClient([{ started_at: '2019-03-04T18:00:00+00:00' }]),
+      [session('2019-03-04T18:00:00Z')]
+    )
+    expect(orphans).toEqual([])
+  })
+
+  it('treats an empty payload as no evidence, not as everything being stale', async () => {
+    // An export carrying no strength sessions must never be read as "delete the
+    // 507 you already have".
+    const stored = [{ started_at: '2019-03-04T18:00:00+00:00' }]
+    expect(await findOrphanedStrengthSessions(readClient(stored), [])).toEqual([])
+    expect(
+      await findOrphanedStrengthSessions(readClient(stored), undefined as unknown as never[])
+    ).toEqual([])
   })
 })

--- a/scripts/preprocess-health.py
+++ b/scripts/preprocess-health.py
@@ -75,6 +75,19 @@ ACTIVITY_MAP: dict[str, str] = {
     'HKWorkoutActivityTypeWalking': 'walking',
 }
 
+# Strength workouts (#413). These land in `weight_room_workouts`, not in
+# `cardio_sessions` — a lifting session has no pace and no distance, and every
+# cardio rollup would need a permanent filter if they shared a table.
+#
+# Traditional Strength Training only, deliberately. Apple files circuit,
+# kettlebell and bootcamp work under *Functional* Strength Training, which is
+# nearer the HIIT sessions tracked in #414 than to a Weight Room session —
+# counting those here would make the session total quietly wrong. Adding it
+# later is one line.
+STRENGTH_ACTIVITY_MAP: dict[str, str] = {
+    'HKWorkoutActivityTypeTraditionalStrengthTraining': 'strength',
+}
+
 # Cap the inferred dwell time between consecutive HR samples. Apple
 # Health samples are ~1/min when sedentary, ~10s during workouts; if
 # the gap is huge (e.g. watch off), don't credit a single sample with
@@ -113,8 +126,19 @@ def zone_for_bpm(bpm: float, max_hr: int) -> int | None:
     return None
 
 
-def parse_workouts(xml_text: str) -> list[dict]:
-    """Extract cardio workouts in our three tracked activities, with raw start/end."""
+def parse_workouts(
+    xml_text: str, activity_map: dict[str, str] | None = None
+) -> list[dict]:
+    """Extract workouts whose `workoutActivityType` is in `activity_map`.
+
+    Args:
+        xml_text: The full export XML.
+        activity_map: `HKWorkoutActivityType` → activity label. Defaults to
+            {@link ACTIVITY_MAP}, the three cardio surfaces. Pass
+            {@link STRENGTH_ACTIVITY_MAP} to pull lifting sessions instead
+            (#413); the parse is identical, and only the destination differs.
+    """
+    activity_map = ACTIVITY_MAP if activity_map is None else activity_map
     open_re = re.compile(r'<Workout\s([^>]+)>')
     block_re = re.compile(r'<Workout\s[^>]*startDate="([^"]*)"[^>]*>([\s\S]*?)</Workout>')
 
@@ -139,7 +163,7 @@ def parse_workouts(xml_text: str) -> list[dict]:
         if not wtype or not start or not end:
             continue
 
-        activity = ACTIVITY_MAP.get(wtype)
+        activity = activity_map.get(wtype)
         if not activity:
             skipped_types[wtype] = skipped_types.get(wtype, 0) + 1
             continue
@@ -510,9 +534,36 @@ def _active_energy_to_kcal(record: str, value: float) -> Optional[float]:
     return value
 
 
+def to_strength_session(workout: dict) -> dict:
+    """Reduce a parsed workout to what a Weight Room session records (#413).
+
+    Deliberately narrow. Health knows a lifting session happened, how long it
+    ran, and what the heart was doing — it does not know what was lifted, so
+    there is nothing here about sets, reps or load. Pace, distance and
+    time-in-zone are dropped as meaningless for lifting.
+
+    `started_at` / `ended_at` rather than the cardio shape's single `date`,
+    because `weight_room_workouts` is a bounded interval and its duration is
+    derived from the two ends rather than stored.
+    """
+    return {
+        'started_at': workout['_start_dt'].isoformat(),
+        'ended_at': workout['_end_dt'].isoformat(),
+        'duration_seconds': workout['duration_seconds'],
+        'avg_hr': workout['avg_hr'],
+        'max_hr': workout['max_hr'],
+    }
+
+
 def build_cardio_data(xml_text: str, max_hr: int) -> dict:
     workouts = parse_workouts(xml_text)
     log(f"Parsed {len(workouts):,} cardio workouts (stair/running/walking)")
+
+    # A second pass rather than one combined map: these land in a different
+    # table with a different shape, and keeping the split here means the cardio
+    # path is provably untouched by #413.
+    strength_workouts = parse_workouts(xml_text, STRENGTH_ACTIVITY_MAP)
+    log(f"Parsed {len(strength_workouts):,} strength workouts (traditional)")
 
     samples = parse_hr_samples(xml_text)
 
@@ -521,10 +572,17 @@ def build_cardio_data(xml_text: str, max_hr: int) -> dict:
         aggregate_session_hr(w, samples, max_hr)
         derive_pace(w)
 
+    # Same HR aggregation, no pace: for a lifting session the HR trace and the
+    # duration are the entire intensity story.
+    for w in strength_workouts:
+        aggregate_session_hr(w, samples, max_hr)
+
     # Strip private parsing fields before serializing.
     sessions = []
     for w in workouts:
         sessions.append({k: v for k, v in w.items() if not k.startswith('_')})
+
+    strength_sessions = [to_strength_session(w) for w in strength_workouts]
 
     log("Parsing resting HR trend...", end='')
     resting = parse_simple_trend(xml_text, 'HKQuantityTypeIdentifierRestingHeartRate')
@@ -569,6 +627,7 @@ def build_cardio_data(xml_text: str, max_hr: int) -> dict:
     return {
         'imported_at': datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z'),
         'sessions': sessions,
+        'strength_sessions': strength_sessions,
         'resting_hr_trend': resting,
         'vo2max_trend': vo2,
         'hrv_trend': hrv,
@@ -647,6 +706,7 @@ def main() -> None:
     print("  Done!")
     print(f"  Output: {output_path} ({out_size:.0f} KB)")
     print(f"  Sessions:           {len(data['sessions']):,}")
+    print(f"  Strength sessions:  {len(data['strength_sessions']):,}")
     print(f"  Resting HR points:  {len(data['resting_hr_trend']):,}")
     print(f"  VO2max points:      {len(data['vo2max_trend']):,}")
     print(f"  HRV points:         {len(data['hrv_trend']):,}")

--- a/supabase/migrations/20260806120000_weight_room_workouts_health_import.sql
+++ b/supabase/migrations/20260806120000_weight_room_workouts_health_import.sql
@@ -1,0 +1,63 @@
+-- #413 — let Apple Health strength workouts land as Weight Room sessions.
+--
+-- `scripts/preprocess-health.py` has kept three activity types since the cardio
+-- import shipped and dropped the rest, so 507 Traditional Strength Training
+-- sessions spanning 2018-01-08 to 2026-07-03 have never been ingested — more
+-- sessions than running. They are lifting sessions, and #374 already models
+-- exactly what they carry: a start, an end, and a duration.
+--
+-- What they do NOT carry is sets. Apple Health records that a workout happened,
+-- not what was done in it, and only a small subset has a corresponding iCloud
+-- note (#400). A setless imported session is therefore the expected steady
+-- state, not a gap waiting to be filled — which is why `source` exists: the
+-- surfaces need to say "imported, sets not recorded" rather than rendering the
+-- empty state meant for a session someone abandoned.
+
+alter table public.weight_room_workouts
+  add column if not exists source text not null default 'manual',
+  add column if not exists avg_hr numeric,
+  add column if not exists max_hr numeric;
+
+do $$
+begin
+  alter table public.weight_room_workouts
+    add constraint weight_room_workouts_source_check
+    check (source in ('manual', 'apple_health'));
+exception
+  when duplicate_object then null;
+end $$;
+
+comment on column public.weight_room_workouts.source is
+  'Where this session came from (#413). ''manual'' — recorded through the app''s '
+  'live recording surface, and carries its own sets. ''apple_health'' — imported '
+  'from a Health export, which records that a workout happened but not what was '
+  'done in it, so it usually has no sets at all. Mirrors the same convention '
+  'body_mass_trend already uses.';
+
+comment on column public.weight_room_workouts.avg_hr is
+  'Average heart rate over the session, BPM. Populated for imported sessions from '
+  'the raw Health sample stream; null for manually recorded ones, which capture no HR. '
+  'For an imported session this and duration are the only intensity signal there is.';
+
+comment on column public.weight_room_workouts.max_hr is
+  'Peak heart rate over the session, BPM. Same provenance as avg_hr.';
+
+-- Idempotency. The export's <Workout> elements carry no UUID — only startDate,
+-- endDate, duration and sourceName — so the natural key is the instant the
+-- session began, which two lifting sessions cannot share. Without this, every
+-- re-export would duplicate 8.5 years of history.
+--
+-- Deliberately NOT partial. A `where source <> 'manual'` predicate would scope
+-- it to imported rows, which reads as the tidier constraint — but Postgres only
+-- infers `ON CONFLICT (source, started_at)` from a *full* unique index, and
+-- supabase-js's `onConflict` option takes column names with no way to restate a
+-- predicate. A partial index therefore fails the upsert outright with "no
+-- unique or exclusion constraint matching the ON CONFLICT specification",
+-- which is how this was caught: rehearsing the import against staging.
+--
+-- Covering manual rows too costs nothing. `started_at` defaults to `now()` at
+-- microsecond precision, and two sessions of the same provenance beginning at
+-- the same instant is not a thing that happens — nor a thing that would mean
+-- anything if it did.
+create unique index if not exists weight_room_workouts_source_started_at_key
+  on public.weight_room_workouts (source, started_at);

--- a/types/weight-room.ts
+++ b/types/weight-room.ts
@@ -91,6 +91,16 @@ export interface StrengthSet {
 export type WorkoutLocation = 'gym' | 'home' | 'travel' | 'other'
 
 /**
+ * How a {@link WeightRoomWorkout} got into the database (#413).
+ *
+ * Not cosmetic — it decides what the session can honestly claim. A `'manual'`
+ * session was recorded set by set, so its tonnage and adherence are
+ * measurements. An `'apple_health'` one knows only that lifting happened and
+ * for how long, so the same fields are *unknown* rather than zero.
+ */
+export type WorkoutSource = 'manual' | 'apple_health'
+
+/**
  * One bounded training session (#374) — mirrors a row of
  * `public.weight_room_workouts`.
  *
@@ -156,6 +166,30 @@ export interface WeightRoomWorkout {
    * captured one.
    */
   prescription?: WorkoutPrescription
+  /**
+   * Where this session came from (#413). Absent is treated as `'manual'`.
+   *
+   * `'manual'` — recorded through the live recording surface, and carries its
+   * own sets. `'apple_health'` — imported from a Health export, which records
+   * that a workout happened but not what was done in it.
+   *
+   * **An imported session usually has no sets at all, and that is the expected
+   * steady state**, not a gap waiting to be filled: only a small subset has a
+   * corresponding iCloud note (#400). Surfaces must say "sets not recorded"
+   * rather than reusing the empty state written for a session someone
+   * abandoned, and must not report a tonnage of zero as though it were measured.
+   */
+  source?: WorkoutSource
+  /**
+   * Mean heart rate over the session, BPM. Present only for imported sessions —
+   * the app captures no HR while recording.
+   *
+   * For an imported session this and the duration are the only intensity signal
+   * that exists, which is why they're worth carrying at all.
+   */
+  avg_hr?: number
+  /** Peak heart rate over the session, BPM. Same provenance as {@link avg_hr}. */
+  max_hr?: number
   /**
    * Free-text label, e.g. `Push Day`. Absent when unnamed. Human-facing only —
    * see {@link template_id} for the link.


### PR DESCRIPTION
`scripts/preprocess-health.py` has kept three activity types since the cardio import shipped — running, walking, stair — and silently dropped the rest at `if not activity: continue`. It even tallies the discards in `skipped_types`, where nobody was looking.

Scanning the current export (`export (2).zip`, Jul 4 2026):

| type | n | span | hrs | kept before |
|---|---:|---|---:|---|
| **TraditionalStrengthTraining** | **507** | 2018-01-08 → 2026-07-03 | 375 | **no** |
| Running | 366 | 2018-01-21 → 2026-07-01 | 134 | yes |
| Walking | 159 | 2021-07-08 → 2026-07-03 | 97 | yes |
| StairClimbing (+Stairs) | 59 | 2018-01-22 → 2026-06-24 | 26 | yes |

**507 strength sessions — more than running — had never been ingested.** 8.5 years, 375 hours, median 40 minutes. The site was showing 27% of the training history. The other 1,083 dropped workouts are catalogued in #414.

## They land in the Weight Room

Not `cardio_sessions`: a lifting session has no pace and no distance, and sharing that table would mean adding a filter to every cardio rollup forever. #374 already models exactly what Health carries — a start, an end, a duration.

**HR came free.** `aggregate_session_hr` already joins the raw sample stream to a workout by time window; strength sessions only had to stop being filtered out before it runs. 506 of 507 have it.

## The setless session is the point, not a gap

Health records that a workout happened, not what was done in it — and only a small subset of these will ever get sets from an iCloud note (#400). So a setless imported session is the **expected steady state**, and `source` exists to let the surfaces say so:

- Sets, reps and tonnage read **`—`**, never `0`. Three zeros say "you did nothing" when the record says the opposite.
- The summary shows **avg HR** in tonnage's place and explains why there's no breakdown, rather than reusing the "No sets logged into this session" copy written for a session someone abandoned.
- The history **badges** them and gains a **Recorded / Apple Health** filter — hundreds of skeletons would otherwise bury the handful with real detail.
- The moment #400 attaches sets to one, it stops being a skeleton and renders like any other session. Covered by a test.

## Scope decisions

- **Traditional only.** Apple files circuit and kettlebell work under *Functional* Strength Training (66 sessions), which belongs with #414's HIIT rather than here — counting it would make "507 lifting sessions" quietly wrong. One line to add later.
- **`location` stays null.** Health doesn't record it; defaulting to `'gym'` would put an inference where nothing established one.

## The bug the staging rehearsal caught

The unique index started out **partial** (`where source <> 'manual'`), which reads as the tidier constraint. Postgres only infers `ON CONFLICT (source, started_at)` from a **full** unique index, and supabase-js's `onConflict` option takes column names with no way to restate a predicate — so the upsert failed outright with *"no unique or exclusion constraint matching the ON CONFLICT specification"*.

**This would have failed on the first production run.** The index is now full; covering manual rows costs nothing, since `started_at` defaults to `now()` at microsecond precision and two sessions of the same provenance starting at the same instant isn't a thing.

Rehearsed against staging: 8 real sessions loaded, re-run, **still 8** — idempotency confirmed, manual rows untouched.

## Import status

Migration applied to **both** projects; `migrations:check` clean at 35/35. Staging holds the 8-session rehearsal sample. **Production has not been imported** — that's yours to run:

```
npm run import-health -- "C:\Users\lucas\Downloads\export (2).zip"
```

It re-imports cardio too (idempotent, same counts) and then upserts the 507. Safe to re-run.

## Test plan

At `/training-facility/weight-room/workouts?preview=demo` — the fixture now includes imported sessions, since they're the majority case:

- [ ] Imported rows carry an **Apple Health** badge and show duration + avg bpm, with **no** "0 sets / 0 reps".
- [ ] The **Recorded / Apple Health** rail appears with correct counts; picking one filters, and picking a template afterwards keeps both.
- [ ] Open an imported session — sets/reps/tonnage read `—`, avg HR replaces tonnage, and the note explains why there's no breakdown.
- [ ] Open a recorded session — unchanged from #377: tonnage, adherence, comparison, records.

Locally:

- [ ] `npm run import-health -- "<export.zip>"` reports `584 sessions` and `507 strength session(s)`.
- [ ] Run it **twice** — the second run reports the same counts and adds no rows.
- [ ] Cardio surfaces unchanged: running/walking/stair counts identical before and after.

Verified: `tsc` clean, `next build` compiles, **2159 unit tests** (160 files, including 9 new for the upsert layer), **65/65 Playwright**, `format:check` clean, `migrations:check` 35/35.

Closes #413.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Apple Health strength-workout imports to workout history.
  * Added filters for recorded and Apple Health sessions, including session counts.
  * Imported workouts display source labels, duration, heart-rate data, and clearer activity names.
  * Added tailored details for imported sessions when sets or rep data are unavailable.
* **Bug Fixes**
  * Unknown imported metrics are no longer shown as zero.
  * Combined source and template filters now remain selected when navigating results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->