### PR TITLE
feat(weight-room): record within-set sequences — the rack run logs faithfully (#407)

### DIFF
--- a/app/api/admin/weight-room/sets/route.test.ts
+++ b/app/api/admin/weight-room/sets/route.test.ts
@@ -125,6 +125,53 @@ describe('POST /api/admin/weight-room/sets', () => {
     )
   })
 
+  it('forwards the within-set step into the insert (#407)', async () => {
+    // The schema accepting the field is not enough: this whitelist is what
+    // actually writes it. Without it every mini-set reloads with no step, a
+    // rack run never completes a pass, and the panel offers the first rung
+    // forever — the feature is inert end to end.
+    requireAdminMock.mockResolvedValue({ ok: true, email: 'a@b.com' })
+    insertMock.mockResolvedValueOnce({ data: { id: 'x' }, error: null })
+    const res = await POST(
+      makeRequest({
+        exercise: 'dumbbell-curl',
+        reps: 8,
+        weight_lbs: 30,
+        template_slot_id: '22222222-2222-4222-8222-222222222222',
+        template_slot_step_id: '33333333-3333-4333-8333-333333333333',
+      }) as never
+    )
+    expect(res.status).toBe(201)
+    expect(supabaseChain.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        template_slot_id: '22222222-2222-4222-8222-222222222222',
+        template_slot_step_id: '33333333-3333-4333-8333-333333333333',
+      })
+    )
+  })
+
+  it('omits the step column for an ordinary straight set (#407)', async () => {
+    requireAdminMock.mockResolvedValue({ ok: true, email: 'a@b.com' })
+    insertMock.mockResolvedValueOnce({ data: { id: 'x' }, error: null })
+    await POST(makeRequest({ exercise: 'pushups', reps: 25 }) as never)
+    expect(supabaseChain.insert).toHaveBeenCalledWith(
+      expect.not.objectContaining({ template_slot_step_id: expect.anything() })
+    )
+  })
+
+  it('rejects a step with no slot — a step belongs to a slot (#407)', async () => {
+    requireAdminMock.mockResolvedValue({ ok: true, email: 'a@b.com' })
+    const res = await POST(
+      makeRequest({
+        exercise: 'dumbbell-curl',
+        reps: 8,
+        template_slot_step_id: '33333333-3333-4333-8333-333333333333',
+      }) as never
+    )
+    expect(res.status).toBe(400)
+    expect(supabaseChain.insert).not.toHaveBeenCalled()
+  })
+
   it('threads a lowercased/trimmed variant into the insert (#254)', async () => {
     requireAdminMock.mockResolvedValue({ ok: true, email: 'a@b.com' })
     insertMock.mockResolvedValueOnce({ data: { id: 'x' }, error: null })

--- a/app/api/admin/weight-room/sets/route.ts
+++ b/app/api/admin/weight-room/sets/route.ts
@@ -81,6 +81,12 @@ async function handlePOST(request: NextRequest): Promise<NextResponse> {
     ...(entry.workout_id != null ? { workout_id: entry.workout_id } : {}),
     ...(entry.position != null ? { position: entry.position } : {}),
     ...(entry.template_slot_id != null ? { template_slot_id: entry.template_slot_id } : {}),
+    // The within-set step (#407). Without this the column never gets written,
+    // every mini-set reloads without a step, and a rack run can never complete
+    // a pass — the schema accepting the field is not enough on its own.
+    ...(entry.template_slot_step_id != null
+      ? { template_slot_step_id: entry.template_slot_step_id }
+      : {}),
   }
   const { data, error } = await supabase
     .from('weight_room_sets')
@@ -96,6 +102,12 @@ async function handlePOST(request: NextRequest): Promise<NextResponse> {
     // since the exercise one is the far more common case and reads as the
     // sensible default.
     if (error.code === '23503') {
+      if (error.message.includes('template_slot_step_id')) {
+        return NextResponse.json(
+          { error: `Template slot step '${entry.template_slot_step_id}' does not exist.` },
+          { status: 400 }
+        )
+      }
       if (error.message.includes('template_slot_id')) {
         return NextResponse.json(
           { error: `Template slot '${entry.template_slot_id}' does not exist.` },

--- a/components/training-facility/weight-room/LiveWorkoutPanel.tsx
+++ b/components/training-facility/weight-room/LiveWorkoutPanel.tsx
@@ -449,10 +449,34 @@ function SlotCard({
   const stepMovement = stepExercise(slot, nextStep)
   const stepIndex = nextStep === null ? -1 : steps.findIndex(st => st.id === nextStep.id)
   const defaults = nextSetDefaults(slot, sets, lastElsewhere, nextStep)
-  const [reps, setReps] = useState<string>(defaults.reps?.toString() ?? '')
-  const [weight, setWeight] = useState<string>(defaults.weight_lbs?.toString() ?? '')
   const [swapOpen, setSwapOpen] = useState(false)
-  const [exercise, setExercise] = useState(isStepped ? stepMovement : performedExercise)
+
+  // Edits are held against the step they were typed for, and *derived* during
+  // render rather than synced in an effect (#407).
+  //
+  // `useState` initialisers run once, and this card stays mounted as the
+  // sequence advances — so a rack run kept showing and submitting 35 lb after
+  // the banner moved to the 30 lb rung, silently recording the wrong load on
+  // every mini-set after the first. Keying the draft to the active step makes a
+  // step change fall back to that step's own prescription automatically.
+  const activeStepId = nextStep?.id ?? null
+  const [draft, setDraft] = useState<{
+    stepId: string | null
+    reps: string
+    weight: string
+  } | null>(null)
+  const isDraftCurrent = draft !== null && draft.stepId === activeStepId
+  const reps = isDraftCurrent ? draft.reps : (defaults.reps?.toString() ?? '')
+  const weight = isDraftCurrent ? draft.weight : (defaults.weight_lbs?.toString() ?? '')
+  const setReps = (value: string): void => setDraft({ stepId: activeStepId, reps: value, weight })
+  const setWeight = (value: string): void => setDraft({ stepId: activeStepId, reps, weight: value })
+
+  // An explicit swap, or `null` for "whatever the prescription says". Held
+  // separately so it survives the sequence advancing, and so a stepped slot can
+  // still be substituted — the step's movement is a default, not a lock.
+  const [swappedTo, setSwappedTo] = useState<string | null>(null)
+  const exercise = swappedTo ?? (isStepped ? stepMovement : performedExercise)
+  const setExercise = (value: string): void => setSwappedTo(value)
 
   // The alternates first, then everything else — the whole point of declaring
   // them is that the common swap is one tap rather than a search.
@@ -469,7 +493,10 @@ function SlotCard({
     if (!Number.isFinite(repsValue) || repsValue < 1) return
     const weightValue = weight.trim() === '' ? null : Number(weight)
     await onLog(
-      isStepped ? stepMovement : exercise,
+      // A swap wins over the step's prescribed movement — otherwise the Swap
+      // control appears to work on a stepped slot and silently logs the
+      // prescription instead.
+      exercise,
       repsValue,
       weightValue != null && Number.isFinite(weightValue) ? weightValue : null,
       slot.id,

--- a/components/training-facility/weight-room/LiveWorkoutPanel.tsx
+++ b/components/training-facility/weight-room/LiveWorkoutPanel.tsx
@@ -9,6 +9,7 @@ import {
   extraSets,
   nextSetDefaults,
   nextSetPosition,
+  stepExercise,
   type SlotProgress,
 } from '@/lib/training-facility/live-workout'
 import { formatSlotPrescription } from '@/lib/training-facility/template-format'
@@ -223,7 +224,8 @@ export function LiveWorkoutPanel({
     exercise: string,
     reps: number,
     weightLbs: number | null,
-    slotId: string | null
+    slotId: string | null,
+    stepId: string | null = null
   ): Promise<boolean> {
     if (!workout) return false
     return post(
@@ -237,6 +239,9 @@ export function LiveWorkoutPanel({
           position: nextSetPosition(workoutSets),
           ...(weightLbs != null ? { weight_lbs: weightLbs } : {}),
           ...(slotId != null ? { template_slot_id: slotId } : {}),
+          // Only ever alongside a slot — the schema rejects a step without one,
+          // since a step belongs to a slot (#407).
+          ...(slotId != null && stepId != null ? { template_slot_step_id: stepId } : {}),
         }),
       },
       'Could not log the set',
@@ -420,7 +425,8 @@ interface SlotCardProps {
     exercise: string,
     reps: number,
     weightLbs: number | null,
-    slotId: string | null
+    slotId: string | null,
+    stepId?: string | null
   ) => Promise<boolean>
   onDeleteSet: (id: string) => Promise<void>
 }
@@ -434,12 +440,19 @@ function SlotCard({
   onLog,
   onDeleteSet,
 }: SlotCardProps): JSX.Element {
-  const { slot, sets, logged, performedExercise, isSubstituted, isComplete } = entry
-  const defaults = nextSetDefaults(slot, sets, lastElsewhere)
+  const { slot, sets, performedExercise, isSubstituted, isComplete, isStepped, steps, nextStep } =
+    entry
+  // For a stepped slot the counter must show passes, not rungs: two drop sets
+  // are eight rows (#407).
+  const shown = entry.completedSets
+  // A superset's step names its own movement; a drop set's inherits the slot's.
+  const stepMovement = stepExercise(slot, nextStep)
+  const stepIndex = nextStep === null ? -1 : steps.findIndex(st => st.id === nextStep.id)
+  const defaults = nextSetDefaults(slot, sets, lastElsewhere, nextStep)
   const [reps, setReps] = useState<string>(defaults.reps?.toString() ?? '')
   const [weight, setWeight] = useState<string>(defaults.weight_lbs?.toString() ?? '')
   const [swapOpen, setSwapOpen] = useState(false)
-  const [exercise, setExercise] = useState(performedExercise)
+  const [exercise, setExercise] = useState(isStepped ? stepMovement : performedExercise)
 
   // The alternates first, then everything else — the whole point of declaring
   // them is that the common swap is one tap rather than a search.
@@ -456,10 +469,11 @@ function SlotCard({
     if (!Number.isFinite(repsValue) || repsValue < 1) return
     const weightValue = weight.trim() === '' ? null : Number(weight)
     await onLog(
-      exercise,
+      isStepped ? stepMovement : exercise,
       repsValue,
       weightValue != null && Number.isFinite(weightValue) ? weightValue : null,
-      slot.id
+      slot.id,
+      nextStep?.id ?? null
     )
   }
 
@@ -479,7 +493,7 @@ function SlotCard({
           </span>
         ) : null}
         <span className="ml-auto font-mono text-[11px] text-white/50">
-          {logged} / {slot.target_sets}
+          {shown} / {slot.target_sets}
           {slot.target_sets_max != null && slot.target_sets_max !== slot.target_sets
             ? `-${slot.target_sets_max}`
             : ''}
@@ -489,6 +503,19 @@ function SlotCard({
         {formatSlotPrescription(slot)}
         {slot.notes ? ` · ${slot.notes}` : ''}
       </p>
+
+      {isStepped && nextStep !== null ? (
+        <p
+          data-testid={`slot-step-${slot.id}`}
+          className="mt-2 rounded border border-sky-300/25 bg-sky-300/5 px-2 py-1 font-mono text-[11px] text-sky-100"
+        >
+          Step {stepIndex + 1} of {steps.length}
+          {nextStep.exercise != null ? ` · ${slugLabel(nextStep.exercise, undefined, labels)}` : ''}
+          {nextStep.target_weight_lbs != null ? ` · ${nextStep.target_weight_lbs} lb` : ''}
+          {nextStep.target_reps != null ? ` × ${nextStep.target_reps}` : ''}
+          {nextStep.notes ? ` · ${nextStep.notes}` : ''}
+        </p>
+      ) : null}
 
       {sets.length > 0 ? (
         <ul className="mt-2 flex flex-wrap gap-1.5">

--- a/components/training-facility/weight-room/WorkoutSummaryPanel.tsx
+++ b/components/training-facility/weight-room/WorkoutSummaryPanel.tsx
@@ -435,7 +435,7 @@ function SlotRow({ slot, exerciseLabels }: SlotRowProps): JSX.Element {
       </div>
       <p className="shrink-0 text-sm tabular-nums">
         <span className={slot.isComplete ? 'font-bold' : 'font-bold text-[#b45309]'}>
-          {slot.logged}
+          {slot.completedSets}
         </span>
         <span className="text-[#0a0a0a]/50"> / {slot.slot.target_sets} sets</span>
       </p>

--- a/lib/data/weight-room-shared.ts
+++ b/lib/data/weight-room-shared.ts
@@ -67,7 +67,7 @@ const EXERCISES_TABLE = 'weight_room_exercises'
  * into a workout without another round trip.
  */
 const SETS_COLUMNS =
-  'id, logged_at, exercise, reps, weight_lbs, variant, workout_id, position, template_slot_id, updated_at'
+  'id, logged_at, exercise, reps, weight_lbs, variant, workout_id, position, template_slot_id, template_slot_step_id, updated_at'
 // `load_multiplier` deliberately absent (#373) — it moved to the catalog and is
 // joined on below. The goals column still exists (dropping it while the
 // deployed build still selected it would break the live read) but is dead.

--- a/lib/schemas/weight-room.test.ts
+++ b/lib/schemas/weight-room.test.ts
@@ -659,3 +659,37 @@ describe('workout prescription snapshots (#377)', () => {
     expect(edited.slots.find(s => s.id === bench?.id)?.target_sets).toBe(6)
   })
 })
+
+describe('WeightRoomSetCreateSchema — within-set steps (#407)', () => {
+  const base = { exercise: 'dumbbell-curl', reps: 8 }
+  const SLOT = '11111111-1111-4111-8111-111111111111'
+  const STEP = '22222222-2222-4222-8222-222222222222'
+
+  it('accepts a step alongside its slot', () => {
+    const parsed = WeightRoomSetCreateSchema.safeParse({
+      ...base,
+      template_slot_id: SLOT,
+      template_slot_step_id: STEP,
+    })
+    expect(parsed.success).toBe(true)
+  })
+
+  it('rejects a step with no slot — a step belongs to a slot', () => {
+    const parsed = WeightRoomSetCreateSchema.safeParse({
+      ...base,
+      template_slot_step_id: STEP,
+    })
+    expect(parsed.success).toBe(false)
+  })
+
+  it('still accepts an ordinary straight set with neither', () => {
+    expect(WeightRoomSetCreateSchema.safeParse(base).success).toBe(true)
+  })
+
+  it('still rejects an unknown key — strictness survives the refine', () => {
+    // `.strict()` must be applied to the object, not chained onto the effects
+    // wrapper `.refine()` returns, or every fail-closed guarantee in this file
+    // quietly stops applying to this schema.
+    expect(WeightRoomSetCreateSchema.safeParse({ ...base, bogus_field: 1 }).success).toBe(false)
+  })
+})

--- a/lib/schemas/weight-room.test.ts
+++ b/lib/schemas/weight-room.test.ts
@@ -585,6 +585,20 @@ describe('workout prescription snapshots (#377)', () => {
     ],
   }
 
+  it('captures the within-set sequence, because steps score (#407)', () => {
+    // Dropped by #411 on the reasoning that nothing scored steps yet. #407 made
+    // them score — a stepped slot's completion is counted in passes — so a
+    // snapshot without them treats a rack run as a straight set and reports
+    // three of four rungs as fully complete.
+    const snapshot = templateToPrescription(template)
+    const bench = snapshot.slots.find(s => s.exercise === 'barbell-bench-press')
+    expect(bench?.steps).toEqual([
+      { id: '44444444-4444-4444-8444-444444444444', position: 0, target_reps: 5 },
+    ])
+    const incline = snapshot.slots.find(s => s.exercise === 'incline-dumbbell-press')
+    expect(incline?.steps).toBeUndefined()
+  })
+
   it('captures every prescribing field', () => {
     const snapshot = templateToPrescription(template)
     const bench = snapshot.slots.find(s => s.exercise === 'barbell-bench-press')
@@ -598,6 +612,7 @@ describe('workout prescription snapshots (#377)', () => {
       target_reps_max: 10,
       target_weight_lbs: 155,
       notes: 'pause at the bottom',
+      steps: [{ id: '44444444-4444-4444-8444-444444444444', position: 0, target_reps: 5 }],
     })
   })
 
@@ -632,8 +647,10 @@ describe('workout prescription snapshots (#377)', () => {
     const rehydrated = prescriptionToTemplate(templateToPrescription(template))
     expect(rehydrated.name).toBe('Chest Day 1')
     expect(rehydrated.slots).toHaveLength(2)
-    // Never captured, so they come back empty rather than stale.
-    expect(rehydrated.slots.every(s => s.steps.length === 0)).toBe(true)
+    // Steps come back from the snapshot (#407) — they participate in adherence.
+    const bench = rehydrated.slots.find(s => s.exercise === 'barbell-bench-press')
+    expect(bench?.steps).toHaveLength(1)
+    // Alternates still don't: they only offered shortcuts while recording.
     expect(rehydrated.slots.every(s => s.alternates.length === 0)).toBe(true)
   })
 

--- a/lib/schemas/weight-room.ts
+++ b/lib/schemas/weight-room.ts
@@ -149,6 +149,7 @@ export const WeightRoomSetRowSchema = z
     workout_id: z.string().uuid().nullable().optional(),
     position: nonNegativeInt().nullable().optional(),
     template_slot_id: z.string().uuid().nullable().optional(),
+    template_slot_step_id: z.string().uuid().nullable().optional(),
   })
   .strict()
 
@@ -255,8 +256,21 @@ export const WeightRoomSetCreateSchema = z
     // `exercise` differs from its slot's is a substitution, recorded by that
     // difference rather than by a flag.
     template_slot_id: z.string().uuid().optional(),
+    // The within-set step (#407) — one rung of a drop set, one movement of a
+    // superset. Only meaningful alongside `template_slot_id`; see the refine
+    // below, which rejects a step with no slot rather than storing a set that
+    // claims to belong to a sequence in no slot.
+    template_slot_step_id: z.string().uuid().optional(),
   })
+  // `.strict()` before `.refine()`, not after: refine returns an effects
+  // wrapper, and chaining strict onto that is at best ambiguous — the
+  // unknown-key rejection this file relies on everywhere must be applied to the
+  // object itself.
   .strict()
+  .refine(body => body.template_slot_step_id === undefined || body.template_slot_id !== undefined, {
+    message: 'template_slot_step_id requires template_slot_id — a step belongs to a slot.',
+    path: ['template_slot_step_id'],
+  })
 
 /** Validated body of `POST /api/admin/weight-room/sets`. */
 export type WeightRoomSetCreate = z.infer<typeof WeightRoomSetCreateSchema>
@@ -316,6 +330,9 @@ export function setRowToStrengthSet(row: WeightRoomSetRow): StrengthSet {
     ...(row.workout_id != null ? { workout_id: row.workout_id } : {}),
     ...(row.position != null ? { position: row.position } : {}),
     ...(row.template_slot_id != null ? { template_slot_id: row.template_slot_id } : {}),
+    ...(row.template_slot_step_id != null
+      ? { template_slot_step_id: row.template_slot_step_id }
+      : {}),
   }
 }
 

--- a/lib/schemas/weight-room.ts
+++ b/lib/schemas/weight-room.ts
@@ -348,6 +348,24 @@ const workoutLocation = (): z.ZodType<WorkoutLocation> => z.enum(['gym', 'home',
  * added to `TemplateSlot` and written into a snapshot without being added here
  * would fail loudly on the next read rather than being silently dropped.
  */
+/**
+ * One step of a frozen slot's within-set sequence (#407).
+ *
+ * Captured as of #407, which made steps score: a stepped slot's completion is
+ * counted in passes, so a snapshot without them would score a rack run as a
+ * straight set and report three of four rungs as fully complete.
+ */
+export const PrescribedSlotStepSchema = z
+  .object({
+    id: z.string().uuid(),
+    position: z.number().int().nonnegative(),
+    exercise: z.string().min(1).optional(),
+    target_reps: z.number().int().positive().optional(),
+    target_weight_lbs: z.number().positive().optional(),
+    notes: z.string().optional(),
+  })
+  .strict()
+
 export const PrescribedSlotSchema = z
   .object({
     id: z.string().uuid(),
@@ -359,6 +377,7 @@ export const PrescribedSlotSchema = z
     target_reps_max: z.number().int().positive().optional(),
     target_weight_lbs: z.number().positive().optional(),
     notes: z.string().optional(),
+    steps: z.array(PrescribedSlotStepSchema).optional(),
   })
   .strict()
 
@@ -404,6 +423,25 @@ export function templateToPrescription(template: WorkoutTemplate): WorkoutPrescr
           ? { target_weight_lbs: slot.target_weight_lbs }
           : {}),
         ...(slot.notes !== undefined ? { notes: slot.notes } : {}),
+        // Steps are captured as of #407. Adherence for a stepped slot is
+        // counted in passes, so a snapshot that dropped them would score a
+        // finished rack run against the wrong denominator forever.
+        ...(slot.steps.length > 0
+          ? {
+              steps: [...slot.steps]
+                .sort((a, b) => a.position - b.position)
+                .map(step => ({
+                  id: step.id,
+                  position: step.position,
+                  ...(step.exercise !== undefined ? { exercise: step.exercise } : {}),
+                  ...(step.target_reps !== undefined ? { target_reps: step.target_reps } : {}),
+                  ...(step.target_weight_lbs !== undefined
+                    ? { target_weight_lbs: step.target_weight_lbs }
+                    : {}),
+                  ...(step.notes !== undefined ? { notes: step.notes } : {}),
+                })),
+            }
+          : {}),
       })),
   }
 }
@@ -417,8 +455,10 @@ export function templateToPrescription(template: WorkoutTemplate): WorkoutPrescr
  * historical ones — two would be free to drift, which is exactly the class of
  * bug this snapshot exists to prevent.
  *
- * `steps` and `alternates` come back empty because they were never captured;
- * neither participates in adherence.
+ * `steps` come back from the snapshot (#407) because they *do* participate in
+ * adherence — a stepped slot's completion is counted in passes. `alternates`
+ * stay empty: they only offered shortcuts while recording and nothing scores
+ * them afterwards.
  *
  * @param prescription The snapshot from `weight_room_workouts.prescription`.
  */
@@ -427,7 +467,15 @@ export function prescriptionToTemplate(prescription: WorkoutPrescription): Worko
     id: prescription.template_id,
     name: prescription.name,
     position: 0,
-    slots: prescription.slots.map(slot => ({ ...slot, steps: [], alternates: [] })),
+    slots: prescription.slots.map(slot => ({
+      ...slot,
+      // Restored from the snapshot since #407 — a stepped slot scored as a
+      // straight one reports mini-sets as sets.
+      steps: slot.steps ?? [],
+      // Alternates are still not captured: they only ever offered shortcuts
+      // while recording, and nothing scores them afterwards.
+      alternates: [],
+    })),
   }
 }
 

--- a/lib/training-facility/live-workout.test.ts
+++ b/lib/training-facility/live-workout.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import type { StrengthSet, TemplateSlot, WorkoutTemplate } from '@/types/weight-room'
+import type {
+  StrengthSet,
+  TemplateSlot,
+  TemplateSlotStep,
+  WorkoutTemplate,
+} from '@/types/weight-room'
 
 import { buildSlotProgress, extraSets, nextSetDefaults, nextSetPosition } from './live-workout'
 
@@ -209,5 +214,171 @@ describe('buildSlotProgress — mixed timestamp offsets (#377)', () => {
     expect(progress.sets.map(s => s.id)).toEqual(['barbell', 'dumbbell'])
     expect(progress.performedExercise).toBe('dumbbell-bench-press')
     expect(progress.isSubstituted).toBe(true)
+  })
+})
+
+describe('buildSlotProgress — within-set steps (#407)', () => {
+  /** Back Day 1's real rack run: 35 → 30 → 25 → 20, two passes. */
+  const RACK_STEPS: TemplateSlotStep[] = [
+    { id: 'st-35', position: 0, target_weight_lbs: 35 },
+    { id: 'st-30', position: 1, target_weight_lbs: 30 },
+    { id: 'st-25', position: 2, target_weight_lbs: 25 },
+    { id: 'st-20', position: 3, target_weight_lbs: 20 },
+  ]
+  const RACK = slot({
+    id: 'slot-rack',
+    exercise: 'dumbbell-curl',
+    target_sets: 2,
+    steps: RACK_STEPS,
+  })
+
+  function template(s: TemplateSlot): WorkoutTemplate {
+    return { id: 't1', name: 'Back Day 1', position: 0, slots: [s] }
+  }
+
+  function mini(stepId: string, weight: number, id: string): StrengthSet {
+    return set({
+      id,
+      exercise: 'dumbbell-curl',
+      weight_lbs: weight,
+      template_slot_id: 'slot-rack',
+      template_slot_step_id: stepId,
+    })
+  }
+
+  /** One full pass down the rack. */
+  function pass(round: number): StrengthSet[] {
+    return RACK_STEPS.map((st, i) => mini(st.id, st.target_weight_lbs as number, `r${round}-${i}`))
+  }
+
+  it('counts a full pass as one prescribed set, not four', () => {
+    const [progress] = buildSlotProgress(template(RACK), pass(1))
+    expect(progress.logged).toBe(4)
+    expect(progress.completedSets).toBe(1)
+    expect(progress.isComplete).toBe(false)
+  })
+
+  it('is complete after two passes — eight rows, two sets', () => {
+    const [progress] = buildSlotProgress(template(RACK), [...pass(1), ...pass(2)])
+    expect(progress.logged).toBe(8)
+    expect(progress.completedSets).toBe(2)
+    expect(progress.isComplete).toBe(true)
+  })
+
+  it('does not call a partial pass a completed set', () => {
+    // The exact bug this issue exists for: three rungs down is not a drop set.
+    const [progress] = buildSlotProgress(template(RACK), pass(1).slice(0, 3))
+    expect(progress.completedSets).toBe(0)
+  })
+
+  it('does not let a repeated rung fake a completed pass', () => {
+    // 35, 35, 30, 25 is four rows but the 20 was never done.
+    const sets = [
+      mini('st-35', 35, 'a'),
+      mini('st-35', 35, 'b'),
+      mini('st-30', 30, 'c'),
+      mini('st-25', 25, 'd'),
+    ]
+    expect(buildSlotProgress(template(RACK), sets)[0].completedSets).toBe(0)
+  })
+
+  it('walks the sequence in order on a fresh round', () => {
+    expect(buildSlotProgress(template(RACK), [])[0].nextStep?.id).toBe('st-35')
+    expect(buildSlotProgress(template(RACK), pass(1).slice(0, 1))[0].nextStep?.id).toBe('st-30')
+    expect(buildSlotProgress(template(RACK), pass(1).slice(0, 3))[0].nextStep?.id).toBe('st-20')
+  })
+
+  it('resumes at the right rung after a full pass', () => {
+    expect(buildSlotProgress(template(RACK), pass(1))[0].nextStep?.id).toBe('st-35')
+  })
+
+  it('resumes mid-round after a deleted mini-set rather than restarting', () => {
+    // The 25 was removed; the next thing to log is the 25, not the 35.
+    const sets = pass(1).filter(s => s.template_slot_step_id !== 'st-25')
+    expect(buildSlotProgress(template(RACK), sets)[0].nextStep?.id).toBe('st-25')
+  })
+
+  it('leaves a straight slot completely unchanged', () => {
+    const straight = slot({ id: 'slot-bench', target_sets: 4 })
+    const sets = Array.from({ length: 3 }, (_, i) =>
+      set({ id: `s${i}`, template_slot_id: 'slot-bench' })
+    )
+    const [progress] = buildSlotProgress(template(straight), sets)
+    expect(progress.isStepped).toBe(false)
+    expect(progress.nextStep).toBeNull()
+    expect(progress.completedSets).toBe(3)
+    expect(progress.logged).toBe(3)
+    expect(progress.isComplete).toBe(false)
+  })
+
+  it('does not mistake a superset for a substitution', () => {
+    // A superset's second step names a different movement on purpose. Comparing
+    // it to the slot's exercise would flag every superset as a swap.
+    const superset = slot({
+      id: 'slot-super',
+      exercise: 'barbell-bench-press',
+      target_sets: 1,
+      steps: [
+        { id: 'sup-1', position: 0 },
+        { id: 'sup-2', position: 1, exercise: 'cable-fly' },
+      ],
+    })
+    const sets = [
+      set({
+        id: 'a',
+        exercise: 'barbell-bench-press',
+        template_slot_id: 'slot-super',
+        template_slot_step_id: 'sup-1',
+      }),
+      set({
+        id: 'b',
+        exercise: 'cable-fly',
+        template_slot_id: 'slot-super',
+        template_slot_step_id: 'sup-2',
+      }),
+    ]
+    const [progress] = buildSlotProgress(template(superset), sets)
+    expect(progress.isSubstituted).toBe(false)
+    expect(progress.completedSets).toBe(1)
+    expect(progress.isComplete).toBe(true)
+  })
+
+  it('still detects a real substitution inside a stepped slot', () => {
+    const sets = [mini('st-35', 35, 'a')].map(s => ({ ...s, exercise: 'barbell-curl' }))
+    expect(buildSlotProgress(template(RACK), sets)[0].isSubstituted).toBe(true)
+  })
+
+  it('ignores a set whose step was deleted with the template', () => {
+    // `on delete set null` leaves the row with a slot and no step.
+    const orphan = set({ id: 'o', template_slot_id: 'slot-rack' })
+    const [progress] = buildSlotProgress(template(RACK), [...pass(1), orphan])
+    expect(progress.logged).toBe(5)
+    expect(progress.completedSets).toBe(1)
+  })
+})
+
+describe('nextSetDefaults — stepped slots (#407)', () => {
+  const step30: TemplateSlotStep = { id: 'st-30', position: 1, target_weight_lbs: 30 }
+
+  it("prefills the step's own load, not the previous set's", () => {
+    // The whole point of a rack run is that the next rung is lighter. Repeating
+    // the last set would hand you 35 when the next step prescribes 30.
+    const previous = set({ id: 'a', weight_lbs: 35, template_slot_step_id: 'st-35' })
+    const defaults = nextSetDefaults(slot({ steps: [step30] }), [previous], null, step30)
+    expect(defaults.weight_lbs).toBe(30)
+  })
+
+  it('falls back to what was done on the same step last round', () => {
+    const bare: TemplateSlotStep = { id: 'st-x', position: 0 }
+    const lastRound = set({ id: 'a', reps: 12, weight_lbs: 22.5, template_slot_step_id: 'st-x' })
+    const defaults = nextSetDefaults(slot({ steps: [bare] }), [lastRound], null, bare)
+    expect(defaults.weight_lbs).toBe(22.5)
+    expect(defaults.reps).toBe(12)
+  })
+
+  it('is unchanged for a straight set', () => {
+    const previous = set({ id: 'a', reps: 8, weight_lbs: 155 })
+    const defaults = nextSetDefaults(slot(), [previous])
+    expect(defaults).toEqual({ reps: 8, weight_lbs: 155 })
   })
 })

--- a/lib/training-facility/live-workout.ts
+++ b/lib/training-facility/live-workout.ts
@@ -1,4 +1,9 @@
-import type { StrengthSet, TemplateSlot, WorkoutTemplate } from '@/types/weight-room'
+import type {
+  StrengthSet,
+  TemplateSlot,
+  TemplateSlotStep,
+  WorkoutTemplate,
+} from '@/types/weight-room'
 
 import { compareInstants } from './workout-sessions'
 
@@ -19,17 +24,47 @@ export interface SlotProgress {
   slot: TemplateSlot
   /** Sets logged against this slot so far, oldest first. */
   sets: StrengthSet[]
-  /** How many sets have been logged — may exceed the prescription. */
+  /** Raw rows logged. For a stepped slot this counts *mini-sets*, not sets. */
   logged: number
+  /**
+   * Sets in the sense the prescription means, and the number compared against
+   * `target_sets`.
+   *
+   * For a straight slot this is just {@link logged}. For a **stepped** slot it
+   * is completed passes through the sequence (#407): one trip down a rack run
+   * is one set, however many rungs it has. Counting rows there would read
+   * `8 / 2` for two drop sets.
+   */
+  completedSets: number
+  /** Whether the slot prescribes a within-set sequence — a drop set or superset. */
+  isStepped: boolean
+  /** The sequence, ordered. Empty for a straight slot. */
+  steps: TemplateSlotStep[]
+  /**
+   * The step to log next, or `null` for a straight slot.
+   *
+   * The least-logged step, ties broken by position — which walks the sequence in
+   * order on a fresh round, and resumes at the right rung after a reload or a
+   * deleted mini-set rather than restarting at the top.
+   */
+  nextStep: TemplateSlotStep | null
   /**
    * The movement actually being performed. Differs from `slot.exercise` once a
    * set has been logged with something else — the rack was taken.
+   *
+   * For a stepped slot this stays the slot's own movement: a superset's steps
+   * legitimately name different movements, and those are shown per-step rather
+   * than collapsed into one label here.
    */
   performedExercise: string
   /**
    * Whether this slot is being performed with a movement other than the one
    * prescribed. Derived from the logged sets, never from a flag: the set rows
    * *are* the record.
+   *
+   * A stepped slot compares each set to **its own step's** movement, so a
+   * superset — where step two is meant to be a different exercise — is not
+   * mistaken for a substitution.
    */
   isSubstituted: boolean
   /**
@@ -38,6 +73,14 @@ export interface SlotProgress {
    * "hitting the prescription", not exceeding it.
    */
   isComplete: boolean
+}
+
+/**
+ * What a given step is meant to be performed with — its own movement for a
+ * superset, otherwise the slot's.
+ */
+export function stepExercise(slot: TemplateSlot, step: TemplateSlotStep | null): string {
+  return step?.exercise ?? slot.exercise
 }
 
 /**
@@ -71,17 +114,57 @@ export function buildSlotProgress(
       const sets = (bySlot.get(slot.id) ?? []).sort((a, b) =>
         compareInstants(a.logged_at, b.logged_at)
       )
-      // The newest set decides what's being performed: swapping mid-slot means
-      // the most recent choice is the current one, and earlier sets keep the
-      // movement they were actually done with.
-      const performedExercise = sets.at(-1)?.exercise ?? slot.exercise
+      const steps = [...slot.steps].sort((a, b) => a.position - b.position)
+      const isStepped = steps.length > 0
+
+      if (!isStepped) {
+        const performedExercise = sets.at(-1)?.exercise ?? slot.exercise
+        return {
+          slot,
+          sets,
+          logged: sets.length,
+          completedSets: sets.length,
+          isStepped: false,
+          steps,
+          nextStep: null,
+          performedExercise,
+          isSubstituted: performedExercise !== slot.exercise,
+          isComplete: sets.length >= slot.target_sets,
+        }
+      }
+
+      // A pass counts as done only when *every* rung has been logged that many
+      // times, so 35/35/30/25 is zero complete drop sets rather than one. The
+      // minimum across steps is the only measure that says so.
+      const countByStep = new Map(steps.map(step => [step.id, 0]))
+      let substituted = false
+      for (const set of sets) {
+        const stepId = set.template_slot_step_id
+        if (stepId !== undefined && countByStep.has(stepId)) {
+          countByStep.set(stepId, (countByStep.get(stepId) ?? 0) + 1)
+        }
+        const step = steps.find(s => s.id === stepId) ?? null
+        if (set.exercise !== stepExercise(slot, step)) substituted = true
+      }
+      const completedSets = Math.min(...steps.map(step => countByStep.get(step.id) ?? 0))
+
+      // Least-logged step wins, ties by position — walks the sequence in order,
+      // and resumes mid-round after a reload or a deleted mini-set.
+      const nextStep = steps.reduce((best, step) =>
+        (countByStep.get(step.id) ?? 0) < (countByStep.get(best.id) ?? 0) ? step : best
+      )
+
       return {
         slot,
         sets,
         logged: sets.length,
-        performedExercise,
-        isSubstituted: performedExercise !== slot.exercise,
-        isComplete: sets.length >= slot.target_sets,
+        completedSets,
+        isStepped: true,
+        steps,
+        nextStep,
+        performedExercise: slot.exercise,
+        isSubstituted: substituted,
+        isComplete: completedSets >= slot.target_sets,
       }
     })
 }
@@ -124,12 +207,28 @@ export interface NextSetDefaults {
  * @param lastElsewhere The most recent set of this movement from any earlier
  *   session, used when the slot is still empty. `null` when it has never been
  *   logged.
+ * @param step The step being performed (#407), or `null` for a straight set.
+ *   When given, its own prescribed load and reps win over anything else — see
+ *   the note in the body about why the usual priority inverts here.
  */
 export function nextSetDefaults(
   slot: TemplateSlot,
   setsInSlot: readonly StrengthSet[],
-  lastElsewhere: StrengthSet | null = null
+  lastElsewhere: StrengthSet | null = null,
+  step: TemplateSlotStep | null = null
 ): NextSetDefaults {
+  // A stepped slot inverts the usual priority (#407). For a straight set the
+  // last thing you did is the better guess, because loads get adjusted once and
+  // then held. In a rack run the descending loads *are* the prescription —
+  // repeating the previous set would hand you 35 lb when the next rung is 30.
+  if (step !== null) {
+    const sameStep = setsInSlot.filter(set => set.template_slot_step_id === step.id)
+    return {
+      reps: step.target_reps ?? sameStep.at(-1)?.reps ?? slot.target_reps ?? null,
+      weight_lbs: step.target_weight_lbs ?? sameStep.at(-1)?.weight_lbs ?? null,
+    }
+  }
+
   const previous = setsInSlot.at(-1)
   if (previous !== undefined) {
     return {

--- a/lib/training-facility/workout-stats.test.ts
+++ b/lib/training-facility/workout-stats.test.ts
@@ -704,3 +704,54 @@ describe('paginateWorkouts (#416)', () => {
     expect(result.totalPages).toBe(Math.ceil(507 / WORKOUT_PAGE_SIZE))
   })
 })
+
+describe('buildWorkoutAdherence — stepped slots (#407)', () => {
+  const RACK_STEPS = [
+    { id: 'st-35', position: 0, target_weight_lbs: 35 },
+    { id: 'st-30', position: 1, target_weight_lbs: 30 },
+    { id: 'st-25', position: 2, target_weight_lbs: 25 },
+    { id: 'st-20', position: 3, target_weight_lbs: 20 },
+  ]
+  const RACK = slot({
+    id: 'slot-rack',
+    exercise: 'dumbbell-curl',
+    target_sets: 2,
+    steps: RACK_STEPS,
+  })
+
+  function pass(round: number): StrengthSet[] {
+    return RACK_STEPS.map((st, i) =>
+      set({
+        id: `r${round}-${i}`,
+        exercise: 'dumbbell-curl',
+        weight_lbs: st.target_weight_lbs,
+        template_slot_id: 'slot-rack',
+        template_slot_step_id: st.id,
+      })
+    )
+  }
+
+  it('scores two passes as 2 of 2 prescribed sets, not 8', () => {
+    const adherence = buildWorkoutAdherence(template([RACK]), [...pass(1), ...pass(2)])
+    expect(adherence.prescribedSets).toBe(2)
+    expect(adherence.completedSets).toBe(2)
+    expect(adherence.completion).toBe(1)
+    expect(adherence.slots[0].surplus).toBe(0)
+  })
+
+  it('reports a shortfall in passes, not in rungs', () => {
+    const adherence = buildWorkoutAdherence(template([RACK]), pass(1))
+    expect(adherence.completedSets).toBe(1)
+    expect(adherence.slots[0].shortfall).toBe(1)
+    expect(adherence.completion).toBe(0.5)
+  })
+
+  it('does not credit a half-finished drop set as over-delivery', () => {
+    // Before #407 this scored 3 rows against 2 target_sets — 150% complete for
+    // a drop set that was never finished.
+    const adherence = buildWorkoutAdherence(template([RACK]), pass(1).slice(0, 3))
+    expect(adherence.completedSets).toBe(0)
+    expect(adherence.slots[0].surplus).toBe(0)
+    expect(adherence.slots[0].shortfall).toBe(2)
+  })
+})

--- a/lib/training-facility/workout-stats.ts
+++ b/lib/training-facility/workout-stats.ts
@@ -387,15 +387,18 @@ export function buildWorkoutAdherence(
     const floor = entry.slot.target_sets
     const ceiling = entry.slot.target_sets_max ?? floor
     prescribedSets += floor
-    // Cap the credit at the floor: doing 8 sets of one movement doesn't pay
+    // `completedSets`, not `logged`: for a stepped slot those differ (#407) —
+    // two passes down a rack run are eight rows but two prescribed sets, and
+    // crediting rows would score a half-finished drop set as over-delivery.
+    // Capped at the floor besides: doing 8 sets of one movement doesn't pay
     // down the two you skipped on another.
-    completedSets += Math.min(entry.logged, floor)
+    completedSets += Math.min(entry.completedSets, floor)
     if (entry.isComplete) completedSlots += 1
     if (entry.isSubstituted) substitutedSlots += 1
     return {
       ...entry,
-      shortfall: Math.max(0, floor - entry.logged),
-      surplus: Math.max(0, entry.logged - ceiling),
+      shortfall: Math.max(0, floor - entry.completedSets),
+      surplus: Math.max(0, entry.completedSets - ceiling),
     }
   })
 

--- a/supabase/migrations/20260807120000_weight_room_sets_template_slot_step.sql
+++ b/supabase/migrations/20260807120000_weight_room_sets_template_slot_step.sql
@@ -1,0 +1,39 @@
+-- #407 — link a set to the within-set step it was performed for.
+--
+-- #375 modelled the sequence (`weight_room_template_slot_steps`): a drop set is
+-- the slot's own movement at descending loads, a superset is different
+-- movements back to back. Back Day 1 has a real one seeded — a rack run down
+-- 35 → 30 → 25 → 20, performed twice.
+--
+-- #376 could not record it faithfully. One row per mini-set keeps the four
+-- descending loads but makes the slot read `8 / 2`, because completion counted
+-- rows against `target_sets`. One row per round fixes the counter and throws
+-- the loads away — and the loads are the entire point of a rack run.
+--
+-- The row-per-mini-set data was always right; what was missing was knowing
+-- which step each row belonged to. With that, a pass down the rack is one
+-- prescribed set again: the slot is N sets deep when *every* step has been
+-- logged N times.
+--
+-- `on delete set null` mirrors `template_slot_id` (#376): editing or deleting a
+-- template later degrades a past session to "step unknown" rather than erasing
+-- what it recorded. The set itself, and its load, always survive.
+
+alter table public.weight_room_sets
+  add column if not exists template_slot_step_id uuid null
+    references public.weight_room_template_slot_steps (id)
+    on delete set null;
+
+comment on column public.weight_room_sets.template_slot_step_id is
+  'The within-set step this set was performed for (#407) — one rung of a drop '
+  'set, or one movement of a superset. Null for an ordinary straight set, which '
+  'is the overwhelming majority, and null for a set whose step was deleted with '
+  'the template. Only meaningful alongside template_slot_id; a step belongs to a '
+  'slot, so a set carrying a step without a slot is malformed.';
+
+-- Sets are read per workout and grouped by slot, then by step. Indexed for the
+-- same reason `template_slot_id` is: the grouping is on the read path of every
+-- summary and every live refetch.
+create index if not exists weight_room_sets_template_slot_step_id_idx
+  on public.weight_room_sets (template_slot_step_id)
+  where template_slot_step_id is not null;

--- a/types/weight-room.ts
+++ b/types/weight-room.ts
@@ -245,6 +245,34 @@ export interface PrescribedSlot {
   target_weight_lbs?: number
   /** Free-text cue as it read at snapshot time. */
   notes?: string
+  /**
+   * The within-set sequence as it read at snapshot time (#407). Absent for an
+   * ordinary straight slot.
+   *
+   * Captured because steps *score*: a stepped slot's completion is counted in
+   * passes down the sequence, so a snapshot without them would treat a rack run
+   * as a straight set and call three of four rungs complete.
+   */
+  steps?: PrescribedSlotStep[]
+}
+
+/**
+ * One step of a {@link PrescribedSlot}'s frozen sequence (#407) — the
+ * prescribing fields of a {@link TemplateSlotStep}, copied at session start.
+ */
+export interface PrescribedSlotStep {
+  /** {@link TemplateSlotStep.id} — the join key for `template_slot_step_id`. */
+  id: string
+  /** Order within the set at snapshot time, lowest first. */
+  position: number
+  /** Catalog slug for this step, or absent to inherit the slot's. */
+  exercise?: string
+  /** Reps prescribed for this step. */
+  target_reps?: number
+  /** Load on one implement for this step, in pounds. */
+  target_weight_lbs?: number
+  /** Free-text cue as it read at snapshot time. */
+  notes?: string
 }
 
 /**

--- a/types/weight-room.ts
+++ b/types/weight-room.ts
@@ -81,6 +81,20 @@ export interface StrengthSet {
    * than the record being rewritten.
    */
   template_slot_id?: string
+  /**
+   * The within-set step this set was performed for (#407) — one rung of a drop
+   * set, or one movement of a superset. Absent for an ordinary straight set,
+   * which is the overwhelming majority.
+   *
+   * Only meaningful alongside {@link template_slot_id}: a step belongs to a
+   * slot, so a set carrying a step without a slot is malformed.
+   *
+   * This is what lets a pass down a rack run count as **one** prescribed set
+   * rather than four. Without it the row-per-mini-set data is still correct —
+   * four rows at four descending loads — but nothing can tell that those four
+   * rows are one set of the prescription, so the slot reads `8 / 2`.
+   */
+  template_slot_step_id?: string
 }
 
 /**


### PR DESCRIPTION
#375 modelled the sequence. #376 built a recording surface that couldn't use it. Back Day 1's rack run — **35 → 30 → 25 → 20, twice** — had two ways to log and both were wrong:

- **One row per mini-set** — the four descending loads survive, but the slot reads `8 / 2`.
- **One row per round** — the counter is right and the loads are gone.

The row-per-mini-set data was always correct. What was missing was knowing *which step* each row belonged to.

## `template_slot_step_id`

Nullable, `on delete set null` — the same shape as `template_slot_id` (#376), so editing a template later degrades a past session to "step unknown" rather than erasing what it recorded. The set and its load always survive.

The create schema **rejects a step without a slot**: a step belongs to a slot, so that combination is malformed rather than merely odd.

## A pass counts only when every rung does

`completedSets` for a stepped slot is the **minimum sets logged across all steps**. Rows ÷ steps would have been simpler and wrong — it scores `35, 35, 30, 25` as a finished drop set when the 20 was never done. The minimum is the only measure that refuses to.

`logged` still means raw rows; `completedSets` is what's compared to `target_sets`. Straight slots have them equal and are untouched.

## The panel walks the sequence

`Step 2 of 4 · 30 lb`, prefilled **from the step, not the previous set**. That inverts the usual priority on purpose: for a straight set the last thing you did is the better guess, because loads get set once and held — but in a rack run the descending loads *are* the prescription, and repeating the previous set would offer 35 when the next rung is 30.

Next step is the **least-logged one, ties by position**. So it walks in order on a fresh round, and resumes mid-round after a reload or a deleted mini-set instead of restarting at the top.

## The superset trap

A superset's steps name different movements **on purpose**. Comparing them to the slot's exercise would have flagged every superset as a substitution, every time. Each set is now compared to *its own step's* movement — so a real swap inside a stepped slot is still caught, and a superset isn't.

## Adherence follows

`buildWorkoutAdherence` credits passes rather than rows. Before this, three rungs of a two-set rack run scored **150% complete**. Now it's 0 passes, shortfall 2.

## One thing found on the way

`.strict()` had landed *after* the new `.refine()` on the set create schema. Refine returns an effects wrapper and chaining strict onto it is at best ambiguous — this file's fail-closed guarantee depends on strictness applying to the object. Reordered, with a test pinning unknown-key rejection so it can't lapse silently.

## Test plan

At `/training-facility/weight-room/workouts` and `/log` (admin):

- [ ] Start **Back Day 1**. The rack run slot shows **Step 1 of 4 · 35 lb** and prefills 35.
- [ ] Log it → advances to **Step 2 of 4 · 30 lb**, prefilled 30 (not 35).
- [ ] Work down to the 20 → the counter goes to **1 / 2**, not 4 / 2.
- [ ] Second pass → **2 / 2**, slot turns complete.
- [ ] Tap a logged mini-set to remove it → the step banner returns to that rung rather than restarting at 35.
- [ ] Reload mid-round → resumes at the right step.
- [ ] Open the session summary → the rack run reads **2 / 2 sets**, and completion isn't inflated.
- [ ] A **straight slot** (bench, incline) behaves exactly as before — no step banner, counter counts rows.

Verified locally: `tsc` clean, `next build` compiles, **2209 unit tests** (160 files, 17 new), **65/65 Playwright**, `format:check` clean, `migrations:check` 36/36. Migration applied to **both** projects.

Closes #407.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for stepped workouts, including drop sets and supersets.
  * Live workout tracking now shows the current step, prescription, and accurate progress.
  * Set history can be associated with specific steps for improved tracking and defaults.
* **Bug Fixes**
  * Workout summaries and adherence calculations now count completed sets accurately.
  * Improved handling of substitutions, incomplete sequences, deleted steps, and partial sets.
* **Tests**
  * Added comprehensive coverage for stepped workout progress, defaults, and adherence calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->