### PR TITLE
refactor(training-facility): make the day bucket's timezone a parameter (#429)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -105,6 +105,49 @@ const eslintConfig = [
       ],
     },
   },
+  {
+    // The strength modules must reach the calendar through a `DayClock`, not
+    // through the Pacific-bound shim (#429).
+    //
+    // `day-keys.ts` still exists and is still correct for the surfaces that are
+    // legitimately Pacific-only — the data layer, the admin routes, the
+    // components. But these modules are the ones heading for a shared package,
+    // where hardcoding one home timezone is the bug. Importing the shim here
+    // would re-hardwire Pacific in a way no test in this repo could see, since
+    // this repo *is* Pacific.
+    //
+    // Scoped to the shipping set rather than all of `lib/**`, so the shim stays
+    // freely available everywhere it's still the right answer.
+    files: [
+      'lib/training-facility/achievements.ts',
+      'lib/training-facility/exercise-progression.ts',
+      'lib/training-facility/load-management.ts',
+      'lib/training-facility/monthly-focus.ts',
+      'lib/training-facility/strength-streaks.ts',
+      'lib/training-facility/strength-today.ts',
+      'lib/training-facility/weight-room-history.ts',
+      'lib/training-facility/workout-sessions.ts',
+      'lib/training-facility/workout-stats.ts',
+    ],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: ['**/day-keys', '@/lib/training-facility/day-keys'],
+              message:
+                'Import from ./clock and take a DayClock parameter instead. day-keys.ts is the Pacific-bound shim; these modules ship in a package where the zone is the caller’s choice.',
+            },
+            {
+              group: ['@/components/*', '@/components/**'],
+              message: 'The domain layer must not import from components.',
+            },
+          ],
+        },
+      ],
+    },
+  },
 ]
 
 export default eslintConfig

--- a/lib/training-facility/achievements.ts
+++ b/lib/training-facility/achievements.ts
@@ -8,7 +8,7 @@ import type {
 } from '@/types/weight-room'
 
 import { targetResolverFor } from './goal-targets'
-import { mondayOfDayKey, safePacificDayKey, shiftDayKey } from './day-keys'
+import { PACIFIC_CLOCK, mondayOfDayKey, shiftDayKey, type DayClock } from './clock'
 
 /**
  * Pure resolver for the Weight Room Trophy Room (#336) — "grease the groove"
@@ -292,7 +292,8 @@ function emptyMetrics(): MovementMetrics {
 function buildMetrics(
   sets: readonly StrengthSet[],
   goals: readonly ExerciseGoal[],
-  exercises: readonly WeightRoomExercise[] = []
+  exercises: readonly WeightRoomExercise[] = [],
+  clock: DayClock = PACIFIC_CLOCK
 ): Map<string | null, MovementMetrics> {
   // Implements moved per set, per exercise. Catalog first, then the goal's
   // joined copy, then a single implement — the only safe default, since it can
@@ -323,7 +324,7 @@ function buildMetrics(
   // Sets arrive oldest-first from the data layer, but sort defensively: the
   // `'set'` and `'lifetime'` earn dates both depend on chronological order.
   const ordered = [...sets]
-    .map(s => ({ set: s, day: safePacificDayKey(s.logged_at) }))
+    .map(s => ({ set: s, day: clock.safeDayKey(s.logged_at) }))
     .filter(entry => entry.day !== '')
     .sort((a, b) => (a.day < b.day ? -1 : a.day > b.day ? 1 : 0))
 
@@ -536,15 +537,18 @@ function resolveMetric(
  * @param achievements The ladder from `weight_room_achievements`; may be empty.
  * @param exercises The movement catalog, supplying `load_multiplier` for
  *   movements with no daily goal — see {@link buildMetrics}.
+ * @param clock Zone every day, week and month bucket is measured in; defaults
+ *   to Pacific (#429).
  * @returns One {@link ResolvedAchievement} per tier, in the order supplied.
  */
 export function resolveAchievements(
   sets: readonly StrengthSet[],
   goals: readonly ExerciseGoal[],
   achievements: readonly WeightRoomAchievement[],
-  exercises: readonly WeightRoomExercise[] = []
+  exercises: readonly WeightRoomExercise[] = [],
+  clock: DayClock = PACIFIC_CLOCK
 ): ResolvedAchievement[] {
-  const metrics = buildMetrics(sets, goals, exercises)
+  const metrics = buildMetrics(sets, goals, exercises, clock)
 
   return achievements.map(achievement => {
     const outcome = resolveMetric(metrics.get(achievement.exercise) ?? emptyMetrics(), achievement)
@@ -586,12 +590,14 @@ const STRIP_SIZE = 6
  *   deliberately not FK'd to goals — deleting a goal keeps its badges — so the
  *   label has to come from the catalog, not from `goals`, or a movement with
  *   tiers and no goal renders its raw slug.
+ * @param clock Zone every bucket is measured in; defaults to Pacific (#429).
  */
 export function buildAchievementBoard(
   sets: readonly StrengthSet[],
   goals: readonly ExerciseGoal[],
   achievements: readonly WeightRoomAchievement[],
-  exercises: readonly WeightRoomExercise[] = []
+  exercises: readonly WeightRoomExercise[] = [],
+  clock: DayClock = PACIFIC_CLOCK
 ): AchievementBoard {
   const colorByExercise = new Map(goals.map(g => [g.exercise, g.color]))
   // Catalog first, goal-joined label second (#384). Achievements outlive their
@@ -611,7 +617,7 @@ export function buildAchievementBoard(
 
   // Attached once here rather than inside `resolveAchievements` so the groups
   // and both strips read the same label off the same objects.
-  const resolved = resolveAchievements(sets, goals, achievements, exercises).map(entry => {
+  const resolved = resolveAchievements(sets, goals, achievements, exercises, clock).map(entry => {
     const slug = entry.achievement.exercise
     const label = slug === null || slug === undefined ? undefined : labelByExercise.get(slug)
     return label === undefined ? entry : { ...entry, displayName: label }

--- a/lib/training-facility/clock-threading.test.ts
+++ b/lib/training-facility/clock-threading.test.ts
@@ -1,0 +1,327 @@
+import { describe, expect, it } from 'vitest'
+
+import type {
+  ExerciseGoal,
+  MonthlyFocus,
+  StrengthSet,
+  WeightRoomAchievement,
+  WeightRoomWorkout,
+} from '@/types/weight-room'
+
+import { PACIFIC_CLOCK, createDayClock, type DayClock } from './clock'
+import { buildAchievementBoard, resolveAchievements } from './achievements'
+import {
+  buildExerciseProgression,
+  buildSetDetailCoverage,
+  trendableExercises,
+} from './exercise-progression'
+import { buildMovementLoadView, buildMovementLoads } from './load-management'
+import {
+  buildFocusLaneCells,
+  computeFocusAdherence,
+  computeFocusLoadStats,
+  summarizeFocusCampaigns,
+} from './monthly-focus'
+import { computeStrengthStreaks as computeGoalStreaks } from './strength-streaks'
+import {
+  filterSetsForDay,
+  formatDayLabel,
+  localNoonIsoForDay,
+  toLocalDateKey,
+} from './strength-today'
+import {
+  buildStrengthHeatmap,
+  buildWeeklyVolume,
+  computeStrengthStats,
+  computeStrengthStreaks,
+} from './weight-room-history'
+import { workoutDayKey } from './workout-sessions'
+import { buildWorkoutHistory, workoutYear, workoutYearOptions } from './workout-stats'
+
+/**
+ * The gate for the `DayClock` refactor (#429).
+ *
+ * Threading a clock through ~25 functions has one failure mode, and it is
+ * silent: a function accepts the parameter and forgets to hand it to a helper.
+ * **Every other test in this repo still passes** when that happens, because
+ * this repo is Pacific and the default is Pacific — so the mistake ships, and
+ * surfaces months later in a consumer whose clients are somewhere else, as
+ * off-by-one days in streaks and heatmaps.
+ *
+ * So each zone-consuming entry point runs twice over the same fixture — once in
+ * Pacific, once in `Pacific/Kiritimati` (UTC+14, the furthest-forward zone
+ * there is) — and the two results must **differ**. A dropped clock produces
+ * byte-identical output and fails here.
+ *
+ * ## The fixture is the hard part
+ *
+ * Shifting every timestamp by 21 hours moves all the days together, and most
+ * rollups are invariant under that — a streak of 1 is a streak of 1 whichever
+ * zone you count it in. An assertion built on such a fixture would pass whether
+ * or not the clock was honored, which is worse than no assertion.
+ *
+ * What actually discriminates is two sets on the **same Pacific day that fall
+ * on different Kiritimati days**. Pacific 2026-07-14 runs 07:00Z→07:00Z, and
+ * Kiritimati's midnight lands at 10:00Z inside it:
+ *
+ * - `08:00Z` → Pacific Jul 14 01:00 · Kiritimati Jul 14 22:00
+ * - `12:00Z` → Pacific Jul 14 05:00 · Kiritimati Jul 15 02:00
+ *
+ * So Pacific sees one 120-rep day; Kiritimati sees two 60-rep days. That single
+ * difference propagates into every daily rollup, every streak, and the
+ * hundred-rep achievement. Week and year boundaries get the same treatment.
+ *
+ * When this file is copied into the shared package, keep it. It's the only test
+ * here that can fail for the right reason.
+ */
+
+/** UTC+14 — the largest offset in the tz database, ~21h ahead of Pacific. */
+const KIRITIMATI = createDayClock('Pacific/Kiritimati')
+
+/** Pacific Jul 14 01:00 · Kiritimati Jul 14 22:00. */
+const SPLIT_EARLY = '2026-07-14T08:00:00Z'
+/** Pacific Jul 14 05:00 · Kiritimati Jul **15** 02:00 — the same Pacific day. */
+const SPLIT_LATE = '2026-07-14T12:00:00Z'
+/** Pacific Sun Jul 12 · Kiritimati Mon Jul 13 — different ISO weeks. */
+const WEEK_STRADDLE = '2026-07-12T12:00:00Z'
+/** Pacific Dec 31 2026 · Kiritimati Jan 1 2027. */
+const YEAR_STRADDLE = '2026-12-31T12:00:00Z'
+/** "Now", late enough that every fixture day has elapsed in both zones. */
+const NOW = new Date('2026-07-16T20:00:00Z')
+
+const GOAL: ExerciseGoal = { exercise: 'pushups', daily_target: 50, color: '#EA580C' }
+
+function set(overrides: Partial<StrengthSet> = {}): StrengthSet {
+  return { id: 'set-1', logged_at: SPLIT_EARLY, exercise: 'pushups', reps: 60, ...overrides }
+}
+
+function workout(overrides: Partial<WeightRoomWorkout> = {}): WeightRoomWorkout {
+  return { id: 'w1', started_at: SPLIT_LATE, source: 'manual', ...overrides }
+}
+
+/** The discriminating pair, plus a weighted set on the late side. */
+const SETS: StrengthSet[] = [
+  set({ id: 's1', logged_at: SPLIT_EARLY, reps: 60 }),
+  set({ id: 's2', logged_at: SPLIT_LATE, reps: 60 }),
+  set({ id: 's3', logged_at: SPLIT_LATE, reps: 10, weight_lbs: 45 }),
+]
+
+/**
+ * Eight distinct training days so the ramp panel's `MIN_TRAINING_DAYS_IN_WINDOW`
+ * gate is cleared and `buildMovementLoadView` returns a card at all — plus the
+ * split pair, which is what makes the two zones disagree.
+ */
+const FREQUENT_SETS: StrengthSet[] = [
+  ...Array.from({ length: 8 }, (_, i) =>
+    set({ id: `f${i}`, logged_at: `2026-07-0${i + 1}T20:00:00Z`, reps: 50 })
+  ),
+  ...SETS,
+]
+
+const FOCUS: MonthlyFocus = {
+  id: 'f1',
+  exercise: 'pushups',
+  daily_target: 50,
+  target_kind: 'reps',
+  color: '#C9A268',
+  category: 'upper',
+  // Closes on the Pacific day the split pair lands on, so Kiritimati's later
+  // half falls outside the window entirely.
+  start_date: '2026-07-01',
+  end_date: '2026-07-14',
+}
+
+/** 100 reps in a day — cleared by Pacific's merged 120, missed by Kiritimati's 60s. */
+const LADDER: WeightRoomAchievement[] = [
+  { id: 'a1', label: 'Century', exercise: 'pushups', scope: 'day', threshold: 100 },
+]
+
+/**
+ * Assert an entry point actually consults the clock it was handed.
+ *
+ * @param run Called once per zone; whatever it returns is compared structurally.
+ */
+function dependsOnZone(run: (clock: DayClock) => unknown): void {
+  expect(JSON.stringify(run(KIRITIMATI))).not.toBe(JSON.stringify(run(PACIFIC_CLOCK)))
+}
+
+describe('the fixture actually straddles a boundary', () => {
+  it('splits one Pacific day across two Kiritimati days', () => {
+    expect(PACIFIC_CLOCK.safeDayKey(SPLIT_EARLY)).toBe('2026-07-14')
+    expect(PACIFIC_CLOCK.safeDayKey(SPLIT_LATE)).toBe('2026-07-14')
+    expect(KIRITIMATI.safeDayKey(SPLIT_EARLY)).toBe('2026-07-14')
+    expect(KIRITIMATI.safeDayKey(SPLIT_LATE)).toBe('2026-07-15')
+  })
+
+  it('splits an ISO week', () => {
+    expect(PACIFIC_CLOCK.safeDayKey(WEEK_STRADDLE)).toBe('2026-07-12') // Sunday
+    expect(KIRITIMATI.safeDayKey(WEEK_STRADDLE)).toBe('2026-07-13') // Monday
+  })
+
+  it('splits a calendar year', () => {
+    expect(PACIFIC_CLOCK.safeDayKey(YEAR_STRADDLE)).toBe('2026-12-31')
+    expect(KIRITIMATI.safeDayKey(YEAR_STRADDLE)).toBe('2027-01-01')
+  })
+})
+
+describe('every zone-consuming entry point honors its clock', () => {
+  it('workoutDayKey', () => {
+    dependsOnZone(clock => workoutDayKey(workout(), clock))
+  })
+
+  it('toLocalDateKey', () => {
+    dependsOnZone(clock => toLocalDateKey(SPLIT_LATE, clock))
+  })
+
+  it('filterSetsForDay', () => {
+    dependsOnZone(clock => filterSetsForDay(SETS, '2026-07-14', clock).map(s => s.id))
+  })
+
+  it('localNoonIsoForDay', () => {
+    dependsOnZone(clock => localNoonIsoForDay('2026-07-14', clock))
+  })
+
+  it('computeStrengthStreaks (per-goal)', () => {
+    dependsOnZone(clock => computeGoalStreaks(SETS, [GOAL], NOW, clock))
+  })
+
+  it('computeStrengthStreaks (history)', () => {
+    dependsOnZone(clock => computeStrengthStreaks(SETS, GOAL, NOW, clock))
+  })
+
+  it('buildStrengthHeatmap', () => {
+    dependsOnZone(clock =>
+      buildStrengthHeatmap(SETS, GOAL, new Date('2026-07-01T20:00:00Z'), NOW, clock)
+        .grid.flat()
+        .filter(cell => cell.reps > 0)
+        .map(cell => `${cell.dayKey}:${cell.reps}`)
+    )
+  })
+
+  it('computeStrengthStats', () => {
+    dependsOnZone(clock => computeStrengthStats(SETS, [GOAL], NOW, [], clock))
+  })
+
+  it('buildWeeklyVolume', () => {
+    const weekly = [...SETS, set({ id: 'wk', logged_at: WEEK_STRADDLE, reps: 33 })]
+    dependsOnZone(clock =>
+      buildWeeklyVolume(weekly, GOAL, 4, NOW, clock).map(p => `${p.weekKey}:${p.reps}`)
+    )
+  })
+
+  it('buildMovementLoads', () => {
+    dependsOnZone(clock => buildMovementLoads(SETS, [GOAL], NOW, [], clock).map(l => l.sparkline))
+  })
+
+  it('buildMovementLoadView', () => {
+    dependsOnZone(clock =>
+      buildMovementLoadView(FREQUENT_SETS, [GOAL], NOW, [], clock).loads.map(l => l.sparkline)
+    )
+  })
+
+  it('resolveAchievements', () => {
+    dependsOnZone(clock =>
+      resolveAchievements(SETS, [GOAL], LADDER, [], clock).map(r => `${r.best}:${r.earned}`)
+    )
+  })
+
+  it('buildAchievementBoard', () => {
+    dependsOnZone(clock => buildAchievementBoard(SETS, [GOAL], LADDER, [], clock).earnedCount)
+  })
+
+  it('computeFocusAdherence', () => {
+    // Adherence reports day *counts*, not volume, so the bar has to sit between
+    // the merged Pacific day (60 + 10 = 70) and Kiritimati's leading half (60).
+    // Pacific hits it, Kiritimati doesn't — one day hit versus none.
+    const strictFocus: MonthlyFocus = { ...FOCUS, daily_target: 65 }
+    dependsOnZone(clock => computeFocusAdherence(strictFocus, SETS, NOW, clock))
+  })
+
+  it('computeFocusLoadStats', () => {
+    dependsOnZone(clock => computeFocusLoadStats(FOCUS, SETS, 1, clock))
+  })
+
+  it('buildFocusLaneCells', () => {
+    dependsOnZone(clock =>
+      buildFocusLaneCells([FOCUS], SETS, 'upper', '2026-07-14', clock).map(
+        c => `${c.dayKey}:${c.volume}`
+      )
+    )
+  })
+
+  it('summarizeFocusCampaigns', () => {
+    dependsOnZone(clock => summarizeFocusCampaigns([FOCUS], 'pushups', SETS, NOW, clock))
+  })
+
+  it('buildExerciseProgression', () => {
+    dependsOnZone(clock =>
+      buildExerciseProgression('pushups', SETS, [], [], clock)?.points.map(
+        p => `${p.dayKey}:${p.reps}`
+      )
+    )
+  })
+
+  it('buildSetDetailCoverage', () => {
+    // Pacific dates the import to 7/14, strictly before the 7/15 cutoff, so it
+    // counts. Kiritimati dates it to 7/15, which is not before it.
+    const imported = [workout({ id: 'imported', source: 'apple_health' })]
+    dependsOnZone(clock => buildSetDetailCoverage('2026-07-15', imported, [], clock))
+  })
+
+  it('trendableExercises', () => {
+    // Pacific has both last-trained on 7/14 — a tie, broken alphabetically.
+    // Kiritimati puts squats a day later, so it sorts first. The returned
+    // ordering itself flips.
+    const mixed = [
+      set({ id: 'a', exercise: 'pullups', logged_at: SPLIT_EARLY }),
+      set({ id: 'b', exercise: 'squats', logged_at: SPLIT_LATE }),
+    ]
+    dependsOnZone(clock => trendableExercises(mixed, clock))
+  })
+
+  it('workoutYearOptions', () => {
+    const entries = buildWorkoutHistory([workout({ started_at: YEAR_STRADDLE })], [])
+    dependsOnZone(clock => workoutYearOptions(entries, clock))
+  })
+
+  it('workoutYear', () => {
+    const [entry] = buildWorkoutHistory([workout({ started_at: YEAR_STRADDLE })], [])
+    dependsOnZone(clock => workoutYear(entry, clock))
+  })
+})
+
+describe('formatDayLabel is deliberately zone-stable', () => {
+  it('names the same day in both zones, because that is the point', () => {
+    // The label must agree with the key it came from *everywhere* — a Pacific
+    // `2026-07-14` should not render as "Jul 15" for a reader in Kiritimati.
+    // So unlike its neighbours, a difference here would be the bug.
+    expect(formatDayLabel('2026-07-14', KIRITIMATI)).toBe(
+      formatDayLabel('2026-07-14', PACIFIC_CLOCK)
+    )
+  })
+
+  it('still resolves the zone underneath', () => {
+    // Proof the clock isn't being ignored: ask for the zone name and the two
+    // answers diverge, even though the calendar day does not.
+    dependsOnZone(clock => clock.format('2026-07-14', { timeZoneName: 'short' }, 'en-US'))
+  })
+})
+
+describe('the Pacific default is unchanged', () => {
+  it('omitting the clock matches passing PACIFIC_CLOCK explicitly', () => {
+    // The other half of the contract: courtfolio passes no clock anywhere, so
+    // the default has to reproduce the old behavior exactly.
+    expect(workoutDayKey(workout())).toBe(workoutDayKey(workout(), PACIFIC_CLOCK))
+    expect(toLocalDateKey(SPLIT_LATE)).toBe(toLocalDateKey(SPLIT_LATE, PACIFIC_CLOCK))
+    expect(formatDayLabel('2026-07-14')).toBe(formatDayLabel('2026-07-14', PACIFIC_CLOCK))
+    expect(JSON.stringify(computeStrengthStats(SETS, [GOAL], NOW))).toBe(
+      JSON.stringify(computeStrengthStats(SETS, [GOAL], NOW, [], PACIFIC_CLOCK))
+    )
+    expect(JSON.stringify(buildExerciseProgression('pushups', SETS))).toBe(
+      JSON.stringify(buildExerciseProgression('pushups', SETS, [], [], PACIFIC_CLOCK))
+    )
+    expect(JSON.stringify(buildAchievementBoard(SETS, [GOAL], LADDER))).toBe(
+      JSON.stringify(buildAchievementBoard(SETS, [GOAL], LADDER, [], PACIFIC_CLOCK))
+    )
+  })
+})

--- a/lib/training-facility/clock.ts
+++ b/lib/training-facility/clock.ts
@@ -1,0 +1,291 @@
+/**
+ * Turning a timestamp into a calendar day, anchored to a timezone the caller
+ * chooses (#429).
+ *
+ * This is `day-keys.ts` with its one hardcoded assumption pulled out. That
+ * module bucketed everything in `America/Los_Angeles`, which is right for a
+ * personal log — the training happens where it happens, so logging on a trip
+ * still lands on the home day and a flight can't break a streak — and wrong the
+ * moment two people in different zones share the code.
+ *
+ * The zone lives in a {@link DayClock} value that callers pass explicitly.
+ * {@link PACIFIC_CLOCK} is the default everywhere in this repo, so nothing here
+ * reads differently than it did; a consumer serving other people's clients
+ * builds one clock per client instead.
+ *
+ * **Why a value and not a module-level setting.** A `configureTimeZone()` setter
+ * would be far less code and is disqualified outright: a server rendering one
+ * client in Denver and another in Boston within the same tick would race on it,
+ * and the symptom would be days silently attributed to the wrong person's
+ * calendar. Threading a parameter is tedious exactly once.
+ *
+ * **Keys stay bare `YYYY-MM-DD` strings, and that's load-bearing.** PostgREST
+ * renders a Postgres `date` in exactly that canonical zero-padded form, so
+ * lexicographic string comparison *is* chronological comparison. Every window
+ * test, sort, and boundary check downstream relies on it — which is why the
+ * arithmetic below stays on the calendar numbers rather than round-tripping
+ * through a zoned `Date`.
+ */
+
+/** IANA zone this repo's own day buckets are anchored to. */
+export const PACIFIC_TZ = 'America/Los_Angeles'
+
+/** Matches a bare `YYYY-MM-DD` key. */
+const DAY_KEY_PATTERN = /^\d{4}-\d{2}-\d{2}$/
+
+/** Whether `value` has the exact `YYYY-MM-DD` shape this module works in. */
+export function isDayKey(value: string): boolean {
+  return DAY_KEY_PATTERN.test(value)
+}
+
+/**
+ * Shift a `YYYY-MM-DD` key by `delta` days.
+ *
+ * Arithmetic runs in UTC on the bare calendar numbers — no zone, no DST — so
+ * the result is always a clean calendar date. Doing this with millisecond math
+ * on a zoned `Date` lands on the wrong day twice a year, when a "day" is 23 or
+ * 25 hours long. Zone-free, so it needs no clock.
+ *
+ * @param key `YYYY-MM-DD` to shift.
+ * @param delta Days to add; negative goes back.
+ */
+export function shiftDayKey(key: string, delta: number): string {
+  const [y, m, d] = key.split('-').map(Number)
+  const dt = new Date(Date.UTC(y, m - 1, d + delta))
+  const yy = dt.getUTCFullYear()
+  const mm = String(dt.getUTCMonth() + 1).padStart(2, '0')
+  const dd = String(dt.getUTCDate()).padStart(2, '0')
+  return `${yy}-${mm}-${dd}`
+}
+
+/**
+ * ISO weekday for a day key: 1 = Monday … 7 = Sunday. Zone-free.
+ *
+ * @param key `YYYY-MM-DD`.
+ */
+export function isoWeekdayOfDayKey(key: string): number {
+  const [y, m, d] = key.split('-').map(Number)
+  const dow = new Date(Date.UTC(y, m - 1, d)).getUTCDay()
+  return dow === 0 ? 7 : dow
+}
+
+/**
+ * The Monday of the ISO week containing `key`. Weeks run Mon–Sun to match the
+ * heatmap's row layout and the stats panel's week rollups. Zone-free.
+ *
+ * @param key `YYYY-MM-DD` anywhere in the week.
+ */
+export function mondayOfDayKey(key: string): string {
+  return shiftDayKey(key, -(isoWeekdayOfDayKey(key) - 1))
+}
+
+/**
+ * Inclusive count of calendar days from `startKey` through `endKey`. `1` when
+ * they're the same day; `0` when `endKey` precedes `startKey`. Zone-free.
+ *
+ * @param startKey `YYYY-MM-DD` first day.
+ * @param endKey `YYYY-MM-DD` last day.
+ */
+export function inclusiveDaySpan(startKey: string, endKey: string): number {
+  if (endKey < startKey) return 0
+  const toUtcMs = (key: string): number => {
+    const [y, m, d] = key.split('-').map(Number)
+    return Date.UTC(y, m - 1, d)
+  }
+  return Math.round((toUtcMs(endKey) - toUtcMs(startKey)) / 86_400_000) + 1
+}
+
+/** First day of the calendar month containing `key`. Zone-free. */
+export function firstDayOfMonth(key: string): string {
+  return `${key.slice(0, 7)}-01`
+}
+
+/** Last day of the calendar month containing `key`. Zone-free. */
+export function lastDayOfMonth(key: string): string {
+  const [y, m] = key.split('-').map(Number)
+  // Day 0 of the following month is the last day of this one.
+  const dt = new Date(Date.UTC(y, m, 0))
+  return `${dt.getUTCFullYear()}-${String(dt.getUTCMonth() + 1).padStart(2, '0')}-${String(dt.getUTCDate()).padStart(2, '0')}`
+}
+
+/** Zero-based month index (0 = January) for a day key. Zone-free. */
+export function monthIndexOfDayKey(key: string): number {
+  return Number(key.slice(5, 7)) - 1
+}
+
+/**
+ * A timezone, bound to the handful of operations that actually need one.
+ *
+ * Built by {@link createDayClock}, which memoizes the two `Intl.DateTimeFormat`
+ * instances involved — constructing those per call is expensive enough to show
+ * up when bucketing thousands of sets.
+ */
+export interface DayClock {
+  /** IANA zone this clock is anchored to. */
+  readonly timeZone: string
+  /**
+   * The `YYYY-MM-DD` calendar day an instant falls on, in this clock's zone.
+   *
+   * @param d Any `Date`; callers usually pass `new Date(set.logged_at)`.
+   */
+  dayKey(d: Date): string
+  /**
+   * {@link dayKey} that tolerates bad input, returning `''` rather than
+   * throwing or emitting `NaN-NaN-NaN`.
+   *
+   * Callers treat `''` as "skip this row" — it sorts before every real key and
+   * matches no window, so a corrupt timestamp drops out of a rollup instead of
+   * poisoning it.
+   *
+   * @param input ISO 8601 string, or a `Date` the caller already built.
+   */
+  safeDayKey(input: string | Date): string
+  /**
+   * Today's key in this clock's zone.
+   *
+   * @param now Clock override; defaults to `new Date()`.
+   */
+  today(now?: Date): string
+  /**
+   * A `Date` positioned at **noon** on `key` in this clock's zone.
+   *
+   * Noon, not midnight, is the point: midnight in one zone is the previous or
+   * next day in another, so a midnight-anchored `Date` renders as the wrong day
+   * for any viewer east or west of the anchor. Noon has ~12 hours of slack in
+   * both directions, which no real offset crosses.
+   *
+   * @param key `YYYY-MM-DD`.
+   * @returns The `Date`, or `null` when `key` isn't a valid calendar day.
+   */
+  toNoon(key: string): Date | null
+  /**
+   * ISO timestamp at noon on `key` — what a backdated set is stamped with so it
+   * buckets onto the day the user picked.
+   *
+   * @param key `YYYY-MM-DD`.
+   * @returns The ISO string, or `''` when `key` isn't a valid calendar day.
+   */
+  toNoonIso(key: string): string
+  /**
+   * Human-format a day key, rendering the calendar day in this clock's zone.
+   *
+   * Use this rather than `toNoon(key).toLocaleDateString(...)`. That instant is
+   * mid-day *here*, which can already be the next day for a viewer far enough
+   * east — so in Tokyo a `2026-07-11` Pacific key would render as "Jul 12",
+   * contradicting the key it came from. Pinning `timeZone` makes the label agree
+   * with the key everywhere.
+   *
+   * The locale is left to the viewer unless a caller pins one; only the *zone*
+   * has to be fixed, because only the zone can change which day is named.
+   *
+   * @param key `YYYY-MM-DD`.
+   * @param options `Intl.DateTimeFormat` options. A caller-supplied `timeZone`
+   *   is ignored; that's the whole point.
+   * @param locale BCP-47 tag, or `undefined` for the viewer's.
+   * @returns The formatted label, or `''` when `key` isn't a valid calendar day.
+   */
+  format(key: string, options: Intl.DateTimeFormatOptions, locale?: string): string
+}
+
+/**
+ * Build a {@link DayClock} for an IANA timezone.
+ *
+ * @param timeZone e.g. `America/Los_Angeles`, `America/Denver`. Invalid zones
+ *   throw from `Intl.DateTimeFormat`, which is the right moment to find out.
+ */
+export function createDayClock(timeZone: string): DayClock {
+  // Two memoized formatters. `en-CA` yields ISO-ordered date parts; the offset
+  // formatter needs a full wall clock in `h23` so midnight reads `00`, not `24`.
+  const dateFormat = new Intl.DateTimeFormat('en-CA', {
+    timeZone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  })
+  const wallClockFormat = new Intl.DateTimeFormat('en-US', {
+    timeZone,
+    hourCycle: 'h23',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  })
+
+  /** Assembled from `formatToParts` so a locale or ICU quirk can't reorder the fields. */
+  function dayKey(d: Date): string {
+    const parts = dateFormat.formatToParts(d)
+    let year = ''
+    let month = ''
+    let day = ''
+    for (const part of parts) {
+      if (part.type === 'year') year = part.value
+      else if (part.type === 'month') month = part.value
+      else if (part.type === 'day') day = part.value
+    }
+    return `${year}-${month}-${day}`
+  }
+
+  /** This zone's offset from UTC at `instant`, in milliseconds (east is positive). */
+  function offsetMsAt(instant: Date): number {
+    const parts = wallClockFormat.formatToParts(instant)
+    const field = (type: Intl.DateTimeFormatPartTypes): number =>
+      Number(parts.find(p => p.type === type)?.value ?? '0')
+    const asIfUtc = Date.UTC(
+      field('year'),
+      field('month') - 1,
+      field('day'),
+      field('hour'),
+      field('minute'),
+      field('second')
+    )
+    return asIfUtc - instant.getTime()
+  }
+
+  function toNoon(key: string): Date | null {
+    if (!isDayKey(key)) return null
+    // The wall clock we want, read as though it were UTC. Subtracting this
+    // zone's offset at that moment converts it to a real instant.
+    const wanted = Date.parse(`${key}T12:00:00Z`)
+    if (!Number.isFinite(wanted)) return null
+    // Two passes: the first uses the offset at the wrong instant, the second
+    // corrects it. Converges immediately in practice — noon sits 12 hours from
+    // either midnight, and no DST shift is anywhere near that large.
+    let instant = new Date(wanted - offsetMsAt(new Date(wanted)))
+    instant = new Date(wanted - offsetMsAt(instant))
+    if (!Number.isFinite(instant.getTime())) return null
+    // Guard against calendar-invalid input the shape check can't catch, e.g.
+    // `2026-02-31`, which `Date` would silently roll into March.
+    return dayKey(instant) === key ? instant : null
+  }
+
+  return {
+    timeZone,
+    dayKey,
+    safeDayKey(input: string | Date): string {
+      const d = typeof input === 'string' ? new Date(input) : input
+      return Number.isFinite(d.getTime()) ? dayKey(d) : ''
+    },
+    today(now: Date = new Date()): string {
+      return dayKey(now)
+    },
+    toNoon,
+    toNoonIso(key: string): string {
+      return toNoon(key)?.toISOString() ?? ''
+    },
+    format(key: string, options: Intl.DateTimeFormatOptions, locale?: string): string {
+      const d = toNoon(key)
+      if (d === null) return ''
+      return d.toLocaleDateString(locale, { ...options, timeZone })
+    },
+  }
+}
+
+/**
+ * The clock every Training Facility surface in this repo uses.
+ *
+ * The default argument on each zone-consuming function, so courtfolio call
+ * sites read exactly as they did before the parameter existed.
+ */
+export const PACIFIC_CLOCK = createDayClock(PACIFIC_TZ)

--- a/lib/training-facility/day-keys.ts
+++ b/lib/training-facility/day-keys.ts
@@ -1,64 +1,54 @@
 /**
  * The one place the Training Facility turns a timestamp into a calendar day
- * (#319).
+ * (#319) — now a Pacific-bound view of the zone-agnostic {@link DayClock}
+ * (#429).
  *
- * **Everything buckets in Pacific.** Before this module there were three
- * parallel conventions: `pacificDayKey` (load-management), a server-local
- * `toDateKey` (weight-room-history), and a browser-local `toLocalDateKey`
- * (strength-today). The server-local one was a live bug — the History page is
- * a Server Component, so on Vercel "local" is UTC, and an evening Pacific
- * session straddles UTC midnight. Split across two UTC days, neither half
- * reaches the daily target, so the heatmap and streaks under-counted goal-hit
- * days while the Pacific-bucketed Load Management panel and Trophy Room on the
- * same page counted them correctly.
+ * **Everything here buckets in Pacific.** Before #319 there were three parallel
+ * conventions: `pacificDayKey` (load-management), a server-local `toDateKey`
+ * (weight-room-history), and a browser-local `toLocalDateKey` (strength-today).
+ * The server-local one was a live bug — the History page is a Server Component,
+ * so on Vercel "local" is UTC, and an evening Pacific session straddles UTC
+ * midnight. Split across two UTC days, neither half reaches the daily target, so
+ * the heatmap and streaks under-counted goal-hit days while the Pacific-bucketed
+ * Load Management panel and Trophy Room on the same page counted them correctly.
  *
- * A single home timezone is the right model here: the log is anchored to where
- * the training happens, not to where the reader happens to be. Logging while
- * travelling still lands on the Pacific day, which is what keeps a streak from
- * breaking because of a flight.
+ * A single home timezone is the right model *for this log*: it's anchored to
+ * where the training happens, not to where the reader happens to be, so logging
+ * while travelling still lands on the Pacific day and a flight can't break a
+ * streak.
  *
- * **Keys are bare `YYYY-MM-DD` strings, and that's load-bearing.** PostgREST
- * renders a Postgres `date` in exactly that canonical zero-padded form, so
- * lexicographic string comparison *is* chronological comparison. Every window
- * test, sort, and boundary check in this directory relies on it — which is why
- * the arithmetic below stays on the calendar numbers rather than round-tripping
- * through a zoned `Date`.
+ * It is the wrong model for anyone else, which is why the mechanism moved to
+ * `clock.ts` and only the *binding* lives here. Every export below is
+ * `PACIFIC_CLOCK` applied — kept so the ~30 call sites across the data layer,
+ * the admin routes, and the components read exactly as they always have.
+ *
+ * **New code inside the domain layer should take a `DayClock` instead.** These
+ * wrappers exist for the surfaces that are legitimately Pacific-only.
  */
 
-/** IANA zone every Training Facility day bucket is anchored to. */
-export const PACIFIC_TZ = 'America/Los_Angeles'
+import { PACIFIC_CLOCK } from './clock'
 
-/** Reused formatter — constructing an `Intl.DateTimeFormat` per call is expensive. */
-const PACIFIC_DATE_FORMAT = new Intl.DateTimeFormat('en-CA', {
-  timeZone: PACIFIC_TZ,
-  year: 'numeric',
-  month: '2-digit',
-  day: '2-digit',
-})
-
-/** Matches a bare `YYYY-MM-DD` key. */
-const DAY_KEY_PATTERN = /^\d{4}-\d{2}-\d{2}$/
+export {
+  PACIFIC_TZ,
+  isDayKey,
+  shiftDayKey,
+  isoWeekdayOfDayKey,
+  mondayOfDayKey,
+  inclusiveDaySpan,
+  firstDayOfMonth,
+  lastDayOfMonth,
+  monthIndexOfDayKey,
+  type DayClock,
+} from './clock'
 
 /**
  * The `YYYY-MM-DD` **Pacific** calendar day a timestamp falls on. A set logged
  * at `2026-07-12T05:00:00Z` (10pm PT on the 11th) buckets to `2026-07-11`.
  *
- * Assembled from `formatToParts` rather than string-parsing the formatter's
- * output, so a locale or ICU quirk can't reorder the fields.
- *
  * @param d Any `Date`; callers usually pass `new Date(set.logged_at)`.
  */
 export function pacificDayKey(d: Date): string {
-  const parts = PACIFIC_DATE_FORMAT.formatToParts(d)
-  let year = ''
-  let month = ''
-  let day = ''
-  for (const part of parts) {
-    if (part.type === 'year') year = part.value
-    else if (part.type === 'month') month = part.value
-    else if (part.type === 'day') day = part.value
-  }
-  return `${year}-${month}-${day}`
+  return PACIFIC_CLOCK.dayKey(d)
 }
 
 /**
@@ -72,97 +62,11 @@ export function pacificDayKey(d: Date): string {
  * @param input ISO 8601 timestamp string, or a `Date` the caller already built.
  */
 export function safePacificDayKey(input: string | Date): string {
-  const d = typeof input === 'string' ? new Date(input) : input
-  return Number.isFinite(d.getTime()) ? pacificDayKey(d) : ''
-}
-
-/** Whether `value` has the exact `YYYY-MM-DD` shape this module works in. */
-export function isDayKey(value: string): boolean {
-  return DAY_KEY_PATTERN.test(value)
-}
-
-/**
- * Shift a `YYYY-MM-DD` key by `delta` days.
- *
- * Arithmetic runs in UTC on the bare calendar numbers — no zone, no DST — so
- * the result is always a clean calendar date. Doing this with millisecond math
- * on a zoned `Date` lands on the wrong day twice a year, when a "day" is 23 or
- * 25 hours long.
- *
- * @param key `YYYY-MM-DD` to shift.
- * @param delta Days to add; negative goes back.
- */
-export function shiftDayKey(key: string, delta: number): string {
-  const [y, m, d] = key.split('-').map(Number)
-  const dt = new Date(Date.UTC(y, m - 1, d + delta))
-  const yy = dt.getUTCFullYear()
-  const mm = String(dt.getUTCMonth() + 1).padStart(2, '0')
-  const dd = String(dt.getUTCDate()).padStart(2, '0')
-  return `${yy}-${mm}-${dd}`
-}
-
-/**
- * ISO weekday for a day key: 1 = Monday … 7 = Sunday.
- *
- * @param key `YYYY-MM-DD`.
- */
-export function isoWeekdayOfDayKey(key: string): number {
-  const [y, m, d] = key.split('-').map(Number)
-  const dow = new Date(Date.UTC(y, m - 1, d)).getUTCDay()
-  return dow === 0 ? 7 : dow
-}
-
-/**
- * The Monday of the ISO week containing `key`. Weeks run Mon–Sun to match the
- * heatmap's row layout and the stats panel's week rollups.
- *
- * @param key `YYYY-MM-DD` anywhere in the week.
- */
-export function mondayOfDayKey(key: string): string {
-  return shiftDayKey(key, -(isoWeekdayOfDayKey(key) - 1))
-}
-
-/**
- * Inclusive count of calendar days from `startKey` through `endKey`. `1` when
- * they're the same day; `0` when `endKey` precedes `startKey`.
- *
- * @param startKey `YYYY-MM-DD` first day.
- * @param endKey `YYYY-MM-DD` last day.
- */
-export function inclusiveDaySpan(startKey: string, endKey: string): number {
-  if (endKey < startKey) return 0
-  const toUtcMs = (key: string): number => {
-    const [y, m, d] = key.split('-').map(Number)
-    return Date.UTC(y, m - 1, d)
-  }
-  return Math.round((toUtcMs(endKey) - toUtcMs(startKey)) / 86_400_000) + 1
-}
-
-/** First day of the calendar month containing `key`. */
-export function firstDayOfMonth(key: string): string {
-  return `${key.slice(0, 7)}-01`
-}
-
-/** Last day of the calendar month containing `key`. */
-export function lastDayOfMonth(key: string): string {
-  const [y, m] = key.split('-').map(Number)
-  // Day 0 of the following month is the last day of this one.
-  const dt = new Date(Date.UTC(y, m, 0))
-  return `${dt.getUTCFullYear()}-${String(dt.getUTCMonth() + 1).padStart(2, '0')}-${String(dt.getUTCDate()).padStart(2, '0')}`
-}
-
-/** Zero-based month index (0 = January) for a day key. */
-export function monthIndexOfDayKey(key: string): number {
-  return Number(key.slice(5, 7)) - 1
+  return PACIFIC_CLOCK.safeDayKey(input)
 }
 
 /**
  * A `Date` positioned at **noon Pacific** on `key`.
- *
- * Noon, not midnight, is the point: midnight in one zone is the previous or
- * next day in another, so a midnight-anchored `Date` renders as the wrong day
- * for any viewer east or west of the anchor. Noon has ~12 hours of slack in
- * both directions, which no real offset crosses.
  *
  * Used where an API wants a `Date` rather than a key — chart axis labels,
  * `toLocaleDateString`, and the `logged_at` stamp for a backdated set.
@@ -171,15 +75,7 @@ export function monthIndexOfDayKey(key: string): number {
  * @returns The `Date`, or `null` when `key` isn't a valid calendar day.
  */
 export function dayKeyToPacificNoon(key: string): Date | null {
-  if (!isDayKey(key)) return null
-  // Pacific is UTC-8 (PST) or UTC-7 (PDT); 19:00Z is noon in the first and
-  // 12:00 PDT in the second. Either way it's the middle of the target day, so
-  // one fixed offset works year-round without a DST lookup.
-  const d = new Date(`${key}T19:00:00Z`)
-  if (!Number.isFinite(d.getTime())) return null
-  // Guard against calendar-invalid input the shape check can't catch, e.g.
-  // `2026-02-31`, which `Date` would silently roll into March.
-  return pacificDayKey(d) === key ? d : null
+  return PACIFIC_CLOCK.toNoon(key)
 }
 
 /**
@@ -190,26 +86,16 @@ export function dayKeyToPacificNoon(key: string): Date | null {
  * @returns The ISO string, or `''` when `key` isn't a valid calendar day.
  */
 export function dayKeyToPacificNoonIso(key: string): string {
-  return dayKeyToPacificNoon(key)?.toISOString() ?? ''
+  return PACIFIC_CLOCK.toNoonIso(key)
 }
 
 /** Today's Pacific day key. @param now Clock override; defaults to `new Date()`. */
 export function todayDayKey(now: Date = new Date()): string {
-  return pacificDayKey(now)
+  return PACIFIC_CLOCK.today(now)
 }
 
 /**
  * Human-format a day key, rendering the **Pacific** calendar day.
- *
- * Use this rather than `dayKeyToPacificNoon(key).toLocaleDateString(...)`.
- * That instant is 19:00Z, which is *already the next local day* for any viewer
- * at UTC+5 or further east — so in Tokyo a `2026-07-11` key would render as
- * "Jul 12", contradicting the key it came from. Pinning `timeZone` makes the
- * label agree with the key everywhere.
- *
- * The locale is left to the viewer (`undefined`) unless a caller pins one;
- * only the *zone* has to be fixed, because only the zone can change which day
- * is named.
  *
  * @param key `YYYY-MM-DD`.
  * @param options `Intl.DateTimeFormat` options — e.g.
@@ -223,7 +109,5 @@ export function formatDayKey(
   options: Intl.DateTimeFormatOptions,
   locale?: string
 ): string {
-  const d = dayKeyToPacificNoon(key)
-  if (d === null) return ''
-  return d.toLocaleDateString(locale, { ...options, timeZone: PACIFIC_TZ })
+  return PACIFIC_CLOCK.format(key, options, locale)
 }

--- a/lib/training-facility/exercise-progression.ts
+++ b/lib/training-facility/exercise-progression.ts
@@ -19,21 +19,23 @@ import {
  * runs across sessions, and — in this log — mostly *outside* them. Every set on
  * record today is loose grease-the-groove logging with no `workout_id`, so a
  * per-session trend would plot nothing at all. The unit here is therefore the
- * **Pacific training day**: it holds loose sets and session sets alike, and a
- * session recorded through #376 lands in its own day without special-casing.
+ * **training day**: it holds loose sets and session sets alike, and a session
+ * recorded through #376 lands in its own day without special-casing. Which
+ * calendar day that is comes from the caller's {@link DayClock} — Pacific for
+ * this site, the client's own zone for a consumer serving other people (#429).
  *
- * Pure and isomorphic, like its sibling — no Supabase client, no React, no
- * clock. The arithmetic that misleads when it's wrong (what counts as the top
- * set, which estimates are worth plotting) is unit-testable rather than only
- * observable by squinting at a chart.
+ * Pure and isomorphic, like its sibling — no Supabase client, no React, and no
+ * wall clock beyond the zone it's handed. The arithmetic that misleads when
+ * it's wrong (what counts as the top set, which estimates are worth plotting)
+ * is unit-testable rather than only observable by squinting at a chart.
  */
 
 /** One training day's worth of a single movement. */
 export interface ExerciseDayPoint {
-  /** Pacific day key, `YYYY-MM-DD`. */
+  /** Calendar day key in the caller's clock zone, `YYYY-MM-DD`. */
   dayKey: string
   /**
-   * Pacific noon of {@link dayKey}, as the chart's x value. Noon rather than
+   * Noon on {@link dayKey} in the clock's zone, as the chart's x value. Noon rather than
    * midnight so a DST boundary can't shunt a point onto the adjacent day.
    */
   date: Date
@@ -306,7 +308,7 @@ export interface SetDetailCoverage {
    * would put a number behind a sentence that doesn't describe it.
    */
   sessionsBefore: number
-  /** Pacific day key of the earliest such session, or `null` when there are none. */
+  /** Day key of the earliest such session, or `null` when there are none. */
   earliestSessionDayKey: string | null
 }
 
@@ -314,7 +316,7 @@ export interface SetDetailCoverage {
  * Count the **imported** sessions that predate a movement's first logged set and
  * have no sets of their own.
  *
- * @param firstDayKey The movement's first training day, Pacific. `null` yields
+ * @param firstDayKey The movement's first training day, in `clock's` zone. `null` yields
  *   an empty coverage report rather than counting the whole history as "before".
  * @param workouts Every recorded session. Only `apple_health` ones are counted —
  *   see {@link SetDetailCoverage.sessionsBefore}.

--- a/lib/training-facility/exercise-progression.ts
+++ b/lib/training-facility/exercise-progression.ts
@@ -1,6 +1,6 @@
 import type { StrengthSet, WeightRoomExercise, WeightRoomWorkout } from '@/types/weight-room'
 
-import { dayKeyToPacificNoon, safePacificDayKey } from './day-keys'
+import { PACIFIC_CLOCK, type DayClock } from './clock'
 import { workoutDayKey } from './workout-sessions'
 import {
   E1RM_MAX_RELIABLE_REPS,
@@ -155,7 +155,8 @@ function reliableOneRepMax(load: number, reps: number): number | null {
  *   half.
  * @param workouts Recorded sessions, so a session's sets stay on the session's
  *   own day. Omitting it dates every set by its own timestamp, which splits a
- *   session that ran past Pacific midnight across two points.
+ *   session that ran past midnight across two points.
+ * @param clock Zone every day bucket is measured in; defaults to Pacific (#429).
  * @returns The progression, or `null` when the movement has no plottable sets —
  *   a real state (a catalog row added before its first session), and one the
  *   caller renders as an empty view rather than as a broken chart.
@@ -164,7 +165,8 @@ export function buildExerciseProgression(
   exercise: string,
   sets: readonly StrengthSet[],
   exercises: readonly WeightRoomExercise[] = [],
-  workouts: readonly WeightRoomWorkout[] = []
+  workouts: readonly WeightRoomWorkout[] = [],
+  clock: DayClock = PACIFIC_CLOCK
 ): ExerciseProgression | null {
   const multipliers = loadMultipliersBySlug(exercises)
 
@@ -174,19 +176,19 @@ export function buildExerciseProgression(
   // in each.
   const sessionDay = new Map<string, string>()
   for (const workout of workouts) {
-    const dayKey = workoutDayKey(workout)
+    const dayKey = workoutDayKey(workout, clock)
     if (dayKey !== null) sessionDay.set(workout.id, dayKey)
   }
 
-  // Bucket by Pacific day key rather than by raw timestamp: this renders on a
-  // UTC server, where a 10pm-Pacific set belongs to the following calendar day
-  // and would split one evening's work across two points.
+  // Bucket by day key rather than by raw timestamp: this renders on a UTC
+  // server, where a 10pm set belongs to the following calendar day and would
+  // split one evening's work across two points.
   const byDay = new Map<string, StrengthSet[]>()
   for (const set of sets) {
     if (set.exercise !== exercise) continue
     const dayKey =
       (set.workout_id === undefined ? undefined : sessionDay.get(set.workout_id)) ??
-      safePacificDayKey(set.logged_at)
+      clock.safeDayKey(set.logged_at)
     // An unparseable timestamp has no day to belong to. Dropped rather than
     // bucketed under the epoch, which would drag the x-axis back to 1970.
     if (dayKey === '') continue
@@ -209,7 +211,7 @@ export function buildExerciseProgression(
   // `YYYY-MM-DD` sorts chronologically as a string, which is the whole point of
   // the day-key format — no Date round-trip needed to order the x-axis.
   for (const dayKey of [...byDay.keys()].sort()) {
-    const date = dayKeyToPacificNoon(dayKey)
+    const date = clock.toNoon(dayKey)
     if (date === null) continue
     const daySets = byDay.get(dayKey) ?? []
 
@@ -319,11 +321,13 @@ export interface SetDetailCoverage {
  * @param sets Every logged set — used only to tell which sessions carry detail.
  *   A session with sets isn't part of the gap even if it predates this movement;
  *   it recorded what happened, just not this movement.
+ * @param clock Zone each session's day is measured in; defaults to Pacific (#429).
  */
 export function buildSetDetailCoverage(
   firstDayKey: string | null,
   workouts: readonly WeightRoomWorkout[],
-  sets: readonly StrengthSet[]
+  sets: readonly StrengthSet[],
+  clock: DayClock = PACIFIC_CLOCK
 ): SetDetailCoverage {
   if (firstDayKey === null) return { sessionsBefore: 0, earliestSessionDayKey: null }
 
@@ -337,7 +341,7 @@ export function buildSetDetailCoverage(
   for (const workout of workouts) {
     if (workout.source !== 'apple_health') continue
     if (workoutsWithSets.has(workout.id)) continue
-    const dayKey = safePacificDayKey(workout.started_at)
+    const dayKey = clock.safeDayKey(workout.started_at)
     // Day keys compare as strings — `2018-01-08` < `2026-05-25` lexicographically
     // and chronologically alike.
     if (dayKey === '' || dayKey >= firstDayKey) continue
@@ -355,13 +359,17 @@ export function buildSetDetailCoverage(
  * nothing to trend, so it never gets a link that lands on an empty page.
  *
  * @param sets Every logged set.
+ * @param clock Zone each day is measured in; defaults to Pacific (#429).
  * @returns Slugs, newest training day first, then alphabetically among movements
  *   last trained the same day.
  */
-export function trendableExercises(sets: readonly StrengthSet[]): string[] {
+export function trendableExercises(
+  sets: readonly StrengthSet[],
+  clock: DayClock = PACIFIC_CLOCK
+): string[] {
   const lastDay = new Map<string, string>()
   for (const set of sets) {
-    const dayKey = safePacificDayKey(set.logged_at)
+    const dayKey = clock.safeDayKey(set.logged_at)
     if (dayKey === '') continue
     const seen = lastDay.get(set.exercise)
     if (seen === undefined || dayKey > seen) lastDay.set(set.exercise, dayKey)

--- a/lib/training-facility/load-management.ts
+++ b/lib/training-facility/load-management.ts
@@ -12,7 +12,7 @@ import type {
   WeightRoomExercise,
 } from '@/types/weight-room'
 
-import { pacificDayKey, shiftDayKey } from './day-keys'
+import { PACIFIC_CLOCK, shiftDayKey, type DayClock } from './clock'
 
 /**
  * Ramp-rate aggregation for the Weight Room Load Management panel (#316).
@@ -256,14 +256,17 @@ export interface MovementLoadView {
  *   as load- or rep-driven from its `equipment` rather than guessing from the
  *   share of weighted sets. Omitted or missing a movement falls back to the
  *   pre-#384 threshold — see {@link isLoadDriven}.
+ * @param clock zone every window boundary is measured in; defaults to Pacific
+ *   (#429).
  */
 export function buildMovementLoads(
   sets: readonly StrengthSet[],
   goals: readonly ExerciseGoal[] = [],
   now: Date = new Date(),
-  exercises: readonly WeightRoomExercise[] = []
+  exercises: readonly WeightRoomExercise[] = [],
+  clock: DayClock = PACIFIC_CLOCK
 ): MovementLoad[] {
-  const todayKey = pacificDayKey(now)
+  const todayKey = clock.dayKey(now)
   const colorByExercise = new Map(goals.map(g => [g.exercise, g.color]))
   const equipmentByExercise = new Map(exercises.map(e => [e.slug, e.equipment]))
   const labelByExercise = new Map(exercises.map(e => [e.slug, e.display_name]))
@@ -305,7 +308,7 @@ export function buildMovementLoads(
     for (const s of exSets) {
       const d = new Date(s.logged_at)
       if (!Number.isFinite(d.getTime())) continue
-      const key = pacificDayKey(d)
+      const key = clock.dayKey(d)
       if (earliestKey === null || key < earliestKey) earliestKey = key
       const offset = offsetByKey.get(key)
       if (offset === undefined) continue // outside the trailing chronic window
@@ -399,9 +402,10 @@ export function buildMovementLoadView(
   sets: readonly StrengthSet[],
   goals: readonly ExerciseGoal[] = [],
   now: Date = new Date(),
-  exercises: readonly WeightRoomExercise[] = []
+  exercises: readonly WeightRoomExercise[] = [],
+  clock: DayClock = PACIFIC_CLOCK
 ): MovementLoadView {
-  const all = buildMovementLoads(sets, goals, now, exercises)
+  const all = buildMovementLoads(sets, goals, now, exercises, clock)
   const loads: MovementLoad[] = []
   const infrequent: InfrequentMovement[] = []
 

--- a/lib/training-facility/load-management.ts
+++ b/lib/training-facility/load-management.ts
@@ -396,7 +396,10 @@ export function buildMovementLoads(
  * therefore still reports every actively-trained movement, and a future caller
  * that wants the unfiltered set (an export, a per-movement page) has it.
  *
- * @see buildMovementLoads for the parameters.
+ * @see buildMovementLoads for `sets`, `goals`, `now`, and `exercises`.
+ * @param clock Zone every window boundary is measured in; defaults to Pacific
+ *   (#429). Forwarded to {@link buildMovementLoads}, so the day a set counts
+ *   toward — and therefore the acute/chronic split — follows it.
  */
 export function buildMovementLoadView(
   sets: readonly StrengthSet[],

--- a/lib/training-facility/monthly-focus.ts
+++ b/lib/training-facility/monthly-focus.ts
@@ -337,8 +337,14 @@ export interface FocusDayCell {
  *   `category` internally.
  * @param sets All logged sets, usually `WeightRoomData.sets`.
  * @param category Body-region lane to build — `'upper'` or `'lower'`.
- * @param today Local `YYYY-MM-DD` key for the viewed day. An empty string
- *   or a key before the earliest focus window returns an empty array.
+ * @param today `YYYY-MM-DD` key for the viewed day. An empty string or a key
+ *   before the earliest focus window returns an empty array. **Must have been
+ *   produced by `clock`** — it bounds the cell range while the sets inside are
+ *   bucketed with `clock`, so a key from a different zone silently shifts the
+ *   last cell relative to the volume that fills it. Callers holding a clock
+ *   should pass `clock.today()`.
+ * @param clock Zone each day's volume is bucketed in; defaults to Pacific
+ *   (#429). See the constraint on `today`.
  */
 export function buildFocusLaneCells(
   focuses: readonly MonthlyFocus[],

--- a/lib/training-facility/monthly-focus.ts
+++ b/lib/training-facility/monthly-focus.ts
@@ -1,5 +1,5 @@
 import type { FocusCategory, MonthlyFocus, StrengthSet } from '@/types/weight-room'
-import { inclusiveDaySpan, pacificDayKey, safePacificDayKey, shiftDayKey } from './day-keys'
+import { PACIFIC_CLOCK, inclusiveDaySpan, shiftDayKey, type DayClock } from './clock'
 
 export type { FocusCategory }
 
@@ -143,10 +143,11 @@ export interface FocusAdherence {
 export function computeFocusAdherence(
   focus: MonthlyFocus,
   sets: readonly StrengthSet[],
-  now: Date = new Date()
+  now: Date = new Date(),
+  clock: DayClock = PACIFIC_CLOCK
 ): FocusAdherence {
   const daysInWindow = inclusiveDaySpan(focus.start_date, focus.end_date)
-  const today = pacificDayKey(now)
+  const today = clock.dayKey(now)
 
   // Last elapsed day = min(today, end_date); nothing elapsed if today is
   // before the window opens.
@@ -163,7 +164,7 @@ export function computeFocusAdherence(
   const volumeByDay = new Map<string, number>()
   for (const s of sets) {
     if (s.exercise !== focus.exercise) continue
-    const day = safePacificDayKey(s.logged_at)
+    const day = clock.safeDayKey(s.logged_at)
     if (day === '' || day < focus.start_date || day > lastElapsed) continue
     const increment = focus.target_kind === 'sets' ? 1 : s.reps
     volumeByDay.set(day, (volumeByDay.get(day) ?? 0) + increment)
@@ -255,7 +256,8 @@ export interface FocusLoadStats {
 export function computeFocusLoadStats(
   focus: MonthlyFocus,
   sets: readonly StrengthSet[],
-  loadMultiplier = 1
+  loadMultiplier = 1,
+  clock: DayClock = PACIFIC_CLOCK
 ): FocusLoadStats {
   const implements_ = Math.max(1, loadMultiplier)
   let topSetLbs: number | null = null
@@ -265,7 +267,7 @@ export function computeFocusLoadStats(
 
   for (const s of sets) {
     if (s.exercise !== focus.exercise) continue
-    const day = safePacificDayKey(s.logged_at)
+    const day = clock.safeDayKey(s.logged_at)
     if (day === '' || day < focus.start_date || day > focus.end_date) continue
     if (s.weight_lbs == null) continue
     weightedSets++
@@ -342,7 +344,8 @@ export function buildFocusLaneCells(
   focuses: readonly MonthlyFocus[],
   sets: readonly StrengthSet[],
   category: FocusCategory,
-  today: string
+  today: string,
+  clock: DayClock = PACIFIC_CLOCK
 ): FocusDayCell[] {
   const laneFocuses = focuses.filter(f => f.category === category)
   if (laneFocuses.length === 0 || today === '') return []
@@ -358,7 +361,7 @@ export function buildFocusLaneCells(
   const repsByKey = new Map<string, number>()
   const setCountByKey = new Map<string, number>()
   for (const s of sets) {
-    const day = safePacificDayKey(s.logged_at)
+    const day = clock.safeDayKey(s.logged_at)
     if (day === '') continue
     const k = `${s.exercise}|${day}`
     repsByKey.set(k, (repsByKey.get(k) ?? 0) + s.reps)
@@ -495,20 +498,21 @@ export function summarizeFocusCampaigns(
   focuses: readonly MonthlyFocus[],
   exercise: string,
   sets: readonly StrengthSet[],
-  now: Date = new Date()
+  now: Date = new Date(),
+  clock: DayClock = PACIFIC_CLOCK
 ): FocusCampaignSummary | null {
   const windows = focuses
     .filter(focus => focus.exercise === exercise)
     .sort((a, b) => (a.start_date < b.start_date ? -1 : a.start_date > b.start_date ? 1 : 0))
   if (windows.length === 0) return null
 
-  const today = pacificDayKey(now)
+  const today = clock.dayKey(now)
   let daysHit = 0
   let daysElapsed = 0
   let isActive = false
 
   for (const focus of windows) {
-    const adherence = computeFocusAdherence(focus, sets, now)
+    const adherence = computeFocusAdherence(focus, sets, now, clock)
     daysHit += adherence.daysHit
     daysElapsed += adherence.daysElapsed
     if (isFocusActiveOnDay(focus, today)) isActive = true
@@ -521,7 +525,7 @@ export function summarizeFocusCampaigns(
   let campaignReps = 0
   for (const s of sets) {
     if (s.exercise !== exercise) continue
-    const day = safePacificDayKey(s.logged_at)
+    const day = clock.safeDayKey(s.logged_at)
     if (day === '') continue
     if (windows.some(focus => isFocusActiveOnDay(focus, day))) campaignReps += s.reps
   }

--- a/lib/training-facility/strength-streaks.ts
+++ b/lib/training-facility/strength-streaks.ts
@@ -1,6 +1,6 @@
 import type { ExerciseGoal, StrengthSet } from '@/types/weight-room'
 
-import { pacificDayKey, safePacificDayKey } from './day-keys'
+import { PACIFIC_CLOCK, type DayClock } from './clock'
 import { targetResolverFor } from './goal-targets'
 import { type StreakCounts, streakFromDailyReps } from './hit-day-streaks'
 
@@ -44,11 +44,13 @@ export type StrengthStreakResult = StreakCounts
  *   to `new Date()`. Pass an explicit value from the viewer's clock
  *   when calling from a server-rendered surface so server-side UTC
  *   doesn't disagree with the visitor's local timezone (#197).
+ * @param clock Zone the day buckets are measured in; defaults to Pacific (#429).
  */
 export function computeStrengthStreaks(
   sets: readonly StrengthSet[],
   goals: readonly ExerciseGoal[],
-  now: Date = new Date()
+  now: Date = new Date(),
+  clock: DayClock = PACIFIC_CLOCK
 ): Record<string, StrengthStreakResult> {
   const result: Record<string, StrengthStreakResult> = {}
 
@@ -57,7 +59,7 @@ export function computeStrengthStreaks(
   // sorts keys explicitly so the input order doesn't matter.
   const repsByExerciseAndDay = new Map<string, Map<string, number>>()
   for (const s of sets) {
-    const day = safePacificDayKey(s.logged_at)
+    const day = clock.safeDayKey(s.logged_at)
     if (day === '') continue
     let dayMap = repsByExerciseAndDay.get(s.exercise)
     if (!dayMap) {
@@ -67,7 +69,7 @@ export function computeStrengthStreaks(
     dayMap.set(day, (dayMap.get(day) ?? 0) + s.reps)
   }
 
-  const todayKey = pacificDayKey(now)
+  const todayKey = clock.dayKey(now)
 
   for (const goal of goals) {
     if (goal.daily_target <= 0) {

--- a/lib/training-facility/strength-today.ts
+++ b/lib/training-facility/strength-today.ts
@@ -1,6 +1,6 @@
 import type { ExerciseGoal, StrengthSet } from '@/types/weight-room'
 
-import { dayKeyToPacificNoonIso, formatDayKey, safePacificDayKey } from './day-keys'
+import { PACIFIC_CLOCK, type DayClock } from './clock'
 import { targetForDay } from './goal-targets'
 
 /**
@@ -24,18 +24,19 @@ import { targetForDay } from './goal-targets'
  * Strips off the time-of-day so two sets logged at 06:00 and 23:00 of
  * the same day collapse to the same key.
  *
- * Thin alias over {@link safePacificDayKey}, kept because this is the name
- * the Today View surfaces import. New code should reach for `day-keys.ts`
+ * Thin alias over {@link DayClock.safeDayKey}, kept because this is the name
+ * the Today View surfaces import. New code should reach for `clock.ts`
  * directly.
  *
  * @param input ISO 8601 timestamp string from
  *   {@link StrengthSet.logged_at}, or a Date already constructed by
  *   the caller.
- * @returns `YYYY-MM-DD` Pacific, or `''` when `input` is unparseable (so
- *   callers can use `key === ''` as a skip condition without throwing).
+ * @param clock Zone the day is measured in; defaults to Pacific (#429).
+ * @returns `YYYY-MM-DD`, or `''` when `input` is unparseable (so callers can
+ *   use `key === ''` as a skip condition without throwing).
  */
-export function toLocalDateKey(input: string | Date): string {
-  return safePacificDayKey(input)
+export function toLocalDateKey(input: string | Date, clock: DayClock = PACIFIC_CLOCK): string {
+  return clock.safeDayKey(input)
 }
 
 /**
@@ -47,10 +48,16 @@ export function toLocalDateKey(input: string | Date): string {
  * @param dayKey `YYYY-MM-DD` key as produced by {@link toLocalDateKey}.
  *   Pass an empty string to get an empty array back (defensive — keeps
  *   callers from having to special-case unparseable "now" inputs).
+ * @param clock Zone the day is measured in; defaults to Pacific (#429). Must
+ *   match the clock `dayKey` was produced with, or nothing matches.
  */
-export function filterSetsForDay(sets: readonly StrengthSet[], dayKey: string): StrengthSet[] {
+export function filterSetsForDay(
+  sets: readonly StrengthSet[],
+  dayKey: string,
+  clock: DayClock = PACIFIC_CLOCK
+): StrengthSet[] {
   if (dayKey === '') return []
-  return sets.filter(s => toLocalDateKey(s.logged_at) === dayKey)
+  return sets.filter(s => toLocalDateKey(s.logged_at, clock) === dayKey)
 }
 
 /**
@@ -192,12 +199,13 @@ export function computeRingPercent(totalReps: number, goal: ExerciseGoal, dayKey
  *
  * @param dayKey `YYYY-MM-DD` key as produced by {@link toLocalDateKey}
  *   or an `<input type="date">` value.
- * @returns ISO 8601 UTC timestamp of the day's Pacific noon, or `''` when
- *   `dayKey` isn't a valid day key (so callers can fall back to the
- *   server-side `now()` default instead of throwing).
+ * @param clock Zone noon is measured in; defaults to Pacific (#429).
+ * @returns ISO 8601 UTC timestamp of the day's noon, or `''` when `dayKey`
+ *   isn't a valid day key (so callers can fall back to the server-side `now()`
+ *   default instead of throwing).
  */
-export function localNoonIsoForDay(dayKey: string): string {
-  return dayKeyToPacificNoonIso(dayKey)
+export function localNoonIsoForDay(dayKey: string, clock: DayClock = PACIFIC_CLOCK): string {
+  return clock.toNoonIso(dayKey)
 }
 
 /**
@@ -208,9 +216,10 @@ export function localNoonIsoForDay(dayKey: string): string {
  * backfills more than a few days old are rare.
  *
  * @param dayKey `YYYY-MM-DD` key as produced by {@link toLocalDateKey}.
+ * @param clock Zone the label names the day in; defaults to Pacific (#429).
  * @returns Locale-formatted weekday + date, or `''` when `dayKey` is
  *   unparseable.
  */
-export function formatDayLabel(dayKey: string): string {
-  return formatDayKey(dayKey, { weekday: 'short', month: 'short', day: 'numeric' })
+export function formatDayLabel(dayKey: string, clock: DayClock = PACIFIC_CLOCK): string {
+  return clock.format(dayKey, { weekday: 'short', month: 'short', day: 'numeric' })
 }

--- a/lib/training-facility/weight-room-history.ts
+++ b/lib/training-facility/weight-room-history.ts
@@ -1,16 +1,15 @@
 import type { ExerciseGoal, MonthlyFocus, StrengthSet } from '@/types/weight-room'
 
 import {
-  dayKeyToPacificNoon,
+  PACIFIC_CLOCK,
   firstDayOfMonth,
   inclusiveDaySpan,
   lastDayOfMonth,
   mondayOfDayKey,
   monthIndexOfDayKey,
-  pacificDayKey,
-  safePacificDayKey,
   shiftDayKey,
-} from './day-keys'
+  type DayClock,
+} from './clock'
 import {
   type GoalTargetChange,
   goalTargetChanges,
@@ -240,7 +239,8 @@ export function buildStrengthHeatmap(
   sets: readonly StrengthSet[],
   goal: ExerciseGoal,
   dateFrom?: Date | null,
-  dateTo?: Date | null
+  dateTo?: Date | null,
+  clock: DayClock = PACIFIC_CLOCK
 ): StrengthHeatmapGrid {
   // Column boundaries walk day keys, not milliseconds (#319): a DST week is
   // 23 or 25 hours long, so `+ 7 * DAY_MS` drifts off the Monday twice a year.
@@ -249,10 +249,10 @@ export function buildStrengthHeatmap(
   // from user-derived state: `pacificDayKey` throws `RangeError` on an Invalid
   // Date, which would take the whole page down rather than degrading. An
   // unusable bound falls back to the same default as omitting it.
-  const endKey = safePacificDayKey(dateTo ?? new Date())
-  const endMondayKey = mondayOfDayKey(endKey === '' ? pacificDayKey(new Date()) : endKey)
+  const endKey = clock.safeDayKey(dateTo ?? new Date())
+  const endMondayKey = mondayOfDayKey(endKey === '' ? clock.dayKey(new Date()) : endKey)
 
-  const startKey = dateFrom ? safePacificDayKey(dateFrom) : ''
+  const startKey = dateFrom ? clock.safeDayKey(dateFrom) : ''
   let startMondayKey: string
   if (startKey !== '') {
     startMondayKey = mondayOfDayKey(startKey)
@@ -269,7 +269,7 @@ export function buildStrengthHeatmap(
   const lookup = new Map<string, { reps: number; setCount: number }>()
   for (const s of sets) {
     if (s.exercise !== goal.exercise) continue
-    const key = safePacificDayKey(s.logged_at)
+    const key = clock.safeDayKey(s.logged_at)
     if (key === '') continue
     const entry = lookup.get(key) ?? { reps: 0, setCount: 0 }
     entry.reps += s.reps
@@ -297,7 +297,7 @@ export function buildStrengthHeatmap(
       const dailyTarget = targetFor(key)
       // Pacific noon, so a renderer calling `toLocaleDateString` shows the
       // day the cell actually represents rather than the one before it.
-      const date = dayKeyToPacificNoon(key) ?? new Date(NaN)
+      const date = clock.toNoon(key) ?? new Date(NaN)
       grid[row].push({
         date,
         dayKey: key,
@@ -345,16 +345,17 @@ export function buildStrengthHeatmap(
 export function computeStrengthStreaks(
   sets: readonly StrengthSet[],
   goal: ExerciseGoal,
-  now: Date = new Date()
+  now: Date = new Date(),
+  clock: DayClock = PACIFIC_CLOCK
 ): StreakCounts {
   const dailyReps = new Map<string, number>()
   for (const s of sets) {
     if (s.exercise !== goal.exercise) continue
-    const key = safePacificDayKey(s.logged_at)
+    const key = clock.safeDayKey(s.logged_at)
     if (key === '') continue
     dailyReps.set(key, (dailyReps.get(key) ?? 0) + s.reps)
   }
-  return streakFromDailyReps(dailyReps, targetResolverFor(goal), pacificDayKey(now))
+  return streakFromDailyReps(dailyReps, targetResolverFor(goal), clock.dayKey(now))
 }
 
 /**
@@ -391,13 +392,14 @@ export function computeStrengthStats(
   sets: readonly StrengthSet[],
   goals: readonly ExerciseGoal[],
   now: Date = new Date(),
-  focuses: readonly MonthlyFocus[] = []
+  focuses: readonly MonthlyFocus[] = [],
+  clock: DayClock = PACIFIC_CLOCK
 ): StrengthExerciseStats[] {
   // Every boundary is a Pacific day key (#319), so the week and month a set
   // falls into matches the day its heatmap cell lands on. Derived by calendar
   // arithmetic rather than `Date` offsets — a DST week is 23 or 25 hours, and
   // millisecond math drifts off the Monday twice a year.
-  const todayKey = pacificDayKey(now)
+  const todayKey = clock.dayKey(now)
   const thisWeekStart = mondayOfDayKey(todayKey)
   const thisWeekEnd = shiftDayKey(thisWeekStart, 6)
   const lastWeekStart = shiftDayKey(thisWeekStart, -7)
@@ -416,7 +418,7 @@ export function computeStrengthStats(
     const windowHistory = focusTargetHistory(focuses, goal.exercise)
     const scoringGoal: ExerciseGoal =
       windowHistory.length > 0 ? { ...goal, target_history: windowHistory } : goal
-    const focusSummary = summarizeFocusCampaigns(focuses, goal.exercise, sets, now)
+    const focusSummary = summarizeFocusCampaigns(focuses, goal.exercise, sets, now, clock)
 
     const dailyReps = new Map<string, number>()
     let allTimeReps = 0
@@ -428,7 +430,7 @@ export function computeStrengthStats(
 
     for (const s of sets) {
       if (s.exercise !== goal.exercise) continue
-      const key = safePacificDayKey(s.logged_at)
+      const key = clock.safeDayKey(s.logged_at)
       if (key === '') continue
 
       // All-time + active-day rollups.
@@ -502,17 +504,18 @@ export function buildWeeklyVolume(
   sets: readonly StrengthSet[],
   goal: ExerciseGoal,
   weeks = 12,
-  now: Date = new Date()
+  now: Date = new Date(),
+  clock: DayClock = PACIFIC_CLOCK
 ): WeeklyVolumePoint[] {
   const span = Math.max(1, Math.floor(weeks))
-  const currentMondayKey = mondayOfDayKey(pacificDayKey(now))
+  const currentMondayKey = mondayOfDayKey(clock.dayKey(now))
   const startMondayKey = shiftDayKey(currentMondayKey, -(span - 1) * DAYS_PER_WEEK)
 
   // weekKey (Monday YYYY-MM-DD, Pacific) → reps + set tallies for this exercise.
   const lookup = new Map<string, { reps: number; setCount: number }>()
   for (const s of sets) {
     if (s.exercise !== goal.exercise) continue
-    const dayKey = safePacificDayKey(s.logged_at)
+    const dayKey = clock.safeDayKey(s.logged_at)
     if (dayKey === '') continue
     const key = mondayOfDayKey(dayKey)
     const entry = lookup.get(key) ?? { reps: 0, setCount: 0 }
@@ -527,7 +530,7 @@ export function buildWeeklyVolume(
     // the snap-back through `getMondayOf` this replaces existed only to undo
     // that millisecond drift.
     const weekKey = shiftDayKey(startMondayKey, i * DAYS_PER_WEEK)
-    const weekStart = dayKeyToPacificNoon(weekKey) ?? new Date(NaN)
+    const weekStart = clock.toNoon(weekKey) ?? new Date(NaN)
     const entry = lookup.get(weekKey)
     points.push({
       weekStart,

--- a/lib/training-facility/workout-sessions.ts
+++ b/lib/training-facility/workout-sessions.ts
@@ -1,6 +1,6 @@
 import type { WeightRoomWorkout } from '@/types/weight-room'
 
-import { pacificDayKey } from './day-keys'
+import { PACIFIC_CLOCK, type DayClock } from './clock'
 
 /**
  * Pure helpers for bounded workout sessions (#374).
@@ -33,17 +33,21 @@ const STALE_WORKOUT_MS = STALE_WORKOUT_HOURS * 60 * 60 * 1000
  * splitting one workout across two days would be wrong in every rollup that
  * consumes it.
  *
- * Pacific rather than the server's zone for the reason #319 unified on — Vercel
+ * A fixed zone rather than the server's for the reason #319 unified on — Vercel
  * runs the server in UTC, so local-time bucketing would silently shift every
  * boundary between SSR and the browser.
  *
  * @param workout The session to place.
+ * @param clock Zone the day is measured in; defaults to Pacific (#429).
  * @returns The day key, or `null` when `started_at` isn't a parseable timestamp.
  */
-export function workoutDayKey(workout: Pick<WeightRoomWorkout, 'started_at'>): string | null {
+export function workoutDayKey(
+  workout: Pick<WeightRoomWorkout, 'started_at'>,
+  clock: DayClock = PACIFIC_CLOCK
+): string | null {
   const started = new Date(workout.started_at)
   if (!Number.isFinite(started.getTime())) return null
-  return pacificDayKey(started)
+  return clock.dayKey(started)
 }
 
 /**

--- a/lib/training-facility/workout-stats.ts
+++ b/lib/training-facility/workout-stats.ts
@@ -6,7 +6,7 @@ import type {
 } from '@/types/weight-room'
 
 import { buildSlotProgress, extraSets, type SlotProgress } from './live-workout'
-import { safePacificDayKey } from './day-keys'
+import { PACIFIC_CLOCK, type DayClock } from './clock'
 import { compareInstants, isStaleOpenWorkout, workoutDurationMinutes } from './workout-sessions'
 
 /**
@@ -759,11 +759,15 @@ export interface WorkoutYearOption {
  * 2020 chips would bury that under uniformity.
  *
  * @param entries History entries, in any order.
+ * @param clock Zone the year boundary is measured in; defaults to Pacific (#429).
  */
-export function workoutYearOptions(entries: readonly WorkoutHistoryEntry[]): WorkoutYearOption[] {
+export function workoutYearOptions(
+  entries: readonly WorkoutHistoryEntry[],
+  clock: DayClock = PACIFIC_CLOCK
+): WorkoutYearOption[] {
   const counts = new Map<number, number>()
   for (const entry of entries) {
-    const dayKey = safePacificDayKey(entry.workout.started_at)
+    const dayKey = clock.safeDayKey(entry.workout.started_at)
     if (dayKey === '') continue
     const year = Number(dayKey.slice(0, 4))
     if (!Number.isFinite(year)) continue
@@ -775,11 +779,17 @@ export function workoutYearOptions(entries: readonly WorkoutHistoryEntry[]): Wor
 }
 
 /**
- * Which Pacific calendar year an entry belongs to, or `null` when its timestamp
- * can't be parsed.
+ * Which calendar year an entry belongs to, or `null` when its timestamp can't be
+ * parsed.
+ *
+ * @param entry The history entry to place.
+ * @param clock Zone the year boundary is measured in; defaults to Pacific (#429).
  */
-export function workoutYear(entry: WorkoutHistoryEntry): number | null {
-  const dayKey = safePacificDayKey(entry.workout.started_at)
+export function workoutYear(
+  entry: WorkoutHistoryEntry,
+  clock: DayClock = PACIFIC_CLOCK
+): number | null {
+  const dayKey = clock.safeDayKey(entry.workout.started_at)
   if (dayKey === '') return null
   const year = Number(dayKey.slice(0, 4))
   return Number.isFinite(year) ? year : null


### PR DESCRIPTION
Stage 2 of #425 — the last change before the extraction, and the one with a failure mode that no existing test can see.

## The problem

`day-keys.ts` anchored every calendar-day bucket to a module constant. Correct for this log: the training happens where it happens, so logging on a trip still lands on the Pacific day and a flight can't break a streak. Wrong for a product whose users are other people's clients, which is where these modules are heading.

## The shape

`clock.ts` owns the mechanism; a `DayClock` carries the zone:

```ts
const clock = createDayClock('America/Denver')
clock.dayKey(new Date(set.logged_at))   // '2026-07-14'
```

Every zone-consuming function takes `clock: DayClock = PACIFIC_CLOCK` **last**, so all ~30 courtfolio call sites are byte-identical and `day-keys.ts` survives as a Pacific-bound shim for the data layer, admin routes, and components that are legitimately Pacific-only.

**A module global with a `configureTimeZone()` setter would have been a tenth of the work and is disqualified**, not merely worse: a server rendering a Denver client and a Boston client in one tick would race on it, and the symptom is days attributed to the wrong person's calendar.

Scope: 52 call sites, ~25 exported functions, 9 modules.

## One behavior change worth naming

`toNoon` computes actual noon in the target zone. The old code used a fixed `T19:00:00Z`, which its own comment conceded is 11am in PST — a shortcut that can't generalize. Pacific summer keys are unchanged (`19:00Z` either way); winter keys move one hour, still mid-day, still bucketing to the same day. The only visible effect is the `logged_at` stamped on a *backdated* winter set, and both values round-trip to the same Pacific day.

## The gate — the actual deliverable

A function that accepts the clock and forgets to pass it downstream **leaves all 2,260 existing tests green**, because this repo is Pacific and so is the default. The bug would surface months later in a consumer, as off-by-one days in streaks and heatmaps.

So `clock-threading.test.ts` runs every entry point twice — Pacific and `Pacific/Kiritimati` (UTC+14) — and requires the answers to differ.

**Getting the fixture right took three attempts, and that's the interesting part.** Shifting every timestamp 21 hours moves all the days together, and most rollups are invariant under that — a streak of 1 is a streak of 1 in any zone. Eight of my first assertions passed for that reason, which is worse than not having them.

What discriminates is two sets on the **same Pacific day that straddle Kiritimati's midnight**:

| | Pacific | Kiritimati |
|---|---|---|
| `2026-07-14T08:00Z` | Jul 14 01:00 | Jul 14 22:00 |
| `2026-07-14T12:00Z` | Jul 14 05:00 | **Jul 15** 02:00 |

Pacific sees one 120-rep day; Kiritimati sees two of 60. That propagates into every daily rollup, both streak implementations, the heatmap, and a 100-rep achievement that one zone earns and the other doesn't. Week and year boundaries get the same treatment (a Sunday that's a Monday; a Dec 31 that's Jan 1).

`formatDayLabel` is the deliberate exception — it must name the same day in both zones, or a Pacific `2026-07-14` would render as "Jul 15" for a reader further east. It's asserted stable, with a separate check that the clock is still consulted underneath.

**Verified the gate can fail.** Dropping one `clock` forward in `buildAchievementBoard`:

- `clock-threading.test.ts` → **1 failed**
- `achievements.test.ts` → **75 passed**, entirely blind to it

That's the scenario the gate exists for, demonstrated rather than asserted.

Secondary guard: an eslint rule bans the nine shipping modules from importing `day-keys`, so new code can't quietly re-hardwire Pacific. The shim stays freely available everywhere it's still right.

## Test plan

Nothing should look different anywhere — this is a pure refactor for courtfolio.

- [ ] `/training-facility/weight-room` — rings, today's totals, and the focus strip unchanged
- [ ] `/history` — heatmaps, streaks, weekly volume, Load Management cards, stats cards
- [ ] `/achievements` — same badges earned, same "next up" ordering
- [ ] `/workouts` — the year rail still groups sessions into the right years
- [ ] `/exercises/shrugs` — day points and the recent-days table unchanged
- [ ] `/log` — pick a past day and log a set; it lands on the day you picked

Verified locally: `tsc --noEmit` · `next build` · `npm test` **2,288 passing** (up 28) · `npm run test:e2e` 68 passing · `lint` · `prettier --check` repo-wide.

Closes #429. Refs #425.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added timezone-aware calendar handling across workout tracking, strength insights, achievements, progression, focus, load management, and history.
  - Date-based calculations can now use a selected timezone, with Pacific time remaining the default.
  - Added consistent utilities for day, week, month, year, and weekday calculations.

- **Bug Fixes**
  - Improved accuracy for dates near midnight and across day, week, month, and year boundaries.
  - Preserved existing behavior for invalid timestamps and omitted timezone settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->