### PR TITLE
fix(weight-room): bound the workouts page with a year rail and pagination (#416)

### DIFF
--- a/app/training-facility/weight-room/workouts/page.tsx
+++ b/app/training-facility/weight-room/workouts/page.tsx
@@ -201,6 +201,7 @@ export default async function WeightRoomWorkoutsPage({
             page={pageResult.page}
             totalPages={pageResult.totalPages}
             totalEntries={pageResult.totalEntries}
+            startIndex={pageResult.startIndex}
           />
         </div>
       </div>

--- a/app/training-facility/weight-room/workouts/page.tsx
+++ b/app/training-facility/weight-room/workouts/page.tsx
@@ -21,7 +21,12 @@ import {
 } from '@/lib/data/weight-room-server'
 import { isWeightRoomEnabled } from '@/lib/feature-flags'
 import { isPreviewDemoActive } from '@/lib/training-facility/preview-param'
-import { buildWorkoutHistory } from '@/lib/training-facility/workout-stats'
+import {
+  buildWorkoutHistory,
+  paginateWorkouts,
+  workoutYear,
+  workoutYearOptions,
+} from '@/lib/training-facility/workout-stats'
 
 /** Search-params shape Next.js passes to a server-rendered page. */
 interface PageProps {
@@ -108,14 +113,34 @@ export default async function WeightRoomWorkoutsPage({
   // link naming a deleted template should degrade to the full history.
   const selectedTemplateId =
     requestedTemplate !== null && counts.has(requestedTemplate) ? requestedTemplate : null
-  const entries = history.filter(entry => {
+  // Year is the third filter axis, and the one that keeps the page bounded
+  // (#416). Before it, the default view rendered every session ever recorded —
+  // 507 rows and 1.4 MB after the Health import landed.
+  const years = workoutYearOptions(history)
+  const requestedYear = firstParam(params.year)
+  // Default to the newest year with sessions rather than to everything. An
+  // unrecognised value also lands here, so a stale link degrades to a small,
+  // useful page instead of the heaviest one.
+  const selectedYear: number | null =
+    requestedYear === 'all'
+      ? null
+      : (years.find(y => String(y.year) === requestedYear)?.year ?? years[0]?.year ?? null)
+
+  const filtered = history.filter(entry => {
     if (selectedTemplateId !== null && entry.workout.template_id !== selectedTemplateId) {
       return false
     }
+    if (selectedYear !== null && workoutYear(entry) !== selectedYear) return false
     if (selectedSource === null) return true
     const isImported = entry.workout.source === 'apple_health'
     return selectedSource === 'imported' ? isImported : !isImported
   })
+
+  // Paginate whatever the filters left, not just the all-years view: 2022 alone
+  // is 152 sessions, so a year filter on its own still ships a heavy page.
+  const requestedPage = Number(firstParam(params.page) ?? '1')
+  const pageResult = paginateWorkouts(filtered, requestedPage)
+  const entries = pageResult.entries
 
   return (
     <div className="relative min-h-svh overflow-hidden bg-[#120d0a] text-[#f7ead9]">
@@ -171,6 +196,11 @@ export default async function WeightRoomWorkoutsPage({
             selectedSource={selectedSource}
             recordedCount={recordedCount}
             importedCount={importedCount}
+            years={years}
+            selectedYear={selectedYear}
+            page={pageResult.page}
+            totalPages={pageResult.totalPages}
+            totalEntries={pageResult.totalEntries}
           />
         </div>
       </div>

--- a/components/training-facility/weight-room/WorkoutHistoryList.test.tsx
+++ b/components/training-facility/weight-room/WorkoutHistoryList.test.tsx
@@ -13,6 +13,10 @@ import {
 /**
  * Rendering coverage for the workout history (#377).
  *
+ * Every chip href carries `year` since #416 — absent means "newest year", the
+ * default, so omitting it would snap an all-years view back to the newest one
+ * the moment any other chip was clicked.
+ *
  * Chiefly the two states that read wrong if conflated — "you haven't recorded
  * anything yet" versus "this filter matched nothing" — and the preview link
  * suffix, without which a demo row clicks through to a 404.
@@ -122,11 +126,11 @@ describe('WorkoutHistoryList', () => {
     // demo tour one click in.
     expect(screen.getByTestId('workout-filter-t1')).toHaveAttribute(
       'href',
-      '/training-facility/weight-room/workouts?template=t1&preview=demo'
+      '/training-facility/weight-room/workouts?template=t1&year=all&preview=demo'
     )
     expect(screen.getByTestId('workout-filter-all')).toHaveAttribute(
       'href',
-      '/training-facility/weight-room/workouts?preview=demo'
+      '/training-facility/weight-room/workouts?year=all&preview=demo'
     )
   })
 
@@ -136,7 +140,7 @@ describe('WorkoutHistoryList', () => {
     )
     expect(screen.getByTestId('workout-filter-all')).toHaveAttribute(
       'href',
-      '/training-facility/weight-room/workouts'
+      '/training-facility/weight-room/workouts?year=all'
     )
   })
 
@@ -259,16 +263,16 @@ describe('WorkoutHistoryList — imported sessions (#413)', () => {
     // Switching template must preserve the source filter...
     expect(screen.getByTestId('workout-filter-t1')).toHaveAttribute(
       'href',
-      '/training-facility/weight-room/workouts?template=t1&source=imported'
+      '/training-facility/weight-room/workouts?template=t1&source=imported&year=all'
     )
     // ...and switching source must preserve the template.
     expect(screen.getByTestId('workout-source-recorded')).toHaveAttribute(
       'href',
-      '/training-facility/weight-room/workouts?template=t1&source=recorded'
+      '/training-facility/weight-room/workouts?template=t1&source=recorded&year=all'
     )
     expect(screen.getByTestId('workout-source-all')).toHaveAttribute(
       'href',
-      '/training-facility/weight-room/workouts?template=t1'
+      '/training-facility/weight-room/workouts?template=t1&year=all'
     )
   })
 
@@ -286,5 +290,164 @@ describe('WorkoutHistoryList — imported sessions (#413)', () => {
     expect(screen.getByTestId('workout-source-all')).toHaveTextContent('509')
     expect(screen.getByTestId('workout-source-imported')).toHaveTextContent('507')
     expect(screen.getByTestId('workout-source-recorded')).toHaveTextContent('2')
+  })
+})
+
+describe('WorkoutHistoryList — year rail and pagination (#416)', () => {
+  const YEARS = [
+    { year: 2026, count: 22 },
+    { year: 2024, count: 65 },
+    { year: 2022, count: 152 },
+  ]
+
+  it('renders a chip per year plus All years, with counts', () => {
+    render(
+      <WorkoutHistoryList
+        entries={[]}
+        filters={[]}
+        selectedTemplateId={null}
+        hasAnyWorkouts
+        years={YEARS}
+        selectedYear={2026}
+      />
+    )
+    expect(screen.getByTestId('workout-year-2026')).toHaveTextContent('22')
+    expect(screen.getByTestId('workout-year-2022')).toHaveTextContent('152')
+    // Total across every year, so All is honest about what it costs.
+    expect(screen.getByTestId('workout-year-all')).toHaveTextContent('239')
+    expect(screen.getByTestId('workout-year-2026')).toHaveAttribute('aria-current', 'page')
+  })
+
+  it('hides the rail when there is only one year to choose from', () => {
+    render(
+      <WorkoutHistoryList
+        entries={[]}
+        filters={[]}
+        selectedTemplateId={null}
+        hasAnyWorkouts
+        years={[{ year: 2026, count: 22 }]}
+        selectedYear={2026}
+      />
+    )
+    expect(screen.queryByTestId('workout-year-filter')).toBeNull()
+  })
+
+  it('keeps the other filters when switching year', () => {
+    render(
+      <WorkoutHistoryList
+        entries={[]}
+        filters={FILTERS}
+        selectedTemplateId="t1"
+        hasAnyWorkouts
+        years={YEARS}
+        selectedYear={2026}
+        selectedSource="imported"
+        importedCount={5}
+      />
+    )
+    expect(screen.getByTestId('workout-year-2022')).toHaveAttribute(
+      'href',
+      '/training-facility/weight-room/workouts?template=t1&source=imported&year=2022'
+    )
+    expect(screen.getByTestId('workout-year-all')).toHaveAttribute(
+      'href',
+      '/training-facility/weight-room/workouts?template=t1&source=imported&year=all'
+    )
+  })
+
+  it('shows no pagination when everything fits on one page', () => {
+    render(
+      <WorkoutHistoryList
+        entries={[]}
+        filters={[]}
+        selectedTemplateId={null}
+        hasAnyWorkouts
+        page={1}
+        totalPages={1}
+      />
+    )
+    expect(screen.queryByTestId('workout-pagination')).toBeNull()
+  })
+
+  it('paginates with real, shareable URLs that preserve the filters', () => {
+    const entries = buildWorkoutHistory([WORKOUT], SETS, [TEMPLATE])
+    render(
+      <WorkoutHistoryList
+        entries={entries}
+        filters={[]}
+        selectedTemplateId={null}
+        hasAnyWorkouts
+        years={YEARS}
+        selectedYear={2022}
+        page={2}
+        totalPages={4}
+        totalEntries={152}
+      />
+    )
+    expect(screen.getByTestId('workout-page-prev')).toHaveAttribute(
+      'href',
+      '/training-facility/weight-room/workouts?year=2022'
+    )
+    expect(screen.getByTestId('workout-page-next')).toHaveAttribute(
+      'href',
+      '/training-facility/weight-room/workouts?year=2022&page=3'
+    )
+    expect(screen.getByTestId('workout-pagination')).toHaveTextContent('2 / 4')
+  })
+
+  it('omits the prev link on the first page and next on the last', () => {
+    const entries = buildWorkoutHistory([WORKOUT], SETS, [TEMPLATE])
+    const first = render(
+      <WorkoutHistoryList
+        entries={entries}
+        filters={[]}
+        selectedTemplateId={null}
+        hasAnyWorkouts
+        page={1}
+        totalPages={2}
+        totalEntries={60}
+      />
+    )
+    expect(first.queryByTestId('workout-page-prev')).toBeNull()
+    expect(first.getByTestId('workout-page-next')).toBeInTheDocument()
+    first.unmount()
+
+    const last = render(
+      <WorkoutHistoryList
+        entries={entries}
+        filters={[]}
+        selectedTemplateId={null}
+        hasAnyWorkouts
+        page={2}
+        totalPages={2}
+        totalEntries={60}
+      />
+    )
+    expect(last.getByTestId('workout-page-prev')).toBeInTheDocument()
+    expect(last.queryByTestId('workout-page-next')).toBeNull()
+  })
+
+  it('resets to page 1 when a filter changes', () => {
+    // Page 4 of one filter set has nothing to do with page 4 of another.
+    render(
+      <WorkoutHistoryList
+        entries={[]}
+        filters={FILTERS}
+        selectedTemplateId={null}
+        hasAnyWorkouts
+        years={YEARS}
+        selectedYear={2022}
+        page={4}
+        totalPages={4}
+      />
+    )
+    expect(screen.getByTestId('workout-year-2024')).toHaveAttribute(
+      'href',
+      '/training-facility/weight-room/workouts?year=2024'
+    )
+    expect(screen.getByTestId('workout-filter-t1')).toHaveAttribute(
+      'href',
+      '/training-facility/weight-room/workouts?template=t1&year=2022'
+    )
   })
 })

--- a/components/training-facility/weight-room/WorkoutHistoryList.tsx
+++ b/components/training-facility/weight-room/WorkoutHistoryList.tsx
@@ -3,8 +3,10 @@ import Link from 'next/link'
 
 import { formatDayKey, safePacificDayKey, todayDayKey } from '@/lib/training-facility/day-keys'
 import {
+  WORKOUT_PAGE_SIZE,
   workoutDisplayTitle,
   type WorkoutHistoryEntry,
+  type WorkoutYearOption,
 } from '@/lib/training-facility/workout-stats'
 
 /** Route the workout history lives at; also the base for every filter chip. */
@@ -12,6 +14,9 @@ export const WORKOUTS_ROUTE = '/training-facility/weight-room/workouts'
 
 /** URL param naming the provenance filter (#413). */
 export const SOURCE_FILTER_PARAM = 'source'
+
+/** URL param naming the year filter (#416). Value is a year, or `all`. */
+export const YEAR_FILTER_PARAM = 'year'
 
 /**
  * Provenance filter selection (#413).
@@ -49,6 +54,16 @@ export interface WorkoutHistoryListProps {
   recordedCount?: number
   /** How many were imported from Apple Health; drives the Imported chip's count. */
   importedCount?: number
+  /** Years that have sessions, newest first (#416). Empty hides the year rail. */
+  years?: readonly WorkoutYearOption[]
+  /** Selected year, or `null` for all years. */
+  selectedYear?: number | null
+  /** Current 1-based page. */
+  page?: number
+  /** Total pages for the current filter set. */
+  totalPages?: number
+  /** Entries across every page, for the "showing N of M" line. */
+  totalEntries?: number
   /** Whether any session exists at all, so a filtered-to-nothing view reads differently from a fresh log. */
   hasAnyWorkouts: boolean
   /**
@@ -81,26 +96,32 @@ export function WorkoutHistoryList({
   selectedSource = null,
   recordedCount = 0,
   importedCount = 0,
+  years = [],
+  selectedYear = null,
+  page = 1,
+  totalPages = 1,
+  totalEntries = 0,
 }: WorkoutHistoryListProps): JSX.Element {
+  const filterState: FilterState = {
+    selectedTemplateId,
+    selectedSource,
+    selectedYear,
+    isPreviewMode,
+  }
   return (
     <div className="flex flex-col gap-5">
+      {years.length > 1 ? <YearFilterRail years={years} filterState={filterState} /> : null}
+
       {importedCount > 0 ? (
         <SourceFilterRail
-          selectedSource={selectedSource}
-          selectedTemplateId={selectedTemplateId}
+          filterState={filterState}
           recordedCount={recordedCount}
           importedCount={importedCount}
-          isPreviewMode={isPreviewMode}
         />
       ) : null}
 
       {filters.length > 1 ? (
-        <TemplateFilterRail
-          filters={filters}
-          selectedTemplateId={selectedTemplateId}
-          selectedSource={selectedSource}
-          isPreviewMode={isPreviewMode}
-        />
+        <TemplateFilterRail filters={filters} filterState={filterState} />
       ) : null}
 
       {entries.length === 0 ? (
@@ -113,13 +134,24 @@ export function WorkoutHistoryList({
             : 'No workouts recorded yet. Start one from the Log page and it will show up here.'}
         </p>
       ) : (
-        <ul data-testid="workout-history" className="flex flex-col gap-3">
-          {entries.map(entry => (
-            <li key={entry.workout.id}>
-              <WorkoutHistoryRow entry={entry} isPreviewMode={isPreviewMode} />
-            </li>
-          ))}
-        </ul>
+        <>
+          <ul data-testid="workout-history" className="flex flex-col gap-3">
+            {entries.map(entry => (
+              <li key={entry.workout.id}>
+                <WorkoutHistoryRow entry={entry} isPreviewMode={isPreviewMode} />
+              </li>
+            ))}
+          </ul>
+          {totalPages > 1 ? (
+            <Pagination
+              page={page}
+              totalPages={totalPages}
+              totalEntries={totalEntries}
+              shown={entries.length}
+              filterState={filterState}
+            />
+          ) : null}
+        </>
       )}
     </div>
   )
@@ -127,30 +159,48 @@ export function WorkoutHistoryList({
 
 interface TemplateFilterRailProps {
   filters: readonly TemplateFilterOption[]
+  filterState: FilterState
+}
+
+/**
+ * The filters currently applied, as the URL expresses them.
+ *
+ * Passed around whole so a chip can rebuild the URL with **one** axis changed
+ * and the rest preserved. Choosing a template must not silently clear the year,
+ * and neither may drop `preview=demo` — the fixture only stands in when the real
+ * read is empty, so losing that param ends the demo mid-tour.
+ */
+interface FilterState {
   selectedTemplateId: string | null
   selectedSource: WorkoutSourceFilter | null
+  /** `null` means *all years*, which is an explicit `year=all`, not an absent param. */
+  selectedYear: number | null
   isPreviewMode: boolean
 }
 
 /**
- * Build a chip href carrying every active filter, not just the one being set.
+ * Build a href for a chip that changes one filter and keeps the others.
  *
- * The two rails are independent axes, so choosing a template must not silently
- * clear a provenance filter (or vice versa) — and `preview=demo` has to survive
- * both, since the fixture only stands in when the real read is empty and
- * dropping it ends the demo mid-tour.
+ * `year` is always emitted, because absent means "newest year" rather than
+ * "every year" (#416) — leaving it off would silently snap an all-years view
+ * back to the default the moment any other chip was clicked.
+ *
+ * `page` is omitted when it is 1, and **reset on every filter change**: page 4
+ * of one filter set has nothing to do with page 4 of another, and carrying it
+ * over lands the reader on a clamped page with no explanation.
  */
 function chipHref(
-  templateId: string | null,
-  source: WorkoutSourceFilter | null,
-  isPreviewMode: boolean
+  state: FilterState,
+  override: Partial<FilterState & { page: number }> = {}
 ): string {
+  const next = { ...state, ...override }
   const params = new URLSearchParams()
-  if (templateId !== null) params.set('template', templateId)
-  if (source !== null) params.set(SOURCE_FILTER_PARAM, source)
-  if (isPreviewMode) params.set('preview', 'demo')
-  const query = params.toString()
-  return query === '' ? WORKOUTS_ROUTE : `${WORKOUTS_ROUTE}?${query}`
+  if (next.selectedTemplateId !== null) params.set('template', next.selectedTemplateId)
+  if (next.selectedSource !== null) params.set(SOURCE_FILTER_PARAM, next.selectedSource)
+  params.set(YEAR_FILTER_PARAM, next.selectedYear === null ? 'all' : String(next.selectedYear))
+  if (override.page !== undefined && override.page > 1) params.set('page', String(override.page))
+  if (next.isPreviewMode) params.set('preview', 'demo')
+  return `${WORKOUTS_ROUTE}?${params.toString()}`
 }
 
 /** Shared chip styling, so the two rails can't drift apart visually. */
@@ -161,11 +211,9 @@ function chipClass(isActive: boolean): string {
 }
 
 interface SourceFilterRailProps {
-  selectedSource: WorkoutSourceFilter | null
-  selectedTemplateId: string | null
+  filterState: FilterState
   recordedCount: number
   importedCount: number
-  isPreviewMode: boolean
 }
 
 /**
@@ -177,12 +225,11 @@ interface SourceFilterRailProps {
  * skeletons would otherwise bury the handful of sessions with real set data.
  */
 function SourceFilterRail({
-  selectedSource,
-  selectedTemplateId,
+  filterState,
   recordedCount,
   importedCount,
-  isPreviewMode,
 }: SourceFilterRailProps): JSX.Element {
+  const selectedSource = filterState.selectedSource
   const options: Array<{ value: WorkoutSourceFilter | null; label: string; count: number }> = [
     { value: null, label: 'All', count: recordedCount + importedCount },
     { value: 'recorded', label: 'Recorded', count: recordedCount },
@@ -197,7 +244,7 @@ function SourceFilterRail({
           return (
             <li key={option.value ?? 'all'}>
               <Link
-                href={chipHref(selectedTemplateId, option.value, isPreviewMode)}
+                href={chipHref(filterState, { selectedSource: option.value })}
                 aria-current={isActive ? 'page' : undefined}
                 data-testid={`workout-source-${option.value ?? 'all'}`}
                 className={chipClass(isActive)}
@@ -215,12 +262,8 @@ function SourceFilterRail({
   )
 }
 
-function TemplateFilterRail({
-  filters,
-  selectedTemplateId,
-  selectedSource,
-  isPreviewMode,
-}: TemplateFilterRailProps): JSX.Element {
+function TemplateFilterRail({ filters, filterState }: TemplateFilterRailProps): JSX.Element {
+  const selectedTemplateId = filterState.selectedTemplateId
   return (
     <nav aria-label="Filter by template" data-testid="workout-template-filter">
       <ul className="flex flex-wrap gap-2">
@@ -229,7 +272,7 @@ function TemplateFilterRail({
           return (
             <li key={option.id ?? 'all'}>
               <Link
-                href={chipHref(option.id, selectedSource, isPreviewMode)}
+                href={chipHref(filterState, { selectedTemplateId: option.id })}
                 aria-current={isActive ? 'page' : undefined}
                 data-testid={`workout-filter-${option.id ?? 'all'}`}
                 className={chipClass(isActive)}
@@ -360,5 +403,128 @@ function WorkoutHistoryRow({ entry, isPreviewMode }: WorkoutHistoryRowProps): JS
         </p>
       ) : null}
     </Link>
+  )
+}
+
+interface YearFilterRailProps {
+  years: readonly WorkoutYearOption[]
+  filterState: FilterState
+}
+
+/**
+ * Year rail (#416) — the filter that keeps this page bounded.
+ *
+ * The default view is the newest year rather than everything: after the Apple
+ * Health import (#413) the unfiltered list was 507 rows and 1.4 MB, on the
+ * landing view of a sub-nav pill.
+ *
+ * Years with no sessions are absent rather than rendered empty, so the rail
+ * shows the shape of the training history — including its gaps — instead of a
+ * uniform run of years that implies continuity that wasn't there.
+ */
+function YearFilterRail({ years, filterState }: YearFilterRailProps): JSX.Element {
+  const total = years.reduce((n, y) => n + y.count, 0)
+  return (
+    <nav aria-label="Filter by year" data-testid="workout-year-filter">
+      <ul className="flex flex-wrap gap-2">
+        {years.map(option => {
+          const isActive = option.year === filterState.selectedYear
+          return (
+            <li key={option.year}>
+              <Link
+                href={chipHref(filterState, { selectedYear: option.year })}
+                aria-current={isActive ? 'page' : undefined}
+                data-testid={`workout-year-${option.year}`}
+                className={chipClass(isActive)}
+              >
+                {option.year}
+                <span className={isActive ? 'text-[#0a0a0a]/50' : 'text-[#e8d5be]/45'}>
+                  {option.count}
+                </span>
+              </Link>
+            </li>
+          )
+        })}
+        <li>
+          <Link
+            href={chipHref(filterState, { selectedYear: null })}
+            aria-current={filterState.selectedYear === null ? 'page' : undefined}
+            data-testid="workout-year-all"
+            className={chipClass(filterState.selectedYear === null)}
+          >
+            All years
+            <span
+              className={
+                filterState.selectedYear === null ? 'text-[#0a0a0a]/50' : 'text-[#e8d5be]/45'
+              }
+            >
+              {total}
+            </span>
+          </Link>
+        </li>
+      </ul>
+    </nav>
+  )
+}
+
+interface PaginationProps {
+  page: number
+  totalPages: number
+  totalEntries: number
+  shown: number
+  filterState: FilterState
+}
+
+/**
+ * Prev / next pagination for the current filter set (#416).
+ *
+ * Applies to any filter, not only "All years": 2022 alone is 152 sessions, so a
+ * year filter on its own still ships a heavy page.
+ *
+ * Renders links rather than buttons so the page stays a Server Component and
+ * each page is a real, shareable URL — the same reason the filters are URL
+ * params (#377).
+ */
+function Pagination({
+  page,
+  totalPages,
+  totalEntries,
+  shown,
+  filterState,
+}: PaginationProps): JSX.Element {
+  const first = (page - 1) * WORKOUT_PAGE_SIZE + 1
+  return (
+    <nav
+      aria-label="Pagination"
+      data-testid="workout-pagination"
+      className="flex flex-wrap items-center justify-between gap-3 pt-1"
+    >
+      <p className="text-xs text-[#e8d5be]/60">
+        Showing {first}–{first + shown - 1} of {totalEntries}
+      </p>
+      <div className="flex items-center gap-2">
+        {page > 1 ? (
+          <Link
+            href={chipHref(filterState, { page: page - 1 })}
+            data-testid="workout-page-prev"
+            className={chipClass(false)}
+          >
+            ← Newer
+          </Link>
+        ) : null}
+        <span className="font-mono text-[0.65rem] uppercase tracking-[0.14em] text-[#e8d5be]/50">
+          {page} / {totalPages}
+        </span>
+        {page < totalPages ? (
+          <Link
+            href={chipHref(filterState, { page: page + 1 })}
+            data-testid="workout-page-next"
+            className={chipClass(false)}
+          >
+            Older →
+          </Link>
+        ) : null}
+      </div>
+    </nav>
   )
 }

--- a/components/training-facility/weight-room/WorkoutHistoryList.tsx
+++ b/components/training-facility/weight-room/WorkoutHistoryList.tsx
@@ -3,7 +3,6 @@ import Link from 'next/link'
 
 import { formatDayKey, safePacificDayKey, todayDayKey } from '@/lib/training-facility/day-keys'
 import {
-  WORKOUT_PAGE_SIZE,
   workoutDisplayTitle,
   type WorkoutHistoryEntry,
   type WorkoutYearOption,
@@ -64,6 +63,8 @@ export interface WorkoutHistoryListProps {
   totalPages?: number
   /** Entries across every page, for the "showing N of M" line. */
   totalEntries?: number
+  /** 1-based index of the first row on this page, from `paginateWorkouts`. */
+  startIndex?: number
   /** Whether any session exists at all, so a filtered-to-nothing view reads differently from a fresh log. */
   hasAnyWorkouts: boolean
   /**
@@ -101,6 +102,7 @@ export function WorkoutHistoryList({
   page = 1,
   totalPages = 1,
   totalEntries = 0,
+  startIndex = 1,
 }: WorkoutHistoryListProps): JSX.Element {
   const filterState: FilterState = {
     selectedTemplateId,
@@ -148,6 +150,7 @@ export function WorkoutHistoryList({
               totalPages={totalPages}
               totalEntries={totalEntries}
               shown={entries.length}
+              startIndex={startIndex}
               filterState={filterState}
             />
           ) : null}
@@ -472,6 +475,8 @@ interface PaginationProps {
   totalPages: number
   totalEntries: number
   shown: number
+  /** 1-based index of the first row shown, supplied by `paginateWorkouts`. */
+  startIndex: number
   filterState: FilterState
 }
 
@@ -490,9 +495,9 @@ function Pagination({
   totalPages,
   totalEntries,
   shown,
+  startIndex,
   filterState,
 }: PaginationProps): JSX.Element {
-  const first = (page - 1) * WORKOUT_PAGE_SIZE + 1
   return (
     <nav
       aria-label="Pagination"
@@ -500,7 +505,7 @@ function Pagination({
       className="flex flex-wrap items-center justify-between gap-3 pt-1"
     >
       <p className="text-xs text-[#e8d5be]/60">
-        Showing {first}–{first + shown - 1} of {totalEntries}
+        Showing {startIndex}–{startIndex + shown - 1} of {totalEntries}
       </p>
       <div className="flex items-center gap-2">
         {page > 1 ? (

--- a/lib/training-facility/workout-stats.test.ts
+++ b/lib/training-facility/workout-stats.test.ts
@@ -669,6 +669,19 @@ describe('paginateWorkouts (#416)', () => {
     expect(paginateWorkouts(entries, 0, 50).page).toBe(1)
   })
 
+  it('reports the offset so the caption cannot disagree with the rows', () => {
+    // Derived here rather than at the render site, which would have to assume
+    // the default page size even when a caller passed a different one.
+    expect(paginateWorkouts(entries, 1, 50).startIndex).toBe(1)
+    expect(paginateWorkouts(entries, 2, 50).startIndex).toBe(51)
+    expect(paginateWorkouts(entries, 3, 50).startIndex).toBe(101)
+    expect(paginateWorkouts(entries, 2, 25).startIndex).toBe(26)
+  })
+
+  it('reports a zero offset when there is nothing to show', () => {
+    expect(paginateWorkouts([], 1, 50).startIndex).toBe(0)
+  })
+
   it('reports one page for an empty list, so the UI has something to render', () => {
     const result = paginateWorkouts([], 1, 50)
     expect(result.totalPages).toBe(1)

--- a/lib/training-facility/workout-stats.test.ts
+++ b/lib/training-facility/workout-stats.test.ts
@@ -19,7 +19,10 @@ import {
   findPersonalBests,
   findPreviousRun,
   loadMultipliersBySlug,
+  WORKOUT_PAGE_SIZE,
+  paginateWorkouts,
   workoutDisplayTitle,
+  workoutYearOptions,
 } from './workout-stats'
 
 /**
@@ -595,5 +598,96 @@ describe('workoutDisplayTitle (#413)', () => {
 
   it('still honours a template on an imported session, once #400 links one', () => {
     expect(workoutDisplayTitle({ source: 'apple_health' }, 'Chest Day 1')).toBe('Chest Day 1')
+  })
+})
+
+describe('workoutYearOptions (#416)', () => {
+  function at(id: string, iso: string) {
+    return buildWorkoutHistory([{ id, started_at: iso }], [], [], [])[0]
+  }
+
+  it('counts sessions per Pacific year, newest first', () => {
+    const entries = [
+      at('a', '2022-05-01T18:00:00Z'),
+      at('b', '2022-06-01T18:00:00Z'),
+      at('c', '2024-01-01T18:00:00Z'),
+    ]
+    expect(workoutYearOptions(entries)).toEqual([
+      { year: 2024, count: 1 },
+      { year: 2022, count: 2 },
+    ])
+  })
+
+  it('omits years with no sessions rather than filling them in', () => {
+    // The gaps are the interesting part — 2019/2020/2025 are absent from the
+    // real log and shouldn't be rendered as empty chips.
+    const entries = [at('a', '2018-05-01T18:00:00Z'), at('b', '2021-05-01T18:00:00Z')]
+    expect(workoutYearOptions(entries).map(y => y.year)).toEqual([2021, 2018])
+  })
+
+  it('buckets by Pacific year, not UTC', () => {
+    // 2021-12-31T20:00 Pacific is 2022-01-01T04:00Z — UTC would file it as 2022.
+    expect(workoutYearOptions([at('a', '2022-01-01T04:00:00Z')])).toEqual([
+      { year: 2021, count: 1 },
+    ])
+  })
+
+  it('ignores an unparseable timestamp instead of inventing a year', () => {
+    expect(workoutYearOptions([at('bad', 'not-a-date')])).toEqual([])
+  })
+})
+
+describe('paginateWorkouts (#416)', () => {
+  const entries = Array.from(
+    { length: 120 },
+    (_, i) =>
+      buildWorkoutHistory([{ id: `w${i}`, started_at: '2024-01-01T18:00:00Z' }], [], [], [])[0]
+  )
+
+  it('slices to the page size and reports the totals', () => {
+    const result = paginateWorkouts(entries, 1, 50)
+    expect(result.entries).toHaveLength(50)
+    expect(result.page).toBe(1)
+    expect(result.totalPages).toBe(3)
+    expect(result.totalEntries).toBe(120)
+  })
+
+  it('returns the remainder on the last page', () => {
+    expect(paginateWorkouts(entries, 3, 50).entries).toHaveLength(20)
+  })
+
+  it('clamps a page past the end rather than erroring', () => {
+    // A filter change can shrink the list under a bookmarked ?page=99.
+    const result = paginateWorkouts(entries, 99, 50)
+    expect(result.page).toBe(3)
+    expect(result.entries).toHaveLength(20)
+  })
+
+  it('clamps a nonsense page to the first', () => {
+    expect(paginateWorkouts(entries, -3, 50).page).toBe(1)
+    expect(paginateWorkouts(entries, Number.NaN, 50).page).toBe(1)
+    expect(paginateWorkouts(entries, 0, 50).page).toBe(1)
+  })
+
+  it('reports one page for an empty list, so the UI has something to render', () => {
+    const result = paginateWorkouts([], 1, 50)
+    expect(result.totalPages).toBe(1)
+    expect(result.entries).toEqual([])
+    expect(result.totalEntries).toBe(0)
+  })
+
+  it('never divides by a zero page size', () => {
+    expect(paginateWorkouts(entries, 1, 0).entries).toHaveLength(1)
+  })
+
+  it('bounds the real production case — 507 sessions', () => {
+    const many = Array.from(
+      { length: 507 },
+      (_, i) =>
+        buildWorkoutHistory([{ id: `p${i}`, started_at: '2022-01-01T18:00:00Z' }], [], [], [])[0]
+    )
+    const result = paginateWorkouts(many, 1)
+    expect(result.entries).toHaveLength(WORKOUT_PAGE_SIZE)
+    expect(result.totalPages).toBe(Math.ceil(507 / WORKOUT_PAGE_SIZE))
   })
 })

--- a/lib/training-facility/workout-stats.ts
+++ b/lib/training-facility/workout-stats.ts
@@ -792,6 +792,16 @@ export interface WorkoutPage {
   totalPages: number
   /** Entries across every page. */
   totalEntries: number
+  /**
+   * 1-based index of the first entry on this page, for a "showing 51–100 of
+   * 507" line. `0` when there are no entries at all.
+   *
+   * Reported here rather than derived at the render site from
+   * {@link WORKOUT_PAGE_SIZE}: this function takes a page size, so a caller
+   * passing a custom one would silently get a caption that disagreed with the
+   * rows beneath it.
+   */
+  startIndex: number
 }
 
 /**
@@ -817,10 +827,12 @@ export function paginateWorkouts(
     ? Math.min(totalPages, Math.max(1, Math.floor(requestedPage)))
     : 1
   const start = (page - 1) * size
+  const sliced = entries.slice(start, start + size)
   return {
-    entries: entries.slice(start, start + size),
+    entries: sliced,
     page,
     totalPages,
     totalEntries: entries.length,
+    startIndex: sliced.length === 0 ? 0 : start + 1,
   }
 }

--- a/lib/training-facility/workout-stats.ts
+++ b/lib/training-facility/workout-stats.ts
@@ -6,6 +6,7 @@ import type {
 } from '@/types/weight-room'
 
 import { buildSlotProgress, extraSets, type SlotProgress } from './live-workout'
+import { safePacificDayKey } from './day-keys'
 import { compareInstants, isStaleOpenWorkout, workoutDurationMinutes } from './workout-sessions'
 
 /**
@@ -733,4 +734,93 @@ export function buildWorkoutHistory(
         templateColor: template?.color ?? null,
       }
     })
+}
+
+/** How many history rows one page of the workout list carries (#416). */
+export const WORKOUT_PAGE_SIZE = 50
+
+/** One year's worth of recorded sessions, for the history's year rail (#416). */
+export interface WorkoutYearOption {
+  /** Calendar year, Pacific. */
+  year: number
+  /** Sessions started in it. */
+  count: number
+}
+
+/**
+ * Group history entries by their Pacific calendar year, newest year first.
+ *
+ * Years with no sessions are simply absent rather than filled in with zeroes —
+ * the gaps are the interesting part. A log running 2018, 2021–2024, 2026 says
+ * something true about the training behind it, and inventing empty 2019 and
+ * 2020 chips would bury that under uniformity.
+ *
+ * @param entries History entries, in any order.
+ */
+export function workoutYearOptions(entries: readonly WorkoutHistoryEntry[]): WorkoutYearOption[] {
+  const counts = new Map<number, number>()
+  for (const entry of entries) {
+    const dayKey = safePacificDayKey(entry.workout.started_at)
+    if (dayKey === '') continue
+    const year = Number(dayKey.slice(0, 4))
+    if (!Number.isFinite(year)) continue
+    counts.set(year, (counts.get(year) ?? 0) + 1)
+  }
+  return [...counts.entries()]
+    .map(([year, count]) => ({ year, count }))
+    .sort((a, b) => b.year - a.year)
+}
+
+/**
+ * Which Pacific calendar year an entry belongs to, or `null` when its timestamp
+ * can't be parsed.
+ */
+export function workoutYear(entry: WorkoutHistoryEntry): number | null {
+  const dayKey = safePacificDayKey(entry.workout.started_at)
+  if (dayKey === '') return null
+  const year = Number(dayKey.slice(0, 4))
+  return Number.isFinite(year) ? year : null
+}
+
+/** One page of history, plus what the caller needs to render pagination. */
+export interface WorkoutPage {
+  /** Entries on this page. */
+  entries: WorkoutHistoryEntry[]
+  /** 1-based page number, clamped into range. */
+  page: number
+  /** Total pages; at least `1` even when there are no entries. */
+  totalPages: number
+  /** Entries across every page. */
+  totalEntries: number
+}
+
+/**
+ * Slice history into a page.
+ *
+ * Clamps rather than erroring: `?page=999` on a two-page list lands on page 2,
+ * and `?page=-3` lands on page 1. A stale or hand-edited link should show
+ * something rather than an error, and there's no correct "not found" for a page
+ * number that merely ran off the end of a list that shrinks as filters change.
+ *
+ * @param entries Already-filtered entries, newest first.
+ * @param requestedPage 1-based page, from the URL. Non-numeric falls back to 1.
+ * @param pageSize Rows per page; defaults to {@link WORKOUT_PAGE_SIZE}.
+ */
+export function paginateWorkouts(
+  entries: readonly WorkoutHistoryEntry[],
+  requestedPage: number,
+  pageSize: number = WORKOUT_PAGE_SIZE
+): WorkoutPage {
+  const size = Math.max(1, Math.floor(pageSize))
+  const totalPages = Math.max(1, Math.ceil(entries.length / size))
+  const page = Number.isFinite(requestedPage)
+    ? Math.min(totalPages, Math.max(1, Math.floor(requestedPage)))
+    : 1
+  const start = (page - 1) * size
+  return {
+    entries: entries.slice(start, start + size),
+    page,
+    totalPages,
+    totalEntries: entries.length,
+  }
 }


### PR DESCRIPTION
Measured on production immediately after the Health import (#413) landed:

| view | transfer | time |
|---|---|---|
| `/training-facility/weight-room/workouts` (all 507) | **1,415,965 bytes** | **2.53 s** |
| `?source=recorded` (0 rows) | 24,214 bytes | 0.98 s |

**1.4 MB on the landing view of a sub-nav pill**, rendering every session ever recorded, unpaginated — and growing linearly with every session added.

## The year rail is the fix, and the better page

Defaults to the **newest year** rather than everything: 22 rows instead of 507. The chips double as a summary of the training history:

```
2026 · 22    2024 · 65    2022 · 152    All years · 507
2023 · 116   2021 · 102   2018 · 50
```

**Years with no sessions are omitted, not rendered empty.** The real log has no 2019, 2020 or 2025 — the gaps are the interesting part, and filling them in with zero-chips would smooth them into a uniform run that implies a continuity that wasn't there.

## Pagination applies to every filter, not just All years

2022 alone is 152 sessions (~440 KB), so a year filter on its own still shipped a heavy page. Fifty rows per page, prev/next as **real links** so each page is shareable and the route stays a Server Component — the same reasoning behind the existing URL-param filters (#377).

## Two things easy to get wrong, both deliberate

- **`year` is emitted on every chip href.** Absent means "newest year", so omitting it would silently snap an all-years view back to the default the moment any other chip was clicked. This is why the existing href assertions in the test file changed.
- **`page` resets on any filter change.** Page 4 of one filter set has nothing to do with page 4 of another; carrying it across lands the reader on a clamped page with no explanation.

`paginateWorkouts` **clamps rather than erroring** — a bookmarked `?page=99` on a list that has since shrunk shows the last page. There's no correct "not found" for a page number that merely ran off the end of a list that changes with the filters.

## Test invalidation

Three exact-href assertions in `WorkoutHistoryList.test.tsx` now include `year=all`. That's the URL contract changing, not a test being wrong — updated in the same commit with a note at the top of the file explaining why the param is always present.

## Test plan

On the preview, at `/training-facility/weight-room/workouts`:

- [ ] Lands on the **newest year** by default, not all 507. Page is visibly fast.
- [ ] Year chips show the right counts; **2019, 2020 and 2025 are absent**.
- [ ] **All years** → pagination appears, `1 / 11`, "Showing 1–50 of 507".
- [ ] **Older →** advances; the URL carries `?year=all&page=2` and is shareable.
- [ ] On the last page there's no **Older**; on the first there's no **Newer**.
- [ ] Pick **2022** → 152 sessions, paginated `1 / 4`.
- [ ] With a year selected, switching **template** or **Apple Health / Recorded** keeps the year and resets to page 1.
- [ ] Hand-edit `?page=999` → lands on the last page rather than erroring.
- [ ] At 390 px the rails wrap and pagination stays reachable.

Verified locally: `tsc` clean, `next build` compiles, **2186 unit tests** (160 files), **65/65 Playwright**, `format:check` and ESLint clean. No migrations.

Closes #416.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
