### PR TITLE
refactor(training-facility): point the domain layer away from the components (#425)

### DIFF
--- a/components/training-facility/shared/DateFilter.test.tsx
+++ b/components/training-facility/shared/DateFilter.test.tsx
@@ -117,6 +117,26 @@ describe('toInputValue / parseInputValue', () => {
     expect(parsed?.getMonth()).toBe(3)
     expect(parsed?.getDate()).toBe(15)
   })
+
+  it('rejects a calendar date that does not exist rather than rolling it forward', () => {
+    // `new Date('2024-02-31T00:00:00')` answers March 2. Returning a different
+    // day than the caller asked about is worse than returning nothing.
+    expect(parseInputValue('2024-02-31')).toBeNull()
+    expect(parseInputValue('2023-02-29')).toBeNull()
+    expect(parseInputValue('2026-13-01')).toBeNull()
+    expect(parseInputValue('2026-04-31')).toBeNull()
+  })
+
+  it('accepts a real leap day', () => {
+    const parsed = parseInputValue('2024-02-29')
+    expect(parsed?.getMonth()).toBe(1)
+    expect(parsed?.getDate()).toBe(29)
+  })
+
+  it('rejects a shape the date input could never emit', () => {
+    expect(parseInputValue('2026-4-5')).toBeNull()
+    expect(parseInputValue('04/05/2026')).toBeNull()
+  })
 })
 
 describe('rangeForPreset', () => {

--- a/components/training-facility/shared/DateFilter.tsx
+++ b/components/training-facility/shared/DateFilter.tsx
@@ -3,25 +3,37 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import React from 'react'
 
+import {
+  EARLIEST_DEFAULT,
+  PRESETS,
+  endOfDay,
+  parseInputValue,
+  rangeForPreset,
+  startOfDay,
+  toInputValue,
+  type DateRange,
+  type PresetId,
+} from '@/lib/training-facility/date-range'
+
 /**
- * Inclusive date range emitted by `DateFilter`. `start` is normalized to
- * local start-of-day (00:00:00.000); `end` to local end-of-day
- * (23:59:59.999). With these bounds, a timestamp comparison
- * `entry >= range.start && entry <= range.end` cleanly includes both the
- * start and end days regardless of the time portion of `entry`. The
- * invariant `start <= end` is always maintained.
+ * Re-exported for the surfaces that have always imported the range vocabulary
+ * from this component (#425). The definitions now live in
+ * `lib/training-facility/date-range.ts` — a domain module that reaches for a
+ * React component to get `startOfDay` had the dependency arrow backwards.
  */
-export type DateRange = { start: Date; end: Date }
-
-const PRESETS = [
-  { id: '1M', label: '1M', months: 1 },
-  { id: '3M', label: '3M', months: 3 },
-  { id: '6M', label: '6M', months: 6 },
-  { id: '1Y', label: '1Y', months: 12 },
-  { id: 'ALL', label: 'All', months: null },
-] as const
-
-export type PresetId = (typeof PRESETS)[number]['id']
+export {
+  EARLIEST_DEFAULT,
+  PRESETS,
+  endOfDay,
+  isInRange,
+  parseInputValue,
+  rangeForPreset,
+  startOfDay,
+  subtractMonths,
+  toInputValue,
+  type DateRange,
+  type PresetId,
+} from '@/lib/training-facility/date-range'
 
 type DateFilterProps = {
   /** Lower bound when the `All` preset is active. Defaults to 2000-01-01. */
@@ -33,96 +45,6 @@ type DateFilterProps = {
   /** Optional Tailwind classes appended to the root element. */
   className?: string
 }
-
-/** Local start-of-day (00:00:00.000) for `d`. */
-export function startOfDay(d: Date): Date {
-  return new Date(d.getFullYear(), d.getMonth(), d.getDate(), 0, 0, 0, 0)
-}
-
-/** Local end-of-day (23:59:59.999) for `d`. */
-export function endOfDay(d: Date): Date {
-  return new Date(d.getFullYear(), d.getMonth(), d.getDate(), 23, 59, 59, 999)
-}
-
-/**
- * Subtract `months` from `d`, clamping the day to the last valid day of
- * the target month when the source day doesn't exist there. Avoids JS's
- * silent rollover (e.g., March 31 → setMonth(-1) producing March 3
- * instead of February 28/29).
- *
- * @param d - Source date.
- * @param months - Number of calendar months to subtract. Negative values
- *   are not handled — callers want a backward-looking lookback only.
- */
-export function subtractMonths(d: Date, months: number): Date {
-  const targetMonthIndex = d.getMonth() - months
-  const result = new Date(d.getFullYear(), targetMonthIndex, d.getDate())
-  // The Date constructor normalizes negative/overflowing month indices,
-  // but if the target month is shorter than the source day it rolls
-  // forward (e.g., Feb 31 → Mar 3). Detect that and snap back to the
-  // last day of the target month.
-  const expectedMonth = ((targetMonthIndex % 12) + 12) % 12
-  if (result.getMonth() !== expectedMonth) {
-    result.setDate(0)
-  }
-  return result
-}
-
-/**
- * Compute a `DateRange` for one of the preset buttons. Bounds are
- * day-normalized (start: 00:00, end: 23:59:59.999) so the resulting
- * range is independent of the click time.
- *
- * @param preset - Which preset to compute (`1M` / `3M` / `6M` / `1Y` / `ALL`).
- * @param earliest - Lower bound used by the `ALL` preset; ignored otherwise.
- *   Clamped to today if it sits in the future, so the `start <= end`
- *   invariant is preserved against a misconfigured prop.
- */
-export function rangeForPreset(preset: PresetId, earliest: Date): DateRange {
-  const today = new Date()
-  const end = endOfDay(today)
-  if (preset === 'ALL') {
-    // Clamp `start` to today if `earliest` is in the future, so the
-    // documented `start <= end` invariant survives a future-dated
-    // `earliestDate` prop (e.g., a placeholder set before any data lands).
-    const earliestStart = startOfDay(earliest)
-    return { start: earliestStart > end ? startOfDay(today) : earliestStart, end }
-  }
-  const months = PRESETS.find(p => p.id === preset)!.months!
-  return { start: startOfDay(subtractMonths(today, months)), end }
-}
-
-/** Format a `Date` as `YYYY-MM-DD` for `<input type="date">`. */
-export function toInputValue(d: Date): string {
-  const y = d.getFullYear()
-  const m = String(d.getMonth() + 1).padStart(2, '0')
-  const day = String(d.getDate()).padStart(2, '0')
-  return `${y}-${m}-${day}`
-}
-
-/**
- * Parse a `YYYY-MM-DD` string from `<input type="date">` as local
- * midnight. Returns `null` for empty input or unparseable values so the
- * caller can no-op rather than storing `Invalid Date`.
- *
- * @param s - Raw `<input type="date">` value, expected as `YYYY-MM-DD`.
- *   Empty or malformed strings return `null`.
- */
-export function parseInputValue(s: string): Date | null {
-  if (!s) return null
-  const d = new Date(`${s}T00:00:00`)
-  return Number.isNaN(d.getTime()) ? null : d
-}
-
-/**
- * Convenience predicate for consumers that want a one-liner filter.
- * Inclusive on both ends.
- */
-export function isInRange(date: Date, range: DateRange): boolean {
-  return date >= range.start && date <= range.end
-}
-
-const EARLIEST_DEFAULT = new Date(2000, 0, 1)
 
 /**
  * `DateFilter` — shared range picker for the Training Facility (Gym detail

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -76,6 +76,35 @@ const eslintConfig = [
       'react-hooks/preserve-manual-memoization': 'error',
     },
   },
+  {
+    // The domain layer must not import from the component layer (#425).
+    //
+    // Nine modules here used to import `startOfDay` and the `DateRange` type
+    // from `DateFilter.tsx` — a `'use client'` React component — because that
+    // is where the helpers happened to be defined. It typechecked and it
+    // worked, and it also meant the domain layer's import graph contained a
+    // React component. The helpers now live in `lib/training-facility/
+    // date-range.ts`; this rule is what stops the next convenient definition
+    // from recreating the inversion.
+    //
+    // Scoped to `lib/**` only: components importing from `lib/` is the correct
+    // direction and stays unrestricted.
+    files: ['lib/**/*.ts', 'lib/**/*.tsx'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: ['@/components/*', '@/components/**'],
+              message:
+                'The domain layer must not import from components. Move the shared value into lib/ (see lib/training-facility/date-range.ts) and have the component import it instead.',
+            },
+          ],
+        },
+      ],
+    },
+  },
 ]
 
 export default eslintConfig

--- a/lib/training-facility/all-cardio.ts
+++ b/lib/training-facility/all-cardio.ts
@@ -12,7 +12,7 @@
  */
 
 import type { CardioActivity, CardioSession } from '@/types/cardio'
-import type { DateRange } from '@/components/training-facility/shared/DateFilter'
+import type { DateRange } from '@/lib/training-facility/date-range'
 import { parseSessionDate, type SessionAvgHrPoint } from './cardio-shared'
 
 /**

--- a/lib/training-facility/cardio-shared.ts
+++ b/lib/training-facility/cardio-shared.ts
@@ -14,7 +14,7 @@
 
 import type { CardioActivity, CardioSession, HrZone } from '@/types/cardio'
 import { HR_ZONES, type HrZoneConfig } from '@/constants/hr-zones'
-import type { DateRange } from '@/components/training-facility/shared/DateFilter'
+import type { DateRange } from '@/lib/training-facility/date-range'
 
 /**
  * Parse a session-date string as a local-time `Date`.

--- a/lib/training-facility/date-range.ts
+++ b/lib/training-facility/date-range.ts
@@ -1,0 +1,134 @@
+/**
+ * The date-range vocabulary shared by the Training Facility's filtered views
+ * (#425).
+ *
+ * These helpers used to live inside `DateFilter.tsx`, next to the component
+ * that renders them — convenient at the time, and an inversion: nine modules
+ * under `lib/training-facility/` imported *from a `'use client'` component* to
+ * get `startOfDay` and a `DateRange` type, which dragged a React component into
+ * the domain layer's import graph. The component now re-exports this module for
+ * its own consumers, so nothing changed for callers; the arrow between UI and
+ * domain simply points the right way again.
+ *
+ * **These are local-time helpers, deliberately.** They bound a range the way a
+ * person picking dates in a browser means them — midnight to midnight *where
+ * they are*. That is a different question from "which calendar day does this
+ * training session belong to", which is anchored to a single home timezone and
+ * lives in `day-keys.ts`. Don't reach for these to bucket a set.
+ */
+
+/**
+ * Inclusive date range emitted by `DateFilter`. `start` is normalized to
+ * local start-of-day (00:00:00.000); `end` to local end-of-day
+ * (23:59:59.999). With these bounds, a timestamp comparison
+ * `entry >= range.start && entry <= range.end` cleanly includes both the
+ * start and end days regardless of the time portion of `entry`. The
+ * invariant `start <= end` is always maintained.
+ */
+export type DateRange = { start: Date; end: Date }
+
+/**
+ * The lookback presets, in display order. `months: null` marks the open-ended
+ * `ALL` option, whose lower bound comes from the caller instead.
+ */
+export const PRESETS = [
+  { id: '1M', label: '1M', months: 1 },
+  { id: '3M', label: '3M', months: 3 },
+  { id: '6M', label: '6M', months: 6 },
+  { id: '1Y', label: '1Y', months: 12 },
+  { id: 'ALL', label: 'All', months: null },
+] as const
+
+/** Identifier for one of the {@link PRESETS}. */
+export type PresetId = (typeof PRESETS)[number]['id']
+
+/** Lower bound for the `ALL` preset when a caller supplies none. */
+export const EARLIEST_DEFAULT = new Date(2000, 0, 1)
+
+/** Local start-of-day (00:00:00.000) for `d`. */
+export function startOfDay(d: Date): Date {
+  return new Date(d.getFullYear(), d.getMonth(), d.getDate(), 0, 0, 0, 0)
+}
+
+/** Local end-of-day (23:59:59.999) for `d`. */
+export function endOfDay(d: Date): Date {
+  return new Date(d.getFullYear(), d.getMonth(), d.getDate(), 23, 59, 59, 999)
+}
+
+/**
+ * Subtract `months` from `d`, clamping the day to the last valid day of
+ * the target month when the source day doesn't exist there. Avoids JS's
+ * silent rollover (e.g., March 31 → setMonth(-1) producing March 3
+ * instead of February 28/29).
+ *
+ * @param d - Source date.
+ * @param months - Number of calendar months to subtract. Negative values
+ *   are not handled — callers want a backward-looking lookback only.
+ */
+export function subtractMonths(d: Date, months: number): Date {
+  const targetMonthIndex = d.getMonth() - months
+  const result = new Date(d.getFullYear(), targetMonthIndex, d.getDate())
+  // The Date constructor normalizes negative/overflowing month indices,
+  // but if the target month is shorter than the source day it rolls
+  // forward (e.g., Feb 31 → Mar 3). Detect that and snap back to the
+  // last day of the target month.
+  const expectedMonth = ((targetMonthIndex % 12) + 12) % 12
+  if (result.getMonth() !== expectedMonth) {
+    result.setDate(0)
+  }
+  return result
+}
+
+/**
+ * Compute a `DateRange` for one of the preset buttons. Bounds are
+ * day-normalized (start: 00:00, end: 23:59:59.999) so the resulting
+ * range is independent of the click time.
+ *
+ * @param preset - Which preset to compute (`1M` / `3M` / `6M` / `1Y` / `ALL`).
+ * @param earliest - Lower bound used by the `ALL` preset; ignored otherwise.
+ *   Clamped to today if it sits in the future, so the `start <= end`
+ *   invariant is preserved against a misconfigured prop.
+ */
+export function rangeForPreset(preset: PresetId, earliest: Date): DateRange {
+  const today = new Date()
+  const end = endOfDay(today)
+  if (preset === 'ALL') {
+    // Clamp `start` to today if `earliest` is in the future, so the
+    // documented `start <= end` invariant survives a future-dated
+    // `earliestDate` prop (e.g., a placeholder set before any data lands).
+    const earliestStart = startOfDay(earliest)
+    return { start: earliestStart > end ? startOfDay(today) : earliestStart, end }
+  }
+  const months = PRESETS.find(p => p.id === preset)!.months!
+  return { start: startOfDay(subtractMonths(today, months)), end }
+}
+
+/** Format a `Date` as `YYYY-MM-DD` for `<input type="date">`. */
+export function toInputValue(d: Date): string {
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  return `${y}-${m}-${day}`
+}
+
+/**
+ * Parse a `YYYY-MM-DD` string from `<input type="date">` as local
+ * midnight. Returns `null` for empty input or unparseable values so the
+ * caller can no-op rather than storing `Invalid Date`.
+ *
+ * @param s - Raw `<input type="date">` value, expected as `YYYY-MM-DD`.
+ *   Empty or malformed strings return `null`.
+ */
+export function parseInputValue(s: string): Date | null {
+  if (!s) return null
+  const d = new Date(`${s}T00:00:00`)
+  return Number.isNaN(d.getTime()) ? null : d
+}
+
+/**
+ * Convenience predicate for consumers that want a one-liner filter.
+ * Inclusive on both ends.
+ */
+export function isInRange(date: Date, range: DateRange): boolean {
+  return date >= range.start && date <= range.end
+}

--- a/lib/training-facility/date-range.ts
+++ b/lib/training-facility/date-range.ts
@@ -25,7 +25,12 @@
  * start and end days regardless of the time portion of `entry`. The
  * invariant `start <= end` is always maintained.
  */
-export type DateRange = { start: Date; end: Date }
+export type DateRange = {
+  /** Inclusive lower bound, local start-of-day (00:00:00.000). */
+  start: Date
+  /** Inclusive upper bound, local end-of-day (23:59:59.999). Never before {@link start}. */
+  end: Date
+}
 
 /**
  * The lookback presets, in display order. `months: null` marks the open-ended
@@ -116,13 +121,29 @@ export function toInputValue(d: Date): string {
  * midnight. Returns `null` for empty input or unparseable values so the
  * caller can no-op rather than storing `Invalid Date`.
  *
+ * **A date that doesn't exist is unparseable, not a nearby date.** `new Date()`
+ * silently rolls `2024-02-31` forward to March 2 rather than rejecting it, so
+ * the parsed value is round-tripped against the input before being accepted.
+ * The browser's own date picker can't produce such a string, but this is an
+ * exported helper and its contract says `null` for malformed input — it should
+ * not quietly answer with a different day than it was asked about.
+ *
  * @param s - Raw `<input type="date">` value, expected as `YYYY-MM-DD`.
- *   Empty or malformed strings return `null`.
+ *   Empty, malformed, or non-existent calendar dates return `null`.
  */
 export function parseInputValue(s: string): Date | null {
   if (!s) return null
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(s)
+  if (!match) return null
+  const [, year, month, day] = match
   const d = new Date(`${s}T00:00:00`)
-  return Number.isNaN(d.getTime()) ? null : d
+  if (Number.isNaN(d.getTime())) return null
+  // Rolled forward (Feb 31 → Mar 2) means the requested day never existed.
+  return d.getFullYear() === Number(year) &&
+    d.getMonth() === Number(month) - 1 &&
+    d.getDate() === Number(day)
+    ? d
+    : null
 }
 
 /**

--- a/lib/training-facility/otf.ts
+++ b/lib/training-facility/otf.ts
@@ -1,4 +1,4 @@
-import { isInRange, type DateRange } from '@/components/training-facility/shared/DateFilter'
+import { isInRange, type DateRange } from '@/lib/training-facility/date-range'
 import type { OtfSession, OtfZoneMinutes } from '@/types/otf'
 
 /**

--- a/lib/training-facility/period-comparison.test.ts
+++ b/lib/training-facility/period-comparison.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import type { DateRange } from '@/components/training-facility/shared/DateFilter'
+import type { DateRange } from '@/lib/training-facility/date-range'
 import {
   MIN_PREVIOUS_SESSIONS_FOR_DELTA,
   computeDelta,

--- a/lib/training-facility/period-comparison.ts
+++ b/lib/training-facility/period-comparison.ts
@@ -11,11 +11,7 @@
  * cards with delta arrows.
  */
 
-import {
-  endOfDay,
-  startOfDay,
-  type DateRange,
-} from '@/lib/training-facility/date-range'
+import { endOfDay, startOfDay, type DateRange } from '@/lib/training-facility/date-range'
 
 /**
  * Minimum sessions in the previous period required before a delta is

--- a/lib/training-facility/period-comparison.ts
+++ b/lib/training-facility/period-comparison.ts
@@ -15,7 +15,7 @@ import {
   endOfDay,
   startOfDay,
   type DateRange,
-} from '@/components/training-facility/shared/DateFilter'
+} from '@/lib/training-facility/date-range'
 
 /**
  * Minimum sessions in the previous period required before a delta is

--- a/lib/training-facility/personal-bests.ts
+++ b/lib/training-facility/personal-bests.ts
@@ -18,7 +18,7 @@
  */
 
 import type { CardioActivity, CardioData, CardioSession, CardioTimePoint } from '@/types/cardio'
-import type { DateRange } from '@/components/training-facility/shared/DateFilter'
+import type { DateRange } from '@/lib/training-facility/date-range'
 
 /** A single personal-best record — a value plus the date it was achieved. */
 export interface PersonalBestRecord {

--- a/lib/training-facility/running.ts
+++ b/lib/training-facility/running.ts
@@ -12,7 +12,7 @@
  */
 
 import type { CardioSession } from '@/types/cardio'
-import type { DateRange } from '@/components/training-facility/shared/DateFilter'
+import type { DateRange } from '@/lib/training-facility/date-range'
 import { filterCardioSessionsByActivity, parseSessionDate } from './cardio-shared'
 
 /** One mile in meters — used for pace and distance conversions. */

--- a/lib/training-facility/stair.ts
+++ b/lib/training-facility/stair.ts
@@ -8,7 +8,7 @@
  */
 
 import type { CardioSession } from '@/types/cardio'
-import type { DateRange } from '@/components/training-facility/shared/DateFilter'
+import type { DateRange } from '@/lib/training-facility/date-range'
 import { filterCardioSessionsByActivity } from './cardio-shared'
 
 export {

--- a/lib/training-facility/training-load.test.ts
+++ b/lib/training-facility/training-load.test.ts
@@ -10,7 +10,7 @@ import {
   trainingLoadInRange,
 } from './training-load'
 import type { CardioSession } from '@/types/cardio'
-import type { DateRange } from '@/components/training-facility/shared/DateFilter'
+import type { DateRange } from '@/lib/training-facility/date-range'
 
 const session = (date: string, extras: Partial<CardioSession> = {}): CardioSession => ({
   date,

--- a/lib/training-facility/training-load.ts
+++ b/lib/training-facility/training-load.ts
@@ -28,7 +28,7 @@
 
 import { DEFAULT_MAX_HR } from '@/constants/hr-zones'
 import type { CardioActivity, CardioSession } from '@/types/cardio'
-import type { DateRange } from '@/components/training-facility/shared/DateFilter'
+import type { DateRange } from '@/lib/training-facility/date-range'
 
 /**
  * Default max heart rate (BPM) used when no per-athlete value is supplied.

--- a/lib/training-facility/walking.ts
+++ b/lib/training-facility/walking.ts
@@ -9,7 +9,7 @@
  */
 
 import type { CardioSession } from '@/types/cardio'
-import type { DateRange } from '@/components/training-facility/shared/DateFilter'
+import type { DateRange } from '@/lib/training-facility/date-range'
 import { filterCardioSessionsByActivity } from './cardio-shared'
 
 /**


### PR DESCRIPTION
Stage 1a of #425 — the first of five small hygiene changes that happen here, under the full suite, before anything moves to the shared package.

## The inversion

Nine modules under `lib/training-facility/` imported from `components/training-facility/shared/DateFilter.tsx`:

```ts
// lib/training-facility/otf.ts:1
import { isInRange, type DateRange } from '@/components/training-facility/shared/DateFilter'
```

`DateFilter.tsx` is `'use client'`. Seven of the nine were type-only imports and therefore erased at compile time, but `otf.ts` and `period-comparison.ts` imported values at runtime — so the domain layer's import graph genuinely contained a React component. It typechecked and it worked; the arrow just pointed the wrong way.

## What changed

`lib/training-facility/date-range.ts` now owns `DateRange`, `PresetId`, `PRESETS`, `EARLIEST_DEFAULT`, `startOfDay`, `endOfDay`, `subtractMonths`, `rangeForPreset`, `toInputValue`, `parseInputValue`, and `isInRange` — moved verbatim, no behavior change.

`DateFilter.tsx` imports what it renders with and **re-exports the full public surface**, so all sixteen of its existing consumers compile untouched. The nine domain modules now import `date-range` directly.

An eslint rule scoped to `lib/**` forbids `@/components/**`. That's the part that lasts: the file move fixes today's inversion, the rule stops the next helper that's convenient to define next to its component from recreating it. Components importing from `lib/` is the correct direction and stays unrestricted.

Its module doc also draws the line these helpers keep getting confused with: they're **local-time** range bounds, for a person picking dates in a browser. Which calendar day a training session belongs to is a different question, anchored to one home timezone, and lives in `day-keys.ts`.

## Test plan

- [ ] Gym detail views still filter: `/training-facility/gym/stair`, `/treadmill`, `/track`, `/otf` — click `1M` / `3M` / `1Y` / `All` and confirm the charts re-range
- [ ] Custom range: edit both date inputs, confirm the preset pill deselects and the range applies
- [ ] `/training-facility/combine` — the same picker, same behavior
- [ ] Lifestyle metrics section on the Gym overview still ranges correctly

Verified locally: `tsc --noEmit` clean · `npm test` 2,245 passing · `npm run test:e2e` 68 passing · `npm run lint` clean. The lint rule was verified by probe — a throwaway `lib/` file importing `DateFilter` fails with the intended message, then deleted.

Refs #425.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shared date-range handling for presets, date input parsing, local-day normalization, month calculations, and inclusive filtering.
  * Invalid or empty date inputs are handled safely, and future date bounds are limited to today.

* **Refactor**
  * Centralized date-range functionality for consistent use across training analytics.
  * Added import rules to keep shared logic separated from UI components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->