### PR TITLE
chore(training-facility): stop baking presentation into the domain modules (#427)

### DIFF
--- a/app/training-facility/weight-room/achievements/page.tsx
+++ b/app/training-facility/weight-room/achievements/page.tsx
@@ -11,7 +11,7 @@ import {
   getWeightRoomDataServer,
 } from '@/lib/data/weight-room-server'
 import { isWeightRoomEnabled } from '@/lib/feature-flags'
-import { buildTrophyRoomView } from '@/lib/training-facility/achievements'
+import { buildAchievementBoard } from '@/lib/training-facility/achievements'
 
 /**
  * Weight Room Trophy Room (#336) — the "grease the groove" achievement wall.
@@ -39,7 +39,7 @@ export default async function WeightRoomAchievementsPage(): Promise<JSX.Element>
     isAdminRequest().catch(() => false),
   ])
 
-  const view = buildTrophyRoomView(
+  const view = buildAchievementBoard(
     data?.sets ?? [],
     data?.goals ?? [],
     achievements,

--- a/components/training-facility/weight-room/LoadManagementPanel.tsx
+++ b/components/training-facility/weight-room/LoadManagementPanel.tsx
@@ -12,6 +12,16 @@ import {
 const SPARK_WIDTH = 220
 const SPARK_HEIGHT = 44
 
+/**
+ * Accent for a movement with no configured goal, and therefore no color of its
+ * own — rim-orange, the Court Vision default (#427).
+ *
+ * Lives here rather than in `load-management.ts` because it answers a rendering
+ * question. The domain reports `color: null`; what to draw instead belongs to
+ * whoever is drawing.
+ */
+const DEFAULT_MOVEMENT_COLOR = '#EA580C'
+
 /** Props for {@link LoadManagementPanel}. */
 export interface LoadManagementPanelProps {
   /**
@@ -111,6 +121,10 @@ interface MovementLoadCardProps {
 function MovementLoadCard({ load }: MovementLoadCardProps): JSX.Element {
   const flagMeta = RAMP_FLAGS[load.flag]
   const volumeLabel = load.metric === 'load' ? '7d load volume' : '7d rep volume'
+  // A gym lift with no daily goal carries no color of its own (#427). The
+  // domain reports that absence; picking what to draw instead is this panel's
+  // call, and rim-orange is the Court Vision accent it has always used.
+  const accent = load.color ?? DEFAULT_MOVEMENT_COLOR
 
   return (
     <article
@@ -122,7 +136,7 @@ function MovementLoadCard({ load }: MovementLoadCardProps): JSX.Element {
       <header className="flex items-baseline justify-between gap-3">
         <h3
           className="font-mono text-sm font-bold uppercase tracking-[0.2em]"
-          style={{ color: load.color }}
+          style={{ color: accent }}
         >
           {load.displayName ?? load.movement}
         </h3>
@@ -166,7 +180,7 @@ function MovementLoadCard({ load }: MovementLoadCardProps): JSX.Element {
             points={load.sparkline.map((p, i) => ({ x: i, y: p.volume }))}
             width={SPARK_WIDTH}
             height={SPARK_HEIGHT}
-            stroke={load.color}
+            stroke={accent}
             ariaLabel={`${load.displayName ?? load.movement} 28-day ${load.metric === 'load' ? 'load' : 'rep'} volume trend`}
           />
         </div>

--- a/components/training-facility/weight-room/TrophyRoom.test.tsx
+++ b/components/training-facility/weight-room/TrophyRoom.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import { render, screen, within } from '@testing-library/react'
 
-import { buildTrophyRoomView } from '@/lib/training-facility/achievements'
+import { buildAchievementBoard } from '@/lib/training-facility/achievements'
 import type { ExerciseGoal, StrengthSet, WeightRoomAchievement } from '@/types/weight-room'
 
 import { TrophyRoom } from './TrophyRoom'
@@ -63,7 +63,7 @@ function renderRoom(
   sets: StrengthSet[] = SETS,
   ladder: WeightRoomAchievement[] = LADDER
 ): ReturnType<typeof render> {
-  return render(<TrophyRoom view={buildTrophyRoomView(sets, GOALS, ladder)} />)
+  return render(<TrophyRoom view={buildAchievementBoard(sets, GOALS, ladder)} />)
 }
 
 describe('TrophyRoom', () => {

--- a/components/training-facility/weight-room/TrophyRoom.tsx
+++ b/components/training-facility/weight-room/TrophyRoom.tsx
@@ -9,7 +9,7 @@ import {
   sectionLabel,
   type AchievementGroup,
   type ResolvedAchievement,
-  type TrophyRoomView,
+  type AchievementBoard,
 } from '@/lib/training-facility/achievements'
 
 /**
@@ -43,11 +43,11 @@ function tint(color: string): string {
 export interface TrophyRoomProps {
   /**
    * The pre-resolved display model from
-   * {@link import('@/lib/training-facility/achievements').buildTrophyRoomView}.
+   * {@link import('@/lib/training-facility/achievements').buildAchievementBoard}.
    * Computed by the page (a Server Component) so the badge math never ships to
    * the browser — the wall is a static render of a pure function's output.
    */
-  view: TrophyRoomView
+  view: AchievementBoard
 }
 
 /**

--- a/lib/training-facility/achievements.test.ts
+++ b/lib/training-facility/achievements.test.ts
@@ -11,7 +11,7 @@ import {
   POOLED_LABEL,
   achievementIcon,
   achievementUnit,
-  buildTrophyRoomView,
+  buildAchievementBoard,
   describeAchievement,
   formatEarnedOn,
   resolveAchievements,
@@ -547,7 +547,7 @@ describe('resolveAchievements — edge cases', () => {
   })
 })
 
-describe('buildTrophyRoomView', () => {
+describe('buildAchievementBoard', () => {
   const LADDER: WeightRoomAchievement[] = [
     tier('pushups', 'day', 100),
     tier('pushups', 'day', 200),
@@ -578,23 +578,23 @@ describe('buildTrophyRoomView', () => {
         muscle_group: 'back' as const,
       },
     ]
-    const view = buildTrophyRoomView(SETS, [], LADDER, catalog)
+    const view = buildAchievementBoard(SETS, [], LADDER, catalog)
     expect(view.groups.map(g => g.label)).toEqual([POOLED_LABEL, 'Pullups', 'Pushups'])
   })
 
   it('falls back to the slug with no catalog', () => {
-    const view = buildTrophyRoomView(SETS, [], LADDER)
+    const view = buildAchievementBoard(SETS, [], LADDER)
     expect(view.groups.map(g => g.label)).toEqual([POOLED_LABEL, 'pullups', 'pushups'])
   })
 
   it('puts the pooled ladder first, then exercises alphabetically', () => {
-    const view = buildTrophyRoomView(SETS, GOALS, LADDER)
+    const view = buildAchievementBoard(SETS, GOALS, LADDER)
     expect(view.groups.map(g => g.label)).toEqual([POOLED_LABEL, 'pullups', 'pushups'])
     expect(view.groups[0].exercise).toBeNull()
   })
 
   it('tallies earned counts overall and per group', () => {
-    const view = buildTrophyRoomView(SETS, GOALS, LADDER)
+    const view = buildAchievementBoard(SETS, GOALS, LADDER)
     // Earned: pushups day-100, pushups lifetime-1000 (270 total? no — 270 < 1000),
     // pullups day-50, pooled day-300 (210 on the 14th — not earned).
     expect(view.totalCount).toBe(5)
@@ -604,38 +604,38 @@ describe('buildTrophyRoomView', () => {
   })
 
   it('carries the exercise goal color onto its group', () => {
-    const view = buildTrophyRoomView(SETS, GOALS, LADDER)
+    const view = buildAchievementBoard(SETS, GOALS, LADDER)
     expect(view.groups.find(g => g.exercise === 'pushups')?.color).toBe('#EA580C')
     expect(view.groups[0].color).toBeNull()
   })
 
   it('orders tiers within a group by scope then ascending threshold', () => {
-    const view = buildTrophyRoomView(SETS, GOALS, LADDER)
+    const view = buildAchievementBoard(SETS, GOALS, LADDER)
     const pushups = view.groups.find(g => g.exercise === 'pushups')
     expect(pushups?.achievements.map(a => a.achievement.threshold)).toEqual([100, 200, 1000])
   })
 
   it('ranks nextUp by progress and excludes untouched tiers', () => {
-    const view = buildTrophyRoomView(SETS, GOALS, LADDER)
+    const view = buildAchievementBoard(SETS, GOALS, LADDER)
     // pushups day-200 (150/200 = .75) beats pooled day-300 (210/300 = .7),
     // which beats pushups lifetime-1000 (270/1000 = .27).
     expect(view.nextUp.map(e => e.achievement.threshold)).toEqual([200, 300, 1000])
   })
 
   it('excludes zero-progress tiers from nextUp', () => {
-    const view = buildTrophyRoomView([], GOALS, LADDER)
+    const view = buildAchievementBoard([], GOALS, LADDER)
     expect(view.nextUp).toEqual([])
     expect(view.earnedCount).toBe(0)
   })
 
   it('lists recently earned badges newest first', () => {
     const sets = [set('2026-07-01', 'pullups', 60), set('2026-07-20', 'pushups', 150)]
-    const view = buildTrophyRoomView(sets, GOALS, LADDER)
+    const view = buildAchievementBoard(sets, GOALS, LADDER)
     expect(view.recent.map(e => e.firstEarnedOn)).toEqual(['2026-07-20', '2026-07-01'])
   })
 
   it('returns an empty view for an empty ladder', () => {
-    const view = buildTrophyRoomView(SETS, GOALS, [])
+    const view = buildAchievementBoard(SETS, GOALS, [])
     expect(view).toEqual({ groups: [], earnedCount: 0, totalCount: 0, recent: [], nextUp: [] })
   })
 })
@@ -693,6 +693,19 @@ describe('achievementIcon', () => {
 
   it('falls back to a scope default', () => {
     expect(achievementIcon(tier('pushups', 'streak', 7))).toBe('🔥')
+  })
+
+  it('lets a caller override the scope defaults', () => {
+    // A consumer wanting clinical iconography passes its own map (#427).
+    expect(achievementIcon(tier('pushups', 'streak', 7), { streak: '▲' })).toBe('▲')
+  })
+
+  it('still prefers the tier’s own icon over an override', () => {
+    expect(achievementIcon(tier('pushups', 'day', 100, { icon: '🚀' }), { day: '▲' })).toBe('🚀')
+  })
+
+  it('renders nothing when neither the tier nor the fallbacks supply a glyph', () => {
+    expect(achievementIcon(tier('pushups', 'streak', 7), {})).toBe('')
   })
 })
 

--- a/lib/training-facility/achievements.ts
+++ b/lib/training-facility/achievements.ts
@@ -87,8 +87,15 @@ export const SCOPE_LABELS: Readonly<Record<AchievementScope, string>> = {
   set: 'Single set',
 }
 
-/** Fallback emoji per scope when a tier carries no configured `icon`. */
-const SCOPE_ICONS: Readonly<Record<AchievementScope, string>> = {
+/**
+ * Fallback emoji per scope when a tier carries no configured `icon`.
+ *
+ * Exported and overridable (#427) rather than evicted like the movement color
+ * was: these glyphs are generic — a flame for a streak, a medal for a month —
+ * so a different consumer may well keep them. One that wants clinical iconography
+ * passes its own map to {@link achievementIcon}, or `{}` for none at all.
+ */
+export const DEFAULT_SCOPE_ICONS: Readonly<Record<AchievementScope, string>> = {
   day: '💯',
   week: '📅',
   month: '🏅',
@@ -220,7 +227,7 @@ export interface AchievementGroup {
 }
 
 /** The Trophy Room's full display model. */
-export interface TrophyRoomView {
+export interface AchievementBoard {
   /** Pooled ladder first (if configured), then one group per exercise, alphabetical. */
   groups: AchievementGroup[]
   /** Total earned across every group. */
@@ -525,7 +532,7 @@ function resolveMetric(
  * @param sets All logged sets, usually `WeightRoomData.sets`.
  * @param goals Configured exercises; supplies each `daily_target` (the bar a
  *   `'streak'` day must clear) and the accent color used by
- *   {@link buildTrophyRoomView}.
+ *   {@link buildAchievementBoard}.
  * @param achievements The ladder from `weight_room_achievements`; may be empty.
  * @param exercises The movement catalog, supplying `load_multiplier` for
  *   movements with no daily goal — see {@link buildMetrics}.
@@ -580,12 +587,12 @@ const STRIP_SIZE = 6
  *   label has to come from the catalog, not from `goals`, or a movement with
  *   tiers and no goal renders its raw slug.
  */
-export function buildTrophyRoomView(
+export function buildAchievementBoard(
   sets: readonly StrengthSet[],
   goals: readonly ExerciseGoal[],
   achievements: readonly WeightRoomAchievement[],
   exercises: readonly WeightRoomExercise[] = []
-): TrophyRoomView {
+): AchievementBoard {
   const colorByExercise = new Map(goals.map(g => [g.exercise, g.color]))
   // Catalog first, goal-joined label second (#384). Achievements outlive their
   // goal, so a goals-only lookup would drop back to the slug for exactly the
@@ -721,9 +728,20 @@ export function achievementUnit(achievement: WeightRoomAchievement): string {
   return achievement.measure === 'tonnage' || achievement.measure === 'load' ? 'lb' : 'reps'
 }
 
-/** The emoji shown on a badge face — the tier's own `icon`, else a scope default. */
-export function achievementIcon(achievement: WeightRoomAchievement): string {
-  return achievement.icon ?? SCOPE_ICONS[achievement.scope]
+/**
+ * The glyph shown on a badge face — the tier's own `icon`, else a scope default.
+ *
+ * @param achievement The tier being rendered.
+ * @param fallbacks Scope → glyph map used when the tier configures no `icon` of
+ *   its own. Defaults to {@link DEFAULT_SCOPE_ICONS}; pass a partial map to
+ *   override some scopes, or `{}` to render nothing where a tier is silent.
+ * @returns The glyph, or `''` when neither the tier nor `fallbacks` supplies one.
+ */
+export function achievementIcon(
+  achievement: WeightRoomAchievement,
+  fallbacks: Readonly<Partial<Record<AchievementScope, string>>> = DEFAULT_SCOPE_ICONS
+): string {
+  return achievement.icon ?? fallbacks[achievement.scope] ?? ''
 }
 
 /**

--- a/lib/training-facility/load-management.test.ts
+++ b/lib/training-facility/load-management.test.ts
@@ -213,7 +213,9 @@ describe('buildMovementLoads', () => {
     expect(sum).toBe(load.chronic28d)
   })
 
-  it('uses the matching goal color, falling back to a default', () => {
+  it('reports the matching goal color, and null when there is no goal', () => {
+    // Null rather than a fallback hex (#427): the color is user data, so what
+    // to draw in its absence is the render site's call, not this module's.
     const goals = [{ exercise: 'pushups', daily_target: 100, color: '#123456' }]
     const loads = buildMovementLoads(
       [set('2026-07-14', 'pushups', 100), set('2026-07-14', 'squats', 100)],
@@ -222,7 +224,7 @@ describe('buildMovementLoads', () => {
     )
     const map = byName(loads)
     expect(map.pushups.color).toBe('#123456')
-    expect(map.squats.color).toBe('#EA580C') // default
+    expect(map.squats.color).toBeNull()
   })
 
   it('ignores sets with an unparseable timestamp', () => {

--- a/lib/training-facility/load-management.ts
+++ b/lib/training-facility/load-management.ts
@@ -79,9 +79,6 @@ const LOADED_SET_FRACTION = 0.5
  */
 export const MIN_TRAINING_DAYS_IN_WINDOW = 6
 
-/** Movement color when no matching {@link ExerciseGoal} supplies one. Rim-orange. */
-const DEFAULT_MOVEMENT_COLOR = '#EA580C'
-
 /** One point in a movement's trailing daily-volume sparkline. */
 export interface DailyVolumePoint {
   /** `YYYY-MM-DD` Pacific calendar day. */
@@ -104,8 +101,16 @@ export interface MovementLoad {
    * (#384). Absent falls back to the slug at the render site.
    */
   displayName?: string
-  /** Hex display color from the matching {@link ExerciseGoal}, or a default. */
-  color: string
+  /**
+   * Hex display color from the matching {@link ExerciseGoal}, or `null` when
+   * the movement has no configured goal to take one from.
+   *
+   * `null` rather than a fallback hex (#427): the color is *user data* — an
+   * accent someone picked per movement — so what to draw when there isn't one
+   * is a rendering decision, not a domain one. The panel supplies its own
+   * default; a different consumer of this module supplies theirs.
+   */
+  color: string | null
   /** Which volume the ramp math is computed on. */
   metric: 'reps' | 'load'
   /** Unit suffix for display — `reps` or `lb`. */
@@ -355,7 +360,7 @@ export function buildMovementLoads(
     loads.push({
       movement,
       displayName: labelByExercise.get(movement),
-      color: colorByExercise.get(movement) ?? DEFAULT_MOVEMENT_COLOR,
+      color: colorByExercise.get(movement) ?? null,
       metric: loaded ? 'load' : 'reps',
       unitLabel: loaded ? 'lb' : 'reps',
       acute7d,

--- a/lib/training-facility/strength-format.test.ts
+++ b/lib/training-facility/strength-format.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+
+import { describeSet, formatLbs } from './strength-format'
+
+/**
+ * Coverage for load formatting (#427).
+ *
+ * The cases worth pinning are the defaults staying exactly as they were — this
+ * is a parameterization, not a redesign, and every existing caller passes no
+ * options — plus the deliberate non-behavior of `unit`: it relabels, it does not
+ * convert.
+ */
+
+describe('formatLbs', () => {
+  it('defaults to whole pounds, thousands separated', () => {
+    expect(formatLbs(0)).toBe('0 lb')
+    expect(formatLbs(60)).toBe('60 lb')
+    expect(formatLbs(12345)).toBe('12,345 lb')
+  })
+
+  it('rounds rather than showing false precision', () => {
+    // An Epley estimate is an estimate; a decimal implies a measurement.
+    expect(formatLbs(204.1666)).toBe('204 lb')
+    expect(formatLbs(0.4)).toBe('0 lb')
+  })
+
+  it('takes a unit label', () => {
+    expect(formatLbs(60, { unit: 'kg' })).toBe('60 kg')
+  })
+
+  it('relabels without converting', () => {
+    // The helper is handed a number and a label; inventing a conversion here
+    // would silently rewrite the caller's data.
+    expect(formatLbs(100, { unit: 'kg' })).toBe('100 kg')
+  })
+
+  it('takes a locale for separators', () => {
+    expect(formatLbs(12345, { locale: 'de-DE' })).toBe('12.345 lb')
+  })
+})
+
+describe('describeSet', () => {
+  it('renders a loaded set as reps × load', () => {
+    expect(describeSet(8, 60)).toBe('8 × 60 lb')
+  })
+
+  it('renders a bodyweight set as reps alone', () => {
+    // Zero load is bodyweight, not a set that moved nothing.
+    expect(describeSet(12, 0)).toBe('12 reps')
+  })
+
+  it('forwards unit and locale to the load half', () => {
+    expect(describeSet(5, 1250, { unit: 'kg', locale: 'de-DE' })).toBe('5 × 1.250 kg')
+  })
+
+  it('ignores options for a bodyweight set, which has no load to label', () => {
+    expect(describeSet(12, 0, { unit: 'kg' })).toBe('12 reps')
+  })
+})

--- a/lib/training-facility/strength-format.ts
+++ b/lib/training-facility/strength-format.ts
@@ -5,25 +5,54 @@
  * can't drift into printing the same set two different ways — one screen saying
  * `8 × 60 lb` while the other says `8 x 60lbs` is the kind of inconsistency
  * nobody files but everybody notices.
+ *
+ * **The unit is a display choice, not a fact about the number** (#427). Every
+ * load in this codebase is stored in pounds, and these helpers still default to
+ * printing `lb` in `en-US` — but plenty of gyms and most clinicians work in
+ * kilos, so the label and the locale are parameters rather than literals. The
+ * caller that knows its audience passes them; nobody else has to care.
  */
 
+/** How a load should be rendered. */
+export interface LoadFormatOptions {
+  /**
+   * Unit suffix appended after the number, e.g. `lb` or `kg`. Defaults to `lb`.
+   *
+   * Purely a **label** — no conversion happens. A caller displaying kilos is
+   * responsible for having converted the value first; this helper will not
+   * silently reinterpret a number it was handed.
+   */
+  unit?: string
+  /** BCP-47 tag for thousands separators. Defaults to `en-US`. */
+  locale?: string
+}
+
 /**
- * Format pounds for display — whole pounds, thousands separated.
+ * Format a load for display — whole units, thousands separated.
  *
  * Tonnage runs to five figures, where a decimal is noise; an Epley estimate is
  * an estimate, where a decimal is false precision. Neither wants fractions.
+ *
+ * @param value The load, in whatever unit `options.unit` names.
+ * @param options Unit label and locale; see {@link LoadFormatOptions}.
  */
-export function formatLbs(value: number): string {
-  return `${Math.round(value).toLocaleString('en-US')} lb`
+export function formatLbs(value: number, options: LoadFormatOptions = {}): string {
+  const { unit = 'lb', locale = 'en-US' } = options
+  return `${Math.round(value).toLocaleString(locale)} ${unit}`
 }
 
 /**
  * Render a set as `8 × 60 lb`, or `12 reps` when it carried no external load.
  *
  * @param reps Reps completed.
- * @param effectiveLoad Pounds actually moved — per-implement weight already
+ * @param effectiveLoad Load actually moved — per-implement weight already
  *   multiplied by the movement's `load_multiplier`. `0` means bodyweight.
+ * @param options Unit label and locale, forwarded to {@link formatLbs}.
  */
-export function describeSet(reps: number, effectiveLoad: number): string {
-  return effectiveLoad > 0 ? `${reps} × ${formatLbs(effectiveLoad)}` : `${reps} reps`
+export function describeSet(
+  reps: number,
+  effectiveLoad: number,
+  options: LoadFormatOptions = {}
+): string {
+  return effectiveLoad > 0 ? `${reps} × ${formatLbs(effectiveLoad, options)}` : `${reps} reps`
 }


### PR DESCRIPTION
Stages 1b–1e of #425, collapsed — they're the same change four times over. The strength modules that are about to ship in `@lucasklawrence/training-domain` were deciding things that belong to whoever renders them.

Doing it **before** the move is a cost argument, not a correctness one. Each of these is a one-line PR today; once the code lives behind a version boundary it's package PR → version bump → publish → dep-bump, forever, for every one-line fix.

## The four

**A movement's fallback color — evicted.** `load-management.ts` defined `DEFAULT_MOVEMENT_COLOR = '#EA580C'` and handed it out for any movement without a goal. But `ExerciseGoal.color` is *user data* — an accent someone picked — so the question "what do I draw when there isn't one" is a rendering question. `MovementLoad.color` is now `string | null`; the rim-orange lives on `LoadManagementPanel`.

Rejected the alternative (`buildMovementLoadView(sets, goals, { defaultColor })`) — an options bag on a hot signature to carry one hex the caller already has.

**Achievement icons — overridden, not evicted.** These went the other way on purpose: a flame for a streak and a medal for a month are generic, not Court Vision. So `DEFAULT_SCOPE_ICONS` is exported and `achievementIcon(achievement, fallbacks?)` takes an optional map. Zero call-site churn; a consumer passes clinical glyphs, or `{}` to render nothing.

**Pounds and locale — parameterized.** `formatLbs` / `describeSet` hardcoded `'en-US'` and `' lb'`. Plenty of clinicians work in kilos. Now `formatLbs(value, { unit = 'lb', locale = 'en-US' })`, defaults unchanged. Note the deliberate non-behavior, which the tests pin: **`unit` relabels, it does not convert.** A helper that silently reinterpreted the number it was handed would be worse than one that can't do kilos at all.

**`TrophyRoomView` → `AchievementBoard`.** The one export in the shipping set whose name a reader outside this repo would misparse. The *page* is still the Trophy Room; only the domain symbol moved. Explicitly not renaming `WeightRoom*` → `Strength*` — that's ordinary gym English and would touch ~250 sites for nothing.

## Tests

`strength-format.ts` had no test file at all. It has one now — defaults, rounding, the unit/locale parameters, and the relabel-not-convert contract. `achievementIcon` gained override cases; the `load-management` color test now asserts the `null` contract instead of the old hex.

163 files / 2,260 tests passing, up 12.

## Test plan

- [ ] `/training-facility/weight-room/history` — Load Management cards: pushups/pullups/squats keep their goal colors; a gym lift with no goal (shrugs, dumbbell lateral raise) still renders rim-orange, both in the heading and its sparkline
- [ ] `/training-facility/weight-room/achievements` — every badge shows the same glyph as before; tiers with a configured `icon` still win over the scope default
- [ ] `/training-facility/weight-room/workouts/<id>` — top set still reads `8 × 155 lb`, tonnage still thousands-separated
- [ ] `/training-facility/weight-room/exercises/shrugs` — records row and recent-days table unchanged
- [ ] Nothing visual should differ anywhere. This is a refactor; if a color or a glyph moved, that's a bug.

Verified locally: `tsc --noEmit` · `next build` · `npm test` 2,260 passing · `npm run test:e2e` 68 passing · `npm run lint` · `prettier --check` repo-wide.

Closes #427. Refs #425.
