### PR TITLE
feat(weight-room): per-exercise strength view — top set and e1RM over time (#412)

### DIFF
--- a/app/training-facility/weight-room/exercises/[slug]/page.tsx
+++ b/app/training-facility/weight-room/exercises/[slug]/page.tsx
@@ -9,7 +9,11 @@ import { ExerciseProgressionPanel } from '@/components/training-facility/weight-
 import { WeightRoomSubNav } from '@/components/training-facility/weight-room/WeightRoomSubNav'
 import { buildWeightRoomDemoData, buildWorkoutDemoData } from '@/constants/weight-room-demo-fixture'
 import { isAdminRequest } from '@/lib/auth/admin-session'
-import { getWeightRoomDataServer, getWeightRoomWorkoutsServer } from '@/lib/data/weight-room-server'
+import {
+  getWeightRoomDataServer,
+  getWeightRoomExercisesServer,
+  getWeightRoomWorkoutsServer,
+} from '@/lib/data/weight-room-server'
 import { isWeightRoomEnabled } from '@/lib/feature-flags'
 import {
   buildExerciseProgression,
@@ -48,10 +52,15 @@ export default async function WeightRoomExercisePage({
 }: PageProps): Promise<JSX.Element> {
   if (!isWeightRoomEnabled()) notFound()
 
-  const [{ slug }, query, data, realWorkouts, isAdmin] = await Promise.all([
+  const [{ slug }, query, data, realExercises, realWorkouts, isAdmin] = await Promise.all([
     params,
     searchParams,
     getWeightRoomDataServer().catch(() => null),
+    // The roster is read on its own rather than taken off `data.exercises`:
+    // `assembleWeightRoomData` answers `null` when the sets and goals tables are
+    // both empty, which would drop the catalog with them and 404 a movement that
+    // is on the roster and simply hasn't been trained yet.
+    getWeightRoomExercisesServer().catch(() => []),
     getWeightRoomWorkoutsServer().catch(() => []),
     isAdminRequest().catch(() => false),
   ])
@@ -78,11 +87,11 @@ export default async function WeightRoomExercisePage({
   const sets = isPreviewMode
     ? [...(grooveDemo?.sets ?? []), ...(workoutDemo?.sets ?? [])]
     : realSets
-  const exercises = workoutDemo?.exercises ?? data?.exercises ?? []
+  const exercises = workoutDemo?.exercises ?? realExercises
   const goals = grooveDemo?.goals ?? data?.goals ?? []
   const workouts = workoutDemo?.workouts ?? realWorkouts
 
-  const progression = buildExerciseProgression(exercise, sets, exercises)
+  const progression = buildExerciseProgression(exercise, sets, exercises, workouts)
   const catalogRow = exercises.find(e => e.slug === exercise)
   const goal = goals.find(g => g.exercise === exercise)
   if (progression === null && catalogRow === undefined) notFound()

--- a/app/training-facility/weight-room/exercises/[slug]/page.tsx
+++ b/app/training-facility/weight-room/exercises/[slug]/page.tsx
@@ -1,0 +1,162 @@
+import type { JSX } from 'react'
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+
+import { BackToCourtButton } from '@/components/common/BackToCourtButton'
+import { FacilityBackLink } from '@/components/training-facility/FacilityBackLink'
+import { PreviewModeBadge } from '@/components/training-facility/shared/PreviewModeBadge'
+import { ExerciseProgressionPanel } from '@/components/training-facility/weight-room/ExerciseProgressionPanel'
+import { WeightRoomSubNav } from '@/components/training-facility/weight-room/WeightRoomSubNav'
+import { buildWeightRoomDemoData, buildWorkoutDemoData } from '@/constants/weight-room-demo-fixture'
+import { isAdminRequest } from '@/lib/auth/admin-session'
+import { getWeightRoomDataServer, getWeightRoomWorkoutsServer } from '@/lib/data/weight-room-server'
+import { isWeightRoomEnabled } from '@/lib/feature-flags'
+import {
+  buildExerciseProgression,
+  buildSetDetailCoverage,
+} from '@/lib/training-facility/exercise-progression'
+import { buildExerciseLabels, slugLabel } from '@/lib/training-facility/exercise-labels'
+import { isPreviewDemoActive } from '@/lib/training-facility/preview-param'
+
+/** Route + search params for the per-exercise trend. */
+interface PageProps {
+  /** Async per-request route params (Next 15+). `slug` is the movement's catalog slug. */
+  params: Promise<{ slug: string }>
+  /** Async per-request search params; only `preview` is consumed. */
+  searchParams: Promise<Record<string, string | string[] | undefined>>
+}
+
+/** History route, for the breadcrumb back-link. */
+const HISTORY_ROUTE = '/training-facility/weight-room/history'
+
+/**
+ * Per-exercise strength view (#412) — one movement trended over time.
+ *
+ * Public and read-only, like the rest of the Weight Room. Reached from the
+ * per-exercise rows of a workout summary and from the History view's exercise
+ * cards; there's deliberately no sub-nav pill, because this is a leaf about one
+ * movement rather than a section of the room.
+ *
+ * A movement with a catalog row but no logged sets renders an empty state rather
+ * than a 404 — a movement added to the roster before its first session is a
+ * normal state, not a bad URL. A slug that's in neither the log nor the catalog
+ * is a bad URL, and 404s.
+ */
+export default async function WeightRoomExercisePage({
+  params,
+  searchParams,
+}: PageProps): Promise<JSX.Element> {
+  if (!isWeightRoomEnabled()) notFound()
+
+  const [{ slug }, query, data, realWorkouts, isAdmin] = await Promise.all([
+    params,
+    searchParams,
+    getWeightRoomDataServer().catch(() => null),
+    getWeightRoomWorkoutsServer().catch(() => []),
+    isAdminRequest().catch(() => false),
+  ])
+
+  // Slugs are stored lowercase (the API lowercases on write), so a hand-typed
+  // `/exercises/Pushups` should find the same movement rather than 404.
+  const exercise = slug.toLowerCase()
+  const realSets = data?.sets ?? []
+
+  // Same contract as every other Weight Room surface: the fixture is reachable
+  // only when the real read is empty, so it can never stand in front of real
+  // training.
+  //
+  // Both fixtures, because this page is reached from both sides: the History
+  // cards link movements that live in the grease-the-groove fixture, the workout
+  // breakdown links ones that live in the gym fixture, and a preview tour
+  // arriving from either must not dead-end on a 404. It also means the demo
+  // shows both registers — bodyweight reps and loaded work whose low-rep sets
+  // are, for now, the only thing the estimated-1RM overlay has to draw.
+  const isPreviewMode = realSets.length === 0 && isPreviewDemoActive(query.preview)
+  const grooveDemo = isPreviewMode ? buildWeightRoomDemoData() : null
+  const workoutDemo = isPreviewMode ? buildWorkoutDemoData() : null
+
+  const sets = isPreviewMode
+    ? [...(grooveDemo?.sets ?? []), ...(workoutDemo?.sets ?? [])]
+    : realSets
+  const exercises = workoutDemo?.exercises ?? data?.exercises ?? []
+  const goals = grooveDemo?.goals ?? data?.goals ?? []
+  const workouts = workoutDemo?.workouts ?? realWorkouts
+
+  const progression = buildExerciseProgression(exercise, sets, exercises)
+  const catalogRow = exercises.find(e => e.slug === exercise)
+  const goal = goals.find(g => g.exercise === exercise)
+  if (progression === null && catalogRow === undefined) notFound()
+
+  // Catalog first, then the label joined onto a goal, then the slug (#384) — the
+  // grease-the-groove movements carry no catalog row of their own.
+  const displayName = slugLabel(exercise, goal, buildExerciseLabels(exercises))
+  const coverage = buildSetDetailCoverage(progression?.points[0]?.dayKey ?? null, workouts, sets)
+  // The movement's own color where it has a daily goal, so the trend matches the
+  // ring and heatmap it's already drawn in elsewhere. Gym lifts have no goal and
+  // fall back to the panel's default.
+  const goalColor = goal?.color
+
+  return (
+    <div className="relative min-h-svh overflow-hidden bg-[#120d0a] text-[#f7ead9]">
+      <div
+        aria-hidden="true"
+        className="absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(248,214,170,0.16),transparent_30%),linear-gradient(180deg,#241811_0%,#120d0a_55%,#0b0806_100%)]"
+      />
+
+      <div className="relative z-10 mx-auto flex min-h-svh w-full max-w-5xl flex-col px-4 py-6 sm:px-6 sm:py-8 lg:px-10">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <BackToCourtButton />
+          <FacilityBackLink />
+        </div>
+
+        <header className="mt-12">
+          <p className="font-mono text-[11px] uppercase tracking-[0.32em] text-amber-300/80">
+            Weight Room ·{' '}
+            {/* Keeps the preview alive on the way back — without the param the
+                read is empty again and the demo vanishes mid-tour. */}
+            <Link
+              href={isPreviewMode ? `${HISTORY_ROUTE}?preview=demo` : HISTORY_ROUTE}
+              className="underline-offset-4 hover:underline"
+            >
+              History
+            </Link>
+          </p>
+          <h1 className="mt-2 text-3xl font-black uppercase tracking-[0.06em] text-[#fff7ec] sm:text-5xl">
+            {displayName}
+          </h1>
+          <p className="mt-3 max-w-xl text-sm leading-7 text-[#e8d5be] sm:text-base">
+            One movement over time — the heaviest set of each training day, what it implies about a
+            one-rep max, and how many reps went into a single set. Loose sets and recorded sessions
+            count the same; the day is the unit.
+          </p>
+          <WeightRoomSubNav active="exercises" className="mt-5" isAdmin={isAdmin} />
+        </header>
+
+        {isPreviewMode ? (
+          <div className="mt-6">
+            <PreviewModeBadge description="This movement’s history is illustrative — not Lucas’s real training log." />
+          </div>
+        ) : null}
+
+        <div className="mt-8 pb-16">
+          {progression === null ? (
+            <p
+              data-testid="exercise-progression-empty"
+              className="rounded-[1.2rem] border border-white/10 bg-white/5 p-6 text-center text-sm text-[#e8d5be]/70"
+            >
+              No {displayName} sets logged yet. This movement is on the roster; the trend starts at
+              its first recorded set.
+            </p>
+          ) : (
+            <ExerciseProgressionPanel
+              progression={progression}
+              displayName={displayName}
+              coverage={coverage}
+              {...(goalColor === undefined ? {} : { accentColor: goalColor })}
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/training-facility/weight-room/history/page.tsx
+++ b/app/training-facility/weight-room/history/page.tsx
@@ -6,6 +6,7 @@ import { BackToCourtButton } from '@/components/common/BackToCourtButton'
 import { FacilityBackLink } from '@/components/training-facility/FacilityBackLink'
 import { PreviewModeBadge } from '@/components/training-facility/shared/PreviewModeBadge'
 import { ExerciseFilterChips } from '@/components/training-facility/weight-room/ExerciseFilterChips'
+import { exerciseTrendHref } from '@/components/training-facility/weight-room/ExerciseProgressionPanel'
 import { FocusLaneHeatmap } from '@/components/training-facility/weight-room/FocusLaneHeatmap'
 import { LoadManagementPanel } from '@/components/training-facility/weight-room/LoadManagementPanel'
 import { PastFocusCard } from '@/components/training-facility/weight-room/PastFocusCard'
@@ -357,7 +358,14 @@ export default async function WeightRoomHistoryPage({
                 </h2>
                 <div className="mt-4 grid gap-4 md:grid-cols-2">
                   {visibleStats.map(stat => (
-                    <ExerciseStatCard key={stat.exercise} stat={stat} />
+                    // Each card's heading opens that movement's own trend
+                    // (#412), carrying the preview flag so a demo tour stays in
+                    // the demo.
+                    <ExerciseStatCard
+                      key={stat.exercise}
+                      stat={stat}
+                      href={exerciseTrendHref(stat.exercise, isPreviewMode)}
+                    />
                   ))}
                 </div>
               </section>

--- a/app/training-facility/weight-room/history/page.tsx
+++ b/app/training-facility/weight-room/history/page.tsx
@@ -26,6 +26,7 @@ import {
   parseExerciseSelection,
 } from '@/lib/training-facility/exercise-filter'
 import { pacificDayKey } from '@/lib/training-facility/day-keys'
+import { trendableExercises } from '@/lib/training-facility/exercise-progression'
 import { exerciseLabel } from '@/lib/training-facility/exercise-labels'
 import { buildMovementLoadView } from '@/lib/training-facility/load-management'
 import {
@@ -123,6 +124,9 @@ export default async function WeightRoomHistoryPage({
   // totals for no benefit. Passing `focuses` scores their days against the
   // rotation's target rather than the anchor's scalar.
   const stats = computeStrengthStats(sets, goals, new Date(), focuses)
+  // Which movements have something to trend (#412) — a goal with no logged sets
+  // still renders a stat card, and linking it would land on an empty view.
+  const trendable = new Set(trendableExercises(sets))
 
   // Filtering happens here, on the server (#367). The route is dynamic
   // already — `isAdminRequest()` reads cookies — so resolving the selection
@@ -360,11 +364,16 @@ export default async function WeightRoomHistoryPage({
                   {visibleStats.map(stat => (
                     // Each card's heading opens that movement's own trend
                     // (#412), carrying the preview flag so a demo tour stays in
-                    // the demo.
+                    // the demo. Only movements with logged sets get the link:
+                    // `computeStrengthStats` cards every configured goal, and a
+                    // focus anchor that's never been trained has nothing to
+                    // trend.
                     <ExerciseStatCard
                       key={stat.exercise}
                       stat={stat}
-                      href={exerciseTrendHref(stat.exercise, isPreviewMode)}
+                      {...(trendable.has(stat.exercise)
+                        ? { href: exerciseTrendHref(stat.exercise, isPreviewMode) }
+                        : {})}
                     />
                   ))}
                 </div>

--- a/app/training-facility/weight-room/workouts/[id]/page.tsx
+++ b/app/training-facility/weight-room/workouts/[id]/page.tsx
@@ -5,6 +5,7 @@ import { notFound } from 'next/navigation'
 import { BackToCourtButton } from '@/components/common/BackToCourtButton'
 import { FacilityBackLink } from '@/components/training-facility/FacilityBackLink'
 import { PreviewModeBadge } from '@/components/training-facility/shared/PreviewModeBadge'
+import { exerciseTrendHref } from '@/components/training-facility/weight-room/ExerciseProgressionPanel'
 import { WORKOUTS_ROUTE } from '@/components/training-facility/weight-room/WorkoutHistoryList'
 import { WorkoutSummaryPanel } from '@/components/training-facility/weight-room/WorkoutSummaryPanel'
 import { WeightRoomSubNav } from '@/components/training-facility/weight-room/WeightRoomSubNav'
@@ -177,6 +178,10 @@ export default async function WeightRoomWorkoutSummaryPage({
             personalBests={personalBests}
             templateName={template?.name ?? null}
             exerciseLabels={exerciseLabels}
+            // Each movement in the breakdown links to its own trend (#412). The
+            // preview flag rides along so a demo tour lands on the demo trend
+            // rather than on a 404 for a movement that only exists in fixtures.
+            exerciseHref={slug => exerciseTrendHref(slug, isPreviewMode)}
           />
         </div>
       </div>

--- a/components/training-facility/weight-room/ExerciseProgressionPanel.test.tsx
+++ b/components/training-facility/weight-room/ExerciseProgressionPanel.test.tsx
@@ -182,6 +182,24 @@ describe('ExerciseProgressionPanel', () => {
     expect(note).not.toHaveTextContent('earlier sessions')
   })
 
+  it('drops both panels for a single training day rather than stacking empty plots', () => {
+    const oneDay = progressionFor(
+      daily('shrugs', [{ day: '2026-08-05', reps: 20, weight: 30 }]),
+      'shrugs'
+    )
+
+    render(
+      <ExerciseProgressionPanel progression={oneDay} displayName="Shrugs" coverage={NO_COVERAGE} />
+    )
+
+    expect(screen.queryByRole('heading', { name: 'Top set' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('heading', { name: 'Best set' })).not.toBeInTheDocument()
+    expect(screen.getByTestId('exercise-single-day-note')).toHaveTextContent('One training day')
+    // The record and the day itself still carry the movement.
+    expect(screen.getByTestId('exercise-records')).toBeInTheDocument()
+    expect(screen.getByTestId('exercise-day-2026-08-05')).toBeInTheDocument()
+  })
+
   it('lists recent training days newest first', () => {
     render(
       <ExerciseProgressionPanel

--- a/components/training-facility/weight-room/ExerciseProgressionPanel.test.tsx
+++ b/components/training-facility/weight-room/ExerciseProgressionPanel.test.tsx
@@ -1,0 +1,215 @@
+import { describe, expect, it } from 'vitest'
+import { render, screen, within } from '@testing-library/react'
+
+import {
+  buildExerciseProgression,
+  buildSetDetailCoverage,
+  type ExerciseProgression,
+} from '@/lib/training-facility/exercise-progression'
+import type { StrengthSet, WeightRoomExercise, WeightRoomWorkout } from '@/types/weight-room'
+
+import { ExerciseProgressionPanel, exerciseTrendHref } from './ExerciseProgressionPanel'
+
+/**
+ * Coverage for the per-exercise trend panel (#412).
+ *
+ * The assertions worth having are about *honesty*, not layout: that a loaded
+ * movement with nothing but 20-rep sets gets no estimate line and an explanation
+ * instead, that a bodyweight movement doesn't render a load panel at all, and
+ * that the years of duration-only imports before the first set are stated rather
+ * than left as a suspiciously short axis.
+ */
+
+const CATALOG: WeightRoomExercise[] = [
+  {
+    slug: 'barbell-bench-press',
+    display_name: 'Barbell Bench Press',
+    equipment: 'barbell',
+    muscle_group: 'chest',
+  },
+  {
+    slug: 'shrugs',
+    display_name: 'Shrugs',
+    equipment: 'dumbbell',
+    muscle_group: 'back',
+    load_multiplier: 2,
+  },
+  { slug: 'pullups', display_name: 'Pullups', equipment: 'bodyweight', muscle_group: 'back' },
+]
+
+const NO_COVERAGE = { sessionsBefore: 0, earliestSessionDayKey: null }
+
+/** Sets across four training days, one per day. */
+function daily(
+  exercise: string,
+  days: readonly { day: string; reps: number; weight?: number }[]
+): StrengthSet[] {
+  return days.map(({ day, reps, weight }, i) => ({
+    id: `${exercise}-${i}`,
+    logged_at: `${day}T19:00:00-07:00`,
+    exercise,
+    reps,
+    ...(weight === undefined ? {} : { weight_lbs: weight }),
+  }))
+}
+
+function progressionFor(sets: StrengthSet[], exercise: string): ExerciseProgression {
+  const built = buildExerciseProgression(exercise, sets, CATALOG)
+  if (built === null) throw new Error(`fixture produced no progression for ${exercise}`)
+  return built
+}
+
+/** A loaded movement trained low-rep — the shape that earns an estimate line. */
+const LOW_REP_BENCH = progressionFor(
+  daily('barbell-bench-press', [
+    { day: '2026-07-06', reps: 5, weight: 155 },
+    { day: '2026-07-13', reps: 5, weight: 165 },
+    { day: '2026-07-20', reps: 5, weight: 175 },
+  ]),
+  'barbell-bench-press'
+)
+
+/** A loaded movement trained entirely above the cutoff — every real one, today. */
+const HIGH_REP_SHRUGS = progressionFor(
+  daily('shrugs', [
+    { day: '2026-07-06', reps: 25, weight: 50 },
+    { day: '2026-07-13', reps: 25, weight: 55 },
+    { day: '2026-07-20', reps: 20, weight: 60 },
+  ]),
+  'shrugs'
+)
+
+/** A bodyweight movement. */
+const PULLUPS = progressionFor(
+  daily('pullups', [
+    { day: '2026-07-06', reps: 8 },
+    { day: '2026-07-13', reps: 10 },
+    { day: '2026-07-20', reps: 12 },
+  ]),
+  'pullups'
+)
+
+describe('ExerciseProgressionPanel', () => {
+  it('draws the estimated-1RM overlay when low-rep sets support one', () => {
+    const { container } = render(
+      <ExerciseProgressionPanel
+        progression={LOW_REP_BENCH}
+        displayName="Barbell Bench Press"
+        coverage={NO_COVERAGE}
+      />
+    )
+
+    expect(container.querySelector('[data-testid="rough-line-overlay"]')).not.toBeNull()
+    expect(screen.getByText(/Dashed: estimated 1RM/)).toBeInTheDocument()
+    // 175 × (1 + 5/30) ≈ 204
+    expect(screen.getByText('~204 lb')).toBeInTheDocument()
+  })
+
+  it('omits the estimate line and says why when every loaded set is high-rep', () => {
+    const { container } = render(
+      <ExerciseProgressionPanel
+        progression={HIGH_REP_SHRUGS}
+        displayName="Shrugs"
+        coverage={NO_COVERAGE}
+      />
+    )
+
+    expect(container.querySelector('[data-testid="rough-line-overlay"]')).toBeNull()
+    expect(screen.getByTestId('exercise-estimate-note')).toHaveTextContent(
+      /all 3 loaded sets ran above 12 reps/
+    )
+    expect(screen.queryByText('Best est. 1RM')).not.toBeInTheDocument()
+  })
+
+  it('renders no load panel for a bodyweight movement', () => {
+    render(
+      <ExerciseProgressionPanel
+        progression={PULLUPS}
+        displayName="Pullups"
+        coverage={NO_COVERAGE}
+      />
+    )
+
+    expect(screen.queryByRole('heading', { name: 'Top set' })).not.toBeInTheDocument()
+    expect(screen.queryByText('Heaviest set')).not.toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Best set' })).toBeInTheDocument()
+    expect(screen.getByText('Most reps')).toBeInTheDocument()
+  })
+
+  it('reports the heaviest set at the load actually moved, not per implement', () => {
+    render(
+      <ExerciseProgressionPanel
+        progression={HIGH_REP_SHRUGS}
+        displayName="Shrugs"
+        coverage={NO_COVERAGE}
+      />
+    )
+
+    // 60 per hand, two at a time.
+    expect(
+      within(screen.getByTestId('exercise-records')).getByText('20 × 120 lb')
+    ).toBeInTheDocument()
+  })
+
+  it('states the imported sessions that predate the first recorded set', () => {
+    const workouts: WeightRoomWorkout[] = [
+      { id: 'w1', started_at: '2018-01-08T18:00:00Z', source: 'apple_health' },
+      { id: 'w2', started_at: '2022-06-01T18:00:00Z', source: 'apple_health' },
+    ]
+    const coverage = buildSetDetailCoverage(PULLUPS.points[0].dayKey, workouts, [])
+
+    render(
+      <ExerciseProgressionPanel progression={PULLUPS} displayName="Pullups" coverage={coverage} />
+    )
+
+    const note = screen.getByTestId('exercise-coverage-note')
+    expect(note).toHaveTextContent('Set-level detail for Pullups begins July 6, 2026')
+    expect(note).toHaveTextContent('2 earlier sessions')
+    expect(note).toHaveTextContent('January 2018')
+  })
+
+  it('leaves the caption at the start date when nothing predates it', () => {
+    render(
+      <ExerciseProgressionPanel
+        progression={PULLUPS}
+        displayName="Pullups"
+        coverage={NO_COVERAGE}
+      />
+    )
+
+    const note = screen.getByTestId('exercise-coverage-note')
+    expect(note).toHaveTextContent('Set-level detail for Pullups begins July 6, 2026')
+    expect(note).not.toHaveTextContent('earlier sessions')
+  })
+
+  it('lists recent training days newest first', () => {
+    render(
+      <ExerciseProgressionPanel
+        progression={PULLUPS}
+        displayName="Pullups"
+        coverage={NO_COVERAGE}
+      />
+    )
+
+    const rows = screen.getAllByTestId(/^exercise-day-/)
+    expect(rows.map(row => row.getAttribute('data-testid'))).toEqual([
+      'exercise-day-2026-07-20',
+      'exercise-day-2026-07-13',
+      'exercise-day-2026-07-06',
+    ])
+  })
+})
+
+describe('exerciseTrendHref', () => {
+  it('builds a plain route by default', () => {
+    expect(exerciseTrendHref('barbell-bench-press')).toBe(
+      '/training-facility/weight-room/exercises/barbell-bench-press'
+    )
+  })
+
+  it('carries the preview param so a demo tour does not dead-end', () => {
+    expect(exerciseTrendHref('pullups', true)).toBe(
+      '/training-facility/weight-room/exercises/pullups?preview=demo'
+    )
+  })
+})

--- a/components/training-facility/weight-room/ExerciseProgressionPanel.tsx
+++ b/components/training-facility/weight-room/ExerciseProgressionPanel.tsx
@@ -92,6 +92,11 @@ export function ExerciseProgressionPanel({
   // this log — that's the same span as the reps panel, so the two align.
   const loadedDays = points.filter(p => p.topSet !== null)
   const estimateDays = points.filter(p => p.estimatedOneRepMax !== null)
+  // One training day is a real state — every movement starts there — and it is
+  // not a trend. Rendering the cards anyway stacks two tall empty plots above a
+  // records row and a table that both have plenty to say, so the panels are
+  // dropped entirely and one line explains the absence.
+  const hasTrend = points.length >= MIN_TREND_POINTS
 
   return (
     <div
@@ -100,7 +105,18 @@ export function ExerciseProgressionPanel({
     >
       <RecordsRow progression={progression} />
 
-      {isBodyweight ? null : (
+      {hasTrend ? null : (
+        <p
+          data-testid="exercise-single-day-note"
+          className="rounded-[1.2rem] border border-white/10 bg-white/[0.04] px-5 py-4 text-sm leading-6 text-[#e8d5be]/75"
+        >
+          {points.length === 1
+            ? 'One training day so far. A trend needs two — the day below is the whole record.'
+            : 'Not enough training days yet to draw a trend.'}
+        </p>
+      )}
+
+      {isBodyweight || !hasTrend ? null : (
         <ChartCard
           title="Top set"
           subtitle={
@@ -129,26 +145,28 @@ export function ExerciseProgressionPanel({
         </ChartCard>
       )}
 
-      <ChartCard
-        title="Best set"
-        subtitle={
-          isBodyweight
-            ? 'Most reps in a single set each training day'
-            : 'Most reps in a single set each training day — the other half of the same work'
-        }
-      >
-        <TrendChart
-          data={points}
-          y={p => p.bestRepSet.reps}
-          stroke={isBodyweight ? accentColor : chartPalette.hardwoodTan}
-          width={width}
-          height={height}
-          yLabel="reps"
-          yTickFormat={value => String(Math.round(value))}
-          ariaLabel={`${displayName} best set in reps across ${points.length} training days`}
-          emptyMessage={`Not enough ${displayName} training days yet`}
-        />
-      </ChartCard>
+      {!hasTrend ? null : (
+        <ChartCard
+          title="Best set"
+          subtitle={
+            isBodyweight
+              ? 'Most reps in a single set each training day'
+              : 'Most reps in a single set each training day — the other half of the same work'
+          }
+        >
+          <TrendChart
+            data={points}
+            y={p => p.bestRepSet.reps}
+            stroke={isBodyweight ? accentColor : chartPalette.hardwoodTan}
+            width={width}
+            height={height}
+            yLabel="reps"
+            yTickFormat={value => String(Math.round(value))}
+            ariaLabel={`${displayName} best set in reps across ${points.length} training days`}
+            emptyMessage={`Not enough ${displayName} training days yet`}
+          />
+        </ChartCard>
+      )}
 
       <CoverageNote progression={progression} displayName={displayName} coverage={coverage} />
       <RecentDaysTable progression={progression} displayName={displayName} />

--- a/components/training-facility/weight-room/ExerciseProgressionPanel.tsx
+++ b/components/training-facility/weight-room/ExerciseProgressionPanel.tsx
@@ -1,0 +1,473 @@
+import type { JSX } from 'react'
+
+import { RoughLine, chartPalette } from '@/components/training-facility/shared/charts'
+import { formatDayKey } from '@/lib/training-facility/day-keys'
+import type {
+  ExerciseDayPoint,
+  ExerciseProgression,
+  SetDetailCoverage,
+} from '@/lib/training-facility/exercise-progression'
+import { describeSet, formatLbs } from '@/lib/training-facility/strength-format'
+import { E1RM_MAX_RELIABLE_REPS } from '@/lib/training-facility/workout-stats'
+
+/** Route base for the per-exercise trend (#412). */
+export const EXERCISES_ROUTE = '/training-facility/weight-room/exercises'
+
+/**
+ * Link to one movement's trend.
+ *
+ * @param slug Catalog slug — encoded, since it lands in the path.
+ * @param isPreviewMode Carry the `?preview=demo` param through, so a preview
+ *   tour doesn't dead-end on a page whose own read is empty.
+ */
+export function exerciseTrendHref(slug: string, isPreviewMode = false): string {
+  const path = `${EXERCISES_ROUTE}/${encodeURIComponent(slug)}`
+  return isPreviewMode ? `${path}?preview=demo` : path
+}
+
+/** Cream axis ink that reads on the Weight Room's dark page surface. */
+const AXIS_COLOR = 'rgba(247, 234, 217, 0.55)'
+
+/**
+ * Stroke for the estimated-1RM overlay — court-line cream against the
+ * movement's saturated accent, and dashed by {@link RoughLine}'s overlay
+ * treatment, which reads as "computed" rather than "measured".
+ */
+const ESTIMATE_STROKE = chartPalette.courtLineCream
+
+/** How many training days the recent-days table lists. */
+const RECENT_DAY_ROWS = 12
+
+/** A trend needs two anchored points; below that `scaleTime`'s domain collapses. */
+const MIN_TREND_POINTS = 2
+
+/** Props for {@link ExerciseProgressionPanel}. */
+export interface ExerciseProgressionPanelProps {
+  /** The movement's day-by-day history. */
+  progression: ExerciseProgression
+  /**
+   * Human-readable movement name, resolved by the caller with `slugLabel`
+   * (#384) — catalog first, then a goal's joined label, then the slug.
+   */
+  displayName: string
+  /** What the log can't say about the years before it — rendered as a caption. */
+  coverage: SetDetailCoverage
+  /**
+   * Line color for the measured series. Pass the movement's goal color where it
+   * has one so the trend matches its heatmap and rings; defaults to rim orange
+   * for the gym lifts that carry no daily goal.
+   */
+  accentColor?: string
+  /** Chart width in px. Both panels share it so their x-axes line up. Defaults to 760. */
+  width?: number
+  /** Chart height in px. Defaults to 260. */
+  height?: number
+}
+
+/**
+ * One movement's progression over time (#412) — top set and estimated 1RM for
+ * loaded work, best-set reps for bodyweight work.
+ *
+ * Two **separate aligned panels** rather than one dual-axis chart, per the #266
+ * / #363 convention: pounds and reps are different units, and stacking them on a
+ * shared y-axis invents a comparison that doesn't exist. Load and its Epley
+ * estimate *do* share a unit, so those two ride the same axis — the estimate as
+ * a dashed overlay, since it's derived rather than measured.
+ *
+ * A Server Component. `RoughLine` generates its rough.js paths without touching
+ * the DOM, so there's nothing to hydrate.
+ */
+export function ExerciseProgressionPanel({
+  progression,
+  displayName,
+  coverage,
+  accentColor = chartPalette.rimOrange,
+  width = 760,
+  height = 260,
+}: ExerciseProgressionPanelProps): JSX.Element {
+  const { points, isBodyweight } = progression
+
+  // The load panel spans the days the movement was actually loaded. For a
+  // movement that's consistently one or the other — which is every movement in
+  // this log — that's the same span as the reps panel, so the two align.
+  const loadedDays = points.filter(p => p.topSet !== null)
+  const estimateDays = points.filter(p => p.estimatedOneRepMax !== null)
+
+  return (
+    <div
+      className="flex flex-col gap-8"
+      data-testid={`exercise-progression-${progression.exercise}`}
+    >
+      <RecordsRow progression={progression} />
+
+      {isBodyweight ? null : (
+        <ChartCard
+          title="Top set"
+          subtitle={
+            estimateDays.length >= MIN_TREND_POINTS
+              ? 'Heaviest set each training day, with the estimated 1RM it implies'
+              : 'Heaviest set each training day'
+          }
+        >
+          <TrendChart
+            data={loadedDays}
+            y={p => p.topSet?.effectiveLoad ?? 0}
+            overlay={
+              estimateDays.length >= MIN_TREND_POINTS
+                ? estimateDays.map(p => ({ x: p.date, y: p.estimatedOneRepMax ?? 0 }))
+                : undefined
+            }
+            stroke={accentColor}
+            width={width}
+            height={height}
+            yLabel="lb"
+            yTickFormat={value => String(Math.round(value))}
+            ariaLabel={`${displayName} heaviest set in pounds across ${loadedDays.length} training days`}
+            emptyMessage={`Not enough loaded ${displayName} days yet`}
+          />
+          <EstimateNote progression={progression} plotted={estimateDays.length} />
+        </ChartCard>
+      )}
+
+      <ChartCard
+        title="Best set"
+        subtitle={
+          isBodyweight
+            ? 'Most reps in a single set each training day'
+            : 'Most reps in a single set each training day — the other half of the same work'
+        }
+      >
+        <TrendChart
+          data={points}
+          y={p => p.bestRepSet.reps}
+          stroke={isBodyweight ? accentColor : chartPalette.hardwoodTan}
+          width={width}
+          height={height}
+          yLabel="reps"
+          yTickFormat={value => String(Math.round(value))}
+          ariaLabel={`${displayName} best set in reps across ${points.length} training days`}
+          emptyMessage={`Not enough ${displayName} training days yet`}
+        />
+      </ChartCard>
+
+      <CoverageNote progression={progression} displayName={displayName} coverage={coverage} />
+      <RecentDaysTable progression={progression} displayName={displayName} />
+    </div>
+  )
+}
+
+/** Props for the shared chart wrapper. */
+interface ChartCardProps {
+  /** Panel heading. */
+  title: string
+  /** One line saying what the series actually is. */
+  subtitle: string
+  /** The chart, plus any note beneath it. */
+  children: React.ReactNode
+}
+
+/** Titled, horizontally scrollable frame around one chart. */
+function ChartCard({ title, subtitle, children }: ChartCardProps): JSX.Element {
+  return (
+    <section className="rounded-[1.2rem] border border-white/10 bg-white/[0.04] p-5">
+      <h2 className="font-mono text-[11px] uppercase tracking-[0.28em] text-amber-300/80">
+        {title}
+      </h2>
+      <p className="mt-1.5 text-sm leading-6 text-[#e8d5be]/75">{subtitle}</p>
+      {/* Fixed-width SVG: the page scrolls it on a phone rather than squashing
+          a year of training days into 350 px. */}
+      <div className="mt-4 overflow-x-auto">{children}</div>
+    </section>
+  )
+}
+
+/** Props for {@link TrendChart}. */
+interface TrendChartProps {
+  /** Days to plot, oldest first. */
+  data: readonly ExerciseDayPoint[]
+  /** The value to plot for a day. */
+  y: (point: ExerciseDayPoint) => number
+  /** Optional derived series drawn dashed over the same axis. */
+  overlay?: { x: Date; y: number }[]
+  /** Measured-series stroke. */
+  stroke: string
+  /** Chart width in px. */
+  width: number
+  /** Chart height in px. */
+  height: number
+  /** Left-axis unit label. */
+  yLabel: string
+  /** Tick formatter for the left axis. */
+  yTickFormat: (value: number) => string
+  /** Accessible name for the chart. */
+  ariaLabel: string
+  /** Shown in place of the plot when there aren't two days to connect. */
+  emptyMessage: string
+}
+
+/**
+ * One measured series, optionally with a derived overlay.
+ *
+ * Below two points there is no trend to draw — `scaleTime` collapses to a
+ * zero-width domain — so the empty state renders instead. Expected while a
+ * movement is new, not an error.
+ */
+function TrendChart({
+  data,
+  y,
+  overlay,
+  stroke,
+  width,
+  height,
+  yLabel,
+  yTickFormat,
+  ariaLabel,
+  emptyMessage,
+}: TrendChartProps): JSX.Element {
+  const plottable = data.length >= MIN_TREND_POINTS ? [...data] : []
+  return (
+    <RoughLine
+      data={plottable}
+      x={p => p.date}
+      y={y}
+      overlay={plottable.length === 0 ? undefined : overlay}
+      overlayStroke={ESTIMATE_STROKE}
+      width={width}
+      height={height}
+      stroke={stroke}
+      axisColor={AXIS_COLOR}
+      yLabel={yLabel}
+      yTickFormat={yTickFormat}
+      ariaLabel={ariaLabel}
+      emptyMessage={emptyMessage}
+    />
+  )
+}
+
+/** Props for {@link RecordsRow}. */
+interface RecordsRowProps {
+  /** The movement's history. */
+  progression: ExerciseProgression
+}
+
+/** All-time marks: heaviest set, most reps, best estimate, days trained. */
+function RecordsRow({ progression }: RecordsRowProps): JSX.Element {
+  const { heaviestSet, mostRepsSet, bestOneRepMax, points, totalSets, totalReps } = progression
+  return (
+    <dl
+      data-testid="exercise-records"
+      className="grid grid-cols-2 gap-3 sm:grid-cols-4"
+      aria-label="All-time marks"
+    >
+      {heaviestSet === null ? null : (
+        <RecordCell
+          label="Heaviest set"
+          value={describeSet(heaviestSet.reps, heaviestSet.effectiveLoad)}
+        />
+      )}
+      <RecordCell label="Most reps" value={`${mostRepsSet.reps} reps`} />
+      {bestOneRepMax === null ? null : (
+        <RecordCell
+          label="Best est. 1RM"
+          value={`~${formatLbs(bestOneRepMax)}`}
+          title={`Epley estimate from a set of ${E1RM_MAX_RELIABLE_REPS} reps or fewer`}
+        />
+      )}
+      <RecordCell
+        label="Training days"
+        value={String(points.length)}
+        detail={`${totalSets.toLocaleString('en-US')} sets · ${totalReps.toLocaleString('en-US')} reps`}
+      />
+    </dl>
+  )
+}
+
+/** Props for one record tile. */
+interface RecordCellProps {
+  /** What the number is. */
+  label: string
+  /** The number itself. */
+  value: string
+  /** Optional smaller line beneath the value. */
+  detail?: string
+  /** Optional hover explanation. */
+  title?: string
+}
+
+/** One all-time mark. */
+function RecordCell({ label, value, detail, title }: RecordCellProps): JSX.Element {
+  return (
+    <div className="rounded-[1rem] border border-white/10 bg-white/[0.04] px-4 py-3" title={title}>
+      <dt className="font-mono text-[10px] uppercase tracking-[0.22em] text-[#e8d5be]/60">
+        {label}
+      </dt>
+      <dd className="mt-1.5 text-lg font-black tabular-nums text-[#fff7ec]">{value}</dd>
+      {detail === undefined ? null : (
+        <dd className="mt-0.5 font-mono text-[10px] tracking-[0.12em] text-[#e8d5be]/50">
+          {detail}
+        </dd>
+      )}
+    </div>
+  )
+}
+
+/** Props for {@link EstimateNote}. */
+interface EstimateNoteProps {
+  /** The movement's history. */
+  progression: ExerciseProgression
+  /** How many days made it onto the estimate overlay. */
+  plotted: number
+}
+
+/**
+ * Say why the estimate line is missing, when it is.
+ *
+ * A loaded movement trained entirely at 20–25 reps has an Epley number for every
+ * set and no business plotting any of them. Stating that — with the count — is
+ * more honest than an absent line, and more honest than a dashed one the caption
+ * would have to walk back.
+ */
+function EstimateNote({ progression, plotted }: EstimateNoteProps): JSX.Element | null {
+  if (plotted >= MIN_TREND_POINTS) {
+    return (
+      <p className="mt-3 text-xs leading-6 text-[#e8d5be]/60">
+        <span className="mr-1.5 inline-block h-px w-6 translate-y-[-3px] border-t border-dashed border-[#f5f1e6]/70 align-middle" />
+        Dashed: estimated 1RM (Epley), from sets of {E1RM_MAX_RELIABLE_REPS} reps or fewer.
+      </p>
+    )
+  }
+
+  if (progression.loadedSets === 0) return null
+
+  const noneReliable = progression.highRepLoadedSets === progression.loadedSets
+  return (
+    <p data-testid="exercise-estimate-note" className="mt-3 text-xs leading-6 text-[#e8d5be]/60">
+      {noneReliable
+        ? `No estimated 1RM line: all ${progression.loadedSets} loaded sets ran above ${E1RM_MAX_RELIABLE_REPS} reps, and Epley drifts too high past that to plot as a measurement.`
+        : `Not enough low-rep sets to trend an estimated 1RM yet — ${progression.loadedSets - progression.highRepLoadedSets} of ${progression.loadedSets} loaded sets came in at or under ${E1RM_MAX_RELIABLE_REPS} reps.`}
+    </p>
+  )
+}
+
+/** Props for {@link CoverageNote}. */
+interface CoverageNoteProps {
+  /** The movement's history. */
+  progression: ExerciseProgression
+  /** Human-readable movement name. */
+  displayName: string
+  /** Sessions predating it that carry no set detail. */
+  coverage: SetDetailCoverage
+}
+
+/**
+ * State what the x-axis doesn't cover.
+ *
+ * The chart starts at the first *recorded set*, which is not when the training
+ * started — 507 imported Apple Health sessions going back to 2018 record
+ * duration and heart rate and nothing else (#413). Left unsaid, a two-month axis
+ * reads as a two-month training history. Absence here is a true statement about
+ * the log, not missing data to hide.
+ */
+function CoverageNote({ progression, displayName, coverage }: CoverageNoteProps): JSX.Element {
+  const firstDay = progression.points[0]?.dayKey
+  const since =
+    firstDay === undefined
+      ? 'the first recorded set'
+      : formatDayKey(firstDay, { month: 'long', day: 'numeric', year: 'numeric' })
+
+  return (
+    <p
+      data-testid="exercise-coverage-note"
+      className="rounded-[1rem] border border-white/10 bg-white/[0.03] px-4 py-3 text-xs leading-6 text-[#e8d5be]/65"
+    >
+      Set-level detail for {displayName} begins {since}.
+      {coverage.sessionsBefore > 0 && coverage.earliestSessionDayKey !== null ? (
+        <>
+          {' '}
+          {coverage.sessionsBefore.toLocaleString('en-US')} earlier sessions — back to{' '}
+          {formatDayKey(coverage.earliestSessionDayKey, {
+            month: 'long',
+            year: 'numeric',
+          })}{' '}
+          — were imported from Apple Health, which records that a workout happened and for how long,
+          never what was done in it. The training predates the writing-it-down; the chart can only
+          show the part that was written down.
+        </>
+      ) : null}
+    </p>
+  )
+}
+
+/** Props for {@link RecentDaysTable}. */
+interface RecentDaysTableProps {
+  /** The movement's history. */
+  progression: ExerciseProgression
+  /** Human-readable movement name. */
+  displayName: string
+}
+
+/**
+ * The most recent training days as numbers.
+ *
+ * The charts show shape; this shows values, and it's what a screen reader gets
+ * instead of an `aria-label` summarizing a path it can't traverse.
+ */
+function RecentDaysTable({ progression, displayName }: RecentDaysTableProps): JSX.Element {
+  const recent = [...progression.points].reverse().slice(0, RECENT_DAY_ROWS)
+  const showLoad = !progression.isBodyweight
+
+  return (
+    <section
+      aria-label={`Recent ${displayName} training days`}
+      data-testid="exercise-recent-days"
+      className="overflow-x-auto rounded-[1.2rem] border border-white/10 bg-[#f5f1e6] text-[#0a0a0a] shadow-[0_12px_32px_rgba(0,0,0,0.28)]"
+    >
+      <table className="w-full min-w-[30rem] border-collapse text-sm">
+        <caption className="px-5 pt-5 text-left font-mono text-[0.65rem] uppercase tracking-[0.18em] text-[#0a0a0a]/60">
+          Last {recent.length} training {recent.length === 1 ? 'day' : 'days'}
+        </caption>
+        <thead>
+          <tr className="border-b border-black/10 text-left font-mono text-[0.6rem] uppercase tracking-[0.14em] text-[#0a0a0a]/55">
+            <th scope="col" className="px-5 py-2.5 font-normal">
+              Day
+            </th>
+            <th scope="col" className="px-3 py-2.5 text-right font-normal">
+              Sets
+            </th>
+            <th scope="col" className="px-3 py-2.5 text-right font-normal">
+              Reps
+            </th>
+            <th scope="col" className="px-5 py-2.5 text-right font-normal">
+              {showLoad ? 'Top set' : 'Best set'}
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {recent.map(point => (
+            <tr
+              key={point.dayKey}
+              data-testid={`exercise-day-${point.dayKey}`}
+              className="border-b border-black/5 last:border-0"
+            >
+              <th scope="row" className="px-5 py-2.5 text-left font-semibold">
+                {formatDayKey(point.dayKey, { month: 'short', day: 'numeric', year: 'numeric' })}
+              </th>
+              <td className="px-3 py-2.5 text-right tabular-nums">{point.sets}</td>
+              <td className="px-3 py-2.5 text-right tabular-nums">{point.reps}</td>
+              <td className="px-5 py-2.5 text-right tabular-nums">
+                {point.topSet === null
+                  ? `${point.bestRepSet.reps} reps`
+                  : describeSet(point.topSet.reps, point.topSet.effectiveLoad)}
+                {point.estimatedOneRepMax === null ? null : (
+                  <span className="block text-[0.7rem] text-[#0a0a0a]/55">
+                    ~{formatLbs(point.estimatedOneRepMax)} est. 1RM
+                  </span>
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </section>
+  )
+}

--- a/components/training-facility/weight-room/StrengthStats.tsx
+++ b/components/training-facility/weight-room/StrengthStats.tsx
@@ -1,4 +1,5 @@
 import type { JSX } from 'react'
+import Link from 'next/link'
 
 import { describeGoalTargetChange } from '@/lib/training-facility/goal-targets'
 import type { StrengthExerciseStats } from '@/lib/training-facility/weight-room-history'
@@ -61,6 +62,12 @@ const FOCUS_STATUS_LABEL: Record<'active' | 'upcoming' | 'ended', string> = {
 export interface ExerciseStatCardProps {
   /** The pre-computed rollup for one exercise. */
   stat: StrengthExerciseStats
+  /**
+   * Link to this movement's per-exercise trend (#412). Omitted, the card's
+   * heading stays plain text — which is what {@link StrengthStats} renders,
+   * since it has no route to hand down.
+   */
+  href?: string
 }
 
 /**
@@ -69,7 +76,7 @@ export interface ExerciseStatCardProps {
  * cards — can render cards individually instead of handing the whole array to
  * {@link StrengthStats}.
  */
-export function ExerciseStatCard({ stat }: ExerciseStatCardProps): JSX.Element {
+export function ExerciseStatCard({ stat, href }: ExerciseStatCardProps): JSX.Element {
   const isStreaking = stat.currentStreak > 0
   // A rotation that has *ended* reports 0 reps this week and this month —
   // true, but a useless reading of a campaign that closed in July. Swap those
@@ -89,7 +96,16 @@ export function ExerciseStatCard({ stat }: ExerciseStatCardProps): JSX.Element {
           className="flex items-baseline gap-2 font-mono text-sm font-bold uppercase tracking-[0.2em]"
           style={{ color: stat.color }}
         >
-          {stat.displayName ?? stat.exercise}
+          {href === undefined ? (
+            (stat.displayName ?? stat.exercise)
+          ) : (
+            <Link
+              href={href}
+              className="underline decoration-current/30 underline-offset-4 hover:decoration-current"
+            >
+              {stat.displayName ?? stat.exercise}
+            </Link>
+          )}
           {stat.focus ? (
             <span
               data-testid={`strength-stat-focus-badge-${stat.exercise}`}

--- a/components/training-facility/weight-room/WeightRoomSubNav.tsx
+++ b/components/training-facility/weight-room/WeightRoomSubNav.tsx
@@ -6,9 +6,15 @@ import Link from 'next/link'
  * which pill in the sub-nav renders in the active style. Each value
  * corresponds to one of the routes under
  * `/training-facility/weight-room/*`.
+ *
+ * `'exercises'` (#412) deliberately has no pill: the per-exercise trend is a
+ * leaf about one movement, reached from both History and a workout summary, so
+ * neither parent is the honest answer to "which section is this". It renders
+ * with no pill marked `aria-current` rather than pointing at a page the viewer
+ * isn't on.
  */
 export type WeightRoomSubNavSection =
-  'today' | 'history' | 'workouts' | 'achievements' | 'settings' | 'log'
+  'today' | 'history' | 'workouts' | 'exercises' | 'achievements' | 'settings' | 'log'
 
 /** Props for {@link WeightRoomSubNav}. */
 export interface WeightRoomSubNavProps {

--- a/components/training-facility/weight-room/WorkoutHistoryList.tsx
+++ b/components/training-facility/weight-room/WorkoutHistoryList.tsx
@@ -2,6 +2,7 @@ import type { JSX } from 'react'
 import Link from 'next/link'
 
 import { formatDayKey, safePacificDayKey, todayDayKey } from '@/lib/training-facility/day-keys'
+import { describeSet } from '@/lib/training-facility/strength-format'
 import {
   workoutDisplayTitle,
   type WorkoutHistoryEntry,
@@ -401,8 +402,8 @@ function WorkoutHistoryRow({ entry, isPreviewMode }: WorkoutHistoryRowProps): JS
 
       {topLift?.topSet != null ? (
         <p className="mt-1.5 text-xs text-[#0a0a0a]/60">
-          Top set · {topLift.displayName ?? topLift.exercise} {topLift.topSet.reps} ×{' '}
-          {Math.round(topLift.topSet.effectiveLoad).toLocaleString('en-US')} lb
+          Top set · {topLift.displayName ?? topLift.exercise}{' '}
+          {describeSet(topLift.topSet.reps, topLift.topSet.effectiveLoad)}
         </p>
       ) : null}
     </Link>

--- a/components/training-facility/weight-room/WorkoutSummaryPanel.tsx
+++ b/components/training-facility/weight-room/WorkoutSummaryPanel.tsx
@@ -1,4 +1,5 @@
 import type { JSX } from 'react'
+import Link from 'next/link'
 
 import { formatDayKey, safePacificDayKey } from '@/lib/training-facility/day-keys'
 import type {
@@ -9,15 +10,8 @@ import type {
   WorkoutPersonalBest,
   WorkoutSummary,
 } from '@/lib/training-facility/workout-stats'
+import { describeSet, formatLbs } from '@/lib/training-facility/strength-format'
 import type { StrengthSet } from '@/types/weight-room'
-
-/**
- * Format a number of pounds for display — whole pounds, thousands separated.
- * Tonnage runs to five figures, where a decimal is noise.
- */
-function lbs(value: number): string {
-  return `${Math.round(value).toLocaleString('en-US')} lb`
-}
 
 /** Format a signed delta, so `+400 lb` and `−120 lb` both read at a glance. */
 function signed(value: number, unit: string): string {
@@ -34,11 +28,6 @@ function minutes(value: number): string {
   return `${Math.floor(whole / 60)}h ${whole % 60}m`
 }
 
-/** Render a set as `8 × 60 lb` or `12 reps` when bodyweight. */
-function describeSet(reps: number, effectiveLoad: number): string {
-  return effectiveLoad > 0 ? `${reps} × ${lbs(effectiveLoad)}` : `${reps} reps`
-}
-
 /** Props for {@link WorkoutSummaryPanel}. */
 export interface WorkoutSummaryPanelProps {
   /** The session's computed statistics. */
@@ -53,6 +42,14 @@ export interface WorkoutSummaryPanelProps {
   templateName: string | null
   /** Label for each slot's prescribed movement, by catalog slug. */
   exerciseLabels: Readonly<Record<string, string>>
+  /**
+   * Link builder for a movement's per-exercise trend (#412), by catalog slug.
+   *
+   * Optional, and omitted the component renders movement names as plain text —
+   * so a caller that has no route to offer (a test, or a surface where the trend
+   * isn't reachable) doesn't have to invent one.
+   */
+  exerciseHref?: (slug: string) => string
 }
 
 /**
@@ -76,6 +73,7 @@ export function WorkoutSummaryPanel({
   personalBests,
   templateName,
   exerciseLabels,
+  exerciseHref,
 }: WorkoutSummaryPanelProps): JSX.Element {
   // `totalSets > 0` guard: an empty session also has zero weighted sets, and
   // without it the panel announces "Bodyweight session" directly above the
@@ -118,7 +116,11 @@ export function WorkoutSummaryPanel({
       ) : null}
 
       {isImportedSkeleton ? null : (
-        <BreakdownCard exercises={summary.exercises} allBodyweight={allBodyweight} />
+        <BreakdownCard
+          exercises={summary.exercises}
+          allBodyweight={allBodyweight}
+          {...(exerciseHref === undefined ? {} : { exerciseHref })}
+        />
       )}
     </div>
   )
@@ -165,7 +167,7 @@ function HeadlineStats({
                 : `${Math.round(summary.workout.avg_hr)} bpm`
               : allBodyweight
                 ? '—'
-                : lbs(summary.tonnage)
+                : formatLbs(summary.tonnage)
           }
           testId="workout-tonnage"
         />
@@ -196,7 +198,7 @@ function HeadlineStats({
             : `${(density.setsPerMinute * 60).toFixed(1)} sets/hr`}
           {allBodyweight
             ? ` · ${density.repsPerMinute.toFixed(1)} reps/min`
-            : ` · ${lbs(density.tonnagePerMinute)}/min`}
+            : ` · ${formatLbs(density.tonnagePerMinute)}/min`}
         </p>
       ) : null}
 
@@ -274,7 +276,7 @@ function PersonalBestStrip({ bests }: PersonalBestStripProps): JSX.Element {
               {best.previousBest === null
                 ? ' — first time logged'
                 : best.kind === 'load'
-                  ? ` — past ${lbs(best.previousBest)}`
+                  ? ` — past ${formatLbs(best.previousBest)}`
                   : ` — past ${best.previousBest} reps`}
             </span>
           </li>
@@ -484,10 +486,16 @@ function ExtraWorkCard({ sets, exerciseLabels }: ExtraWorkCardProps): JSX.Elemen
 interface BreakdownCardProps {
   exercises: readonly ExerciseBreakdown[]
   allBodyweight: boolean
+  /** See {@link WorkoutSummaryPanelProps.exerciseHref}. */
+  exerciseHref?: (slug: string) => string
 }
 
 /** Per-movement breakdown: sets, reps, tonnage, top set, estimated 1RM. */
-function BreakdownCard({ exercises, allBodyweight }: BreakdownCardProps): JSX.Element {
+function BreakdownCard({
+  exercises,
+  allBodyweight,
+  exerciseHref,
+}: BreakdownCardProps): JSX.Element {
   if (exercises.length === 0) {
     return (
       <p
@@ -538,13 +546,22 @@ function BreakdownCard({ exercises, allBodyweight }: BreakdownCardProps): JSX.El
               className="border-b border-black/5 last:border-0"
             >
               <th scope="row" className="px-5 py-2.5 text-left font-semibold">
-                {entry.displayName ?? entry.exercise}
+                {exerciseHref === undefined ? (
+                  (entry.displayName ?? entry.exercise)
+                ) : (
+                  <Link
+                    href={exerciseHref(entry.exercise)}
+                    className="underline decoration-black/25 underline-offset-4 hover:decoration-black/60"
+                  >
+                    {entry.displayName ?? entry.exercise}
+                  </Link>
+                )}
               </th>
               <td className="px-3 py-2.5 text-right tabular-nums">{entry.sets}</td>
               <td className="px-3 py-2.5 text-right tabular-nums">{entry.reps}</td>
               {allBodyweight ? null : (
                 <td className="px-3 py-2.5 text-right tabular-nums">
-                  {entry.isBodyweight ? '—' : lbs(entry.tonnage)}
+                  {entry.isBodyweight ? '—' : formatLbs(entry.tonnage)}
                 </td>
               )}
               <td className="px-5 py-2.5 text-right tabular-nums">
@@ -560,7 +577,7 @@ function BreakdownCard({ exercises, allBodyweight }: BreakdownCardProps): JSX.El
                         : 'Epley estimate from a high-rep set — treat as a gesture, not a measurement'
                     }
                   >
-                    ~{lbs(entry.estimatedOneRepMax)} est. 1RM
+                    ~{formatLbs(entry.estimatedOneRepMax)} est. 1RM
                     {entry.oneRepMaxIsReliable ? '' : ' ?'}
                   </span>
                 ) : null}

--- a/e2e/chart-overflow.spec.ts
+++ b/e2e/chart-overflow.spec.ts
@@ -87,16 +87,19 @@ test.describe('chart overflow behaviour', () => {
     await page.goto('/training-facility/weight-room/exercises/pullups?preview=demo')
     await expect(page.getByTestId('exercise-progression-pullups')).toBeVisible()
 
-    const measured = await page.evaluate(() => {
-      const boxes = [...document.querySelectorAll<HTMLElement>('.overflow-x-auto')]
-      return {
-        viewport: window.innerWidth,
-        count: boxes.length,
-        overflowing: boxes.filter(el => el.scrollWidth > el.clientWidth).length,
-        docScrollWidth: document.documentElement.scrollWidth,
-        docClientWidth: document.documentElement.clientWidth,
-      }
-    })
+    // Scoped to the panel: an unrelated scroller elsewhere on the page would
+    // otherwise satisfy the overflow assertion while the trend charts sat
+    // squashed inside their cards.
+    const panel = page.getByTestId('exercise-progression-pullups')
+    const measured = await panel.evaluate(root => ({
+      viewport: window.innerWidth,
+      count: root.querySelectorAll('.overflow-x-auto').length,
+      overflowing: [...root.querySelectorAll<HTMLElement>('.overflow-x-auto')].filter(
+        el => el.scrollWidth > el.clientWidth
+      ).length,
+      docScrollWidth: document.documentElement.scrollWidth,
+      docClientWidth: document.documentElement.clientWidth,
+    }))
 
     expect(measured.count).toBeGreaterThan(0)
     if (measured.viewport < LG_BREAKPOINT) {

--- a/e2e/chart-overflow.spec.ts
+++ b/e2e/chart-overflow.spec.ts
@@ -73,4 +73,35 @@ test.describe('chart overflow behaviour', () => {
     // One pixel of slack for sub-pixel layout rounding.
     expect(doc.scrollWidth).toBeLessThanOrEqual(doc.clientWidth + 1)
   })
+
+  test('the per-exercise trend keeps its charts inside the page', async ({ page }) => {
+    // The trend panels (#412) are fixed-width SVGs — 760px, wider than a phone —
+    // so they carry the same two obligations: scroll inside their own card, and
+    // never widen the document.
+    //
+    // Pull-ups specifically, because it's the one movement that resolves in both
+    // environments: CI has no Supabase credentials and falls through to the
+    // fixture, while a local run has real credentials — which *suppresses* the
+    // fixture — and has to find real pull-up sets instead. A demo-only movement
+    // renders the empty state locally and the assertion never runs.
+    await page.goto('/training-facility/weight-room/exercises/pullups?preview=demo')
+    await expect(page.getByTestId('exercise-progression-pullups')).toBeVisible()
+
+    const measured = await page.evaluate(() => {
+      const boxes = [...document.querySelectorAll<HTMLElement>('.overflow-x-auto')]
+      return {
+        viewport: window.innerWidth,
+        count: boxes.length,
+        overflowing: boxes.filter(el => el.scrollWidth > el.clientWidth).length,
+        docScrollWidth: document.documentElement.scrollWidth,
+        docClientWidth: document.documentElement.clientWidth,
+      }
+    })
+
+    expect(measured.count).toBeGreaterThan(0)
+    if (measured.viewport < LG_BREAKPOINT) {
+      expect(measured.overflowing).toBeGreaterThan(0)
+    }
+    expect(measured.docScrollWidth).toBeLessThanOrEqual(measured.docClientWidth + 1)
+  })
 })

--- a/e2e/training-facility-disabled.spec.ts
+++ b/e2e/training-facility-disabled.spec.ts
@@ -19,6 +19,7 @@ const gatedRoutes = [
   '/training-facility/weight-room',
   '/training-facility/weight-room/achievements',
   '/training-facility/weight-room/history',
+  '/training-facility/weight-room/exercises/pullups',
 ]
 
 test.describe('training facility disabled', () => {

--- a/lib/training-facility/exercise-progression.test.ts
+++ b/lib/training-facility/exercise-progression.test.ts
@@ -1,0 +1,280 @@
+import { describe, expect, it } from 'vitest'
+
+import type { StrengthSet, WeightRoomExercise, WeightRoomWorkout } from '@/types/weight-room'
+
+import {
+  buildExerciseProgression,
+  buildSetDetailCoverage,
+  trendableExercises,
+} from './exercise-progression'
+import { E1RM_MAX_RELIABLE_REPS } from './workout-stats'
+
+/**
+ * Coverage for the per-exercise trend (#412).
+ *
+ * The cases that matter are the ones a plausible implementation gets quietly
+ * wrong: a late-evening Pacific set bucketed into tomorrow because the server
+ * runs UTC, a two-dumbbell movement plotted at half the load actually moved, and
+ * an Epley estimate off a set of 25 drawn as though it were a measurement.
+ */
+
+const CATALOG: WeightRoomExercise[] = [
+  {
+    slug: 'barbell-bench-press',
+    display_name: 'Barbell Bench Press',
+    equipment: 'barbell',
+    muscle_group: 'chest',
+  },
+  {
+    slug: 'shrugs',
+    display_name: 'Shrugs',
+    equipment: 'dumbbell',
+    muscle_group: 'back',
+    load_multiplier: 2,
+  },
+  { slug: 'pullups', display_name: 'Pullups', equipment: 'bodyweight', muscle_group: 'back' },
+]
+
+function set(overrides: Partial<StrengthSet> = {}): StrengthSet {
+  return {
+    id: 'set-1',
+    logged_at: '2026-08-01T18:00:00Z',
+    exercise: 'barbell-bench-press',
+    reps: 5,
+    ...overrides,
+  }
+}
+
+function workout(overrides: Partial<WeightRoomWorkout> = {}): WeightRoomWorkout {
+  return {
+    id: 'workout-1',
+    started_at: '2026-01-08T18:00:00Z',
+    source: 'apple_health',
+    ...overrides,
+  }
+}
+
+describe('buildExerciseProgression', () => {
+  it('returns null for a movement with no logged sets', () => {
+    expect(buildExerciseProgression('dips', [set()], CATALOG)).toBeNull()
+  })
+
+  it('buckets sets by Pacific training day, not by UTC calendar day', () => {
+    // 2026-08-02T04:30:00Z is 9:30pm Pacific on 8/1. Bucketed by the raw
+    // timestamp it would open a second, phantom training day.
+    const progression = buildExerciseProgression(
+      'pullups',
+      [
+        set({ id: 'a', exercise: 'pullups', reps: 8, logged_at: '2026-08-01T19:00:00-07:00' }),
+        set({ id: 'b', exercise: 'pullups', reps: 6, logged_at: '2026-08-02T04:30:00Z' }),
+      ],
+      CATALOG
+    )
+
+    expect(progression?.points).toHaveLength(1)
+    expect(progression?.points[0].dayKey).toBe('2026-08-01')
+    expect(progression?.points[0].sets).toBe(2)
+    expect(progression?.points[0].reps).toBe(14)
+  })
+
+  it('orders days oldest first regardless of input order', () => {
+    const progression = buildExerciseProgression(
+      'pullups',
+      [
+        set({ id: 'c', exercise: 'pullups', logged_at: '2026-08-03T18:00:00Z' }),
+        set({ id: 'a', exercise: 'pullups', logged_at: '2026-08-01T18:00:00Z' }),
+        set({ id: 'b', exercise: 'pullups', logged_at: '2026-08-02T18:00:00Z' }),
+      ],
+      CATALOG
+    )
+
+    expect(progression?.points.map(p => p.dayKey)).toEqual([
+      '2026-08-01',
+      '2026-08-02',
+      '2026-08-03',
+    ])
+  })
+
+  it('counts a two-dumbbell movement at the load actually moved', () => {
+    const progression = buildExerciseProgression(
+      'shrugs',
+      [set({ id: 'a', exercise: 'shrugs', reps: 10, weight_lbs: 60 })],
+      CATALOG
+    )
+
+    // 60 per hand, carried two at a time — 120 moved, 1,200 lb of tonnage.
+    expect(progression?.points[0].topSet?.effectiveLoad).toBe(120)
+    expect(progression?.points[0].topSet?.weightLbs).toBe(60)
+    expect(progression?.points[0].tonnage).toBe(1200)
+    expect(progression?.heaviestSet?.effectiveLoad).toBe(120)
+  })
+
+  it('picks the heaviest set of the day, breaking ties toward more reps', () => {
+    const progression = buildExerciseProgression(
+      'barbell-bench-press',
+      [
+        set({ id: 'light', reps: 12, weight_lbs: 135 }),
+        set({ id: 'heavy-5', reps: 5, weight_lbs: 185 }),
+        set({ id: 'heavy-6', reps: 6, weight_lbs: 185 }),
+      ],
+      CATALOG
+    )
+
+    expect(progression?.points[0].topSet?.setId).toBe('heavy-6')
+  })
+
+  it('picks the most-reps set separately, breaking ties toward heavier load', () => {
+    const progression = buildExerciseProgression(
+      'barbell-bench-press',
+      [
+        set({ id: 'light-12', reps: 12, weight_lbs: 95 }),
+        set({ id: 'heavy-12', reps: 12, weight_lbs: 135 }),
+        set({ id: 'heavy-5', reps: 5, weight_lbs: 185 }),
+      ],
+      CATALOG
+    )
+
+    expect(progression?.points[0].bestRepSet.setId).toBe('heavy-12')
+    expect(progression?.mostRepsSet.setId).toBe('heavy-12')
+  })
+
+  it('estimates a 1RM only from sets at or under the reliability cutoff', () => {
+    const progression = buildExerciseProgression(
+      'barbell-bench-press',
+      [
+        // The heaviest set of the day, but far too many reps for Epley.
+        set({ id: 'high-rep', reps: 25, weight_lbs: 155 }),
+        set({ id: 'low-rep', reps: E1RM_MAX_RELIABLE_REPS, weight_lbs: 135 }),
+      ],
+      CATALOG
+    )
+
+    // Off the reliable set (135 × (1 + 12/30) = 189), not off the heavier one.
+    expect(progression?.points[0].estimatedOneRepMax).toBeCloseTo(189, 5)
+    expect(progression?.points[0].topSet?.setId).toBe('high-rep')
+    expect(progression?.bestOneRepMax).toBeCloseTo(189, 5)
+  })
+
+  it('reports no estimate at all when every loaded set is high-rep', () => {
+    const progression = buildExerciseProgression(
+      'shrugs',
+      [
+        set({ id: 'a', exercise: 'shrugs', reps: 25, weight_lbs: 50 }),
+        set({ id: 'b', exercise: 'shrugs', reps: 20, weight_lbs: 50 }),
+      ],
+      CATALOG
+    )
+
+    expect(progression?.points[0].estimatedOneRepMax).toBeNull()
+    expect(progression?.bestOneRepMax).toBeNull()
+    expect(progression?.loadedSets).toBe(2)
+    expect(progression?.highRepLoadedSets).toBe(2)
+  })
+
+  it('treats a movement with no loaded set as bodyweight, with no top set', () => {
+    const progression = buildExerciseProgression(
+      'pullups',
+      [
+        set({ id: 'a', exercise: 'pullups', reps: 8 }),
+        set({ id: 'b', exercise: 'pullups', reps: 5 }),
+      ],
+      CATALOG
+    )
+
+    expect(progression?.isBodyweight).toBe(true)
+    expect(progression?.heaviestSet).toBeNull()
+    expect(progression?.points[0].topSet).toBeNull()
+    expect(progression?.points[0].tonnage).toBe(0)
+    expect(progression?.mostRepsSet.reps).toBe(8)
+  })
+
+  it('counts loose sets and session sets alike', () => {
+    const progression = buildExerciseProgression(
+      'pullups',
+      [
+        set({ id: 'loose', exercise: 'pullups', reps: 5 }),
+        set({ id: 'in-session', exercise: 'pullups', reps: 7, workout_id: 'workout-1' }),
+      ],
+      CATALOG
+    )
+
+    expect(progression?.totalSets).toBe(2)
+    expect(progression?.totalReps).toBe(12)
+  })
+
+  it('drops sets whose timestamp has no day to belong to', () => {
+    const progression = buildExerciseProgression(
+      'pullups',
+      [
+        set({ id: 'good', exercise: 'pullups', reps: 5 }),
+        set({ id: 'bad', exercise: 'pullups', reps: 99, logged_at: 'not-a-timestamp' }),
+      ],
+      CATALOG
+    )
+
+    expect(progression?.totalSets).toBe(1)
+    expect(progression?.mostRepsSet.reps).toBe(5)
+  })
+
+  it('understates rather than invents load when the catalog is missing', () => {
+    const progression = buildExerciseProgression('shrugs', [
+      set({ id: 'a', exercise: 'shrugs', reps: 10, weight_lbs: 60 }),
+    ])
+
+    // No multiplier available, so one implement — half the truth, but never more
+    // than was lifted.
+    expect(progression?.points[0].topSet?.effectiveLoad).toBe(60)
+  })
+})
+
+describe('buildSetDetailCoverage', () => {
+  const sessions = [
+    workout({ id: 'w1', started_at: '2018-01-08T18:00:00Z' }),
+    workout({ id: 'w2', started_at: '2022-06-01T18:00:00Z' }),
+    workout({ id: 'w3', started_at: '2026-08-04T18:00:00Z' }),
+  ]
+
+  it('counts only the detail-free sessions that predate the first set', () => {
+    const coverage = buildSetDetailCoverage('2026-08-01', sessions, [])
+
+    expect(coverage.sessionsBefore).toBe(2)
+    expect(coverage.earliestSessionDayKey).toBe('2018-01-08')
+  })
+
+  it('excludes sessions that carry set detail of their own', () => {
+    const coverage = buildSetDetailCoverage('2026-08-01', sessions, [
+      set({ id: 's', workout_id: 'w2', logged_at: '2022-06-01T19:00:00Z' }),
+    ])
+
+    expect(coverage.sessionsBefore).toBe(1)
+    expect(coverage.earliestSessionDayKey).toBe('2018-01-08')
+  })
+
+  it('reports nothing when the movement has no first day', () => {
+    expect(buildSetDetailCoverage(null, sessions, [])).toEqual({
+      sessionsBefore: 0,
+      earliestSessionDayKey: null,
+    })
+  })
+})
+
+describe('trendableExercises', () => {
+  it('lists movements most-recently-trained first', () => {
+    const sets = [
+      set({ id: 'a', exercise: 'pullups', logged_at: '2026-08-01T18:00:00Z' }),
+      set({ id: 'b', exercise: 'shrugs', logged_at: '2026-08-05T18:00:00Z' }),
+      set({ id: 'c', exercise: 'pullups', logged_at: '2026-07-01T18:00:00Z' }),
+    ]
+
+    expect(trendableExercises(sets)).toEqual(['shrugs', 'pullups'])
+  })
+
+  it('breaks a same-day tie alphabetically', () => {
+    const sets = [
+      set({ id: 'a', exercise: 'squats', logged_at: '2026-08-05T18:00:00Z' }),
+      set({ id: 'b', exercise: 'lunges', logged_at: '2026-08-05T18:00:00Z' }),
+    ]
+
+    expect(trendableExercises(sets)).toEqual(['lunges', 'squats'])
+  })
+})

--- a/lib/training-facility/exercise-progression.test.ts
+++ b/lib/training-facility/exercise-progression.test.ts
@@ -188,6 +188,53 @@ describe('buildExerciseProgression', () => {
     expect(progression?.mostRepsSet.reps).toBe(8)
   })
 
+  it("keeps a session's sets on the session's own day when it runs past midnight", () => {
+    const session = workout({
+      id: 'late-night',
+      source: 'manual',
+      started_at: '2026-08-01T22:30:00-07:00',
+    })
+    const progression = buildExerciseProgression(
+      'pullups',
+      [
+        set({ id: 'before', exercise: 'pullups', reps: 8, workout_id: 'late-night' }),
+        // 12:20am Pacific on 8/2 — the same session, an hour later.
+        set({
+          id: 'after',
+          exercise: 'pullups',
+          reps: 6,
+          workout_id: 'late-night',
+          logged_at: '2026-08-02T00:20:00-07:00',
+        }),
+      ],
+      CATALOG,
+      [session]
+    )
+
+    expect(progression?.points).toHaveLength(1)
+    expect(progression?.points[0].dayKey).toBe('2026-08-01')
+    expect(progression?.points[0].reps).toBe(14)
+  })
+
+  it('dates a set by its own timestamp when its session is unknown', () => {
+    const progression = buildExerciseProgression(
+      'pullups',
+      [
+        set({
+          id: 'orphan',
+          exercise: 'pullups',
+          reps: 6,
+          workout_id: 'missing',
+          logged_at: '2026-08-02T00:20:00-07:00',
+        }),
+      ],
+      CATALOG,
+      []
+    )
+
+    expect(progression?.points[0].dayKey).toBe('2026-08-02')
+  })
+
   it('counts loose sets and session sets alike', () => {
     const progression = buildExerciseProgression(
       'pullups',
@@ -248,6 +295,33 @@ describe('buildSetDetailCoverage', () => {
 
     expect(coverage.sessionsBefore).toBe(1)
     expect(coverage.earliestSessionDayKey).toBe('2018-01-08')
+  })
+
+  it('excludes manually recorded sessions, which were never imports', () => {
+    // The render site names Apple Health as the reason the detail is missing, so
+    // a manual session abandoned before any set was logged must not pad the
+    // number behind that sentence.
+    const coverage = buildSetDetailCoverage(
+      '2026-08-01',
+      [...sessions, workout({ id: 'w4', source: 'manual', started_at: '2026-07-01T18:00:00Z' })],
+      []
+    )
+
+    expect(coverage.sessionsBefore).toBe(2)
+  })
+
+  it('excludes a session started on the first training day itself', () => {
+    const coverage = buildSetDetailCoverage('2018-01-08', sessions, [])
+
+    expect(coverage.sessionsBefore).toBe(0)
+    expect(coverage.earliestSessionDayKey).toBeNull()
+  })
+
+  it('ignores a session whose start timestamp has no day to belong to', () => {
+    const coverage = buildSetDetailCoverage('2026-08-01', [workout({ started_at: 'nope' })], [])
+
+    expect(coverage.sessionsBefore).toBe(0)
+    expect(coverage.earliestSessionDayKey).toBeNull()
   })
 
   it('reports nothing when the movement has no first day', () => {

--- a/lib/training-facility/exercise-progression.ts
+++ b/lib/training-facility/exercise-progression.ts
@@ -1,6 +1,7 @@
 import type { StrengthSet, WeightRoomExercise, WeightRoomWorkout } from '@/types/weight-room'
 
 import { dayKeyToPacificNoon, safePacificDayKey } from './day-keys'
+import { workoutDayKey } from './workout-sessions'
 import {
   E1RM_MAX_RELIABLE_REPS,
   effectiveSetLoad,
@@ -152,6 +153,9 @@ function reliableOneRepMax(load: number, reps: number): number | null {
  * @param exercises The catalog, for `load_multiplier`. Omitting it treats every
  *   movement as single-implement, which understates a two-dumbbell movement by
  *   half.
+ * @param workouts Recorded sessions, so a session's sets stay on the session's
+ *   own day. Omitting it dates every set by its own timestamp, which splits a
+ *   session that ran past Pacific midnight across two points.
  * @returns The progression, or `null` when the movement has no plottable sets —
  *   a real state (a catalog row added before its first session), and one the
  *   caller renders as an empty view rather than as a broken chart.
@@ -159,9 +163,20 @@ function reliableOneRepMax(load: number, reps: number): number | null {
 export function buildExerciseProgression(
   exercise: string,
   sets: readonly StrengthSet[],
-  exercises: readonly WeightRoomExercise[] = []
+  exercises: readonly WeightRoomExercise[] = [],
+  workouts: readonly WeightRoomWorkout[] = []
 ): ExerciseProgression | null {
   const multipliers = loadMultipliersBySlug(exercises)
+
+  // A session owns its calendar day, and its 12:20am sets belong to the evening
+  // that started them — the same rule `workoutDayKey` applies everywhere else.
+  // Without it a late gym session lands as two training days with half the work
+  // in each.
+  const sessionDay = new Map<string, string>()
+  for (const workout of workouts) {
+    const dayKey = workoutDayKey(workout)
+    if (dayKey !== null) sessionDay.set(workout.id, dayKey)
+  }
 
   // Bucket by Pacific day key rather than by raw timestamp: this renders on a
   // UTC server, where a 10pm-Pacific set belongs to the following calendar day
@@ -169,7 +184,9 @@ export function buildExerciseProgression(
   const byDay = new Map<string, StrengthSet[]>()
   for (const set of sets) {
     if (set.exercise !== exercise) continue
-    const dayKey = safePacificDayKey(set.logged_at)
+    const dayKey =
+      (set.workout_id === undefined ? undefined : sessionDay.get(set.workout_id)) ??
+      safePacificDayKey(set.logged_at)
     // An unparseable timestamp has no day to belong to. Dropped rather than
     // bucketed under the epoch, which would drag the x-axis back to 1970.
     if (dayKey === '') continue
@@ -277,19 +294,28 @@ export function buildExerciseProgression(
  * suspiciously short x-axis to be misread.
  */
 export interface SetDetailCoverage {
-  /** Sessions that predate the movement's first set and carry no set detail. */
+  /**
+   * **Imported** sessions that predate the movement's first set and carry no set
+   * detail.
+   *
+   * Imports only, because the render site names Apple Health as the reason the
+   * detail is missing. A manually recorded session that was abandoned before any
+   * set was logged is also detail-free, but it isn't an import — counting it
+   * would put a number behind a sentence that doesn't describe it.
+   */
   sessionsBefore: number
   /** Pacific day key of the earliest such session, or `null` when there are none. */
   earliestSessionDayKey: string | null
 }
 
 /**
- * Count the recorded sessions that predate a movement's first logged set and
+ * Count the **imported** sessions that predate a movement's first logged set and
  * have no sets of their own.
  *
  * @param firstDayKey The movement's first training day, Pacific. `null` yields
  *   an empty coverage report rather than counting the whole history as "before".
- * @param workouts Every recorded session.
+ * @param workouts Every recorded session. Only `apple_health` ones are counted —
+ *   see {@link SetDetailCoverage.sessionsBefore}.
  * @param sets Every logged set — used only to tell which sessions carry detail.
  *   A session with sets isn't part of the gap even if it predates this movement;
  *   it recorded what happened, just not this movement.
@@ -309,6 +335,7 @@ export function buildSetDetailCoverage(
   let sessionsBefore = 0
   let earliest: string | null = null
   for (const workout of workouts) {
+    if (workout.source !== 'apple_health') continue
     if (workoutsWithSets.has(workout.id)) continue
     const dayKey = safePacificDayKey(workout.started_at)
     // Day keys compare as strings — `2018-01-08` < `2026-05-25` lexicographically

--- a/lib/training-facility/exercise-progression.ts
+++ b/lib/training-facility/exercise-progression.ts
@@ -1,0 +1,345 @@
+import type { StrengthSet, WeightRoomExercise, WeightRoomWorkout } from '@/types/weight-room'
+
+import { dayKeyToPacificNoon, safePacificDayKey } from './day-keys'
+import {
+  E1RM_MAX_RELIABLE_REPS,
+  effectiveSetLoad,
+  epleyOneRepMax,
+  loadMultipliersBySlug,
+  type WorkoutSetHighlight,
+} from './workout-stats'
+
+/**
+ * One movement's progression over time (#412) — the exercise-altitude companion
+ * to `workout-stats.ts`.
+ *
+ * That module answers "how did tonight's session go". This one answers "is the
+ * bench going up", which is a different unit of analysis: a movement's history
+ * runs across sessions, and — in this log — mostly *outside* them. Every set on
+ * record today is loose grease-the-groove logging with no `workout_id`, so a
+ * per-session trend would plot nothing at all. The unit here is therefore the
+ * **Pacific training day**: it holds loose sets and session sets alike, and a
+ * session recorded through #376 lands in its own day without special-casing.
+ *
+ * Pure and isomorphic, like its sibling — no Supabase client, no React, no
+ * clock. The arithmetic that misleads when it's wrong (what counts as the top
+ * set, which estimates are worth plotting) is unit-testable rather than only
+ * observable by squinting at a chart.
+ */
+
+/** One training day's worth of a single movement. */
+export interface ExerciseDayPoint {
+  /** Pacific day key, `YYYY-MM-DD`. */
+  dayKey: string
+  /**
+   * Pacific noon of {@link dayKey}, as the chart's x value. Noon rather than
+   * midnight so a DST boundary can't shunt a point onto the adjacent day.
+   */
+  date: Date
+  /** Sets of this movement logged that day. */
+  sets: number
+  /** Reps across those sets. */
+  reps: number
+  /** `Σ reps × effective load` for the day; `0` when every set was bodyweight. */
+  tonnage: number
+  /**
+   * Heaviest set of the day by effective load, ties broken toward more reps.
+   * `null` when the movement was performed bodyweight — the common case in this
+   * log, not an edge case.
+   */
+  topSet: WorkoutSetHighlight | null
+  /** Most reps in a single set that day. Never `null` — every day has sets. */
+  bestRepSet: WorkoutSetHighlight
+  /**
+   * Best Epley estimate of the day, computed **only** from sets at or under
+   * {@link E1RM_MAX_RELIABLE_REPS}. `null` when the day has no such set, which
+   * includes every all-bodyweight day and every day of high-rep loaded work.
+   *
+   * Deliberately not "the estimate off {@link topSet}": a heavy set of 20 has an
+   * Epley number, but plotting it puts a figure the formula cannot support on a
+   * line the eye reads as measurement. Absence is the honest rendering, and the
+   * UI explains it rather than drawing a line it would have to disclaim.
+   */
+  estimatedOneRepMax: number | null
+}
+
+/** A movement's whole recorded history, bucketed by training day. */
+export interface ExerciseProgression {
+  /**
+   * Catalog slug — the stored identity, and the URL token.
+   *
+   * No display label here on purpose: a movement can outlive its catalog row's
+   * label or carry one joined onto a goal instead (#384), so the render site
+   * resolves it with `slugLabel` from the sources it holds. Baking one in would
+   * give a second, staler answer.
+   */
+  exercise: string
+  /** Training days, oldest first. Never empty — see {@link buildExerciseProgression}. */
+  points: ExerciseDayPoint[]
+  /** Whether no set of this movement has ever carried external load. */
+  isBodyweight: boolean
+  /** Sets logged, all time. */
+  totalSets: number
+  /** Reps logged, all time. */
+  totalReps: number
+  /** How many of {@link totalSets} carried external load. */
+  loadedSets: number
+  /**
+   * Loaded sets above {@link E1RM_MAX_RELIABLE_REPS}. Surfaced so the UI can say
+   * *why* a loaded movement has no estimate line — "66 loaded sets, none under
+   * 12 reps" is a fact about the training, not a gap in the chart.
+   */
+  highRepLoadedSets: number
+  /** Heaviest set ever, ties toward more reps; `null` for a bodyweight movement. */
+  heaviestSet: WorkoutSetHighlight | null
+  /** Most reps in one set ever, ties toward heavier load. */
+  mostRepsSet: WorkoutSetHighlight
+  /**
+   * Best estimate across every reliable set, or `null` when there is none. Same
+   * cutoff rule as {@link ExerciseDayPoint.estimatedOneRepMax}.
+   */
+  bestOneRepMax: number | null
+}
+
+/**
+ * Pick the heavier of two sets, ties toward more reps.
+ *
+ * @returns `candidate` when it wins, otherwise `best` — which stays `null` while
+ *   every set seen so far was bodyweight.
+ */
+function heavier(
+  best: WorkoutSetHighlight | null,
+  candidate: WorkoutSetHighlight
+): WorkoutSetHighlight | null {
+  if (candidate.effectiveLoad <= 0) return best
+  if (best === null) return candidate
+  if (candidate.effectiveLoad > best.effectiveLoad) return candidate
+  if (candidate.effectiveLoad === best.effectiveLoad && candidate.reps > best.reps) return candidate
+  return best
+}
+
+/** Pick the higher-rep of two sets, ties toward heavier load. */
+function repsier(
+  best: WorkoutSetHighlight | null,
+  candidate: WorkoutSetHighlight
+): WorkoutSetHighlight {
+  if (best === null) return candidate
+  if (candidate.reps > best.reps) return candidate
+  if (candidate.reps === best.reps && candidate.effectiveLoad > best.effectiveLoad) return candidate
+  return best
+}
+
+/**
+ * Epley estimate for a set, but only when the set is low-rep enough for the
+ * formula to mean anything.
+ *
+ * @returns The estimate in pounds, or `null` for a bodyweight set or one above
+ *   {@link E1RM_MAX_RELIABLE_REPS}.
+ */
+function reliableOneRepMax(load: number, reps: number): number | null {
+  if (reps > E1RM_MAX_RELIABLE_REPS) return null
+  return epleyOneRepMax(load, reps)
+}
+
+/**
+ * Build one movement's day-by-day progression from the whole set log.
+ *
+ * @param exercise Catalog slug to trend. Matched exactly against
+ *   {@link StrengthSet.exercise}; variants are *not* split out, since a wide
+ *   pullup and a close one are the same movement getting stronger.
+ * @param sets Every logged set, in any order — filtered here, so callers pass
+ *   `WeightRoomData.sets` straight through.
+ * @param exercises The catalog, for `load_multiplier`. Omitting it treats every
+ *   movement as single-implement, which understates a two-dumbbell movement by
+ *   half.
+ * @returns The progression, or `null` when the movement has no plottable sets —
+ *   a real state (a catalog row added before its first session), and one the
+ *   caller renders as an empty view rather than as a broken chart.
+ */
+export function buildExerciseProgression(
+  exercise: string,
+  sets: readonly StrengthSet[],
+  exercises: readonly WeightRoomExercise[] = []
+): ExerciseProgression | null {
+  const multipliers = loadMultipliersBySlug(exercises)
+
+  // Bucket by Pacific day key rather than by raw timestamp: this renders on a
+  // UTC server, where a 10pm-Pacific set belongs to the following calendar day
+  // and would split one evening's work across two points.
+  const byDay = new Map<string, StrengthSet[]>()
+  for (const set of sets) {
+    if (set.exercise !== exercise) continue
+    const dayKey = safePacificDayKey(set.logged_at)
+    // An unparseable timestamp has no day to belong to. Dropped rather than
+    // bucketed under the epoch, which would drag the x-axis back to 1970.
+    if (dayKey === '') continue
+    const list = byDay.get(dayKey)
+    if (list) list.push(set)
+    else byDay.set(dayKey, [set])
+  }
+
+  if (byDay.size === 0) return null
+
+  let totalSets = 0
+  let totalReps = 0
+  let loadedSets = 0
+  let highRepLoadedSets = 0
+  let heaviestSet: WorkoutSetHighlight | null = null
+  let mostRepsSet: WorkoutSetHighlight | null = null
+  let bestOneRepMax: number | null = null
+
+  const points: ExerciseDayPoint[] = []
+  // `YYYY-MM-DD` sorts chronologically as a string, which is the whole point of
+  // the day-key format — no Date round-trip needed to order the x-axis.
+  for (const dayKey of [...byDay.keys()].sort()) {
+    const date = dayKeyToPacificNoon(dayKey)
+    if (date === null) continue
+    const daySets = byDay.get(dayKey) ?? []
+
+    let reps = 0
+    let tonnage = 0
+    let dayTop: WorkoutSetHighlight | null = null
+    let dayBestReps: WorkoutSetHighlight | null = null
+    let dayEstimate: number | null = null
+
+    for (const set of daySets) {
+      const effectiveLoad = effectiveSetLoad(set, multipliers)
+      const highlight: WorkoutSetHighlight = {
+        setId: set.id,
+        reps: set.reps,
+        weightLbs: set.weight_lbs ?? null,
+        effectiveLoad,
+        loggedAt: set.logged_at,
+      }
+
+      reps += set.reps
+      tonnage += set.reps * effectiveLoad
+      if (effectiveLoad > 0) {
+        loadedSets += 1
+        if (set.reps > E1RM_MAX_RELIABLE_REPS) highRepLoadedSets += 1
+      }
+
+      dayTop = heavier(dayTop, highlight)
+      dayBestReps = repsier(dayBestReps, highlight)
+      heaviestSet = heavier(heaviestSet, highlight)
+      mostRepsSet = repsier(mostRepsSet, highlight)
+
+      const estimate = reliableOneRepMax(effectiveLoad, set.reps)
+      if (estimate !== null) {
+        if (dayEstimate === null || estimate > dayEstimate) dayEstimate = estimate
+        if (bestOneRepMax === null || estimate > bestOneRepMax) bestOneRepMax = estimate
+      }
+    }
+
+    totalSets += daySets.length
+    totalReps += reps
+
+    points.push({
+      dayKey,
+      date,
+      sets: daySets.length,
+      reps,
+      tonnage,
+      topSet: dayTop,
+      // Safe: `byDay` only holds non-empty arrays, so the loop above assigned at
+      // least one highlight.
+      bestRepSet: dayBestReps as WorkoutSetHighlight,
+      estimatedOneRepMax: dayEstimate,
+    })
+  }
+
+  // Every bucket held an unparseable key — nothing plottable survived.
+  if (points.length === 0 || mostRepsSet === null) return null
+
+  return {
+    exercise,
+    points,
+    isBodyweight: heaviestSet === null,
+    totalSets,
+    totalReps,
+    loadedSets,
+    highRepLoadedSets,
+    heaviestSet,
+    mostRepsSet,
+    bestOneRepMax,
+  }
+}
+
+/**
+ * What the log can and can't say about the years before a movement's first
+ * recorded set (#412, #413).
+ *
+ * The Apple Health import brought in hundreds of lifting sessions that record
+ * only *that* a workout happened and for how long — never what was done in it.
+ * A progression chart that quietly starts at the first set therefore implies the
+ * training started there too. It didn't; the writing-it-down did. This is the
+ * shape of that gap, so a view can state it in numbers instead of leaving a
+ * suspiciously short x-axis to be misread.
+ */
+export interface SetDetailCoverage {
+  /** Sessions that predate the movement's first set and carry no set detail. */
+  sessionsBefore: number
+  /** Pacific day key of the earliest such session, or `null` when there are none. */
+  earliestSessionDayKey: string | null
+}
+
+/**
+ * Count the recorded sessions that predate a movement's first logged set and
+ * have no sets of their own.
+ *
+ * @param firstDayKey The movement's first training day, Pacific. `null` yields
+ *   an empty coverage report rather than counting the whole history as "before".
+ * @param workouts Every recorded session.
+ * @param sets Every logged set — used only to tell which sessions carry detail.
+ *   A session with sets isn't part of the gap even if it predates this movement;
+ *   it recorded what happened, just not this movement.
+ */
+export function buildSetDetailCoverage(
+  firstDayKey: string | null,
+  workouts: readonly WeightRoomWorkout[],
+  sets: readonly StrengthSet[]
+): SetDetailCoverage {
+  if (firstDayKey === null) return { sessionsBefore: 0, earliestSessionDayKey: null }
+
+  const workoutsWithSets = new Set<string>()
+  for (const set of sets) {
+    if (set.workout_id !== undefined) workoutsWithSets.add(set.workout_id)
+  }
+
+  let sessionsBefore = 0
+  let earliest: string | null = null
+  for (const workout of workouts) {
+    if (workoutsWithSets.has(workout.id)) continue
+    const dayKey = safePacificDayKey(workout.started_at)
+    // Day keys compare as strings — `2018-01-08` < `2026-05-25` lexicographically
+    // and chronologically alike.
+    if (dayKey === '' || dayKey >= firstDayKey) continue
+    sessionsBefore += 1
+    if (earliest === null || dayKey < earliest) earliest = dayKey
+  }
+
+  return { sessionsBefore, earliestSessionDayKey: earliest }
+}
+
+/**
+ * Movements with at least one logged set, most-recently-trained first.
+ *
+ * Drives the links into the per-exercise view: a movement with no sets has
+ * nothing to trend, so it never gets a link that lands on an empty page.
+ *
+ * @param sets Every logged set.
+ * @returns Slugs, newest training day first, then alphabetically among movements
+ *   last trained the same day.
+ */
+export function trendableExercises(sets: readonly StrengthSet[]): string[] {
+  const lastDay = new Map<string, string>()
+  for (const set of sets) {
+    const dayKey = safePacificDayKey(set.logged_at)
+    if (dayKey === '') continue
+    const seen = lastDay.get(set.exercise)
+    if (seen === undefined || dayKey > seen) lastDay.set(set.exercise, dayKey)
+  }
+  return [...lastDay.entries()]
+    .sort(([aSlug, aDay], [bSlug, bDay]) => bDay.localeCompare(aDay) || aSlug.localeCompare(bSlug))
+    .map(([slug]) => slug)
+}

--- a/lib/training-facility/strength-format.ts
+++ b/lib/training-facility/strength-format.ts
@@ -1,0 +1,29 @@
+/**
+ * Load and set formatting shared by the Weight Room's strength surfaces.
+ *
+ * Extracted so the per-workout summary (#377) and the per-exercise trend (#412)
+ * can't drift into printing the same set two different ways — one screen saying
+ * `8 × 60 lb` while the other says `8 x 60lbs` is the kind of inconsistency
+ * nobody files but everybody notices.
+ */
+
+/**
+ * Format pounds for display — whole pounds, thousands separated.
+ *
+ * Tonnage runs to five figures, where a decimal is noise; an Epley estimate is
+ * an estimate, where a decimal is false precision. Neither wants fractions.
+ */
+export function formatLbs(value: number): string {
+  return `${Math.round(value).toLocaleString('en-US')} lb`
+}
+
+/**
+ * Render a set as `8 × 60 lb`, or `12 reps` when it carried no external load.
+ *
+ * @param reps Reps completed.
+ * @param effectiveLoad Pounds actually moved — per-implement weight already
+ *   multiplied by the movement's `load_multiplier`. `0` means bodyweight.
+ */
+export function describeSet(reps: number, effectiveLoad: number): string {
+  return effectiveLoad > 0 ? `${reps} × ${formatLbs(effectiveLoad)}` : `${reps} reps`
+}


### PR DESCRIPTION
Trends one movement over time at `/training-facility/weight-room/exercises/[slug]` — the exercise-altitude companion to #377's per-workout summary.

## What it shows

- **Top set** — heaviest set of each training day, in pounds actually moved (`load_multiplier` applied, so a two-dumbbell movement doesn't plot at half).
- **Estimated 1RM** — a dashed overlay on the *same* pounds axis, since a derived number in the same unit belongs on the same scale.
- **Best set** — most reps in a single set per day, in its own aligned panel. Reps and pounds don't share a y-axis (#266 / #363).
- **All-time marks** and the last 12 training days as a table, which is also what a screen reader gets instead of a path it can't traverse.

## Three judgement calls, since the data forced them

**The day is the unit, not the session.** Every one of the 1,460 recorded sets is loose grease-the-groove logging with no `workout_id`, and all 507 workouts are Apple Health imports carrying no sets. "Top set per session" — the issue's wording — would plot an empty chart today. A Pacific day key holds loose sets and session sets alike, so recording through #376 lands in the right bucket with no special case.

**No estimate line unless low-rep sets support one.** Epley estimates come only from sets at or under `E1RM_MAX_RELIABLE_REPS`. Where a movement has fewer than two such days, the panel omits the series and states why — e.g. *"1 of 133 loaded sets came in at or under 12 reps"* — rather than drawing a line the caption would have to walk back. That constant's own doc asked for exactly this.

**Absence is stated, not hidden.** The x-axis starts at the first recorded set, which is not when the training started. A caption says so with numbers: *"Set-level detail for Shrugs begins July 1, 2026. 506 earlier sessions — back to January 2018 — were imported from Apple Health, which records that a workout happened and for how long, never what was done in it."* (#413, #400.)

## Also in here

- `lib/training-facility/strength-format.ts` — `formatLbs` / `describeSet` lifted out of `WorkoutSummaryPanel` so the two surfaces can't drift into formatting the same set differently.
- Optional `exerciseHref` / `href` props on the workout breakdown and the History stat cards. Omitted, both render plain text, so no caller is forced to invent a route.
- `'exercises'` joins `WeightRoomSubNavSection` with **no pill**: the page is a leaf reached from two different parents, so nothing gets a false `aria-current="page"`.

## Test plan

- [ ] `/training-facility/weight-room/exercises/shrugs` — top-set line, best-set line, and the note explaining the missing estimate series.
- [ ] `/training-facility/weight-room/exercises/pullups` — bodyweight: no load panel, no "Heaviest set" tile, reps panel only.
- [ ] `/training-facility/weight-room/exercises/dumbbell-lateral-raise` — a loaded movement that *does* have reliable estimates, for the dashed overlay and its legend.
- [ ] From `/history`, click a stat-card heading → lands on that movement's trend.
- [ ] From a workout summary, click a movement in the per-exercise table → same.
- [ ] Phone width: each chart scrolls inside its own card; the page itself does not scroll sideways.
- [ ] `?preview=demo` on an empty read (preview deploy) renders the fixture rather than 404ing, from either entry point.
- [ ] A nonsense slug (`/exercises/not-a-movement`) 404s; a catalogued movement with no sets renders the empty state.

Verified locally: `tsc --noEmit`, `next build`, `npm test` (2,239 passing), `npm run test:e2e` (68 passing, including two new per-exercise overflow cases and the flag-off 404).

Closes #412.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added per-exercise history pages with progression charts, personal records, load and rep trends, estimated one-rep-max insights, and recent training-day details.
  - Added exercise links from workout summaries and strength history cards.
  - Added coverage messaging for limited or incomplete exercise history.
  - Added support for bodyweight exercises, high-repetition sets, preview mode, and goal-based chart accents.

- **Improvements**
  - Standardized strength and set formatting across weight-room views.
  - Improved mobile chart behavior to prevent horizontal page scrolling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->