### PR TITLE
feat(weight-room): import historical workouts from iCloud Notes, and compare then vs now (#400)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,4 +66,10 @@ screenshots/*
 # before each deploy.
 public/data/cardio.json
 
+# Workout sets transcribed from personal Apple Notes, consumed by
+# `npm run import-icloud-notes` (#400). Same reasoning as the Health export:
+# it is personal training data, and the repo holds the importer, not the
+# training history. Regenerate from the notes rather than committing it.
+.notes-extract/
+
 .vercel

--- a/app/training-facility/weight-room/exercises/[slug]/page.tsx
+++ b/app/training-facility/weight-room/exercises/[slug]/page.tsx
@@ -16,7 +16,7 @@ import {
   getWeightRoomWorkoutsServer,
 } from '@/lib/data/weight-room-server'
 import { isWeightRoomEnabled } from '@/lib/feature-flags'
-import { buildEraComparison } from '@/lib/training-facility/era-comparison'
+import { buildEraComparison, eraIsImported } from '@/lib/training-facility/era-comparison'
 import {
   buildExerciseProgression,
   buildSetDetailCoverage,
@@ -165,7 +165,11 @@ export default async function WeightRoomExercisePage({
           ) : (
             <div className="flex flex-col gap-8">
               {eraComparison === null ? null : (
-                <ThenVsNowPanel comparison={eraComparison} displayName={displayName} />
+                <ThenVsNowPanel
+                  comparison={eraComparison}
+                  displayName={displayName}
+                  earlierEraImported={eraIsImported(eraComparison.then, exercise, sets)}
+                />
               )}
               <ExerciseProgressionPanel
                 progression={progression}

--- a/app/training-facility/weight-room/exercises/[slug]/page.tsx
+++ b/app/training-facility/weight-room/exercises/[slug]/page.tsx
@@ -6,6 +6,7 @@ import { BackToCourtButton } from '@/components/common/BackToCourtButton'
 import { FacilityBackLink } from '@/components/training-facility/FacilityBackLink'
 import { PreviewModeBadge } from '@/components/training-facility/shared/PreviewModeBadge'
 import { ExerciseProgressionPanel } from '@/components/training-facility/weight-room/ExerciseProgressionPanel'
+import { ThenVsNowPanel } from '@/components/training-facility/weight-room/ThenVsNowPanel'
 import { WeightRoomSubNav } from '@/components/training-facility/weight-room/WeightRoomSubNav'
 import { buildWeightRoomDemoData, buildWorkoutDemoData } from '@/constants/weight-room-demo-fixture'
 import { isAdminRequest } from '@/lib/auth/admin-session'
@@ -15,6 +16,7 @@ import {
   getWeightRoomWorkoutsServer,
 } from '@/lib/data/weight-room-server'
 import { isWeightRoomEnabled } from '@/lib/feature-flags'
+import { buildEraComparison } from '@/lib/training-facility/era-comparison'
 import {
   buildExerciseProgression,
   buildSetDetailCoverage,
@@ -100,6 +102,10 @@ export default async function WeightRoomExercisePage({
   // grease-the-groove movements carry no catalog row of their own.
   const displayName = slugLabel(exercise, goal, buildExerciseLabels(exercises))
   const coverage = buildSetDetailCoverage(progression?.points[0]?.dayKey ?? null, workouts, sets)
+  // Null for a movement trained continuously, which is most of them — the panel
+  // only appears where the imported archive actually gives something to compare
+  // the current stretch against (#400).
+  const eraComparison = progression === null ? null : buildEraComparison(progression)
   // The movement's own color where it has a daily goal, so the trend matches the
   // ring and heatmap it's already drawn in elsewhere. Gym lifts have no goal and
   // fall back to the panel's default.
@@ -157,12 +163,17 @@ export default async function WeightRoomExercisePage({
               its first recorded set.
             </p>
           ) : (
-            <ExerciseProgressionPanel
-              progression={progression}
-              displayName={displayName}
-              coverage={coverage}
-              {...(goalColor === undefined ? {} : { accentColor: goalColor })}
-            />
+            <div className="flex flex-col gap-8">
+              {eraComparison === null ? null : (
+                <ThenVsNowPanel comparison={eraComparison} displayName={displayName} />
+              )}
+              <ExerciseProgressionPanel
+                progression={progression}
+                displayName={displayName}
+                coverage={coverage}
+                {...(goalColor === undefined ? {} : { accentColor: goalColor })}
+              />
+            </div>
           )}
         </div>
       </div>

--- a/components/training-facility/weight-room/ExerciseProgressionPanel.tsx
+++ b/components/training-facility/weight-room/ExerciseProgressionPanel.tsx
@@ -7,7 +7,7 @@ import type {
   ExerciseProgression,
   SetDetailCoverage,
 } from '@/lib/training-facility/exercise-progression'
-import { describeSet, formatLbs } from '@/lib/training-facility/strength-format'
+import { describeSetOrHold, formatHold, formatLbs } from '@/lib/training-facility/strength-format'
 import { E1RM_MAX_RELIABLE_REPS } from '@/lib/training-facility/workout-stats'
 
 /** Route base for the per-exercise trend (#412). */
@@ -97,6 +97,11 @@ export function ExerciseProgressionPanel({
   // records row and a table that both have plenty to say, so the panels are
   // dropped entirely and one line explains the absence.
   const hasTrend = points.length >= MIN_TREND_POINTS
+  // An isometric movement is timed, not counted (#400). Every set is one
+  // repetition, so the reps series is a flat line at 1 — true, and useless.
+  // Whether it's a hold is read off the data rather than from a movement list,
+  // so a future timed movement needs no change here.
+  const isHold = points.every(point => point.bestRepSet.durationSeconds !== undefined)
 
   return (
     <div
@@ -145,7 +150,21 @@ export function ExerciseProgressionPanel({
         </ChartCard>
       )}
 
-      {!hasTrend ? null : (
+      {!hasTrend ? null : isHold ? (
+        <ChartCard title="Longest hold" subtitle="Longest single hold each training day">
+          <TrendChart
+            data={points}
+            y={p => p.bestRepSet.durationSeconds ?? 0}
+            stroke={accentColor}
+            width={width}
+            height={height}
+            yLabel="seconds"
+            yTickFormat={value => String(Math.round(value))}
+            ariaLabel={`${displayName} longest hold in seconds across ${points.length} training days`}
+            emptyMessage={`Not enough ${displayName} training days yet`}
+          />
+        </ChartCard>
+      ) : (
         <ChartCard
           title="Best set"
           subtitle={
@@ -271,6 +290,13 @@ interface RecordsRowProps {
 /** All-time marks: heaviest set, most reps, best estimate, days trained. */
 function RecordsRow({ progression }: RecordsRowProps): JSX.Element {
   const { heaviestSet, mostRepsSet, bestOneRepMax, points, totalSets, totalReps } = progression
+  // Longest hold across every day, or null when the movement isn't timed.
+  const longestHold = points.reduce<number | null>((longest, point) => {
+    const held = point.bestRepSet.durationSeconds
+    if (held === undefined) return longest
+    return longest === null || held > longest ? held : longest
+  }, null)
+
   return (
     <dl
       data-testid="exercise-records"
@@ -278,12 +304,14 @@ function RecordsRow({ progression }: RecordsRowProps): JSX.Element {
       aria-label="All-time marks"
     >
       {heaviestSet === null ? null : (
-        <RecordCell
-          label="Heaviest set"
-          value={describeSet(heaviestSet.reps, heaviestSet.effectiveLoad)}
-        />
+        <RecordCell label="Heaviest set" value={describeSetOrHold(heaviestSet)} />
       )}
-      <RecordCell label="Most reps" value={`${mostRepsSet.reps} reps`} />
+      {/* A hold's "most reps" is always 1. Its record is how long it lasted. */}
+      {longestHold === null ? (
+        <RecordCell label="Most reps" value={`${mostRepsSet.reps} reps`} />
+      ) : (
+        <RecordCell label="Longest hold" value={formatHold(longestHold)} />
+      )}
       {bestOneRepMax === null ? null : (
         <RecordCell
           label="Best est. 1RM"
@@ -294,7 +322,11 @@ function RecordsRow({ progression }: RecordsRowProps): JSX.Element {
       <RecordCell
         label="Training days"
         value={String(points.length)}
-        detail={`${totalSets.toLocaleString('en-US')} sets · ${totalReps.toLocaleString('en-US')} reps`}
+        detail={
+          longestHold === null
+            ? `${totalSets.toLocaleString('en-US')} sets · ${totalReps.toLocaleString('en-US')} reps`
+            : `${totalSets.toLocaleString('en-US')} holds`
+        }
       />
     </dl>
   )
@@ -474,8 +506,8 @@ function RecentDaysTable({ progression, displayName }: RecentDaysTableProps): JS
               <td className="px-3 py-2.5 text-right tabular-nums">{point.reps}</td>
               <td className="px-5 py-2.5 text-right tabular-nums">
                 {point.topSet === null
-                  ? `${point.bestRepSet.reps} reps`
-                  : describeSet(point.topSet.reps, point.topSet.effectiveLoad)}
+                  ? describeSetOrHold(point.bestRepSet)
+                  : describeSetOrHold(point.topSet)}
                 {point.estimatedOneRepMax === null ? null : (
                   <span className="block text-[0.7rem] text-[#0a0a0a]/55">
                     ~{formatLbs(point.estimatedOneRepMax)} est. 1RM

--- a/components/training-facility/weight-room/ThenVsNowPanel.tsx
+++ b/components/training-facility/weight-room/ThenVsNowPanel.tsx
@@ -2,7 +2,7 @@ import type { JSX, ReactNode } from 'react'
 
 import { formatDayKey } from '@/lib/training-facility/day-keys'
 import type { EraComparison, TrainingEra } from '@/lib/training-facility/era-comparison'
-import { describeSet, formatLbs } from '@/lib/training-facility/strength-format'
+import { describeSetOrHold, formatLbs } from '@/lib/training-facility/strength-format'
 
 /** Date style for an era's endpoints — month and year is the right altitude for a multi-year span. */
 const ERA_DATE: Intl.DateTimeFormatOptions = { month: 'short', year: 'numeric' }
@@ -108,11 +108,7 @@ function EraColumn({ era, label, isCurrent = false }: EraColumnProps): JSX.Eleme
       <dl className="mt-4 flex flex-col gap-2.5">
         <Measure
           label="Heaviest set"
-          value={
-            era.heaviestSet === null
-              ? null
-              : describeSet(era.heaviestSet.reps, era.heaviestSet.effectiveLoad)
-          }
+          value={era.heaviestSet === null ? null : describeSetOrHold(era.heaviestSet)}
         />
         <Measure
           label="Typical top set"

--- a/components/training-facility/weight-room/ThenVsNowPanel.tsx
+++ b/components/training-facility/weight-room/ThenVsNowPanel.tsx
@@ -1,4 +1,4 @@
-import type { JSX } from 'react'
+import type { JSX, ReactNode } from 'react'
 
 import { formatDayKey } from '@/lib/training-facility/day-keys'
 import type { EraComparison, TrainingEra } from '@/lib/training-facility/era-comparison'
@@ -13,6 +13,15 @@ export interface ThenVsNowPanelProps {
   comparison: EraComparison
   /** Human-readable movement name, resolved by the caller with `slugLabel` (#384). */
   displayName: string
+  /**
+   * Whether the earlier era was transcribed from the Apple Notes archive,
+   * as answered by `eraIsImported`.
+   *
+   * Required rather than assumed: this panel renders for *any* long gap, and a
+   * movement can simply have been left alone for a year. Claiming an import
+   * that never happened would put a false provenance on real training.
+   */
+  earlierEraImported: boolean
 }
 
 /**
@@ -30,7 +39,11 @@ export interface ThenVsNowPanelProps {
  *
  * A Server Component — no state, no effects.
  */
-export function ThenVsNowPanel({ comparison, displayName }: ThenVsNowPanelProps): JSX.Element {
+export function ThenVsNowPanel({
+  comparison,
+  displayName,
+  earlierEraImported,
+}: ThenVsNowPanelProps): JSX.Element {
   const { then, now, gapDays } = comparison
   const gapYears = gapDays / 365
 
@@ -48,7 +61,9 @@ export function ThenVsNowPanel({ comparison, displayName }: ThenVsNowPanelProps)
           {gapYears >= 1
             ? `${gapYears.toFixed(1)} years separate these two stretches of ${displayName.toLowerCase()}.`
             : `${gapDays} days separate these two stretches of ${displayName.toLowerCase()}.`}{' '}
-          The earlier one comes from training logged in Apple Notes and imported into this log.
+          {earlierEraImported
+            ? 'The earlier one comes from training logged in Apple Notes and imported into this log.'
+            : 'The earlier one is training this log already carried.'}
         </p>
       </header>
 
@@ -156,56 +171,99 @@ interface VerdictProps {
   displayName: string
 }
 
+/** The verdict's shared shell, so every branch gets the same box and test id. */
+function Sentence({ children }: { children: ReactNode }): JSX.Element {
+  return (
+    <p
+      data-testid="then-vs-now-verdict"
+      className="mt-4 rounded-[1rem] border border-white/10 bg-white/[0.03] px-4 py-3 text-sm leading-6 text-[#e8d5be]/80"
+    >
+      {children}
+    </p>
+  )
+}
+
 /**
  * One line saying whether the current era has passed the old one.
  *
- * Only rendered when there is a like-for-like comparison to make. A movement
- * that was bodyweight in either era gets a rep-volume sentence instead, because
- * "not yet surpassed" would be a verdict on training that was never measured in
- * pounds.
+ * Four branches, because three of them would otherwise print something false:
+ * a movement bodyweight in *both* eras has no load to compare and gets reps
+ * instead; one loaded on a single side is not comparable by weight at all, and
+ * saying "neither stretch was loaded" is contradicted by the adjacent column;
+ * and a dead heat is neither "passed" nor "still above", both of which would
+ * render as "by 0 lb".
  */
 function Verdict({ comparison, displayName }: VerdictProps): JSX.Element | null {
   const { heaviestDelta, surpassedHeaviest, then, now } = comparison
+  const movement = displayName.toLowerCase()
+  const repsDelta = now.reps - then.reps
+
+  // Every branch below ends its sentence on the bold value, with a `{' '}`
+  // ahead of it. Not a style preference: JSX drops the space between a closing
+  // tag and following text when that text wraps to the next source line, and
+  // prettier rewrites an explicit `{' '}` back into exactly that shape — so
+  // "passed the" reflows into "passedthe" on the next format run. Keeping the
+  // emphasis last means nothing ever follows it to lose a space against.
+  const reps = `${Math.abs(repsDelta).toLocaleString('en-US')} ${repsDelta > 0 ? 'more' : 'fewer'} reps`
 
   if (surpassedHeaviest === null || heaviestDelta === null) {
-    // Bodyweight on at least one side — compare the thing that does exist.
-    const repsDelta = now.reps - then.reps
+    const bothBodyweight = then.heaviestSet === null && now.heaviestSet === null
+
+    if (!bothBodyweight) {
+      const loadedSide = now.heaviestSet !== null ? 'the current stretch' : 'the earlier stretch'
+      if (repsDelta === 0) {
+        return (
+          <Sentence>
+            Only {loadedSide} carried external load, so the two aren&rsquo;t comparable by weight —
+            and both carry the same {movement} rep volume.
+          </Sentence>
+        )
+      }
+      return (
+        <Sentence>
+          Only {loadedSide} carried external load, so the two aren&rsquo;t comparable by weight. In{' '}
+          {movement} reps, this stretch carries{' '}
+          <strong className="font-black text-[#fff7ec]">{reps}</strong>.
+        </Sentence>
+      )
+    }
+
     if (repsDelta === 0) return null
     return (
-      <p
-        data-testid="then-vs-now-verdict"
-        className="mt-4 rounded-[1rem] border border-white/10 bg-white/[0.03] px-4 py-3 text-sm leading-6 text-[#e8d5be]/80"
-      >
-        This stretch carries{' '}
+      <Sentence>
+        Neither stretch was loaded, so the comparison is in reps: this stretch carries{' '}
+        <strong className="font-black text-[#fff7ec]">{reps}</strong> of {movement}.
+      </Sentence>
+    )
+  }
+
+  if (heaviestDelta === 0) {
+    return (
+      <Sentence>
+        Both stretches top out at the same {movement} —{' '}
         <strong className="font-black text-[#fff7ec]">
-          {Math.abs(repsDelta).toLocaleString('en-US')} {repsDelta > 0 ? 'more' : 'fewer'} reps
-        </strong>{' '}
-        of {displayName.toLowerCase()} than the archive — measured in reps, since neither stretch
-        was loaded.
-      </p>
+          {formatLbs(now.heaviestSet?.effectiveLoad ?? 0)}
+        </strong>
+        .
+      </Sentence>
     )
   }
 
   const magnitude = formatLbs(Math.abs(heaviestDelta))
 
   return (
-    <p
-      data-testid="then-vs-now-verdict"
-      className="mt-4 rounded-[1rem] border border-white/10 bg-white/[0.03] px-4 py-3 text-sm leading-6 text-[#e8d5be]/80"
-    >
+    <Sentence>
       {surpassedHeaviest ? (
         <>
-          Current training has <strong className="font-black text-[#fff7ec]">passed</strong> the
-          archive&rsquo;s heaviest {displayName.toLowerCase()} by{' '}
+          Current training has passed the earlier stretch&rsquo;s heaviest {movement} by{' '}
           <strong className="font-black text-[#fff7ec]">{magnitude}</strong>.
         </>
       ) : (
         <>
-          The archive&rsquo;s heaviest {displayName.toLowerCase()} is still{' '}
-          <strong className="font-black text-[#fff7ec]">{magnitude}</strong> above anything in the
-          current stretch.
+          The earlier stretch&rsquo;s heaviest {movement} still leads the current one by{' '}
+          <strong className="font-black text-[#fff7ec]">{magnitude}</strong>.
         </>
       )}
-    </p>
+    </Sentence>
   )
 }

--- a/components/training-facility/weight-room/ThenVsNowPanel.tsx
+++ b/components/training-facility/weight-room/ThenVsNowPanel.tsx
@@ -1,0 +1,211 @@
+import type { JSX } from 'react'
+
+import { formatDayKey } from '@/lib/training-facility/day-keys'
+import type { EraComparison, TrainingEra } from '@/lib/training-facility/era-comparison'
+import { describeSet, formatLbs } from '@/lib/training-facility/strength-format'
+
+/** Date style for an era's endpoints — month and year is the right altitude for a multi-year span. */
+const ERA_DATE: Intl.DateTimeFormatOptions = { month: 'short', year: 'numeric' }
+
+/** Props for {@link ThenVsNowPanel}. */
+export interface ThenVsNowPanelProps {
+  /** The two eras and what changed between them. */
+  comparison: EraComparison
+  /** Human-readable movement name, resolved by the caller with `slugLabel` (#384). */
+  displayName: string
+}
+
+/**
+ * Then-vs-now for one movement (#400 phase 2).
+ *
+ * The reason the iCloud Notes archive was imported at all. A progression chart
+ * draws both eras and lets the eye compare across a two-year silence that
+ * compresses to a few pixels; this states the comparison instead — same
+ * movement, two stretches of training, side by side.
+ *
+ * Both columns render the same rows in the same order so the two are readable
+ * as a pair, and a measure absent from either era renders as an em-dash rather
+ * than a zero: an era of bodyweight work has no heaviest set, and printing
+ * `0 lb` would assert something false about the training.
+ *
+ * A Server Component — no state, no effects.
+ */
+export function ThenVsNowPanel({ comparison, displayName }: ThenVsNowPanelProps): JSX.Element {
+  const { then, now, gapDays } = comparison
+  const gapYears = gapDays / 365
+
+  return (
+    <section
+      data-testid="then-vs-now"
+      className="rounded-[1.4rem] border border-white/10 bg-white/[0.04] p-5 sm:p-6"
+      aria-label={`${displayName}: then versus now`}
+    >
+      <header>
+        <h2 className="font-mono text-[11px] uppercase tracking-[0.28em] text-amber-300/80">
+          Then vs now
+        </h2>
+        <p className="mt-2 text-sm leading-6 text-[#e8d5be]/75">
+          {gapYears >= 1
+            ? `${gapYears.toFixed(1)} years separate these two stretches of ${displayName.toLowerCase()}.`
+            : `${gapDays} days separate these two stretches of ${displayName.toLowerCase()}.`}{' '}
+          The earlier one comes from training logged in Apple Notes and imported into this log.
+        </p>
+      </header>
+
+      <div className="mt-5 grid gap-3 sm:grid-cols-2">
+        <EraColumn era={then} label="Then" />
+        <EraColumn era={now} label="Now" isCurrent />
+      </div>
+
+      <Verdict comparison={comparison} displayName={displayName} />
+    </section>
+  )
+}
+
+/** Props for one era's column. */
+interface EraColumnProps {
+  /** The era to render. */
+  era: TrainingEra
+  /** Column heading — "Then" or "Now". */
+  label: string
+  /** Whether this is the current era, which gets the accent treatment. */
+  isCurrent?: boolean
+}
+
+/** One era's marks, as a definition list so the pairs stay associated for a screen reader. */
+function EraColumn({ era, label, isCurrent = false }: EraColumnProps): JSX.Element {
+  const span = `${formatDayKey(era.startDayKey, ERA_DATE)} – ${formatDayKey(era.endDayKey, ERA_DATE)}`
+
+  return (
+    <div
+      data-testid={`era-${label.toLowerCase()}`}
+      className={`rounded-[1.1rem] border px-4 py-4 ${
+        isCurrent ? 'border-amber-300/30 bg-amber-300/[0.06]' : 'border-white/10 bg-white/[0.03]'
+      }`}
+    >
+      <p className="font-mono text-[10px] uppercase tracking-[0.22em] text-[#e8d5be]/60">{label}</p>
+      <p className="mt-1 text-sm font-semibold tabular-nums text-[#fff7ec]">{span}</p>
+      <p className="mt-0.5 font-mono text-[10px] tracking-[0.12em] text-[#e8d5be]/50">
+        {era.trainingDays.toLocaleString('en-US')} training days ·{' '}
+        {era.sets.toLocaleString('en-US')} sets
+      </p>
+
+      <dl className="mt-4 flex flex-col gap-2.5">
+        <Measure
+          label="Heaviest set"
+          value={
+            era.heaviestSet === null
+              ? null
+              : describeSet(era.heaviestSet.reps, era.heaviestSet.effectiveLoad)
+          }
+        />
+        <Measure
+          label="Typical top set"
+          value={era.typicalTopSet === null ? null : formatLbs(era.typicalTopSet)}
+          title="Median of each training day's heaviest set — what the working weight actually was"
+        />
+        <Measure
+          label="Best est. 1RM"
+          value={era.bestOneRepMax === null ? null : `~${formatLbs(era.bestOneRepMax)}`}
+        />
+        <Measure label="Reps" value={era.reps.toLocaleString('en-US')} />
+        <Measure
+          label="Volume"
+          value={era.tonnage > 0 ? formatLbs(era.tonnage) : null}
+          title="Σ reps × load across the era"
+        />
+      </dl>
+    </div>
+  )
+}
+
+/** Props for one labelled measure. */
+interface MeasureProps {
+  /** What the number is. */
+  label: string
+  /** The formatted number, or `null` when the era has no such measure. */
+  value: string | null
+  /** Optional hover explanation. */
+  title?: string
+}
+
+/**
+ * One measure within an era.
+ *
+ * An absent value renders as an em-dash, not a zero — a bodyweight era has no
+ * heaviest set, and `0 lb` would read as a load that was lifted.
+ */
+function Measure({ label, value, title }: MeasureProps): JSX.Element {
+  return (
+    <div className="flex items-baseline justify-between gap-3" title={title}>
+      <dt className="font-mono text-[10px] uppercase tracking-[0.18em] text-[#e8d5be]/55">
+        {label}
+      </dt>
+      <dd className="text-sm font-black tabular-nums text-[#fff7ec]">
+        {value ?? <span className="text-[#e8d5be]/35">—</span>}
+      </dd>
+    </div>
+  )
+}
+
+/** Props for {@link Verdict}. */
+interface VerdictProps {
+  /** The comparison to summarize. */
+  comparison: EraComparison
+  /** Movement name, for the sentence. */
+  displayName: string
+}
+
+/**
+ * One line saying whether the current era has passed the old one.
+ *
+ * Only rendered when there is a like-for-like comparison to make. A movement
+ * that was bodyweight in either era gets a rep-volume sentence instead, because
+ * "not yet surpassed" would be a verdict on training that was never measured in
+ * pounds.
+ */
+function Verdict({ comparison, displayName }: VerdictProps): JSX.Element | null {
+  const { heaviestDelta, surpassedHeaviest, then, now } = comparison
+
+  if (surpassedHeaviest === null || heaviestDelta === null) {
+    // Bodyweight on at least one side — compare the thing that does exist.
+    const repsDelta = now.reps - then.reps
+    if (repsDelta === 0) return null
+    return (
+      <p
+        data-testid="then-vs-now-verdict"
+        className="mt-4 rounded-[1rem] border border-white/10 bg-white/[0.03] px-4 py-3 text-sm leading-6 text-[#e8d5be]/80"
+      >
+        This stretch carries{' '}
+        <strong className="font-black text-[#fff7ec]">
+          {Math.abs(repsDelta).toLocaleString('en-US')} {repsDelta > 0 ? 'more' : 'fewer'} reps
+        </strong>{' '}
+        of {displayName.toLowerCase()} than the archive — measured in reps, since neither stretch was
+        loaded.
+      </p>
+    )
+  }
+
+  const magnitude = formatLbs(Math.abs(heaviestDelta))
+
+  return (
+    <p
+      data-testid="then-vs-now-verdict"
+      className="mt-4 rounded-[1rem] border border-white/10 bg-white/[0.03] px-4 py-3 text-sm leading-6 text-[#e8d5be]/80"
+    >
+      {surpassedHeaviest ? (
+        <>
+          Current training has <strong className="font-black text-[#fff7ec]">passed</strong>{' '}
+          the archive&rsquo;s heaviest {displayName.toLowerCase()} by{' '}
+          <strong className="font-black text-[#fff7ec]">{magnitude}</strong>.
+        </>
+      ) : (
+        <>
+          The archive&rsquo;s heaviest {displayName.toLowerCase()} is still{' '}
+          <strong className="font-black text-[#fff7ec]">{magnitude}</strong> above anything in the
+          current stretch.
+        </>
+      )}
+    </p>
+  )
+}

--- a/components/training-facility/weight-room/ThenVsNowPanel.tsx
+++ b/components/training-facility/weight-room/ThenVsNowPanel.tsx
@@ -180,8 +180,8 @@ function Verdict({ comparison, displayName }: VerdictProps): JSX.Element | null 
         <strong className="font-black text-[#fff7ec]">
           {Math.abs(repsDelta).toLocaleString('en-US')} {repsDelta > 0 ? 'more' : 'fewer'} reps
         </strong>{' '}
-        of {displayName.toLowerCase()} than the archive — measured in reps, since neither stretch was
-        loaded.
+        of {displayName.toLowerCase()} than the archive — measured in reps, since neither stretch
+        was loaded.
       </p>
     )
   }
@@ -195,8 +195,8 @@ function Verdict({ comparison, displayName }: VerdictProps): JSX.Element | null 
     >
       {surpassedHeaviest ? (
         <>
-          Current training has <strong className="font-black text-[#fff7ec]">passed</strong>{' '}
-          the archive&rsquo;s heaviest {displayName.toLowerCase()} by{' '}
+          Current training has <strong className="font-black text-[#fff7ec]">passed</strong> the
+          archive&rsquo;s heaviest {displayName.toLowerCase()} by{' '}
           <strong className="font-black text-[#fff7ec]">{magnitude}</strong>.
         </>
       ) : (

--- a/components/training-facility/weight-room/WorkoutHistoryList.tsx
+++ b/components/training-facility/weight-room/WorkoutHistoryList.tsx
@@ -2,7 +2,7 @@ import type { JSX } from 'react'
 import Link from 'next/link'
 
 import { formatDayKey, safePacificDayKey, todayDayKey } from '@/lib/training-facility/day-keys'
-import { describeSet } from '@/lib/training-facility/strength-format'
+import { describeSetOrHold } from '@/lib/training-facility/strength-format'
 import {
   workoutDisplayTitle,
   type WorkoutHistoryEntry,
@@ -402,8 +402,7 @@ function WorkoutHistoryRow({ entry, isPreviewMode }: WorkoutHistoryRowProps): JS
 
       {topLift?.topSet != null ? (
         <p className="mt-1.5 text-xs text-[#0a0a0a]/60">
-          Top set · {topLift.displayName ?? topLift.exercise}{' '}
-          {describeSet(topLift.topSet.reps, topLift.topSet.effectiveLoad)}
+          Top set · {topLift.displayName ?? topLift.exercise} {describeSetOrHold(topLift.topSet)}
         </p>
       ) : null}
     </Link>

--- a/components/training-facility/weight-room/WorkoutSummaryPanel.tsx
+++ b/components/training-facility/weight-room/WorkoutSummaryPanel.tsx
@@ -10,7 +10,7 @@ import type {
   WorkoutPersonalBest,
   WorkoutSummary,
 } from '@/lib/training-facility/workout-stats'
-import { describeSet, formatLbs } from '@/lib/training-facility/strength-format'
+import { describeSetOrHold, formatLbs } from '@/lib/training-facility/strength-format'
 import type { StrengthSet } from '@/types/weight-room'
 
 /** Format a signed delta, so `+400 lb` and `−120 lb` both read at a glance. */
@@ -269,9 +269,7 @@ function PersonalBestStrip({ bests }: PersonalBestStripProps): JSX.Element {
         {bests.map(best => (
           <li key={`${best.exercise}-${best.kind}`} data-testid={`workout-pb-${best.exercise}`}>
             <span className="font-semibold">{best.displayName ?? best.exercise}</span>{' '}
-            {best.kind === 'load'
-              ? describeSet(best.set.reps, best.set.effectiveLoad)
-              : `${best.set.reps} reps`}
+            {best.kind === 'load' ? describeSetOrHold(best.set) : `${best.set.reps} reps`}
             <span className="text-[#e8d5be]/60">
               {best.previousBest === null
                 ? ' — first time logged'
@@ -567,7 +565,7 @@ function BreakdownCard({
               <td className="px-5 py-2.5 text-right tabular-nums">
                 {entry.topSet === null
                   ? `${entry.bestRepSet.reps} reps`
-                  : describeSet(entry.topSet.reps, entry.topSet.effectiveLoad)}
+                  : describeSetOrHold(entry.topSet)}
                 {entry.estimatedOneRepMax !== null ? (
                   <span
                     className="block text-[0.7rem] text-[#0a0a0a]/55"

--- a/lib/data/weight-room-shared.ts
+++ b/lib/data/weight-room-shared.ts
@@ -67,7 +67,7 @@ const EXERCISES_TABLE = 'weight_room_exercises'
  * into a workout without another round trip.
  */
 const SETS_COLUMNS =
-  'id, logged_at, exercise, reps, weight_lbs, variant, workout_id, position, template_slot_id, template_slot_step_id, updated_at'
+  'id, logged_at, exercise, reps, weight_lbs, variant, workout_id, position, template_slot_id, template_slot_step_id, source, updated_at'
 // `load_multiplier` deliberately absent (#373) — it moved to the catalog and is
 // joined on below. The goals column still exists (dropping it while the
 // deployed build still selected it would break the live read) but is dead.

--- a/lib/data/weight-room-shared.ts
+++ b/lib/data/weight-room-shared.ts
@@ -67,7 +67,7 @@ const EXERCISES_TABLE = 'weight_room_exercises'
  * into a workout without another round trip.
  */
 const SETS_COLUMNS =
-  'id, logged_at, exercise, reps, weight_lbs, variant, workout_id, position, template_slot_id, template_slot_step_id, source, updated_at'
+  'id, logged_at, exercise, reps, weight_lbs, variant, workout_id, position, template_slot_id, template_slot_step_id, source, duration_seconds, updated_at'
 // `load_multiplier` deliberately absent (#373) — it moved to the catalog and is
 // joined on below. The goals column still exists (dropping it while the
 // deployed build still selected it would break the live read) but is dead.

--- a/lib/schemas/weight-room.ts
+++ b/lib/schemas/weight-room.ts
@@ -150,6 +150,10 @@ export const WeightRoomSetRowSchema = z
     position: nonNegativeInt().nullable().optional(),
     template_slot_id: z.string().uuid().nullable().optional(),
     template_slot_step_id: z.string().uuid().nullable().optional(),
+    // Provenance (#400). Must list every value the column's check constraint
+    // allows — this schema validates the whole set array in one pass, so a
+    // single unlisted value fails the entire read.
+    source: z.enum(['manual', 'icloud_notes']).nullable().optional(),
   })
   .strict()
 
@@ -333,6 +337,10 @@ export function setRowToStrengthSet(row: WeightRoomSetRow): StrengthSet {
     ...(row.template_slot_step_id != null
       ? { template_slot_step_id: row.template_slot_step_id }
       : {}),
+    // `'manual'` is the column default and the absent-field meaning, so it is
+    // omitted rather than carried — the same convention the workout converter
+    // follows for its own source.
+    ...(row.source != null && row.source !== 'manual' ? { source: row.source } : {}),
   }
 }
 
@@ -494,7 +502,13 @@ export const WeightRoomWorkoutRowSchema = z
     started_at: z.string().min(1, 'started_at must be an ISO timestamp'),
     ended_at: z.string().nullable().optional(),
     template_id: z.string().uuid().nullable().optional(),
-    source: z.enum(['manual', 'apple_health']).nullable().optional(),
+    // Must list every value the column's check constraint allows. This schema
+    // validates the whole workout array in one pass, so one unlisted source
+    // fails the entire read — and the read sites catch that as `[]`, so a full
+    // session history renders as "no workouts recorded yet" with nothing
+    // logged. That is exactly what #400's first import did before
+    // `icloud_notes` was added here.
+    source: z.enum(['manual', 'apple_health', 'icloud_notes']).nullable().optional(),
     avg_hr: z.number().nullable().optional(),
     max_hr: z.number().nullable().optional(),
     prescription: WorkoutPrescriptionSchema.nullable().optional(),

--- a/lib/schemas/weight-room.ts
+++ b/lib/schemas/weight-room.ts
@@ -154,6 +154,8 @@ export const WeightRoomSetRowSchema = z
     // allows — this schema validates the whole set array in one pass, so a
     // single unlisted value fails the entire read.
     source: z.enum(['manual', 'icloud_notes']).nullable().optional(),
+    // Seconds a hold lasted (#400); null for every set counted in reps.
+    duration_seconds: nonNegativeInt().nullable().optional(),
   })
   .strict()
 
@@ -341,6 +343,7 @@ export function setRowToStrengthSet(row: WeightRoomSetRow): StrengthSet {
     // omitted rather than carried — the same convention the workout converter
     // follows for its own source.
     ...(row.source != null && row.source !== 'manual' ? { source: row.source } : {}),
+    ...(row.duration_seconds != null ? { duration_seconds: row.duration_seconds } : {}),
   }
 }
 

--- a/lib/training-facility/era-comparison.test.ts
+++ b/lib/training-facility/era-comparison.test.ts
@@ -7,12 +7,7 @@
  */
 import { describe, expect, it } from 'vitest'
 
-import {
-  buildEraComparison,
-  DEFAULT_MIN_GAP_DAYS,
-  daysBetween,
-  median,
-} from './era-comparison'
+import { buildEraComparison, DEFAULT_MIN_GAP_DAYS, daysBetween, median } from './era-comparison'
 import type { ExerciseDayPoint, ExerciseProgression } from './exercise-progression'
 import type { WorkoutSetHighlight } from './workout-stats'
 

--- a/lib/training-facility/era-comparison.test.ts
+++ b/lib/training-facility/era-comparison.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Tests for then-vs-now era comparison (#400 phase 2).
+ *
+ * The cases pin the two ways this misleads: splitting somewhere other than the
+ * real break in the history, and reporting a confident "no change" over a
+ * movement that was never loaded in the first place.
+ */
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildEraComparison,
+  DEFAULT_MIN_GAP_DAYS,
+  daysBetween,
+  median,
+} from './era-comparison'
+import type { ExerciseDayPoint, ExerciseProgression } from './exercise-progression'
+import type { WorkoutSetHighlight } from './workout-stats'
+
+/** A day's top set at a given load. */
+function highlight(effectiveLoad: number, reps = 8): WorkoutSetHighlight {
+  return {
+    setId: `set-${effectiveLoad}-${reps}`,
+    reps,
+    weightLbs: effectiveLoad,
+    effectiveLoad,
+    loggedAt: '2024-01-01T00:00:00Z',
+  }
+}
+
+/** One training day. `load` of 0 means the day was bodyweight-only. */
+function day(dayKey: string, load: number, reps = 8): ExerciseDayPoint {
+  const top = load > 0 ? highlight(load, reps) : null
+  return {
+    dayKey,
+    date: new Date(`${dayKey}T12:00:00Z`),
+    sets: 1,
+    reps,
+    tonnage: load * reps,
+    topSet: top,
+    bestRepSet: top ?? highlight(0, reps),
+    estimatedOneRepMax: load > 0 ? Math.round(load * (1 + reps / 30)) : null,
+  }
+}
+
+/** A progression built from the given days. */
+function progression(points: ExerciseDayPoint[]): ExerciseProgression {
+  return {
+    exercise: 'barbell-bench-press',
+    points,
+    isBodyweight: points.every(p => p.topSet === null),
+    totalSets: points.length,
+    totalReps: points.reduce((sum, p) => sum + p.reps, 0),
+    loadedSets: points.filter(p => p.topSet !== null).length,
+    highRepLoadedSets: 0,
+    heaviestSet: null,
+    mostRepsSet: highlight(0),
+    bestOneRepMax: null,
+  }
+}
+
+describe('daysBetween', () => {
+  it('counts whole days', () => {
+    expect(daysBetween('2024-04-16', '2024-04-18')).toBe(2)
+  })
+
+  it('is unaffected by a daylight-saving boundary', () => {
+    // Spring forward in America/Los_Angeles was 2024-03-10. Measured in a local
+    // zone this stretch would come out a day short.
+    expect(daysBetween('2024-03-09', '2024-03-11')).toBe(2)
+  })
+
+  it('is NaN for an unparseable key', () => {
+    expect(daysBetween('nope', '2024-04-18')).toBeNaN()
+  })
+})
+
+describe('median', () => {
+  it('takes the middle of an odd list', () => {
+    expect(median([100, 135, 115])).toBe(115)
+  })
+
+  it('averages the two middles of an even list', () => {
+    expect(median([100, 110, 120, 130])).toBe(115)
+  })
+
+  it('is null for an empty list', () => {
+    expect(median([])).toBeNull()
+  })
+
+  it('does not mutate its input', () => {
+    const values = [3, 1, 2]
+    median(values)
+    expect(values).toEqual([3, 1, 2])
+  })
+})
+
+describe('buildEraComparison', () => {
+  // The real shape this was built for: an archive that ends when the
+  // note-taking stopped, and a current log that resumes two years later.
+  const archiveThenNow = progression([
+    day('2024-01-10', 135),
+    day('2024-02-14', 145),
+    day('2024-04-16', 155),
+    day('2026-05-20', 165),
+    day('2026-06-24', 185),
+  ])
+
+  it('splits at the long silence and summarizes both sides', () => {
+    const comparison = buildEraComparison(archiveThenNow)
+    expect(comparison).not.toBeNull()
+    expect(comparison?.then.startDayKey).toBe('2024-01-10')
+    expect(comparison?.then.endDayKey).toBe('2024-04-16')
+    expect(comparison?.then.trainingDays).toBe(3)
+    expect(comparison?.now.startDayKey).toBe('2026-05-20')
+    expect(comparison?.now.endDayKey).toBe('2026-06-24')
+    expect(comparison?.now.trainingDays).toBe(2)
+    expect(comparison?.gapDays).toBe(daysBetween('2024-04-16', '2026-05-20'))
+  })
+
+  it('reports what changed across the gap', () => {
+    const comparison = buildEraComparison(archiveThenNow)
+    expect(comparison?.then.heaviestSet?.effectiveLoad).toBe(155)
+    expect(comparison?.now.heaviestSet?.effectiveLoad).toBe(185)
+    expect(comparison?.heaviestDelta).toBe(30)
+    expect(comparison?.surpassedHeaviest).toBe(true)
+  })
+
+  it('uses the median daily top for the typical working load, not the mean', () => {
+    // One heavy single in an otherwise light era would drag a mean up and
+    // overstate what the training actually looked like.
+    const spiky = progression([
+      day('2024-01-10', 100),
+      day('2024-02-14', 100),
+      day('2024-03-14', 300),
+      day('2026-05-20', 150),
+      day('2026-06-24', 150),
+    ])
+    expect(buildEraComparison(spiky)?.then.typicalTopSet).toBe(100)
+  })
+
+  it('splits at the longest silence, not the first one over the threshold', () => {
+    // Two qualifying gaps. Taking the first would make the answer depend on
+    // scan order rather than on the real break in the history.
+    const twoGaps = progression([
+      day('2022-01-10', 95),
+      day('2022-09-10', 105), // ~243-day gap
+      day('2026-05-20', 165), // ~1348-day gap — the real break
+      day('2026-06-24', 185),
+    ])
+    const comparison = buildEraComparison(twoGaps)
+    expect(comparison?.then.endDayKey).toBe('2022-09-10')
+    expect(comparison?.now.startDayKey).toBe('2026-05-20')
+    expect(comparison?.then.trainingDays).toBe(2)
+  })
+
+  it('returns null for continuously trained movements', () => {
+    const continuous = progression([
+      day('2026-05-20', 135),
+      day('2026-06-24', 145),
+      day('2026-07-24', 155),
+    ])
+    expect(buildEraComparison(continuous)).toBeNull()
+  })
+
+  it('returns null when there is only one training day', () => {
+    expect(buildEraComparison(progression([day('2026-05-20', 135)]))).toBeNull()
+  })
+
+  it('respects a custom gap threshold', () => {
+    const shortLayoff = progression([day('2026-01-10', 135), day('2026-04-10', 145)])
+    expect(buildEraComparison(shortLayoff)).toBeNull()
+    expect(buildEraComparison(shortLayoff, 30)).not.toBeNull()
+    expect(DEFAULT_MIN_GAP_DAYS).toBeGreaterThan(90)
+  })
+
+  it('states absence rather than a verdict for a bodyweight movement', () => {
+    // "Not yet surpassed" would read as a judgement on training that was never
+    // being measured in pounds.
+    const bodyweight = progression([
+      day('2024-01-10', 0, 12),
+      day('2024-04-16', 0, 14),
+      day('2026-05-20', 0, 18),
+    ])
+    const comparison = buildEraComparison(bodyweight)
+    expect(comparison).not.toBeNull()
+    expect(comparison?.heaviestDelta).toBeNull()
+    expect(comparison?.surpassedHeaviest).toBeNull()
+    expect(comparison?.then.typicalTopSet).toBeNull()
+    // Rep volume still compares, which is the whole point for bodyweight work.
+    expect(comparison?.now.reps).toBe(18)
+  })
+
+  it('does not claim a gain when only the current era is loaded', () => {
+    const nowLoadedOnly = progression([
+      day('2024-01-10', 0, 10),
+      day('2024-04-16', 0, 10),
+      day('2026-05-20', 135),
+    ])
+    const comparison = buildEraComparison(nowLoadedOnly)
+    expect(comparison?.heaviestDelta).toBeNull()
+    expect(comparison?.surpassedHeaviest).toBeNull()
+    expect(comparison?.now.heaviestSet?.effectiveLoad).toBe(135)
+  })
+})

--- a/lib/training-facility/era-comparison.test.ts
+++ b/lib/training-facility/era-comparison.test.ts
@@ -7,7 +7,15 @@
  */
 import { describe, expect, it } from 'vitest'
 
-import { buildEraComparison, DEFAULT_MIN_GAP_DAYS, daysBetween, median } from './era-comparison'
+import type { StrengthSet } from '@/types/weight-room'
+
+import {
+  buildEraComparison,
+  DEFAULT_MIN_GAP_DAYS,
+  daysBetween,
+  eraIsImported,
+  median,
+} from './era-comparison'
 import type { ExerciseDayPoint, ExerciseProgression } from './exercise-progression'
 import type { WorkoutSetHighlight } from './workout-stats'
 
@@ -195,5 +203,82 @@ describe('buildEraComparison', () => {
     expect(comparison?.heaviestDelta).toBeNull()
     expect(comparison?.surpassedHeaviest).toBeNull()
     expect(comparison?.now.heaviestSet?.effectiveLoad).toBe(135)
+  })
+
+  it('reports a dead heat as neither surpassed nor behind', () => {
+    // heaviestDelta of 0 renders as "by 0 lb" under either phrasing, so the
+    // render site needs to be able to tell a tie from a gain.
+    const tied = progression([
+      day('2024-01-10', 135),
+      day('2024-04-16', 135),
+      day('2026-05-20', 135),
+    ])
+    const comparison = buildEraComparison(tied)
+    expect(comparison?.heaviestDelta).toBe(0)
+    expect(comparison?.surpassedHeaviest).toBe(false)
+  })
+})
+
+describe('eraIsImported', () => {
+  /** A logged set of `exercise` on `dayKey`, optionally from the notes archive. */
+  function set(dayKey: string, exercise: string, source?: 'icloud_notes'): StrengthSet {
+    return {
+      id: `${exercise}-${dayKey}`,
+      // Midday Pacific, so the UTC instant still buckets onto `dayKey`.
+      logged_at: `${dayKey}T20:00:00Z`,
+      exercise,
+      reps: 8,
+      ...(source === undefined ? {} : { source }),
+    }
+  }
+
+  const era = {
+    startDayKey: '2024-01-10',
+    endDayKey: '2024-04-16',
+    trainingDays: 2,
+    sets: 2,
+    reps: 16,
+    tonnage: 0,
+    heaviestSet: null,
+    bestOneRepMax: null,
+    typicalTopSet: null,
+  }
+
+  it('is true when an imported set of this movement falls in the era', () => {
+    expect(
+      eraIsImported(era, 'barbell-bench-press', [
+        set('2024-02-14', 'barbell-bench-press', 'icloud_notes'),
+      ])
+    ).toBe(true)
+  })
+
+  it('is false when the era holds only manually logged sets', () => {
+    // A long gap is not evidence of an import — a movement can simply have been
+    // left alone for a year.
+    expect(
+      eraIsImported(era, 'barbell-bench-press', [set('2024-02-14', 'barbell-bench-press')])
+    ).toBe(false)
+  })
+
+  it('ignores imported sets of a different movement in the same window', () => {
+    expect(
+      eraIsImported(era, 'barbell-bench-press', [set('2024-02-14', 'lat-pulldown', 'icloud_notes')])
+    ).toBe(false)
+  })
+
+  it('ignores imported sets outside the era span', () => {
+    expect(
+      eraIsImported(era, 'barbell-bench-press', [
+        set('2026-05-20', 'barbell-bench-press', 'icloud_notes'),
+      ])
+    ).toBe(false)
+  })
+
+  it('counts a set on the era boundary itself', () => {
+    expect(
+      eraIsImported(era, 'barbell-bench-press', [
+        set('2024-04-16', 'barbell-bench-press', 'icloud_notes'),
+      ])
+    ).toBe(true)
   })
 })

--- a/lib/training-facility/era-comparison.ts
+++ b/lib/training-facility/era-comparison.ts
@@ -1,3 +1,6 @@
+import type { StrengthSet } from '@/types/weight-room'
+
+import { PACIFIC_CLOCK, type DayClock } from './clock'
 import type { ExerciseProgression } from './exercise-progression'
 import type { WorkoutSetHighlight } from './workout-stats'
 
@@ -228,4 +231,37 @@ export function buildEraComparison(
     typicalTopSetDelta: delta(then.typicalTopSet, now.typicalTopSet),
     surpassedHeaviest: heaviestDelta === null ? null : heaviestDelta > 0,
   }
+}
+
+/**
+ * Whether an era's training was transcribed from the Apple Notes archive (#400).
+ *
+ * Asked rather than assumed. A long gap is not evidence of an import — a
+ * movement can simply have been left alone for a year — so a panel that claimed
+ * "the earlier one comes from Apple Notes" on every qualifying gap would state a
+ * provenance it never checked.
+ *
+ * @param era The era to test, from {@link buildEraComparison}.
+ * @param exercise Catalog slug the era belongs to; sets of other movements in
+ *   the same window are irrelevant and must not vote.
+ * @param sets Every logged set — filtered here, so callers pass the same array
+ *   they gave `buildExerciseProgression`.
+ * @param clock Zone each set's day is measured in; defaults to Pacific (#429).
+ * @returns True when at least one imported set of this movement falls inside
+ *   the era's span.
+ */
+export function eraIsImported(
+  era: TrainingEra,
+  exercise: string,
+  sets: readonly StrengthSet[],
+  clock: DayClock = PACIFIC_CLOCK
+): boolean {
+  return sets.some(set => {
+    if (set.exercise !== exercise) return false
+    if (set.source !== 'icloud_notes') return false
+    const dayKey = clock.safeDayKey(set.logged_at)
+    // Day keys compare as strings — `2024-01-10` <= `2024-04-16` lexicographically
+    // and chronologically alike.
+    return dayKey !== '' && dayKey >= era.startDayKey && dayKey <= era.endDayKey
+  })
 }

--- a/lib/training-facility/era-comparison.ts
+++ b/lib/training-facility/era-comparison.ts
@@ -1,0 +1,231 @@
+import type { ExerciseProgression } from './exercise-progression'
+import type { WorkoutSetHighlight } from './workout-stats'
+
+/**
+ * Then-vs-now for a single movement (#400 phase 2).
+ *
+ * Importing the iCloud Notes archive gave this log a shape it didn't have
+ * before: two stretches of real training with a long silence between them. The
+ * 2022-2024 archive ends when the note-taking stopped; the current log begins
+ * in 2026. A plain progression chart draws both and lets the eye do the
+ * comparing across a two-year gap that compresses to a few pixels.
+ *
+ * This module does the comparing instead — same movement, two eras, stated in
+ * numbers. It is the payoff the import was for: "how I used to lift" is only a
+ * question the site can answer once the old sets are in it.
+ *
+ * The split is **discovered, not configured**. Hardcoding "before 2024-05" would
+ * be a fact about this one import that quietly rots the moment another gap
+ * appears — a long injury layoff should divide eras exactly the same way. So the
+ * boundary is the longest silence in the movement's own history, and a movement
+ * trained continuously has no eras and gets no comparison.
+ *
+ * Pure and isomorphic, like its siblings — it consumes a built
+ * {@link ExerciseProgression} and knows nothing about Supabase or React.
+ */
+
+/** How long a silence has to be before it separates two eras, in days. */
+export const DEFAULT_MIN_GAP_DAYS = 180
+
+/** One continuous stretch of training, bounded by a long layoff. */
+export interface TrainingEra {
+  /** First training day in the era, `YYYY-MM-DD`. */
+  startDayKey: string
+  /** Last training day in the era, `YYYY-MM-DD`. */
+  endDayKey: string
+  /** Days on which the movement was trained. Not the calendar span. */
+  trainingDays: number
+  /** Sets logged in the era. */
+  sets: number
+  /** Reps logged in the era. */
+  reps: number
+  /** `Σ reps × effective load` across the era; `0` when it was all bodyweight. */
+  tonnage: number
+  /** Heaviest single set of the era, or `null` when it was all bodyweight. */
+  heaviestSet: WorkoutSetHighlight | null
+  /** Best reliable Epley estimate in the era, or `null` when no set qualified. */
+  bestOneRepMax: number | null
+  /**
+   * Median of each training day's top-set load.
+   *
+   * The honest "what was normal" figure, and deliberately not the mean: one
+   * heavy single in an era of light work drags an average up, and a median of
+   * daily tops says what the working weight actually was. `null` for a
+   * bodyweight era.
+   */
+  typicalTopSet: number | null
+}
+
+/** Two eras of one movement, and what changed between them. */
+export interface EraComparison {
+  /** The earlier stretch. */
+  then: TrainingEra
+  /** The later stretch. */
+  now: TrainingEra
+  /** Calendar days between the last day of {@link then} and the first of {@link now}. */
+  gapDays: number
+  /**
+   * `now − then` on the heaviest set, in pounds of effective load. `null` when
+   * either era was bodyweight-only, since there is no difference to state.
+   */
+  heaviestDelta: number | null
+  /** `now − then` on the best reliable 1RM estimate. `null` when either era lacks one. */
+  bestOneRepMaxDelta: number | null
+  /** `now − then` on the typical (median daily top) working load. */
+  typicalTopSetDelta: number | null
+  /**
+   * Whether current training has passed the archive's heaviest set.
+   *
+   * `null` rather than `false` when the comparison can't be made — a bodyweight
+   * movement hasn't failed to surpass anything, and rendering it as "not yet"
+   * would read as a verdict on training that was never being measured that way.
+   */
+  surpassedHeaviest: boolean | null
+}
+
+/**
+ * Whole days between two `YYYY-MM-DD` keys.
+ *
+ * Parsed as UTC midnight on both sides, so the subtraction is unaffected by
+ * daylight saving — the keys are already zone-resolved by the clock that
+ * produced them, and re-introducing a zone here would make a spring-forward
+ * boundary a day short.
+ *
+ * @param fromDayKey Earlier day key.
+ * @param toDayKey Later day key.
+ * @returns Days between them; negative when the arguments are reversed, and
+ *   `NaN` when either key is unparseable.
+ */
+export function daysBetween(fromDayKey: string, toDayKey: string): number {
+  const from = Date.parse(`${fromDayKey}T00:00:00Z`)
+  const to = Date.parse(`${toDayKey}T00:00:00Z`)
+  if (!Number.isFinite(from) || !Number.isFinite(to)) return Number.NaN
+  return Math.round((to - from) / 86_400_000)
+}
+
+/**
+ * The middle value of a list, averaging the two middles when it is even.
+ *
+ * @param values Numbers to summarize; not mutated.
+ * @returns The median, or `null` for an empty list.
+ */
+export function median(values: readonly number[]): number | null {
+  if (values.length === 0) return null
+  const sorted = [...values].sort((a, b) => a - b)
+  const mid = Math.floor(sorted.length / 2)
+  return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid]
+}
+
+/**
+ * Summarize a run of consecutive progression points as one era.
+ *
+ * @param points A contiguous slice of {@link ExerciseProgression.points}, oldest
+ *   first. Must be non-empty — callers only build eras from real slices.
+ * @returns The era's totals and bests.
+ */
+function summarizeEra(points: ExerciseProgression['points']): TrainingEra {
+  let sets = 0
+  let reps = 0
+  let tonnage = 0
+  let heaviestSet: WorkoutSetHighlight | null = null
+  let bestOneRepMax: number | null = null
+  const dailyTops: number[] = []
+
+  for (const point of points) {
+    sets += point.sets
+    reps += point.reps
+    tonnage += point.tonnage
+
+    if (point.topSet !== null) {
+      dailyTops.push(point.topSet.effectiveLoad)
+      if (heaviestSet === null || point.topSet.effectiveLoad > heaviestSet.effectiveLoad) {
+        heaviestSet = point.topSet
+      }
+    }
+    if (
+      point.estimatedOneRepMax !== null &&
+      (bestOneRepMax === null || point.estimatedOneRepMax > bestOneRepMax)
+    ) {
+      bestOneRepMax = point.estimatedOneRepMax
+    }
+  }
+
+  return {
+    startDayKey: points[0].dayKey,
+    endDayKey: points[points.length - 1].dayKey,
+    trainingDays: points.length,
+    sets,
+    reps,
+    tonnage,
+    heaviestSet,
+    bestOneRepMax,
+    typicalTopSet: median(dailyTops),
+  }
+}
+
+/**
+ * Subtract two possibly-absent measures.
+ *
+ * @returns `now − then`, or `null` when either side is missing — an era with no
+ *   loaded work has no number to compare, and coercing the gap to zero would
+ *   render "no change" over training that was never loaded.
+ */
+function delta(then: number | null, now: number | null): number | null {
+  if (then === null || now === null) return null
+  return now - then
+}
+
+/**
+ * Split a movement's history at its longest layoff and compare the two sides.
+ *
+ * @param progression The movement's full progression, as built by
+ *   `buildExerciseProgression`. Points must be oldest-first, which that
+ *   function guarantees.
+ * @param minGapDays How long a silence must be to count as an era boundary;
+ *   defaults to {@link DEFAULT_MIN_GAP_DAYS}. Shorter than this and the movement
+ *   reads as continuously trained.
+ * @returns The comparison, or `null` when the movement has fewer than two
+ *   training days or no silence long enough to split on. Null is the common
+ *   case for a movement only ever trained in the current era, and the render
+ *   site simply omits the panel.
+ */
+export function buildEraComparison(
+  progression: ExerciseProgression,
+  minGapDays: number = DEFAULT_MIN_GAP_DAYS
+): EraComparison | null {
+  const { points } = progression
+  if (points.length < 2) return null
+
+  // The longest silence, not merely the first one over the threshold: a
+  // movement with two layoffs should divide at the real break in the history,
+  // and taking the first would make the answer depend on scan order.
+  let splitAt = -1
+  let longest = 0
+  for (let i = 1; i < points.length; i += 1) {
+    const gap = daysBetween(points[i - 1].dayKey, points[i].dayKey)
+    if (Number.isFinite(gap) && gap > longest) {
+      longest = gap
+      splitAt = i
+    }
+  }
+
+  if (splitAt < 1 || longest < minGapDays) return null
+
+  const then = summarizeEra(points.slice(0, splitAt))
+  const now = summarizeEra(points.slice(splitAt))
+
+  const heaviestDelta = delta(
+    then.heaviestSet?.effectiveLoad ?? null,
+    now.heaviestSet?.effectiveLoad ?? null
+  )
+
+  return {
+    then,
+    now,
+    gapDays: longest,
+    heaviestDelta,
+    bestOneRepMaxDelta: delta(then.bestOneRepMax, now.bestOneRepMax),
+    typicalTopSetDelta: delta(then.typicalTopSet, now.typicalTopSet),
+    surpassedHeaviest: heaviestDelta === null ? null : heaviestDelta > 0,
+  }
+}

--- a/lib/training-facility/exercise-progression.ts
+++ b/lib/training-facility/exercise-progression.ts
@@ -231,6 +231,7 @@ export function buildExerciseProgression(
         weightLbs: set.weight_lbs ?? null,
         effectiveLoad,
         loggedAt: set.logged_at,
+        ...(set.duration_seconds === undefined ? {} : { durationSeconds: set.duration_seconds }),
       }
 
       reps += set.reps

--- a/lib/training-facility/strength-format.test.ts
+++ b/lib/training-facility/strength-format.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { describeSet, formatLbs } from './strength-format'
+import { describeSet, describeSetOrHold, formatHold, formatLbs } from './strength-format'
 
 /**
  * Coverage for load formatting (#427).
@@ -55,5 +55,46 @@ describe('describeSet', () => {
 
   it('ignores options for a bodyweight set, which has no load to label', () => {
     expect(describeSet(12, 0, { unit: 'kg' })).toBe('12 reps')
+  })
+})
+
+describe('formatHold', () => {
+  it('reads seconds as seconds under a minute', () => {
+    expect(formatHold(45)).toBe('45s')
+    expect(formatHold(59)).toBe('59s')
+  })
+
+  it('switches to minutes:seconds past a minute', () => {
+    // `135s` has to be divided in the head; `2:15` does not.
+    expect(formatHold(60)).toBe('1:00')
+    expect(formatHold(135)).toBe('2:15')
+    expect(formatHold(90)).toBe('1:30')
+  })
+
+  it('rounds rather than claiming precision the source never had', () => {
+    expect(formatHold(44.6)).toBe('45s')
+  })
+})
+
+describe('describeSetOrHold', () => {
+  it('describes a hold by its duration, not as one rep', () => {
+    // A plank is stored as `reps: 1, duration_seconds: 45` so rep rollups keep
+    // working — but "1 rep" is a useless thing to show someone.
+    expect(describeSetOrHold({ reps: 1, effectiveLoad: 0, durationSeconds: 45 })).toBe('45s')
+  })
+
+  it('appends the load when the hold was weighted', () => {
+    expect(describeSetOrHold({ reps: 1, effectiveLoad: 25, durationSeconds: 60 })).toBe(
+      '1:00 × 25 lb'
+    )
+  })
+
+  it('falls back to the rep description when there is no duration', () => {
+    expect(describeSetOrHold({ reps: 8, effectiveLoad: 60 })).toBe('8 × 60 lb')
+    expect(describeSetOrHold({ reps: 12, effectiveLoad: 0, durationSeconds: null })).toBe('12 reps')
+  })
+
+  it('ignores a nonsensical duration rather than rendering it', () => {
+    expect(describeSetOrHold({ reps: 12, effectiveLoad: 0, durationSeconds: 0 })).toBe('12 reps')
   })
 })

--- a/lib/training-facility/strength-format.ts
+++ b/lib/training-facility/strength-format.ts
@@ -56,3 +56,42 @@ export function describeSet(
 ): string {
   return effectiveLoad > 0 ? `${reps} × ${formatLbs(effectiveLoad, options)}` : `${reps} reps`
 }
+
+/**
+ * Format a held set's duration — `45s`, `1:30` past a minute.
+ *
+ * Seconds alone stop reading as a duration somewhere around the two-minute
+ * mark: `135s` has to be divided in the head, where `2:15` does not.
+ *
+ * @param seconds How long the set was held. Rounded — a hold is timed by
+ *   glancing at a clock, and a decimal claims precision the source never had.
+ */
+export function formatHold(seconds: number): string {
+  const whole = Math.max(0, Math.round(seconds))
+  if (whole < 60) return `${whole}s`
+  const minutes = Math.floor(whole / 60)
+  return `${minutes}:${String(whole % 60).padStart(2, '0')}`
+}
+
+/**
+ * Render a set, preferring its duration when it was a hold (#400).
+ *
+ * A plank is stored as one repetition lasting N seconds, so
+ * {@link describeSet} would print `1 rep` — technically true and useless. Any
+ * set carrying a duration is described by it instead, with the load appended
+ * when the hold was weighted.
+ *
+ * @param set The set's reps, effective load, and duration if it had one.
+ * @param options Unit label and locale, forwarded to {@link formatLbs}.
+ */
+export function describeSetOrHold(
+  set: { reps: number; effectiveLoad: number; durationSeconds?: number | null },
+  options: LoadFormatOptions = {}
+): string {
+  const { reps, effectiveLoad, durationSeconds } = set
+  if (durationSeconds === undefined || durationSeconds === null || durationSeconds <= 0) {
+    return describeSet(reps, effectiveLoad, options)
+  }
+  const hold = formatHold(durationSeconds)
+  return effectiveLoad > 0 ? `${hold} × ${formatLbs(effectiveLoad, options)}` : hold
+}

--- a/lib/training-facility/workout-stats.ts
+++ b/lib/training-facility/workout-stats.ts
@@ -112,6 +112,14 @@ export interface WorkoutSetHighlight {
   effectiveLoad: number
   /** ISO timestamp the set was logged. */
   loggedAt: string
+  /**
+   * Seconds the set was held, for an isometric movement (#400).
+   *
+   * Absent for everything counted in repetitions. When present, `reps` is 1 and
+   * this is what the set actually was — render sites should prefer
+   * `describeSetOrHold`, which says `45s` where `describeSet` would say `1 rep`.
+   */
+  durationSeconds?: number
 }
 
 /** One movement's contribution to a session. */
@@ -261,6 +269,7 @@ export function buildWorkoutSummary(
         weightLbs: set.weight_lbs ?? null,
         effectiveLoad,
         loggedAt: set.logged_at,
+        ...(set.duration_seconds === undefined ? {} : { durationSeconds: set.duration_seconds }),
       }
       // Heaviest wins; at equal load the one with more reps is the better set.
       if (

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "import-health": "node scripts/import-health.mjs",
     "cardio:backfill": "node scripts/backfill-cardio.mjs",
     "import-otbeat": "node scripts/import-otbeat.mjs",
+    "import-icloud-notes": "node scripts/import-icloud-notes.mjs",
     "migrations:check": "node scripts/check-migration-drift.mjs",
     "staging:sync": "node scripts/sync-staging.mjs",
     "e2e:dev": "cross-env TELEMETRY_DISABLED=1 NEXT_DIST_DIR=.next-e2e-default NEXT_PUBLIC_ENABLE_TRAINING_FACILITY=false NEXT_PUBLIC_ENABLE_TF_GYM=false NEXT_PUBLIC_ENABLE_TF_WEIGHT_ROOM=false NEXT_PUBLIC_ENABLE_DRAFT_ROOM=false next dev --turbopack --hostname 127.0.0.1 --port 3007",

--- a/scripts/import-icloud-notes.mjs
+++ b/scripts/import-icloud-notes.mjs
@@ -62,7 +62,12 @@ const DEFAULT_TIME_ZONE = 'America/Los_Angeles'
  * @returns {{extractDir: string, manifest: string|null, timeZone: string, dryRun: boolean}}
  */
 function parseArgs(argv) {
-  const get = name => argv.find(arg => arg.startsWith(`--${name}=`))?.split('=').slice(1).join('=')
+  const get = name =>
+    argv
+      .find(arg => arg.startsWith(`--${name}=`))
+      ?.split('=')
+      .slice(1)
+      .join('=')
   return {
     extractDir: get('extract-dir') ?? DEFAULT_EXTRACT_DIR,
     manifest: get('manifest') ?? null,

--- a/scripts/import-icloud-notes.mjs
+++ b/scripts/import-icloud-notes.mjs
@@ -277,7 +277,7 @@ async function main() {
       : fallbackWindow(note.day, timeZone)
 
     const match = matchNoteToSession(window, sessions, timeZone)
-    let workoutId = match?.id ?? null
+    const workoutId = match?.id ?? null
 
     if (match?.method === 'overlap') report.overlap += 1
     else if (match?.method === 'same-day') report.sameDay += 1

--- a/scripts/import-icloud-notes.mjs
+++ b/scripts/import-icloud-notes.mjs
@@ -41,6 +41,7 @@ import path from 'node:path'
 import { createServiceRoleClient, loadEnv } from './lib/cardio-supabase.mjs'
 import { matchNoteToSession, noteWindow, parseNotesCsvStamp } from './lib/icloud-notes-match.mjs'
 import { parseNote, parseNoteDate } from './lib/icloud-notes-parser.mjs'
+import { parseExport } from './lib/icloud-notes-text.mjs'
 import {
   fetchExerciseSlugs,
   fetchLoadMultipliers,
@@ -70,6 +71,7 @@ function parseArgs(argv) {
       .join('=')
   return {
     extractDir: get('extract-dir') ?? DEFAULT_EXTRACT_DIR,
+    fromText: get('from-text') ?? null,
     manifest: get('manifest') ?? null,
     timeZone: get('tz') ?? DEFAULT_TIME_ZONE,
     dryRun: argv.includes('--dry-run'),
@@ -220,14 +222,19 @@ function fallbackWindow(day, timeZone) {
 }
 
 async function main() {
-  const { extractDir, manifest, timeZone, dryRun } = parseArgs(process.argv.slice(2))
+  const { extractDir, fromText, manifest, timeZone, dryRun } = parseArgs(process.argv.slice(2))
 
   loadEnv()
   const supabase = createServiceRoleClient()
 
-  const notes = await loadNotes(extractDir)
+  // Two front ends onto the same pipeline: `--from-text` reads the Shortcuts
+  // export directly (one cell per line, blank lines meaning empty cells), while
+  // the extract directory holds notes already transcribed to JSON.
+  const notes = fromText
+    ? parseExport(await readFile(fromText, 'utf8'))
+    : await loadNotes(extractDir)
   if (notes.length === 0) {
-    console.error(`No notes found in "${extractDir}". Nothing to import.`)
+    console.error(`No notes found in "${fromText ?? extractDir}". Nothing to import.`)
     process.exit(1)
   }
 
@@ -270,6 +277,7 @@ async function main() {
 
   const rows = []
   const unmappedMovements = new Map()
+  const timedMovements = new Map()
   const unknownSlugs = new Map()
   const report = {
     overlap: 0,
@@ -310,9 +318,12 @@ async function main() {
       })
     }
 
-    const { sets, unmapped } = parseNote({ ...note, date: note.day }, multipliers)
+    const { sets, unmapped, timed } = parseNote({ ...note, date: note.day }, multipliers)
     for (const name of unmapped) {
       unmappedMovements.set(name, (unmappedMovements.get(name) ?? 0) + 1)
+    }
+    for (const name of timed ?? []) {
+      timedMovements.set(name, (timedMovements.get(name) ?? 0) + 1)
     }
 
     for (const set of sets) {
@@ -327,6 +338,7 @@ async function main() {
           exercise: set.exercise,
           reps: set.reps,
           weight_lbs: set.weight_lbs,
+          ...(set.variant === undefined ? {} : { variant: set.variant }),
           // Grease-the-groove volume is that day's, not the session's — see
           // #400. Leaving `workout_id` null is what keeps it off the workout.
           workout_id: set.disposition === 'workout' ? workoutId : null,
@@ -360,6 +372,11 @@ async function main() {
     for (const [name, count] of [...unmappedMovements].sort((a, b) => b[1] - a[1])) {
       console.log(`  ${String(count).padStart(4)}x  ${name}`)
     }
+  }
+  if (timedMovements.size > 0) {
+    console.log('')
+    console.log('Duration-measured movements skipped (weight_room_sets has no duration column):')
+    for (const [name, count] of timedMovements) console.log(`  ${count}x  ${name}`)
   }
   if (unknownSlugs.size > 0) {
     console.log('')

--- a/scripts/import-icloud-notes.mjs
+++ b/scripts/import-icloud-notes.mjs
@@ -339,6 +339,7 @@ async function main() {
           reps: set.reps,
           weight_lbs: set.weight_lbs,
           ...(set.variant === undefined ? {} : { variant: set.variant }),
+          ...(set.duration_seconds === undefined ? {} : { duration_seconds: set.duration_seconds }),
           // Grease-the-groove volume is that day's, not the session's — see
           // #400. Leaving `workout_id` null is what keeps it off the workout.
           workout_id: set.disposition === 'workout' ? workoutId : null,

--- a/scripts/import-icloud-notes.mjs
+++ b/scripts/import-icloud-notes.mjs
@@ -284,6 +284,13 @@ async function main() {
     const match = matchNoteToSession(window, sessions, timeZone)
     const workoutId = match?.id ?? null
 
+    // Identity for a note that needs its own session. Keyed by title *and*
+    // start instant, not by day: two unmatched notes can fall on one local date
+    // — which is precisely the situation that defeats overlap matching in the
+    // first place — and a day-keyed map would hand the second note's id to the
+    // first note's sets, silently merging two distinct workouts into one.
+    const noteKey = `${note.title}|${window.start.toISOString()}`
+
     if (match?.method === 'overlap') report.overlap += 1
     else if (match?.method === 'same-day') report.sameDay += 1
     else {
@@ -292,7 +299,7 @@ async function main() {
         startedAt: window.start.toISOString(),
         endedAt: window.end.toISOString(),
         title: note.title,
-        day: note.day,
+        noteKey,
       })
     }
 
@@ -307,7 +314,7 @@ async function main() {
         continue
       }
       rows.push({
-        pendingSessionFor: set.disposition === 'workout' && !workoutId ? note.day : null,
+        pendingSessionFor: set.disposition === 'workout' && !workoutId ? noteKey : null,
         row: {
           logged_at: window.start.toISOString(),
           exercise: set.exercise,
@@ -359,15 +366,15 @@ async function main() {
   }
 
   // Sessions first: a note that matched nothing needs its own row before its
-  // sets can point at one.
-  const sessionIdByDay = new Map()
+  // sets can point at one. Keyed per note rather than per day — see `noteKey`.
+  const sessionIdByNote = new Map()
   for (const session of createdSessions) {
     const id = await upsertNoteSession(supabase, session)
-    sessionIdByDay.set(session.day, id)
+    sessionIdByNote.set(session.noteKey, id)
   }
 
   const prepared = rows.map(({ pendingSessionFor, row }) =>
-    pendingSessionFor ? { ...row, workout_id: sessionIdByDay.get(pendingSessionFor) ?? null } : row
+    pendingSessionFor ? { ...row, workout_id: sessionIdByNote.get(pendingSessionFor) ?? null } : row
   )
 
   const { upserted } = await upsertNoteSets(supabase, prepared)

--- a/scripts/import-icloud-notes.mjs
+++ b/scripts/import-icloud-notes.mjs
@@ -39,7 +39,7 @@ import { readdir, readFile } from 'node:fs/promises'
 import path from 'node:path'
 
 import { createServiceRoleClient, loadEnv } from './lib/cardio-supabase.mjs'
-import { matchNoteToSession, parseNotesCsvStamp } from './lib/icloud-notes-match.mjs'
+import { matchNoteToSession, noteWindow, parseNotesCsvStamp } from './lib/icloud-notes-match.mjs'
 import { parseNote, parseNoteDate } from './lib/icloud-notes-parser.mjs'
 import {
   fetchExerciseSlugs,
@@ -271,15 +271,22 @@ async function main() {
   const rows = []
   const unmappedMovements = new Map()
   const unknownSlugs = new Map()
-  const report = { overlap: 0, sameDay: 0, ownSession: 0, missingManifest: 0 }
+  const report = {
+    overlap: 0,
+    sameDay: 0,
+    ownSession: 0,
+    missingManifest: 0,
+    clampedWindow: 0,
+  }
   const createdSessions = []
 
   for (const note of dated) {
     const entry = manifestIndex.get(`${note.title}|${note.day}`)
     if (!entry) report.missingManifest += 1
     const window = entry
-      ? { start: entry.created, end: entry.modified }
+      ? noteWindow(entry.created, entry.modified)
       : fallbackWindow(note.day, timeZone)
+    if (window.clamped) report.clampedWindow += 1
 
     const match = matchNoteToSession(window, sessions, timeZone)
     const workoutId = match?.id ?? null
@@ -342,6 +349,7 @@ async function main() {
   console.log(`  matched by same day   ${report.sameDay}`)
   console.log(`  own icloud session    ${report.ownSession}`)
   console.log(`  no manifest row       ${report.missingManifest}`)
+  console.log(`  late edit discarded   ${report.clampedWindow}`)
   console.log(`Sets parsed             ${rows.length}`)
   console.log(`  workout               ${workoutSets}`)
   console.log(`  grease-the-groove     ${gtgSets}`)

--- a/scripts/import-icloud-notes.mjs
+++ b/scripts/import-icloud-notes.mjs
@@ -1,0 +1,376 @@
+#!/usr/bin/env node
+/**
+ * `npm run import-icloud-notes` — historical Apple Notes workouts → Supabase (#400).
+ *
+ * Two years of training (2022-2024) were logged one note per session, titled
+ * with the template that was run and holding a `Set | Weight | Reps` table per
+ * exercise. Apple's bulk export flattens notes to plain text, and plain text
+ * cannot hold a table — every one collapses to a `￼` placeholder and the
+ * numbers go with it. So the tables are transcribed from the rendered note into
+ * JSON under `.notes-extract/` (gitignored, personal training data), and this
+ * script is the half that turns that JSON into rows.
+ *
+ * What it does, in order:
+ *
+ * 1. Reads every `.json` in the extract directory.
+ * 2. Reads Apple's `Notes Details.csv` manifest for each note's created and
+ *    last-modified stamps — the window the note was written across.
+ * 3. Attributes each note to an existing `apple_health` session (#413) whose
+ *    window it overlaps. These notes were typed *during* the workout, so the
+ *    overlap is usually total: on 2024-04-16 the Health window was
+ *    21:39:00-22:10:42 and the note spanned 21:40:38-22:07:12. A note that
+ *    matches nothing becomes its own `icloud_notes` session rather than being
+ *    dropped.
+ * 4. Parses each note into sets, keeping the session's own table work apart
+ *    from grease-the-groove rep lists, which are that day's volume and not part
+ *    of the workout they sit inside.
+ * 5. Upserts, keyed on a deterministic `import_key`, so a re-run converges
+ *    instead of doubling two years of history.
+ *
+ * Nothing here deletes. An imported session may already carry Health-derived
+ * duration and heart rate, and a set logged through the app is not ours to
+ * touch.
+ *
+ * Run `--dry-run` first: it does every read, match and parse, prints the same
+ * report, and writes nothing.
+ */
+
+import { readdir, readFile } from 'node:fs/promises'
+import path from 'node:path'
+
+import { createServiceRoleClient, loadEnv } from './lib/cardio-supabase.mjs'
+import { matchNoteToSession, parseNotesCsvStamp } from './lib/icloud-notes-match.mjs'
+import { parseNote, parseNoteDate } from './lib/icloud-notes-parser.mjs'
+import {
+  fetchExerciseSlugs,
+  fetchLoadMultipliers,
+  fetchSessionsInRange,
+  upsertNoteSession,
+  upsertNoteSets,
+} from './lib/icloud-notes-supabase.mjs'
+
+/** Where the transcribed notes live. Gitignored — see `.gitignore`. */
+const DEFAULT_EXTRACT_DIR = '.notes-extract'
+
+/** The zone the note stamps and the training itself are expressed in. */
+const DEFAULT_TIME_ZONE = 'America/Los_Angeles'
+
+/**
+ * Read `--flag=value` style arguments.
+ *
+ * @param {string[]} argv Raw `process.argv.slice(2)`.
+ * @returns {{extractDir: string, manifest: string|null, timeZone: string, dryRun: boolean}}
+ */
+function parseArgs(argv) {
+  const get = name => argv.find(arg => arg.startsWith(`--${name}=`))?.split('=').slice(1).join('=')
+  return {
+    extractDir: get('extract-dir') ?? DEFAULT_EXTRACT_DIR,
+    manifest: get('manifest') ?? null,
+    timeZone: get('tz') ?? DEFAULT_TIME_ZONE,
+    dryRun: argv.includes('--dry-run'),
+  }
+}
+
+/**
+ * Load every transcribed note from the extract directory.
+ *
+ * @param {string} dir Directory holding the per-batch JSON files.
+ * @returns {Promise<Array<object>>} Notes across all batches, in file order.
+ * @throws when the directory is missing or a file is not valid JSON.
+ */
+async function loadNotes(dir) {
+  let entries
+  try {
+    entries = await readdir(dir)
+  } catch {
+    throw new Error(
+      `No extract directory at "${dir}". Transcribe the notes first, or pass --extract-dir=<path>.`
+    )
+  }
+
+  const notes = []
+  for (const entry of entries.filter(name => name.endsWith('.json')).sort()) {
+    const full = path.join(dir, entry)
+    let parsed
+    try {
+      parsed = JSON.parse(await readFile(full, 'utf8'))
+    } catch (error) {
+      throw new Error(`Could not parse ${full}: ${error.message}`)
+    }
+    for (const note of parsed.notes ?? []) {
+      notes.push({ ...note, _batch: entry })
+    }
+  }
+  return notes
+}
+
+/**
+ * Split one CSV line, honouring quoted fields.
+ *
+ * Apple's manifest is not quoted consistently and a note titled with a comma
+ * spills into extra columns. Rather than guess where the title ended, rows
+ * whose shape is wrong are skipped by the caller and reported — a note with no
+ * timestamps still imports, it just falls back to a synthesized window.
+ *
+ * @param {string} line One raw CSV line.
+ * @returns {string[]} Trimmed fields.
+ */
+function splitCsvLine(line) {
+  const fields = []
+  let current = ''
+  let quoted = false
+  for (let i = 0; i < line.length; i += 1) {
+    const char = line[i]
+    if (char === '"') {
+      quoted = !quoted
+    } else if (char === ',' && !quoted) {
+      fields.push(current.trim())
+      current = ''
+    } else {
+      current += char
+    }
+  }
+  fields.push(current.trim())
+  return fields
+}
+
+/**
+ * Index Apple's note manifest by title and local day.
+ *
+ * `(title, day)` rather than title alone because the log reuses six titles
+ * across roughly 130 sessions — "Back Day 1" names 23 different workouts. The
+ * day disambiguates them, and is the one thing both the manifest and the
+ * rendered list agree on.
+ *
+ * @param {string} csv Raw contents of `Notes Details.csv`.
+ * @param {string} timeZone Zone the stamps are expressed in.
+ * @returns {Map<string, {created: Date, modified: Date}>} Keyed `title|YYYY-MM-DD`.
+ */
+export function indexManifest(csv, timeZone) {
+  const index = new Map()
+  const lines = csv.split(/\r?\n/).slice(1)
+
+  for (const line of lines) {
+    if (!line.trim()) continue
+    const fields = splitCsvLine(line)
+    if (fields.length < 3) continue
+
+    // Created and modified are the two stamps; a title containing commas
+    // pushes them right, so locate them from the end of the row instead of by
+    // fixed position. The last four columns are the three Yes/No flags plus a
+    // content hash, so the stamps sit just before those.
+    const stampIndexes = fields
+      .map((value, i) => ({ value, i }))
+      .filter(({ value }) => /^\d{2}-\d{2}-\d{4}\s+\d{2}:\d{2}:\d{2}$/.test(value))
+      .map(({ i }) => i)
+    if (stampIndexes.length < 2) continue
+
+    const created = parseNotesCsvStamp(fields[stampIndexes[0]], timeZone)
+    const modified = parseNotesCsvStamp(fields[stampIndexes[1]], timeZone)
+    if (!created || !modified) continue
+
+    // Everything before the first stamp is the title, commas and all.
+    const title = fields.slice(0, stampIndexes[0]).join(', ')
+    const day = localDay(created, timeZone)
+    index.set(`${title}|${day}`, { created, modified })
+  }
+
+  return index
+}
+
+/**
+ * The `YYYY-MM-DD` a moment falls on in a zone.
+ *
+ * @param {Date} instant The moment.
+ * @param {string} timeZone IANA zone.
+ * @returns {string} Day key.
+ */
+function localDay(instant, timeZone) {
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(instant)
+}
+
+/**
+ * A stand-in window for a note whose manifest row could not be found.
+ *
+ * Midday local, half an hour long. Deliberately not midnight: a midnight stamp
+ * read in the wrong zone slides onto the previous day, and the whole point of
+ * the window is to land the session on the right one.
+ *
+ * @param {string} day `YYYY-MM-DD`.
+ * @param {string} timeZone IANA zone.
+ * @returns {{start: Date, end: Date}} The synthesized window.
+ */
+function fallbackWindow(day, timeZone) {
+  const [year, month, date] = day.split('-').map(Number)
+  const start = parseNotesCsvStamp(
+    `${String(month).padStart(2, '0')}-${String(date).padStart(2, '0')}-${year} 12:00:00`,
+    timeZone
+  )
+  return { start, end: new Date(start.getTime() + 30 * 60_000) }
+}
+
+async function main() {
+  const { extractDir, manifest, timeZone, dryRun } = parseArgs(process.argv.slice(2))
+
+  loadEnv()
+  const supabase = createServiceRoleClient()
+
+  const notes = await loadNotes(extractDir)
+  if (notes.length === 0) {
+    console.error(`No notes found in "${extractDir}". Nothing to import.`)
+    process.exit(1)
+  }
+
+  const manifestIndex = manifest
+    ? indexManifest(await readFile(manifest, 'utf8'), timeZone)
+    : new Map()
+  if (!manifest) {
+    console.warn(
+      'No --manifest given: every session falls back to a synthesized midday window, ' +
+        'which will match far fewer Health sessions. Pass the export\'s "Notes Details.csv".'
+    )
+  }
+
+  const [multipliers, catalogSlugs] = await Promise.all([
+    fetchLoadMultipliers(supabase),
+    fetchExerciseSlugs(supabase),
+  ])
+
+  // Resolve each note's day first so the session read can be scoped to the
+  // range the notes actually cover.
+  const dated = []
+  const undatable = []
+  for (const note of notes) {
+    const day = parseNoteDate(note.date)
+    if (!day) {
+      undatable.push(note)
+      continue
+    }
+    dated.push({ ...note, day })
+  }
+  dated.sort((a, b) => a.day.localeCompare(b.day))
+
+  const first = fallbackWindow(dated[0].day, timeZone).start
+  const last = fallbackWindow(dated[dated.length - 1].day, timeZone).end
+  const sessions = await fetchSessionsInRange(
+    supabase,
+    new Date(first.getTime() - 36 * 3600_000).toISOString(),
+    new Date(last.getTime() + 36 * 3600_000).toISOString()
+  )
+
+  const rows = []
+  const unmappedMovements = new Map()
+  const unknownSlugs = new Map()
+  const report = { overlap: 0, sameDay: 0, ownSession: 0, missingManifest: 0 }
+  const createdSessions = []
+
+  for (const note of dated) {
+    const entry = manifestIndex.get(`${note.title}|${note.day}`)
+    if (!entry) report.missingManifest += 1
+    const window = entry
+      ? { start: entry.created, end: entry.modified }
+      : fallbackWindow(note.day, timeZone)
+
+    const match = matchNoteToSession(window, sessions, timeZone)
+    let workoutId = match?.id ?? null
+
+    if (match?.method === 'overlap') report.overlap += 1
+    else if (match?.method === 'same-day') report.sameDay += 1
+    else {
+      report.ownSession += 1
+      createdSessions.push({
+        startedAt: window.start.toISOString(),
+        endedAt: window.end.toISOString(),
+        title: note.title,
+        day: note.day,
+      })
+    }
+
+    const { sets, unmapped } = parseNote({ ...note, date: note.day }, multipliers)
+    for (const name of unmapped) {
+      unmappedMovements.set(name, (unmappedMovements.get(name) ?? 0) + 1)
+    }
+
+    for (const set of sets) {
+      if (!catalogSlugs.has(set.exercise)) {
+        unknownSlugs.set(set.exercise, (unknownSlugs.get(set.exercise) ?? 0) + 1)
+        continue
+      }
+      rows.push({
+        pendingSessionFor: set.disposition === 'workout' && !workoutId ? note.day : null,
+        row: {
+          logged_at: window.start.toISOString(),
+          exercise: set.exercise,
+          reps: set.reps,
+          weight_lbs: set.weight_lbs,
+          // Grease-the-groove volume is that day's, not the session's — see
+          // #400. Leaving `workout_id` null is what keeps it off the workout.
+          workout_id: set.disposition === 'workout' ? workoutId : null,
+          position: set.position,
+          import_key: set.import_key,
+        },
+      })
+    }
+  }
+
+  const workoutSets = rows.filter(r => r.row.workout_id !== null || r.pendingSessionFor).length
+  const gtgSets = rows.length - workoutSets
+
+  console.log('')
+  console.log(`Notes read              ${notes.length}`)
+  console.log(`  dated                 ${dated.length}`)
+  console.log(`  undatable (skipped)   ${undatable.length}`)
+  console.log(`Attribution`)
+  console.log(`  matched by overlap    ${report.overlap}`)
+  console.log(`  matched by same day   ${report.sameDay}`)
+  console.log(`  own icloud session    ${report.ownSession}`)
+  console.log(`  no manifest row       ${report.missingManifest}`)
+  console.log(`Sets parsed             ${rows.length}`)
+  console.log(`  workout               ${workoutSets}`)
+  console.log(`  grease-the-groove     ${gtgSets}`)
+
+  if (unmappedMovements.size > 0) {
+    console.log('')
+    console.log('Movements with no catalog match (add a real row, not a near-duplicate slug):')
+    for (const [name, count] of [...unmappedMovements].sort((a, b) => b[1] - a[1])) {
+      console.log(`  ${String(count).padStart(4)}x  ${name}`)
+    }
+  }
+  if (unknownSlugs.size > 0) {
+    console.log('')
+    console.log('Resolved to slugs absent from the catalog — these sets were dropped:')
+    for (const [slug, count] of unknownSlugs) console.log(`  ${count}x  ${slug}`)
+  }
+
+  if (dryRun) {
+    console.log('')
+    console.log('--dry-run: nothing written.')
+    return
+  }
+
+  // Sessions first: a note that matched nothing needs its own row before its
+  // sets can point at one.
+  const sessionIdByDay = new Map()
+  for (const session of createdSessions) {
+    const id = await upsertNoteSession(supabase, session)
+    sessionIdByDay.set(session.day, id)
+  }
+
+  const prepared = rows.map(({ pendingSessionFor, row }) =>
+    pendingSessionFor ? { ...row, workout_id: sessionIdByDay.get(pendingSessionFor) ?? null } : row
+  )
+
+  const { upserted } = await upsertNoteSets(supabase, prepared)
+  console.log('')
+  console.log(`Wrote ${createdSessions.length} sessions and ${upserted} sets.`)
+}
+
+main().catch(error => {
+  console.error(error.message)
+  process.exit(1)
+})

--- a/scripts/lib/icloud-notes-match.mjs
+++ b/scripts/lib/icloud-notes-match.mjs
@@ -106,6 +106,51 @@ export function parseNotesCsvStamp(stamp, timeZone) {
 }
 
 /**
+ * How long a note's create→edit span may be before it stops describing a session.
+ *
+ * A lifting session is under two hours; six leaves room for a note finished off
+ * over dinner without admitting anything that is obviously not one sitting.
+ */
+export const MAX_SESSION_HOURS = 6
+
+/**
+ * The window a note was actually written across, guarded against a late edit.
+ *
+ * Create→edit is normally the session itself, because these notes were typed
+ * one row at a time while training. But a note revisited later stretches that
+ * span arbitrarily: in this dataset a `Legs Day 1` created 2024-02-06 was last
+ * edited **2026-02-12**, a two-year window. Handed to
+ * {@link matchNoteToSession} it would overlap every workout in between and win
+ * on whichever happened to be longest — a confidently wrong attribution, which
+ * is precisely the failure this module exists to prevent.
+ *
+ * So an implausibly long span collapses to a short window at the note's
+ * creation, which is when the training actually happened. That usually finds no
+ * overlap and falls through to the same-day rule, which is the honest answer:
+ * the edit tells us nothing about the session.
+ *
+ * @param {Date} created When the note was created.
+ * @param {Date} modified When it was last edited.
+ * @param {number} [maxHours] Span above which the edit is treated as unrelated;
+ *   defaults to {@link MAX_SESSION_HOURS}.
+ * @returns {{start: Date, end: Date, clamped: boolean}} The window to match on,
+ *   and whether the late edit was discarded — reported so the import can say so
+ *   rather than silently narrowing.
+ */
+export function noteWindow(created, modified, maxHours = MAX_SESSION_HOURS) {
+  const start = created.getTime()
+  const end = modified.getTime()
+  const spanHours = (end - start) / 3_600_000
+
+  // `end < start` should not happen, but a clock change or a hand-edited
+  // manifest would produce it, and a negative window silently matches nothing.
+  if (!Number.isFinite(spanHours) || spanHours < 0 || spanHours > maxHours) {
+    return { start: created, end: new Date(start + 30 * 60_000), clamped: true }
+  }
+  return { start: created, end: modified, clamped: false }
+}
+
+/**
  * Pick the stored workout a transcribed note documents.
  *
  * Overlap first, ranked by how much of it there is. A note whose window misses

--- a/scripts/lib/icloud-notes-match.mjs
+++ b/scripts/lib/icloud-notes-match.mjs
@@ -1,0 +1,175 @@
+/**
+ * Attribution between transcribed Apple Notes sessions and the Apple Health
+ * strength workouts already in `weight_room_workouts` (#400, shape shared with
+ * #401).
+ *
+ * The two sources record the same hour from opposite ends. Health knows when a
+ * session started, how long it ran and how hard — but not one thing that was
+ * lifted. The note knows every set — but only bears the timestamps Apple stamped
+ * on the file. Joined, a session gets both halves; joined *wrongly*, a session
+ * gets someone else's heart rate welded onto its sets, and nothing downstream
+ * looks suspicious. So the match is explicit, ranked, and reports what it did.
+ *
+ * The join is tighter than "same day" because these notes were typed *during*
+ * the workout, one row at a time: on 2024-04-16 the Health window was
+ * 21:39:00-22:10:42 and the note's own create/modify span was 21:40:38-22:07:12,
+ * sitting entirely inside it. Overlap is therefore the primary signal, and it is
+ * what separates the 8 days in this history that carry two strength sessions —
+ * days a same-day join would silently coin-flip.
+ */
+
+/**
+ * Milliseconds that two half-open intervals share.
+ *
+ * @param {number} aStart Start of the first interval, epoch ms.
+ * @param {number} aEnd End of the first interval, epoch ms.
+ * @param {number} bStart Start of the second interval, epoch ms.
+ * @param {number} bEnd End of the second interval, epoch ms.
+ * @returns {number} Overlap in ms; 0 when they do not intersect.
+ */
+export function overlapMs(aStart, aEnd, bStart, bEnd) {
+  const start = Math.max(aStart, bStart)
+  const end = Math.min(aEnd, bEnd)
+  return Math.max(0, end - start)
+}
+
+/**
+ * The offset of a time zone at a given instant, in milliseconds.
+ *
+ * Computed from `Intl` rather than hardcoded because this history spans several
+ * years of daylight-saving transitions, and a fixed -08:00 would shift every
+ * summer session by an hour — enough to push a note out of the workout window it
+ * belongs to and break the match that makes the import worth doing.
+ *
+ * @param {Date} instant The moment to measure at.
+ * @param {string} timeZone IANA zone, e.g. `'America/Los_Angeles'`.
+ * @returns {number} Offset east of UTC in ms (negative for the Americas).
+ */
+export function zoneOffsetMs(instant, timeZone) {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone,
+    hour12: false,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  }).formatToParts(instant)
+
+  const at = type => Number(parts.find(part => part.type === type)?.value)
+  // `hour12: false` renders midnight as 24 in some ICU versions.
+  const hour = at('hour') % 24
+
+  const asUtc = Date.UTC(at('year'), at('month') - 1, at('day'), hour, at('minute'), at('second'))
+  return asUtc - instant.getTime()
+}
+
+/**
+ * Interpret a wall-clock local time as a UTC instant.
+ *
+ * Apple's `Notes Details.csv` stamps `MM-DD-YYYY HH:MM:SS` with no offset, in
+ * the exporting device's local zone. Treating that as UTC would land every
+ * session seven or eight hours late and match it against the wrong workout —
+ * or nothing at all.
+ *
+ * Resolved by guessing, measuring the zone's offset at the guess, and
+ * correcting. Ambiguous times in the autumn fall-back hour resolve to the first
+ * of the two; nothing in this dataset lands there, and a one-hour error in that
+ * window would still overlap the session it belongs to.
+ *
+ * @param {{year: number, month: number, day: number, hour?: number,
+ *   minute?: number, second?: number}} parts Wall-clock components, 1-based month.
+ * @param {string} timeZone IANA zone the components are expressed in.
+ * @returns {Date} The corresponding UTC instant.
+ */
+export function localToInstant(parts, timeZone) {
+  const { year, month, day, hour = 0, minute = 0, second = 0 } = parts
+  const guess = Date.UTC(year, month - 1, day, hour, minute, second)
+  const offset = zoneOffsetMs(new Date(guess), timeZone)
+  return new Date(guess - offset)
+}
+
+/**
+ * Parse one `MM-DD-YYYY HH:MM:SS` stamp from Apple's notes manifest.
+ *
+ * @param {string} stamp The raw cell, e.g. `'04-16-2024 21:40:38'`.
+ * @param {string} timeZone IANA zone the stamp is expressed in.
+ * @returns {Date|null} The instant, or null when the cell is not a stamp.
+ */
+export function parseNotesCsvStamp(stamp, timeZone) {
+  if (typeof stamp !== 'string') return null
+  const match = stamp.trim().match(/^(\d{2})-(\d{2})-(\d{4})\s+(\d{2}):(\d{2}):(\d{2})$/)
+  if (!match) return null
+  const [, month, day, year, hour, minute, second] = match.map(Number)
+  return localToInstant({ year, month, day, hour, minute, second }, timeZone)
+}
+
+/**
+ * Pick the stored workout a transcribed note documents.
+ *
+ * Overlap first, ranked by how much of it there is. A note whose window misses
+ * every session — typed up after the fact, or logged on a day the watch was on
+ * the charger — falls back to a same-day match, but *only* when that day holds
+ * exactly one session; two candidates and one note is not something to resolve
+ * by guessing, so it returns null and the caller records the note as its own
+ * session instead.
+ *
+ * @param {{start: Date, end: Date}} noteWindow The note's create/modify span.
+ * @param {Array<{id: string, started_at: string, ended_at: string|null}>} sessions
+ *   Candidate stored workouts.
+ * @param {string} timeZone IANA zone used for the same-day fallback.
+ * @returns {{id: string, method: 'overlap'|'same-day', overlapMs: number}|null}
+ *   The chosen session, or null when nothing matched confidently.
+ */
+export function matchNoteToSession(noteWindow, sessions, timeZone) {
+  const noteStart = noteWindow.start.getTime()
+  const noteEnd = noteWindow.end.getTime()
+  if (!Number.isFinite(noteStart) || !Number.isFinite(noteEnd)) return null
+
+  /** @type {{id: string, overlap: number}|null} */
+  let best = null
+  for (const session of sessions) {
+    const start = new Date(session.started_at).getTime()
+    // A session with no recorded end is treated as instantaneous rather than
+    // open-ended; an unbounded window would swallow every note that day.
+    const end = session.ended_at ? new Date(session.ended_at).getTime() : start
+    if (!Number.isFinite(start) || !Number.isFinite(end)) continue
+
+    const overlap = overlapMs(noteStart, noteEnd, start, end)
+    if (overlap > 0 && (!best || overlap > best.overlap)) {
+      best = { id: session.id, overlap }
+    }
+  }
+  if (best) return { id: best.id, method: 'overlap', overlapMs: best.overlap }
+
+  const dayKey = instant => localDayKey(instant, timeZone)
+  const noteDay = dayKey(noteWindow.start)
+  const sameDay = sessions.filter(
+    session => dayKey(new Date(session.started_at)) === noteDay
+  )
+  if (sameDay.length === 1) {
+    return { id: sameDay[0].id, method: 'same-day', overlapMs: 0 }
+  }
+
+  return null
+}
+
+/**
+ * The `YYYY-MM-DD` a moment falls on in a given zone.
+ *
+ * @param {Date} instant The moment.
+ * @param {string} timeZone IANA zone.
+ * @returns {string} Day key, or `''` for an invalid date.
+ */
+export function localDayKey(instant, timeZone) {
+  if (!(instant instanceof Date) || Number.isNaN(instant.getTime())) return ''
+  const parts = new Intl.DateTimeFormat('en-CA', {
+    timeZone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).formatToParts(instant)
+  const at = type => parts.find(part => part.type === type)?.value
+  return `${at('year')}-${at('month')}-${at('day')}`
+}

--- a/scripts/lib/icloud-notes-match.mjs
+++ b/scripts/lib/icloud-notes-match.mjs
@@ -145,9 +145,7 @@ export function matchNoteToSession(noteWindow, sessions, timeZone) {
 
   const dayKey = instant => localDayKey(instant, timeZone)
   const noteDay = dayKey(noteWindow.start)
-  const sameDay = sessions.filter(
-    session => dayKey(new Date(session.started_at)) === noteDay
-  )
+  const sameDay = sessions.filter(session => dayKey(new Date(session.started_at)) === noteDay)
   if (sameDay.length === 1) {
     return { id: sameDay[0].id, method: 'same-day', overlapMs: 0 }
   }

--- a/scripts/lib/icloud-notes-match.test.ts
+++ b/scripts/lib/icloud-notes-match.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Tests for note-to-session attribution (#400).
+ *
+ * The cases pin the failure this code exists to prevent: a note's sets welded
+ * onto the wrong session's heart rate, which nothing downstream would render
+ * as suspicious. Anchored on the real 2024-04-16 pair, and on the two ways the
+ * naive join breaks — a summer date read at the wrong UTC offset, and one of
+ * the eight days in this history that carry two strength sessions.
+ */
+import { describe, expect, it } from 'vitest'
+
+import {
+  localDayKey,
+  localToInstant,
+  matchNoteToSession,
+  overlapMs,
+  parseNotesCsvStamp,
+  zoneOffsetMs,
+} from './icloud-notes-match.mjs'
+
+const LA = 'America/Los_Angeles'
+
+describe('overlapMs', () => {
+  it('measures a genuine intersection', () => {
+    expect(overlapMs(0, 100, 50, 150)).toBe(50)
+  })
+
+  it('is zero for disjoint and for merely touching intervals', () => {
+    expect(overlapMs(0, 100, 200, 300)).toBe(0)
+    expect(overlapMs(0, 100, 100, 200)).toBe(0)
+  })
+
+  it('reports full containment as the contained span', () => {
+    expect(overlapMs(50, 80, 0, 100)).toBe(30)
+  })
+})
+
+describe('zoneOffsetMs', () => {
+  it('tracks daylight saving rather than assuming a fixed offset', () => {
+    // -08:00 in winter, -07:00 in summer. Assuming either one year-round
+    // shifts half the history by an hour.
+    expect(zoneOffsetMs(new Date('2024-01-15T20:00:00Z'), LA)).toBe(-8 * 3600_000)
+    expect(zoneOffsetMs(new Date('2024-07-15T20:00:00Z'), LA)).toBe(-7 * 3600_000)
+  })
+})
+
+describe('localToInstant / parseNotesCsvStamp', () => {
+  it('reads an unmarked local stamp as local, not UTC', () => {
+    // The note manifest stamps wall-clock time with no offset. Read as UTC
+    // this lands seven hours early and matches nothing.
+    expect(parseNotesCsvStamp('04-16-2024 21:40:38', LA)?.toISOString()).toBe(
+      '2024-04-17T04:40:38.000Z'
+    )
+  })
+
+  it('applies the winter offset to a winter stamp', () => {
+    expect(parseNotesCsvStamp('01-22-2024 21:09:05', LA)?.toISOString()).toBe(
+      '2024-01-23T05:09:05.000Z'
+    )
+  })
+
+  it('rejects a cell that is not a stamp', () => {
+    expect(parseNotesCsvStamp('', LA)).toBeNull()
+    expect(parseNotesCsvStamp('not a date', LA)).toBeNull()
+    expect(parseNotesCsvStamp(undefined as unknown as string, LA)).toBeNull()
+  })
+
+  it('round-trips through localDayKey', () => {
+    const instant = localToInstant({ year: 2024, month: 4, day: 16, hour: 21 }, LA)
+    expect(localDayKey(instant, LA)).toBe('2024-04-16')
+  })
+
+  it('keeps a late-evening local time on its own local day', () => {
+    // 21:40 local is already tomorrow in UTC; bucketing on the UTC date would
+    // file this session under the 17th.
+    const instant = parseNotesCsvStamp('04-16-2024 21:40:38', LA)!
+    expect(instant.toISOString().slice(0, 10)).toBe('2024-04-17')
+    expect(localDayKey(instant, LA)).toBe('2024-04-16')
+  })
+})
+
+describe('matchNoteToSession', () => {
+  // The real pair that established the approach: the note was typed during the
+  // workout, so its create/modify span sits inside the Health window.
+  const sessions = [
+    {
+      id: 'apr-15',
+      started_at: '2024-04-16T04:19:01Z',
+      ended_at: '2024-04-16T05:06:10Z',
+    },
+    {
+      id: 'apr-16',
+      started_at: '2024-04-17T04:39:00Z',
+      ended_at: '2024-04-17T05:10:42Z',
+    },
+    {
+      id: 'apr-17',
+      started_at: '2024-04-18T02:05:51Z',
+      ended_at: '2024-04-18T02:53:03Z',
+    },
+  ]
+
+  const noteWindow = {
+    start: parseNotesCsvStamp('04-16-2024 21:40:38', LA)!,
+    end: parseNotesCsvStamp('04-16-2024 22:07:12', LA)!,
+  }
+
+  it('attributes a note to the session it was typed inside', () => {
+    const match = matchNoteToSession(noteWindow, sessions, LA)
+    expect(match?.id).toBe('apr-16')
+    expect(match?.method).toBe('overlap')
+    expect(match?.overlapMs).toBe(26 * 60_000 + 34_000)
+  })
+
+  it('prefers the larger overlap when two sessions both intersect', () => {
+    // One of the 8 two-session days. A same-day join would coin-flip these.
+    const twoOnOneDay = [
+      { id: 'morning', started_at: '2024-04-17T04:30:00Z', ended_at: '2024-04-17T04:45:00Z' },
+      { id: 'evening', started_at: '2024-04-17T04:39:00Z', ended_at: '2024-04-17T05:10:42Z' },
+    ]
+    expect(matchNoteToSession(noteWindow, twoOnOneDay, LA)?.id).toBe('evening')
+  })
+
+  it('falls back to the day when nothing overlaps and the day is unambiguous', () => {
+    // Typed up after the fact — still the same session, just not concurrent.
+    const written = {
+      start: parseNotesCsvStamp('04-16-2024 23:30:00', LA)!,
+      end: parseNotesCsvStamp('04-16-2024 23:40:00', LA)!,
+    }
+    const match = matchNoteToSession(written, sessions, LA)
+    expect(match?.id).toBe('apr-16')
+    expect(match?.method).toBe('same-day')
+  })
+
+  it('refuses to guess when the day holds two sessions and none overlap', () => {
+    const written = {
+      start: parseNotesCsvStamp('04-16-2024 23:30:00', LA)!,
+      end: parseNotesCsvStamp('04-16-2024 23:40:00', LA)!,
+    }
+    const ambiguous = [
+      { id: 'a', started_at: '2024-04-17T01:00:00Z', ended_at: '2024-04-17T01:30:00Z' },
+      { id: 'b', started_at: '2024-04-17T04:39:00Z', ended_at: '2024-04-17T05:10:42Z' },
+    ]
+    expect(matchNoteToSession(written, ambiguous, LA)).toBeNull()
+  })
+
+  it('returns null when the day has no session at all', () => {
+    const orphan = {
+      start: parseNotesCsvStamp('05-01-2024 18:00:00', LA)!,
+      end: parseNotesCsvStamp('05-01-2024 18:45:00', LA)!,
+    }
+    expect(matchNoteToSession(orphan, sessions, LA)).toBeNull()
+  })
+
+  it('does not let an unfinished session swallow every note that day', () => {
+    // A null `ended_at` treated as open-ended would overlap everything after it.
+    const openEnded = [{ id: 'open', started_at: '2024-04-17T00:01:00Z', ended_at: null }]
+    expect(matchNoteToSession(noteWindow, openEnded, LA)?.method).toBe('same-day')
+  })
+
+  it('returns null for an unparseable note window', () => {
+    const bad = { start: new Date('nope'), end: new Date('nope') }
+    expect(matchNoteToSession(bad, sessions, LA)).toBeNull()
+  })
+})

--- a/scripts/lib/icloud-notes-match.test.ts
+++ b/scripts/lib/icloud-notes-match.test.ts
@@ -13,6 +13,7 @@ import {
   localDayKey,
   localToInstant,
   matchNoteToSession,
+  noteWindow,
   overlapMs,
   parseNotesCsvStamp,
   zoneOffsetMs,
@@ -76,6 +77,54 @@ describe('localToInstant / parseNotesCsvStamp', () => {
     const instant = parseNotesCsvStamp('04-16-2024 21:40:38', LA)!
     expect(instant.toISOString().slice(0, 10)).toBe('2024-04-17')
     expect(localDayKey(instant, LA)).toBe('2024-04-16')
+  })
+})
+
+describe('noteWindow', () => {
+  it('keeps a normal create-to-edit span, which is the session itself', () => {
+    const created = parseNotesCsvStamp('04-16-2024 21:40:38', LA)!
+    const modified = parseNotesCsvStamp('04-16-2024 22:07:12', LA)!
+    const window = noteWindow(created, modified)
+    expect(window.end).toEqual(modified)
+    expect(window.clamped).toBe(false)
+  })
+
+  it('discards an edit made years after the session', () => {
+    // Real row in this export: a Legs Day 1 created 2024-02-06 was last edited
+    // 2026-02-12. Matched on that span it would overlap every workout in
+    // between and win on whichever was longest.
+    const created = parseNotesCsvStamp('02-06-2024 19:00:00', LA)!
+    const modified = parseNotesCsvStamp('02-12-2026 09:00:00', LA)!
+    const window = noteWindow(created, modified)
+    expect(window.clamped).toBe(true)
+    expect(window.start).toEqual(created)
+    expect(window.end.getTime() - created.getTime()).toBe(30 * 60_000)
+  })
+
+  it('discards an edit two days later, which is not one sitting either', () => {
+    const created = parseNotesCsvStamp('10-02-2023 18:00:00', LA)!
+    const modified = parseNotesCsvStamp('10-04-2023 18:00:00', LA)!
+    expect(noteWindow(created, modified).clamped).toBe(true)
+  })
+
+  it('treats a backwards span as unusable rather than matching nothing silently', () => {
+    const created = parseNotesCsvStamp('04-16-2024 22:00:00', LA)!
+    const modified = parseNotesCsvStamp('04-16-2024 21:00:00', LA)!
+    expect(noteWindow(created, modified).clamped).toBe(true)
+  })
+
+  it('a clamped window still finds its session by the same-day rule', () => {
+    // The point of clamping is to decline a wrong overlap, not to drop the note.
+    const created = parseNotesCsvStamp('02-06-2024 19:00:00', LA)!
+    const modified = parseNotesCsvStamp('02-12-2026 09:00:00', LA)!
+    const window = noteWindow(created, modified)
+    const sessions = [
+      { id: 'right', started_at: '2024-02-07T02:30:00Z', ended_at: '2024-02-07T03:20:00Z' },
+      // A much longer session two years later: the unclamped window would have
+      // preferred this one outright.
+      { id: 'wrong', started_at: '2026-02-12T17:00:00Z', ended_at: '2026-02-12T19:00:00Z' },
+    ]
+    expect(matchNoteToSession(window, sessions, LA)?.id).toBe('right')
   })
 })
 

--- a/scripts/lib/icloud-notes-parser.mjs
+++ b/scripts/lib/icloud-notes-parser.mjs
@@ -95,10 +95,101 @@ const RAW_MOVEMENT_ALIASES = {
   // --- core ---
   Planks: 'plank',
   'Knee Tucks': 'knee-tucks',
+  'Hanging Knee tuck': 'knee-tucks',
   'Hanging leg raises': 'hanging-leg-raise',
+  'Leg raises': 'hanging-leg-raise',
   'Heavy Russian Twists': 'russian-twist',
   'Russian Twists': 'russian-twist',
   'Decline Weighted Crunches': 'decline-crunch',
+  'Decline crunches': 'decline-crunch',
+
+  // --- wordings only the older notes use ---
+  'Standing curls': 'dumbbell-curl',
+  'Cable curl': 'rope-curl',
+  'DB curls': 'dumbbell-curl',
+  'DB curl': 'dumbbell-curl',
+  'Dumbell shrug': 'shrugs',
+  Deadlift: 'barbell-deadlift',
+  'Side lateral raise': 'dumbbell-lateral-raise',
+  'Front lateral raise': 'dumbbell-lateral-raise',
+  'Lateral shoulder raise': 'dumbbell-lateral-raise',
+  'Lateral DB raises': 'dumbbell-lateral-raise',
+  'Lateral raises side': 'dumbbell-lateral-raise',
+  'Lateral raises front': 'dumbbell-lateral-raise',
+  'Rope tricep push down': 'cable-tricep-pushdown',
+  'Rope tricep press down': 'cable-tricep-pushdown',
+  'Tricep push down': 'cable-tricep-pushdown',
+  'Tricep press down': 'cable-tricep-pushdown',
+  'Seated Tricep push down': 'cable-tricep-pushdown',
+  'Light sled push': 'sled-push',
+  'Sled push': 'sled-push',
+  'Seated Alt Shoulder DB': 'dumbbell-shoulder-press',
+  'Seated Alt Shoulder Press DB': 'dumbbell-shoulder-press',
+  'Standing shoulder DB press': 'dumbbell-shoulder-press',
+  'Body weight squat': 'squats',
+  'Balance board squat': 'squats',
+  'Medicine ball squat': 'squats',
+  'Back row machine': 'seated-cable-row',
+  'Seated row': 'seated-cable-row',
+  'Lat pull down': 'lat-pulldown',
+  'Lat pull-down': 'lat-pulldown',
+  'Pec fly machine': 'pec-deck',
+  'Rear delt machine': 'cable-face-pull',
+  'Preacher curl machine': 'preacher-curl',
+  'Machine preacher curl': 'preacher-curl',
+  'Seated calf raise machine': 'seated-calf-raise',
+  'Standing calf raise': 'calf-raise',
+  'Glute press': 'barbell-hip-thrust',
+  'Glute leg press': 'leg-press',
+  Bench: 'barbell-bench-press',
+  'Incline barbell bench press': 'barbell-incline-press',
+  // Typos preserved from the source rather than corrected there.
+  'Incline barbell ress': 'barbell-incline-press',
+  'Incline Barbell press': 'barbell-incline-press',
+  'Ez curl': 'ez-bar-curl',
+  'Ez curl standing': 'ez-bar-curl',
+  'Walking lunges': 'walking-lunges',
+
+  // Plyo box work. The height is the load and rides on the set's variant, so
+  // every height resolves to one movement — see the #400 catalog migration.
+  '18 inch plyo': 'box-jump',
+  '24 inch plyo': 'box-jump',
+  '30 inch plyo': 'box-jump',
+  '12 inch plyo': 'box-jump',
+  'One leg 12 inch plyo': 'box-jump',
+  'One leg plyo 12 inch': 'box-jump',
+  Plyo: 'box-jump',
+
+  'Assisted pull ups': 'assisted-pullups',
+  Assisted: 'assisted-pullups',
+
+  // Typos preserved from the source.
+  'Inclined DB press': 'dumbbell-incline-press',
+  'Db lateral raise': 'dumbbell-lateral-raise',
+  'Side lateral': 'dumbbell-lateral-raise',
+  'Front layer raise': 'dumbbell-lateral-raise',
+}
+
+/**
+ * Box height stated in a plyo movement's name, e.g. `24 inch plyo`.
+ *
+ * Kept as the set's variant rather than as three near-duplicate slugs: a box
+ * jump is one movement, and the height is what changes between sets — the same
+ * role grip and tempo play for other movements.
+ */
+const PLYO_HEIGHT = /(\d+)\s*inch/i
+
+/**
+ * The variant a movement's wording implies, if any.
+ *
+ * @param {string} name Movement name as written in the note.
+ * @param {string} slug The slug it resolved to.
+ * @returns {string|null} A lowercase variant, or null when the name adds nothing.
+ */
+export function variantFor(name, slug) {
+  if (slug !== 'box-jump') return null
+  const height = String(name ?? '').match(PLYO_HEIGHT)
+  return height ? `${height[1]} inch` : null
 }
 
 /**
@@ -239,6 +330,12 @@ export function perImplementWeight(raw, header, slug, loadMultiplier) {
   if (text === '') return null
   if (/^bw$/i.test(text)) return null
 
+  // Assistance, not load. `BW - 40` and `BW assisted` describe a dip made
+  // *easier* by 40 lb of counterweight; reading the number as added weight
+  // would record the opposite of what happened.
+  if (/assist/i.test(text)) return null
+  if (/^bw\s*-\s*\d/i.test(text)) return null
+
   // Tolerate "135 lb", "37.5lbs", "22.5 DB" — the notes are handwritten.
   const match = text.match(/-?\d+(?:\.\d+)?/)
   if (!match) return null
@@ -260,6 +357,31 @@ export function perImplementWeight(raw, header, slug, loadMultiplier) {
 }
 
 /**
+ * Read a rep count out of a hand-written measure cell.
+ *
+ * The cell is not always a bare number. Unilateral work is annotated in place —
+ * `10 Each leg`, `8each leg`, `10 each leg` — and taking `Number()` of those
+ * yields `NaN`, which would silently drop every set of walking lunges, one-leg
+ * RDLs and step-ups from the import. The leading integer is the count; the
+ * annotation says it was per side, which the catalog already records as
+ * `is_unilateral`.
+ *
+ * A cell with no leading number (`Each leg` alone, `Hanging Knee tuck`) is not
+ * a count and yields null.
+ *
+ * @param {unknown} raw The measure cell.
+ * @returns {number|null} The rep count, or null when the cell records none.
+ */
+export function parseReps(raw) {
+  if (typeof raw === 'number') return Number.isFinite(raw) && raw > 0 ? raw : null
+  if (typeof raw !== 'string') return null
+  const match = raw.trim().match(/^(\d{1,3})\b/)
+  if (!match) return null
+  const reps = Number(match[1])
+  return Number.isFinite(reps) && reps > 0 ? reps : null
+}
+
+/**
  * Whether a transcribed table row records a set that actually happened.
  *
  * The templates carry more rows than were ever used — a `Pull ups 4 sets` table
@@ -272,8 +394,27 @@ export function perImplementWeight(raw, header, slug, loadMultiplier) {
  */
 export function isPerformedSet(row) {
   if (!row || typeof row !== 'object') return false
-  const reps = typeof row.reps === 'string' ? Number(row.reps) : row.reps
-  return typeof reps === 'number' && Number.isFinite(reps) && reps > 0
+  return parseReps(row.reps) !== null
+}
+
+/**
+ * Third-column headers that do not count reps.
+ *
+ * A plank's `Time (seconds)` column holds 45, and storing that as `reps` would
+ * record forty-five plank repetitions. `weight_room_sets` has no duration
+ * column, so those rows are reported and skipped rather than mistranslated.
+ * `Steps` is kept: a walking-lunge step *is* a rep of the movement.
+ */
+const TIME_MEASURE = /^time\b/i
+
+/**
+ * Whether a table's measure column counts something `reps` can hold.
+ *
+ * @param {string|null|undefined} header The third column header, verbatim.
+ * @returns {boolean} False for duration columns.
+ */
+export function isRepMeasure(header) {
+  return !TIME_MEASURE.test(String(header ?? '').trim())
 }
 
 /**
@@ -358,7 +499,20 @@ export function mintImportKey({ title, date, slug, index }) {
 export function parseNote(note, loadMultipliers = {}) {
   const sets = []
   const unmapped = []
+  const timed = []
   let position = 0
+
+  // Import-key indexes run per movement across the *whole* note, not per block.
+  // One note can log the same movement twice — `Shrugs / 35 DB / 20 / 20` then
+  // `40 DB / 12 / 12` is two blocks of shrugs — and restarting the count in the
+  // second block mints keys the first block already used, which the unique
+  // index rejects and the import fails on.
+  const seen = new Map()
+  const nextIndex = key => {
+    const index = seen.get(key) ?? 0
+    seen.set(key, index + 1)
+    return index
+  }
 
   for (const exercise of note.exercises ?? []) {
     const slug = resolveTableMovement(exercise.name)
@@ -366,12 +520,20 @@ export function parseNote(note, loadMultipliers = {}) {
       unmapped.push(exercise.name)
       continue
     }
+    // A duration column has no rep count to record — see isRepMeasure.
+    if (!isRepMeasure(exercise.measure_header)) {
+      timed.push(exercise.name)
+      continue
+    }
 
+    const variant = variantFor(exercise.name, slug)
     const performed = (exercise.sets ?? []).filter(isPerformedSet)
-    performed.forEach((row, index) => {
+    performed.forEach(row => {
+      const index = nextIndex(slug)
       sets.push({
         exercise: slug,
-        reps: Number(row.reps),
+        ...(variant === null ? {} : { variant }),
+        reps: parseReps(row.reps),
         weight_lbs: perImplementWeight(
           row.weight,
           exercise.weight_header,
@@ -397,13 +559,16 @@ export function parseNote(note, loadMultipliers = {}) {
       continue
     }
 
+    const listVariant = variantFor(list.movement, slug)
     const reps = (list.reps ?? [])
       .map(value => (typeof value === 'string' ? Number(value) : value))
       .filter(value => typeof value === 'number' && Number.isFinite(value) && value > 0)
 
-    reps.forEach((count, index) => {
+    reps.forEach(count => {
+      const index = nextIndex(`gtg:${slug}`)
       sets.push({
         exercise: slug,
+        ...(listVariant === null ? {} : { variant: listVariant }),
         reps: count,
         weight_lbs: null,
         disposition: 'gtg',
@@ -420,5 +585,5 @@ export function parseNote(note, loadMultipliers = {}) {
     })
   }
 
-  return { sets, unmapped }
+  return { sets, unmapped, timed }
 }

--- a/scripts/lib/icloud-notes-parser.mjs
+++ b/scripts/lib/icloud-notes-parser.mjs
@@ -1,0 +1,424 @@
+/**
+ * Parser for historical workout notes transcribed from Apple Notes (#400).
+ *
+ * Two years of training (2022-2024) were logged one note per session, titled
+ * with the template that was run and holding a `Set | Weight | Reps` table per
+ * exercise. Apple's bulk Data & Privacy export flattens every note to plain
+ * text, and plain text cannot represent a table — each one collapses to a
+ * single `￼` placeholder, taking the numbers with it. The tables survive
+ * only in the rendered note, so they were transcribed from iCloud web into the
+ * JSON this module consumes.
+ *
+ * Everything here is pure. Extraction is upstream, Supabase is downstream, and
+ * the interesting decisions — which movement a name means, whether a number is
+ * per-hand or combined, whether a rep list is part of the workout at all — are
+ * all testable without either.
+ */
+
+/**
+ * Note movement names to `weight_room_exercises` slugs.
+ *
+ * Keys are normalized by {@link normalizeName}, so spacing, case, punctuation
+ * and a trailing plural are already accounted for and do not need their own
+ * entries. What does need an entry is anything where the note's wording and the
+ * catalog's slug are genuinely different words ("Military press" /
+ * `barbell-overhead-press`), because guessing across that gap is how volume
+ * silently lands on the wrong movement.
+ *
+ * Several of these were resolved during #375's template transcription and are
+ * reused rather than re-derived.
+ */
+const RAW_MOVEMENT_ALIASES = {
+  // --- pulling ---
+  'Pull ups': 'pullups',
+  'Chin ups': 'chinups',
+  'Seated two arm Row': 'seated-cable-row',
+  'Seated Row': 'seated-cable-row',
+  'One arm DB Row': 'dumbbell-row',
+  'DB Row': 'dumbbell-row',
+  'Barbell Bent Over Rows': 'barbell-row',
+  'Bent Over Rows': 'barbell-row',
+  'Lat Pulldowns': 'lat-pulldown',
+  'Upright Rows': 'upright-row',
+  'Back extension': 'back-extension',
+  'Back ext': 'back-extension',
+  'DB shrugs': 'shrugs',
+  Shrugs: 'shrugs',
+
+  // --- curls ---
+  'EZ curl standing': 'ez-bar-curl',
+  'EZ curl': 'ez-bar-curl',
+  'Seated Alt Curls': 'dumbbell-curl',
+  'Seated alt db curls': 'dumbbell-curl',
+  'Alt db curls': 'dumbbell-curl',
+  'Alt Curls': 'dumbbell-curl',
+  'Preacher curls': 'preacher-curl',
+  'Rope curls': 'rope-curl',
+
+  // --- pressing ---
+  'Barbell Bench Press': 'barbell-bench-press',
+  'Bench Press': 'barbell-bench-press',
+  'Incline barbell press': 'barbell-incline-press',
+  'Decline Barbell Press': 'barbell-decline-press',
+  'Military press': 'barbell-overhead-press',
+  'DB Flat Press': 'dumbbell-bench-press',
+  'Incline DB press': 'dumbbell-incline-press',
+  'Seated DB press Alt': 'dumbbell-shoulder-press',
+  'Seated DB press': 'dumbbell-shoulder-press',
+  'Seated Alt Shoulder Press DB': 'dumbbell-shoulder-press',
+  'Alt Shoulder Press DB': 'dumbbell-shoulder-press',
+  'Close grip bench press': 'close-grip-bench-press',
+  'Push ups': 'pushups',
+  Dips: 'dips',
+  'Bench dips': 'dips',
+
+  // --- triceps ---
+  'Skull Crushers': 'skull-crushers',
+  'Tricep Pressdowns': 'cable-tricep-pushdown',
+  'Rope Overhead Ext': 'rope-overhead-extension',
+  'Rope Overhead Extension': 'rope-overhead-extension',
+
+  // --- legs ---
+  // NOT the bodyweight `squats` movement — see resolveTableMovement.
+  Squats: 'barbell-back-squat',
+  'Walking Lunges': 'walking-lunges',
+  Lunges: 'lunges',
+  'One Leg RDL': 'single-leg-romanian-deadlift',
+  'RDL Barbell': 'barbell-romanian-deadlift',
+  'Barbell RDL': 'barbell-romanian-deadlift',
+  'Leg Press': 'leg-press',
+  'Calf Leg Press': 'calf-press-machine',
+  'Seated Calf Raises': 'seated-calf-raise',
+  'Step Ups': 'step-ups',
+  'Sled Push': 'sled-push',
+
+  // --- core ---
+  Planks: 'plank',
+  'Knee Tucks': 'knee-tucks',
+  'Hanging leg raises': 'hanging-leg-raise',
+  'Heavy Russian Twists': 'russian-twist',
+  'Russian Twists': 'russian-twist',
+  'Decline Weighted Crunches': 'decline-crunch',
+}
+
+/**
+ * The alias table keyed the way lookups arrive.
+ *
+ * Built by pushing {@link RAW_MOVEMENT_ALIASES}' human-readable keys through
+ * {@link normalizeName}, so both sides of every comparison are normalized by
+ * the same code. Writing the keys pre-normalized by hand looks equivalent and
+ * is not: `normalizeName` strips one trailing `s`, which turns every `…Press`
+ * into `…pres`, and a hand-written `barbellbenchpress` silently never matches.
+ */
+export const MOVEMENT_ALIASES = Object.freeze(
+  Object.fromEntries(
+    Object.entries(RAW_MOVEMENT_ALIASES).map(([name, slug]) => [normalizeName(name), slug])
+  )
+)
+
+/**
+ * Slugs whose catalog `load_multiplier` is 2 — two implements move per set.
+ *
+ * Only these can meaningfully carry a `Weight (total)` column, and only these
+ * get halved when one appears. Mirrors the catalog rather than replacing it;
+ * {@link perImplementWeight} takes the live multiplier when the caller has it.
+ */
+export const TWO_IMPLEMENT_SLUGS = Object.freeze(
+  new Set([
+    'dumbbell-bench-press',
+    'dumbbell-incline-press',
+    'dumbbell-shoulder-press',
+    'dumbbell-lateral-raise',
+    'dumbbell-curl',
+    'dumbbell-lunge',
+    'dumbbell-romanian-deadlift',
+    'farmers-carry',
+    'shrugs',
+  ])
+)
+
+/**
+ * Movements that are bodyweight grease-the-groove staples in this log.
+ *
+ * A bare rep list under one of these names is daily volume, not part of the
+ * session it happens to sit inside — see {@link parseNote}.
+ */
+export const GTG_MOVEMENTS = Object.freeze(
+  Object.fromEntries(
+    Object.entries({
+      'Pull ups': 'pullups',
+      'Push ups': 'pushups',
+      Squats: 'squats',
+      Dips: 'dips',
+    }).map(([name, slug]) => [normalizeName(name), slug])
+  )
+)
+
+/**
+ * Collapse a note's free-hand movement name to a lookup key.
+ *
+ * Strips case, whitespace and punctuation, then a single trailing `s`, so
+ * `"Barbell Bent Over Rows"`, `"barbell bent-over row"` and `"BARBELL BENT OVER
+ * ROW"` all reach the same entry. Deliberately blunt: the alias table is the
+ * place for real synonyms, and a cleverer normalizer would start silently
+ * equating movements that differ by one word.
+ *
+ * @param {string} raw Movement name exactly as written in the note.
+ * @returns {string} Lookup key; `''` when the input is not a usable string.
+ */
+export function normalizeName(raw) {
+  if (typeof raw !== 'string') return ''
+  const stripped = raw
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(/[^a-z0-9]/g, '')
+  return stripped.endsWith('s') ? stripped.slice(0, -1) : stripped
+}
+
+/**
+ * Resolve a movement named in an exercise **table** to a catalog slug.
+ *
+ * Table entries are gym work, which is what makes `Squats` safe to send to
+ * `barbell-back-squat` here: a loaded barbell squat and the bodyweight `squats`
+ * that feed the daily ring are different movements that share a word, and
+ * #400 calls out mapping the former onto the latter as the way this import
+ * quietly corrupts the grease-the-groove streak.
+ *
+ * @param {string} name Movement name as written in the note.
+ * @returns {string|null} Catalog slug, or null when nothing matches — callers
+ *   report those rather than guessing a near-duplicate slug into existence.
+ */
+export function resolveTableMovement(name) {
+  const key = normalizeName(name)
+  if (!key) return null
+  return MOVEMENT_ALIASES[key] ?? null
+}
+
+/**
+ * Resolve a movement named above a bare **rep list** to a catalog slug.
+ *
+ * The mirror image of {@link resolveTableMovement}, and the reason the two are
+ * separate functions: an unloaded rep list of `Squats` is the bodyweight
+ * movement, so the same word has to resolve differently depending on which
+ * shape it appeared in. Anything outside the small grease-the-groove set falls
+ * through to the table mapping, since a rep list under `Dips` is still dips.
+ *
+ * @param {string} name Movement name as written above the rep list.
+ * @returns {string|null} Catalog slug, or null when nothing matches.
+ */
+export function resolveRepListMovement(name) {
+  const key = normalizeName(name)
+  if (!key) return null
+  return GTG_MOVEMENTS[key] ?? MOVEMENT_ALIASES[key] ?? null
+}
+
+/**
+ * Convert a transcribed Weight cell into the per-implement load the schema wants.
+ *
+ * `weight_room_sets.weight_lbs` is per implement — a 60 lb dumbbell shrug is
+ * 60, and the catalog's `load_multiplier` supplies the ×2 when tonnage is
+ * computed. The notes are not consistent about this: most tables head the
+ * column `Weight` and mean per hand, but some head it `Weight (total)` and mean
+ * the pair. Importing a `(total)` figure verbatim records double the real load,
+ * and nothing downstream would look wrong — which is why the header is read per
+ * table rather than assumed once.
+ *
+ * @param {number|string|null|undefined} raw The Weight cell. `'BW'` (bodyweight)
+ *   and blanks both become null, which is what the schema uses for unloaded work.
+ * @param {string|null|undefined} header The column header verbatim, e.g.
+ *   `'Weight'` or `'Weight (total)'`.
+ * @param {string} slug Catalog slug the row resolved to.
+ * @param {number} [loadMultiplier] The catalog's live multiplier for `slug`.
+ *   Defaults to 2 for {@link TWO_IMPLEMENT_SLUGS} and 1 otherwise.
+ * @returns {number|null} Per-implement pounds, or null for bodyweight/blank.
+ */
+export function perImplementWeight(raw, header, slug, loadMultiplier) {
+  if (raw === null || raw === undefined || raw === '') return null
+
+  const text = String(raw).trim()
+  if (text === '') return null
+  if (/^bw$/i.test(text)) return null
+
+  // Tolerate "135 lb", "37.5lbs", "22.5 DB" — the notes are handwritten.
+  const match = text.match(/-?\d+(?:\.\d+)?/)
+  if (!match) return null
+  const value = Number(match[0])
+  if (!Number.isFinite(value) || value < 0) return null
+
+  const multiplier =
+    typeof loadMultiplier === 'number' && loadMultiplier > 0
+      ? loadMultiplier
+      : TWO_IMPLEMENT_SLUGS.has(slug)
+        ? 2
+        : 1
+
+  const isTotal = typeof header === 'string' && /\(\s*total\s*\)/i.test(header)
+  if (isTotal && multiplier > 1) {
+    return value / multiplier
+  }
+  return value
+}
+
+/**
+ * Whether a transcribed table row records a set that actually happened.
+ *
+ * The templates carry more rows than were ever used — a `Pull ups 4 sets` table
+ * can run to eighteen numbered rows with `BW` pre-filled down the Weight column
+ * and the Reps left blank. Those are stationery, not training, and importing
+ * them would invent sets. Reps is the discriminator: no reps, no set.
+ *
+ * @param {{set?: unknown, weight?: unknown, reps?: unknown}} row A transcribed row.
+ * @returns {boolean} True when the row carries a positive rep count.
+ */
+export function isPerformedSet(row) {
+  if (!row || typeof row !== 'object') return false
+  const reps = typeof row.reps === 'string' ? Number(row.reps) : row.reps
+  return typeof reps === 'number' && Number.isFinite(reps) && reps > 0
+}
+
+/**
+ * Normalize the date shown against a note in the iCloud list to `YYYY-MM-DD`.
+ *
+ * The list renders US short dates (`4/16/24`), and the export manifest uses
+ * `MM-DD-YYYY`; both have to reach the same key for a note to find its
+ * timestamps. Two-digit years resolve into the 2000s, which is safe here — the
+ * account's notes begin in 2018 and the training log ends in 2024.
+ *
+ * @param {string} raw The date as written, e.g. `'4/16/24'` or `'2024-04-16'`.
+ * @returns {string|null} `YYYY-MM-DD`, or null when it is not a date. A
+ *   relative label like `'Yesterday'` — which iCloud shows for recent notes —
+ *   returns null rather than a guess.
+ */
+export function parseNoteDate(raw) {
+  if (typeof raw !== 'string') return null
+  const text = raw.trim()
+
+  const iso = text.match(/^(\d{4})-(\d{2})-(\d{2})$/)
+  if (iso) return text
+
+  const slashed = text.match(/^(\d{1,2})\/(\d{1,2})\/(\d{2}|\d{4})$/)
+  if (!slashed) return null
+
+  const [, month, day, year] = slashed
+  const fullYear = year.length === 2 ? 2000 + Number(year) : Number(year)
+  if (Number(month) < 1 || Number(month) > 12) return null
+  if (Number(day) < 1 || Number(day) > 31) return null
+
+  return `${fullYear}-${String(Number(month)).padStart(2, '0')}-${String(Number(day)).padStart(2, '0')}`
+}
+
+/**
+ * Mint the deterministic key that makes re-importing a note converge.
+ *
+ * A set has no natural key of its own — the same movement at the same weight
+ * for the same reps legitimately repeats within a session, and `logged_at` is
+ * derived rather than observed, so it cannot separate them. Identity therefore
+ * comes from where the set sits in the source note, which is stable across
+ * re-runs as long as the note is unchanged.
+ *
+ * @param {object} parts Key components.
+ * @param {string} parts.title Note title, e.g. `'Back Day 1'`.
+ * @param {string} parts.date Note date as `YYYY-MM-DD`.
+ * @param {string} parts.slug Catalog slug the set resolved to.
+ * @param {number} parts.index 0-based position of this set within its movement.
+ * @returns {string} Key of the form `icloud:<title>:<date>:<slug>:<index>`.
+ */
+export function mintImportKey({ title, date, slug, index }) {
+  return `icloud:${title}:${date}:${slug}:${index}`
+}
+
+/**
+ * Turn one transcribed note into the sets it records.
+ *
+ * Splits into two piles, which is the distinction #400 flags as easiest to get
+ * wrong. Table entries are the session's own work and carry a `workout`
+ * disposition. Bare rep lists are grease-the-groove volume — pull-ups and
+ * push-ups ran at 100/day for a stretch, so they appear under nearly every
+ * session note without belonging to it — and carry a `gtg` disposition so the
+ * caller can leave `workout_id` null. The same movement can be both on
+ * different days, so the discriminator is the shape it was written in, per
+ * note, not the movement's name.
+ *
+ * @param {object} note A transcribed note.
+ * @param {string} note.title Note title.
+ * @param {string} note.date Note date as `YYYY-MM-DD`.
+ * @param {Array<{name: string, weight_header?: string|null,
+ *   sets?: Array<{set?: number, weight?: unknown, reps?: unknown}>}>} [note.exercises]
+ *   Table-backed exercises.
+ * @param {Array<{movement: string, reps?: unknown[]}>} [note.rep_lists]
+ *   Bare rep lists.
+ * @param {Record<string, number>} [loadMultipliers] Live catalog multipliers
+ *   keyed by slug. Falls back to {@link TWO_IMPLEMENT_SLUGS} when absent.
+ * @returns {{sets: Array<{exercise: string, reps: number, weight_lbs: number|null,
+ *   disposition: 'workout'|'gtg', position: number|null, import_key: string}>,
+ *   unmapped: string[]}} Parsed sets in note order, plus every movement name
+ *   that resolved to nothing — reported so it gets a real catalog row rather
+ *   than a near-duplicate slug.
+ */
+export function parseNote(note, loadMultipliers = {}) {
+  const sets = []
+  const unmapped = []
+  let position = 0
+
+  for (const exercise of note.exercises ?? []) {
+    const slug = resolveTableMovement(exercise.name)
+    if (!slug) {
+      unmapped.push(exercise.name)
+      continue
+    }
+
+    const performed = (exercise.sets ?? []).filter(isPerformedSet)
+    performed.forEach((row, index) => {
+      sets.push({
+        exercise: slug,
+        reps: Number(row.reps),
+        weight_lbs: perImplementWeight(
+          row.weight,
+          exercise.weight_header,
+          slug,
+          loadMultipliers[slug]
+        ),
+        disposition: 'workout',
+        position: position++,
+        import_key: mintImportKey({
+          title: note.title,
+          date: note.date,
+          slug,
+          index,
+        }),
+      })
+    })
+  }
+
+  for (const list of note.rep_lists ?? []) {
+    const slug = resolveRepListMovement(list.movement)
+    if (!slug) {
+      unmapped.push(list.movement)
+      continue
+    }
+
+    const reps = (list.reps ?? [])
+      .map(value => (typeof value === 'string' ? Number(value) : value))
+      .filter(value => typeof value === 'number' && Number.isFinite(value) && value > 0)
+
+    reps.forEach((count, index) => {
+      sets.push({
+        exercise: slug,
+        reps: count,
+        weight_lbs: null,
+        disposition: 'gtg',
+        position: null,
+        // `gtg:` keeps a rep list from colliding with a table of the same
+        // movement in the same note — Chest Day 2 has both push-up shapes.
+        import_key: mintImportKey({
+          title: note.title,
+          date: note.date,
+          slug: `gtg:${slug}`,
+          index,
+        }),
+      })
+    })
+  }
+
+  return { sets, unmapped }
+}

--- a/scripts/lib/icloud-notes-parser.mjs
+++ b/scripts/lib/icloud-notes-parser.mjs
@@ -398,12 +398,32 @@ export function isPerformedSet(row) {
 }
 
 /**
- * Third-column headers that do not count reps.
+ * Movements performed as a held position rather than for repetitions.
  *
- * A plank's `Time (seconds)` column holds 45, and storing that as `reps` would
- * record forty-five plank repetitions. `weight_room_sets` has no duration
- * column, so those rows are reported and skipped rather than mistranslated.
- * `Steps` is kept: a walking-lunge step *is* a rep of the movement.
+ * The measure is time whatever column it arrived in, which matters because this
+ * log wrote planks three ways across the years: a `Time (seconds)` table
+ * column, a bare list of numbers under `Planks`, and `45 seconds` spelled out
+ * per set. Keying off the *movement* rather than the column catches all three —
+ * the freeform shapes carry no header to inspect, and they are how 12 sets
+ * claiming "50 reps" of plank got in.
+ */
+const ISOMETRIC_HOLDS = Object.freeze(new Set(['plank']))
+
+/**
+ * Whether a movement is held rather than repeated.
+ *
+ * @param {string} slug Catalog slug.
+ * @returns {boolean} True when its numbers are seconds.
+ */
+export function isIsometricHold(slug) {
+  return ISOMETRIC_HOLDS.has(slug)
+}
+
+/**
+ * Third-column headers that measure time rather than repetitions.
+ *
+ * A plank's `Time (seconds)` column holds 45; storing that as `reps` records
+ * forty-five plank repetitions.
  */
 const TIME_MEASURE = /^time\b/i
 
@@ -411,10 +431,29 @@ const TIME_MEASURE = /^time\b/i
  * Whether a table's measure column counts something `reps` can hold.
  *
  * @param {string|null|undefined} header The third column header, verbatim.
- * @returns {boolean} False for duration columns.
+ * @returns {boolean} False for duration columns. `Steps` is true — a
+ *   walking-lunge step *is* a rep of the movement.
  */
 export function isRepMeasure(header) {
   return !TIME_MEASURE.test(String(header ?? '').trim())
+}
+
+/**
+ * Read a duration out of a hand-written cell.
+ *
+ * Tolerates the units the notes spell out (`45 seconds`, `40 sec`) as well as a
+ * bare number, since both shapes appear for the same movement.
+ *
+ * @param {unknown} raw The cell.
+ * @returns {number|null} Seconds, or null when the cell holds no number.
+ */
+export function parseDuration(raw) {
+  if (typeof raw === 'number') return Number.isFinite(raw) && raw > 0 ? raw : null
+  if (typeof raw !== 'string') return null
+  const match = raw.trim().match(/^(\d{1,4})\b/)
+  if (!match) return null
+  const seconds = Number(match[1])
+  return Number.isFinite(seconds) && seconds > 0 ? seconds : null
 }
 
 /**
@@ -520,20 +559,29 @@ export function parseNote(note, loadMultipliers = {}) {
       unmapped.push(exercise.name)
       continue
     }
-    // A duration column has no rep count to record — see isRepMeasure.
-    if (!isRepMeasure(exercise.measure_header)) {
+    // A hold is measured in seconds however it was written — see
+    // isIsometricHold. A duration column on any other movement is a shape this
+    // parser has no rule for, so it is reported rather than guessed at.
+    const held = isIsometricHold(slug)
+    if (!held && !isRepMeasure(exercise.measure_header)) {
       timed.push(exercise.name)
       continue
     }
 
     const variant = variantFor(exercise.name, slug)
-    const performed = (exercise.sets ?? []).filter(isPerformedSet)
+    const performed = (exercise.sets ?? []).filter(row =>
+      held ? parseDuration(row.reps) !== null : isPerformedSet(row)
+    )
     performed.forEach(row => {
       const index = nextIndex(slug)
+      const duration = held ? parseDuration(row.reps) : null
       sets.push({
         exercise: slug,
         ...(variant === null ? {} : { variant }),
-        reps: parseReps(row.reps),
+        // One repetition of the hold, lasting `duration_seconds` — see the
+        // #400 duration migration for why `reps` stays populated.
+        reps: held ? 1 : parseReps(row.reps),
+        ...(duration === null ? {} : { duration_seconds: duration }),
         weight_lbs: perImplementWeight(
           row.weight,
           exercise.weight_header,
@@ -564,12 +612,16 @@ export function parseNote(note, loadMultipliers = {}) {
       .map(value => (typeof value === 'string' ? Number(value) : value))
       .filter(value => typeof value === 'number' && Number.isFinite(value) && value > 0)
 
+    // A bare list under `Planks` is seconds per hold, not reps — the shape that
+    // slipped past the column check and landed "50 reps" of plank.
+    const heldList = isIsometricHold(slug)
     reps.forEach(count => {
       const index = nextIndex(`gtg:${slug}`)
       sets.push({
         exercise: slug,
         ...(listVariant === null ? {} : { variant: listVariant }),
-        reps: count,
+        reps: heldList ? 1 : count,
+        ...(heldList ? { duration_seconds: count } : {}),
         weight_lbs: null,
         disposition: 'gtg',
         position: null,

--- a/scripts/lib/icloud-notes-parser.test.ts
+++ b/scripts/lib/icloud-notes-parser.test.ts
@@ -1,0 +1,247 @@
+/**
+ * Tests for the iCloud Notes workout parser (#400).
+ *
+ * The cases pin the four ways this import can quietly record the wrong thing:
+ * a `Weight (total)` column halved (or not) against the movement's implement
+ * count, a bodyweight `Squats` rep list landing on the barbell movement (or the
+ * reverse), the templates' unused rows importing as sets that never happened,
+ * and a re-run duplicating two years of history because the keys moved.
+ */
+import { describe, expect, it } from 'vitest'
+
+import {
+  isPerformedSet,
+  mintImportKey,
+  normalizeName,
+  parseNote,
+  parseNoteDate,
+  perImplementWeight,
+  resolveRepListMovement,
+  resolveTableMovement,
+} from './icloud-notes-parser.mjs'
+
+describe('parseNoteDate', () => {
+  it('reads the US short date the iCloud list renders', () => {
+    expect(parseNoteDate('4/16/24')).toBe('2024-04-16')
+    expect(parseNoteDate('12/4/23')).toBe('2023-12-04')
+    expect(parseNoteDate('04/16/2024')).toBe('2024-04-16')
+  })
+
+  it('passes an already-normalized date through', () => {
+    expect(parseNoteDate('2024-04-16')).toBe('2024-04-16')
+  })
+
+  it('returns null for the relative labels iCloud shows on recent notes', () => {
+    // "Yesterday" and "11:22 AM" appear against notes from the last few days.
+    // Guessing a date for those would file a session on the wrong day.
+    expect(parseNoteDate('Yesterday')).toBeNull()
+    expect(parseNoteDate('11:22 AM')).toBeNull()
+    expect(parseNoteDate('')).toBeNull()
+  })
+
+  it('rejects an impossible month or day', () => {
+    expect(parseNoteDate('13/1/24')).toBeNull()
+    expect(parseNoteDate('4/32/24')).toBeNull()
+  })
+})
+
+describe('normalizeName', () => {
+  it('collapses case, spacing, punctuation and a trailing plural to one key', () => {
+    const expected = normalizeName('Barbell Bent Over Row')
+    expect(normalizeName('barbell bent-over rows')).toBe(expected)
+    expect(normalizeName('BARBELL  BENT OVER ROWS')).toBe(expected)
+  })
+
+  it('returns an empty key for a non-string', () => {
+    expect(normalizeName(undefined as unknown as string)).toBe('')
+  })
+})
+
+describe('resolveTableMovement', () => {
+  it('maps the wordings that differ from the catalog slug', () => {
+    // Resolved during #375's template pass; reused rather than re-derived.
+    expect(resolveTableMovement('Military press')).toBe('barbell-overhead-press')
+    expect(resolveTableMovement('DB Flat Press')).toBe('dumbbell-bench-press')
+    expect(resolveTableMovement('Seated two arm Row')).toBe('seated-cable-row')
+    expect(resolveTableMovement('One arm DB Row')).toBe('dumbbell-row')
+    expect(resolveTableMovement('RDL Barbell')).toBe('barbell-romanian-deadlift')
+    expect(resolveTableMovement('Tricep Pressdowns')).toBe('cable-tricep-pushdown')
+  })
+
+  it('sends a loaded Squats table to the barbell movement, not the bodyweight ring', () => {
+    // #400: mapping gym squats onto `squats` dumps them into the 100/day
+    // grease-the-groove ring and corrupts that streak.
+    expect(resolveTableMovement('Squats')).toBe('barbell-back-squat')
+  })
+
+  it('returns null rather than guessing at an unknown movement', () => {
+    expect(resolveTableMovement('Rack Run')).toBeNull()
+  })
+})
+
+describe('resolveRepListMovement', () => {
+  it('sends a bare Squats rep list to the bodyweight movement', () => {
+    // Same word, opposite answer from the table case — the shape it was
+    // written in is the discriminator, not the name.
+    expect(resolveRepListMovement('Squats')).toBe('squats')
+    expect(resolveTableMovement('Squats')).toBe('barbell-back-squat')
+  })
+
+  it('falls through to the table mapping for movements outside the GTG set', () => {
+    expect(resolveRepListMovement('Lat Pulldowns')).toBe('lat-pulldown')
+  })
+})
+
+describe('perImplementWeight', () => {
+  it('halves a (total) column on a two-implement movement', () => {
+    // The sharpest trap in the source data: 37.5 total is 18.75 per hand, and
+    // storing 37.5 records double the real load with nothing looking wrong.
+    expect(perImplementWeight(37.5, 'Weight (total)', 'dumbbell-incline-press')).toBe(18.75)
+  })
+
+  it('leaves a plain Weight column alone on the same movement', () => {
+    expect(perImplementWeight(40, 'Weight', 'dumbbell-incline-press')).toBe(40)
+  })
+
+  it('leaves a (total) column alone on a single-implement movement', () => {
+    // A barbell is one implement; "total" and "per implement" are the same
+    // number, and halving would invent a load that was never lifted.
+    expect(perImplementWeight(135, 'Weight (total)', 'barbell-bench-press')).toBe(135)
+    expect(perImplementWeight(50, 'Weight (total)', 'dumbbell-row')).toBe(50)
+  })
+
+  it('prefers the live catalog multiplier over the built-in fallback', () => {
+    expect(perImplementWeight(60, 'Weight (total)', 'shrugs', 2)).toBe(30)
+    expect(perImplementWeight(60, 'Weight (total)', 'shrugs', 1)).toBe(60)
+  })
+
+  it('treats BW and blanks as unloaded', () => {
+    expect(perImplementWeight('BW', 'Weight', 'pullups')).toBeNull()
+    expect(perImplementWeight('bw', 'Weight', 'pullups')).toBeNull()
+    expect(perImplementWeight('', 'Weight', 'pullups')).toBeNull()
+    expect(perImplementWeight(null, 'Weight', 'pullups')).toBeNull()
+  })
+
+  it('reads a number out of a handwritten cell', () => {
+    expect(perImplementWeight('135 lb', 'Weight', 'barbell-bench-press')).toBe(135)
+    expect(perImplementWeight('22.5 DB', 'Weight', 'dumbbell-curl')).toBe(22.5)
+  })
+
+  it('is case- and space-insensitive about the (total) marker', () => {
+    expect(perImplementWeight(50, 'Weight ( TOTAL )', 'dumbbell-curl')).toBe(25)
+  })
+})
+
+describe('isPerformedSet', () => {
+  it('keeps a row with reps', () => {
+    expect(isPerformedSet({ set: 1, weight: 'BW', reps: 6 })).toBe(true)
+  })
+
+  it('drops the templates unused rows', () => {
+    // A `Pull ups 4 sets` table runs to eighteen numbered rows with BW
+    // pre-filled and Reps blank. Those are stationery, not training.
+    expect(isPerformedSet({ set: 12, weight: 'BW', reps: null })).toBe(false)
+    expect(isPerformedSet({ set: 13, weight: null, reps: null })).toBe(false)
+    expect(isPerformedSet({ set: 14, weight: 'BW', reps: 0 })).toBe(false)
+  })
+})
+
+describe('parseNote', () => {
+  const note = {
+    title: 'Chest Day 1',
+    date: '2024-03-05',
+    exercises: [
+      {
+        name: 'Barbell Bench Press',
+        weight_header: 'Weight',
+        sets: [
+          { set: 1, weight: 95, reps: 12 },
+          { set: 2, weight: 135, reps: 10 },
+          { set: 3, weight: null, reps: null },
+        ],
+      },
+      {
+        name: 'Incline DB press',
+        weight_header: 'Weight (total)',
+        sets: [{ set: 1, weight: 37.5, reps: 10 }],
+      },
+      { name: 'Rack Run', weight_header: 'Weight', sets: [{ set: 1, weight: 30, reps: 8 }] },
+    ],
+    rep_lists: [{ movement: 'Pull ups', reps: [8, 8, 7, 6] }],
+  }
+
+  it('separates session work from grease-the-groove volume', () => {
+    // #400: the rep lists appear under nearly every session note without
+    // belonging to it, so they must not inherit the workout.
+    const { sets } = parseNote(note)
+    const workout = sets.filter(set => set.disposition === 'workout')
+    const gtg = sets.filter(set => set.disposition === 'gtg')
+
+    expect(workout.map(set => set.exercise)).toEqual([
+      'barbell-bench-press',
+      'barbell-bench-press',
+      'dumbbell-incline-press',
+    ])
+    expect(gtg).toHaveLength(4)
+    expect(gtg.every(set => set.exercise === 'pullups')).toBe(true)
+    expect(gtg.every(set => set.position === null)).toBe(true)
+  })
+
+  it('applies the (total) halving through the full parse', () => {
+    const { sets } = parseNote(note)
+    const incline = sets.find(set => set.exercise === 'dumbbell-incline-press')
+    expect(incline?.weight_lbs).toBe(18.75)
+  })
+
+  it('numbers workout sets consecutively across movements', () => {
+    const { sets } = parseNote(note)
+    const positions = sets
+      .filter(set => set.disposition === 'workout')
+      .map(set => set.position)
+    expect(positions).toEqual([0, 1, 2])
+  })
+
+  it('reports an unmapped movement instead of inventing a slug', () => {
+    const { unmapped } = parseNote(note)
+    expect(unmapped).toEqual(['Rack Run'])
+  })
+
+  it('mints stable keys, and keeps a rep list from colliding with its own table', () => {
+    // Chest Day 2 has push-ups in both shapes on one day; without the `gtg:`
+    // qualifier the two would upsert over each other.
+    const both = parseNote({
+      title: 'Chest Day 2',
+      date: '2024-03-12',
+      exercises: [
+        { name: 'Push ups', weight_header: 'Weight', sets: [{ set: 1, weight: 'BW', reps: 20 }] },
+      ],
+      rep_lists: [{ movement: 'Push ups', reps: [10] }],
+    })
+
+    const keys = both.sets.map(set => set.import_key)
+    expect(new Set(keys).size).toBe(keys.length)
+    expect(keys).toContain('icloud:Chest Day 2:2024-03-12:pushups:0')
+    expect(keys).toContain('icloud:Chest Day 2:2024-03-12:gtg:pushups:0')
+  })
+
+  it('produces identical keys on a re-run so the import converges', () => {
+    expect(parseNote(note).sets.map(s => s.import_key)).toEqual(
+      parseNote(note).sets.map(s => s.import_key)
+    )
+  })
+
+  it('survives a note with neither tables nor rep lists', () => {
+    expect(parseNote({ title: 'Back Day 1', date: '2024-04-16' })).toEqual({
+      sets: [],
+      unmapped: [],
+    })
+  })
+})
+
+describe('mintImportKey', () => {
+  it('is fully determined by the note identity and the set position', () => {
+    expect(
+      mintImportKey({ title: 'Back Day 1', date: '2024-04-16', slug: 'pullups', index: 2 })
+    ).toBe('icloud:Back Day 1:2024-04-16:pullups:2')
+  })
+})

--- a/scripts/lib/icloud-notes-parser.test.ts
+++ b/scripts/lib/icloud-notes-parser.test.ts
@@ -195,9 +195,7 @@ describe('parseNote', () => {
 
   it('numbers workout sets consecutively across movements', () => {
     const { sets } = parseNote(note)
-    const positions = sets
-      .filter(set => set.disposition === 'workout')
-      .map(set => set.position)
+    const positions = sets.filter(set => set.disposition === 'workout').map(set => set.position)
     expect(positions).toEqual([0, 1, 2])
   })
 

--- a/scripts/lib/icloud-notes-parser.test.ts
+++ b/scripts/lib/icloud-notes-parser.test.ts
@@ -232,6 +232,7 @@ describe('parseNote', () => {
     expect(parseNote({ title: 'Back Day 1', date: '2024-04-16' })).toEqual({
       sets: [],
       unmapped: [],
+      timed: [],
     })
   })
 })

--- a/scripts/lib/icloud-notes-supabase.mjs
+++ b/scripts/lib/icloud-notes-supabase.mjs
@@ -1,0 +1,174 @@
+/**
+ * Supabase writer for workouts transcribed from Apple Notes (#400).
+ *
+ * Kept apart from `weight-room-supabase.mjs` for the same reason that file is
+ * kept apart from the cardio writer: that one owns the Apple Health half of
+ * `weight_room_workouts`, this one owns the sets that attach to it, and folding
+ * them together would put two very different idempotency stories behind one
+ * name.
+ *
+ * Everything here is upsert-only. Nothing this module writes ever deletes a
+ * row — an imported session may already carry Health-derived duration and heart
+ * rate that this import has no business overwriting, and a set logged in the
+ * app is not ours to touch.
+ */
+
+/** Table that owns bounded Weight Room sessions (#374). */
+const WORKOUTS_TABLE = 'weight_room_workouts'
+
+/** Table that owns individual logged sets (#79). */
+const SETS_TABLE = 'weight_room_sets'
+
+/** Provenance marker for rows this module writes. */
+export const ICLOUD_NOTES_SOURCE = 'icloud_notes'
+
+/** Rows per upsert request. */
+const UPSERT_BATCH = 200
+
+/**
+ * Read the stored strength sessions a set of notes could attribute to.
+ *
+ * Scoped to a date range rather than reading all 507, because the notes cover
+ * about two years of an eight-year history and pulling the rest only widens the
+ * field of things a note can be matched to by mistake.
+ *
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase Service-role client.
+ * @param {string} fromIso Inclusive lower bound, ISO instant.
+ * @param {string} toIso Exclusive upper bound, ISO instant.
+ * @returns {Promise<Array<{id: string, started_at: string, ended_at: string|null, source: string}>>}
+ * @throws when the read fails.
+ */
+export async function fetchSessionsInRange(supabase, fromIso, toIso) {
+  const { data, error } = await supabase
+    .from(WORKOUTS_TABLE)
+    .select('id, started_at, ended_at, source')
+    .gte('started_at', fromIso)
+    .lt('started_at', toIso)
+    .order('started_at')
+  if (error) {
+    throw new Error(`Failed to read existing sessions: ${error.message}`)
+  }
+  return data ?? []
+}
+
+/**
+ * Create (or re-find) the session row for a note that matched no Health workout.
+ *
+ * The residue case: a session the watch missed. `(source, started_at)` is
+ * unique, and `started_at` comes from the note's own creation stamp, so
+ * re-running converges on the same row rather than minting a second one.
+ *
+ * `location` is left null deliberately — the note does not say where it
+ * happened, and defaulting to `'gym'` would record an inference as a fact.
+ *
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase Service-role client.
+ * @param {{startedAt: string, endedAt: string, title: string}} note The note's
+ *   window and title; the title becomes the session title, which is how the
+ *   template that was run stays visible on the imported session.
+ * @returns {Promise<string>} The session's id.
+ * @throws when the upsert or the follow-up read fails.
+ */
+export async function upsertNoteSession(supabase, { startedAt, endedAt, title }) {
+  const { data, error } = await supabase
+    .from(WORKOUTS_TABLE)
+    .upsert(
+      {
+        started_at: startedAt,
+        ended_at: endedAt,
+        title,
+        source: ICLOUD_NOTES_SOURCE,
+      },
+      { onConflict: 'source,started_at' }
+    )
+    .select('id')
+    .single()
+
+  if (error) {
+    throw new Error(`Failed to upsert session for "${title}" at ${startedAt}: ${error.message}`)
+  }
+  return data.id
+}
+
+/**
+ * Upsert transcribed sets.
+ *
+ * Keyed on `import_key`, which the parser mints deterministically from the note
+ * identity and the set's position within it. That is what makes a second run of
+ * a two-year import converge instead of doubling it.
+ *
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase Service-role client.
+ * @param {Array<{logged_at: string, exercise: string, reps: number,
+ *   weight_lbs: number|null, workout_id: string|null, position: number|null,
+ *   import_key: string}>} rows Sets to write.
+ * @returns {Promise<{upserted: number}>} How many rows were sent.
+ * @throws when any batch fails, naming the Supabase error.
+ */
+export async function upsertNoteSets(supabase, rows) {
+  if (!Array.isArray(rows) || rows.length === 0) return { upserted: 0 }
+
+  // Collapse a duplicated key inside one payload. The database would reject the
+  // whole batch on the unique index, and "duplicate key" is a long way from the
+  // cause, so fail here where the note and movement are still in hand.
+  const byKey = new Map()
+  for (const row of rows) {
+    if (byKey.has(row.import_key)) {
+      throw new Error(
+        `Two sets share the import key "${row.import_key}" — the note identity is not unique.`
+      )
+    }
+    byKey.set(row.import_key, { ...row, source: ICLOUD_NOTES_SOURCE })
+  }
+
+  const prepared = [...byKey.values()]
+  for (let i = 0; i < prepared.length; i += UPSERT_BATCH) {
+    const batch = prepared.slice(i, i + UPSERT_BATCH)
+    const { error } = await supabase.from(SETS_TABLE).upsert(batch, { onConflict: 'import_key' })
+    if (error) {
+      throw new Error(
+        `Failed to upsert sets (batch ${Math.floor(i / UPSERT_BATCH) + 1}): ${error.message}`
+      )
+    }
+  }
+
+  return { upserted: prepared.length }
+}
+
+/**
+ * Read the movement catalog's load multipliers.
+ *
+ * Taken live rather than hardcoded so a `Weight (total)` column is halved by
+ * the number of implements the catalog actually records for that movement — if
+ * someone corrects a multiplier later, the importer follows.
+ *
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase Service-role client.
+ * @returns {Promise<Record<string, number>>} Multipliers keyed by slug.
+ * @throws when the read fails.
+ */
+export async function fetchLoadMultipliers(supabase) {
+  const { data, error } = await supabase
+    .from('weight_room_exercises')
+    .select('slug, load_multiplier')
+  if (error) {
+    throw new Error(`Failed to read the movement catalog: ${error.message}`)
+  }
+  return Object.fromEntries((data ?? []).map(row => [row.slug, row.load_multiplier]))
+}
+
+/**
+ * The catalog slugs that exist, for validating what the parser resolved.
+ *
+ * `weight_room_sets.exercise` is a foreign key onto this catalog, so a slug the
+ * parser invented fails the insert with a `23503` a long way from its cause.
+ * Checking up front lets the importer name the movement and the note instead.
+ *
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase Service-role client.
+ * @returns {Promise<Set<string>>} Every catalog slug.
+ * @throws when the read fails.
+ */
+export async function fetchExerciseSlugs(supabase) {
+  const { data, error } = await supabase.from('weight_room_exercises').select('slug')
+  if (error) {
+    throw new Error(`Failed to read the movement catalog: ${error.message}`)
+  }
+  return new Set((data ?? []).map(row => row.slug))
+}

--- a/scripts/lib/icloud-notes-text.mjs
+++ b/scripts/lib/icloud-notes-text.mjs
@@ -1,0 +1,335 @@
+/**
+ * Parser for the Shortcuts export of historical workout notes (#400).
+ *
+ * Apple's bulk Data & Privacy export flattens notes to plain text and drops
+ * every table on the way, so the weights and reps only survive in the rendered
+ * note. A Shortcut reading `Note Body` on-device *does* keep them — but as one
+ * cell per line, with an empty line for an empty cell:
+ *
+ *     Squats 5 sets
+ *     Set
+ *     Weight
+ *     Reps
+ *     1
+ *     95
+ *     10
+ *     2
+ *     115
+ *
+ * The last row there is set 2 at 115 for *no recorded reps*, not a set of 115
+ * reps. That is the whole difficulty of this format: blank lines are data, so
+ * nothing here may discard them, and a row is exactly three lines whatever they
+ * contain.
+ *
+ * Pure text→structure. Movement mapping, load conversion and the
+ * grease-the-groove split all live in `icloud-notes-parser.mjs`, which consumes
+ * what this produces.
+ */
+
+/**
+ * Note boundary in the Shortcuts output, e.g. `===  Back Day 1| 2024-04-16=== `.
+ *
+ * Matched globally rather than per line because the separator does not reliably
+ * start one: a note whose body ends without a trailing newline runs straight
+ * into the next header (`Workout pace: 35 min ===  Chest Day 2| 2024-03-18===`).
+ */
+const NOTE_SEPARATOR = /===\s*([^|]+?)\s*\|\s*(\d{4}-\d{2}-\d{2})\s*===/g
+
+/** A table's `Set` column header. Sometimes pluralized, sometimes annotated. */
+const SET_HEADER = /^sets?\b/i
+
+/** A table's `Weight` column header — `Weight`, `Weight (total)`, `Weight `. */
+const WEIGHT_HEADER = /^weight\b/i
+
+/**
+ * A table's third column header.
+ *
+ * Not always reps: walking lunges count `Steps`, planks record
+ * `Time (seconds)`. Captured verbatim so the consumer can decide what the
+ * number means rather than assuming.
+ */
+const MEASURE_HEADER = /^(reps?|steps|time\b)/i
+
+/** `180 - 15` — the older freeform "weight - reps" shorthand. */
+const PAIR_LINE = /^\s*([\d.]+)\s*-\s*(\d+)\s*$/
+
+/** A bare rep count on its own line. */
+const BARE_INT = /^\s*(\d{1,3})\s*$/
+
+/**
+ * A `Set 1` / `Set 2:` line from a non-tabular block.
+ *
+ * Sled pushes and rack runs were written as loose `Set N` labels with the load
+ * underneath rather than as tables. Those labels are not movements, and reading
+ * them as such invents an exercise called "Set 1" performed for 55 reps.
+ */
+const SET_LABEL = /^set\s*\d+\s*:?\s*$/i
+
+/**
+ * A line that states a load rather than naming a movement.
+ *
+ * The older notes put the weight on its own line under the movement and the
+ * reps beneath it:
+ *
+ *     Shrugs
+ *     35 DB
+ *     20
+ *     20
+ *
+ * Read naively that is a movement called "35 DB". It is really two sets of
+ * shrugs at 35 lb per hand, and treating the line as a heading loses both the
+ * load and the movement.
+ */
+const LOAD_LINE =
+  /^(bw(\s*[+-]\s*\d+(\.\d+)?)?|\d+(\.\d+)?\s*(db|lbs?|kg|medicine ball)?|light)\s*$/i
+
+/** Plausible set numbers. Tables in this log run to 18 rows at most. */
+const MAX_SET_ROWS = 40
+
+/**
+ * Split the Shortcuts output into individual notes.
+ *
+ * @param {string} text Whole exported file.
+ * @returns {Array<{title: string, date: string, body: string}>} Notes in file
+ *   order. Text before the first separator is dropped — it is the file's
+ *   preamble, not a note.
+ */
+export function splitNotes(text) {
+  if (typeof text !== 'string') return []
+  const parts = text.split(NOTE_SEPARATOR)
+  const notes = []
+  // parts[0] is the preamble; then repeating [title, date, body].
+  for (let i = 1; i + 2 < parts.length + 1; i += 3) {
+    const title = parts[i]
+    const date = parts[i + 1]
+    const body = parts[i + 2]
+    if (title === undefined || date === undefined) break
+    notes.push({ title: title.trim(), date, body: body ?? '' })
+  }
+  return notes
+}
+
+/**
+ * Whether three consecutive lines are a table's column headers.
+ *
+ * @param {string[]} lines All lines of the note.
+ * @param {number} i Index of the candidate `Set` line.
+ * @returns {boolean} True when lines `i..i+2` head a table.
+ */
+function isHeaderAt(lines, i) {
+  return (
+    SET_HEADER.test((lines[i] ?? '').trim()) &&
+    WEIGHT_HEADER.test((lines[i + 1] ?? '').trim()) &&
+    MEASURE_HEADER.test((lines[i + 2] ?? '').trim())
+  )
+}
+
+/**
+ * Find the movement name a table belongs to.
+ *
+ * Scans backwards from the header for the nearest line that names a movement,
+ * preferring one that declares a set count (`Squats 5 sets`). A table is often
+ * preceded by a bare qualifier — `Machine`, `Barbell`, `Did cable curl` — which
+ * describes the movement without being its name, so those are stepped over.
+ *
+ * @param {string[]} lines All lines of the note.
+ * @param {number} headerIndex Index of the header's `Set` line.
+ * @returns {{name: string, declared: string|null, note: string|null}} The
+ *   heading, its declared set count if it stated one, and any qualifier line
+ *   found between the heading and the table.
+ */
+function headingFor(lines, headerIndex) {
+  const candidates = []
+  for (let i = headerIndex - 1; i >= 0 && candidates.length < 4; i -= 1) {
+    const line = (lines[i] ?? '').trim()
+    if (line === '') continue
+    candidates.push(line)
+    if (/\d+\s*(-\s*\d+)?\s*sets?\b/i.test(line)) break
+  }
+  if (candidates.length === 0) return { name: '', declared: null, note: null }
+
+  // Nearest-last: candidates[0] is closest to the table.
+  const declaredIndex = candidates.findIndex(line => /\d+\s*(-\s*\d+)?\s*sets?\b/i.test(line))
+  const headingLine = declaredIndex >= 0 ? candidates[declaredIndex] : candidates[0]
+  const qualifier = declaredIndex > 0 ? candidates[0] : null
+
+  const declared = headingLine.match(/(\d+\s*(?:-\s*\d+)?\s*sets?)/i)?.[1] ?? null
+  const name = headingLine.replace(/\d+\s*(?:-\s*\d+)?\s*sets?\b/i, '').trim()
+
+  return { name, declared, note: qualifier }
+}
+
+/**
+ * Read a table's rows, starting just past its headers.
+ *
+ * Rows are strictly three lines each — set, weight, measure — because an empty
+ * cell is an empty line. Reading stops at the first triple whose leading cell
+ * is not a plausible set number, which is what separates the table from the
+ * blank line or next heading that follows it.
+ *
+ * @param {string[]} lines All lines of the note.
+ * @param {number} start Index of the first row's set-number line.
+ * @returns {{rows: Array<{set: number, weight: string, reps: string}>, next: number}}
+ *   The rows, and the index to resume scanning from.
+ */
+function readRows(lines, start) {
+  let i = start
+  // Blank lines between the header and the first row are layout, not a cell.
+  while (i < lines.length && (lines[i] ?? '').trim() === '') i += 1
+
+  const rows = []
+  while (i + 2 < lines.length + 2 && rows.length < MAX_SET_ROWS) {
+    const setCell = (lines[i] ?? '').trim()
+    const setNumber = Number(setCell.match(/^(\d{1,2})/)?.[1])
+    if (!Number.isFinite(setNumber) || setNumber < 1 || setNumber > MAX_SET_ROWS) break
+
+    rows.push({
+      set: setNumber,
+      weight: (lines[i + 1] ?? '').trim(),
+      reps: (lines[i + 2] ?? '').trim(),
+    })
+    i += 3
+  }
+  return { rows, next: i }
+}
+
+/**
+ * Parse one note body into tables, rep lists and leftover text.
+ *
+ * @param {string} body The note's text, separator stripped.
+ * @returns {{exercises: Array<{name: string, declared: string|null,
+ *   weight_header: string, measure_header: string, note: string|null,
+ *   sets: Array<{set: number, weight: string, reps: string}>}>,
+ *   rep_lists: Array<{movement: string, reps: number[]}>, loose_text: string[]}}
+ */
+export function parseNoteBody(body) {
+  const lines = String(body ?? '').split(/\r?\n/)
+  const exercises = []
+  const repLists = []
+  const looseText = []
+
+  /** Lines already consumed by a table, so the rep-list pass skips them. */
+  const consumed = new Set()
+
+  for (let i = 0; i < lines.length; i += 1) {
+    if (!isHeaderAt(lines, i)) continue
+    const { name, declared, note } = headingFor(lines, i)
+    const { rows, next } = readRows(lines, i + 3)
+    for (let j = i; j < next; j += 1) consumed.add(j)
+
+    exercises.push({
+      name,
+      declared,
+      weight_header: (lines[i + 1] ?? '').trim(),
+      measure_header: (lines[i + 2] ?? '').trim(),
+      note,
+      sets: rows,
+    })
+    i = next - 1
+  }
+
+  // Second pass: headings followed by bare numbers (grease-the-groove volume)
+  // or `weight - reps` pairs (the older freeform shorthand).
+  //
+  // `lastHeading` carries the most recent line that actually named a movement,
+  // so a bare load line underneath it can be attributed to the right exercise
+  // rather than becoming one.
+  let lastHeading = null
+
+  for (let i = 0; i < lines.length; i += 1) {
+    if (consumed.has(i)) continue
+    const heading = (lines[i] ?? '').trim()
+    if (heading === '' || BARE_INT.test(heading) || PAIR_LINE.test(heading)) continue
+    if (isHeaderAt(lines, i)) continue
+    // A loose `Set 1` label belongs to the block above it, not to a movement.
+    if (SET_LABEL.test(heading)) continue
+
+    const isLoadLine = LOAD_LINE.test(heading)
+    if (!isLoadLine) lastHeading = heading
+
+    const reps = []
+    const pairs = []
+    let j = i + 1
+    // Tolerate one blank line between the heading and its numbers.
+    while (j < lines.length && (lines[j] ?? '').trim() === '') j += 1
+    const firstValue = j
+
+    while (j < lines.length && !consumed.has(j)) {
+      const line = (lines[j] ?? '').trim()
+      if (line === '') break
+      const pair = line.match(PAIR_LINE)
+      if (pair) {
+        pairs.push({ weight: pair[1], reps: Number(pair[2]) })
+        j += 1
+        continue
+      }
+      const bare = line.match(BARE_INT)
+      if (bare) {
+        reps.push(Number(bare[1]))
+        j += 1
+        continue
+      }
+      break
+    }
+
+    if (j === firstValue) {
+      // No numbers followed — it is prose, and worth keeping verbatim.
+      if (!/^(set|weight|reps?|steps|sets)\b/i.test(heading)) looseText.push(heading)
+      continue
+    }
+
+    if (pairs.length > 0) {
+      exercises.push({
+        name: heading,
+        declared: null,
+        weight_header: 'Weight',
+        measure_header: 'Reps',
+        note: 'freeform weight - reps',
+        sets: pairs.map((pair, index) => ({
+          set: index + 1,
+          weight: pair.weight,
+          reps: String(pair.reps),
+        })),
+      })
+    } else if (reps.length > 0 && isLoadLine && lastHeading !== null) {
+      // `Shrugs / 35 DB / 20 / 20` — the load applies to every rep beneath it.
+      exercises.push({
+        name: lastHeading,
+        declared: null,
+        weight_header: 'Weight',
+        measure_header: 'Reps',
+        note: 'load stated above the reps',
+        sets: reps.map((count, index) => ({
+          set: index + 1,
+          weight: heading,
+          reps: String(count),
+        })),
+      })
+    } else if (reps.length > 0 && !isLoadLine) {
+      repLists.push({ movement: heading, reps })
+    }
+    for (let k = i; k < j; k += 1) consumed.add(k)
+    i = j - 1
+  }
+
+  return { exercises, rep_lists: repLists, loose_text: looseText }
+}
+
+/**
+ * Parse a whole Shortcuts export.
+ *
+ * @param {string} text The exported file.
+ * @returns {Array<{title: string, date: string,
+ *   exercises: Array<{name: string, declared: string|null, weight_header: string,
+ *     measure_header: string, note: string|null,
+ *     sets: Array<{set: number, weight: string, reps: string}>}>,
+ *   rep_lists: Array<{movement: string, reps: number[]}>, loose_text: string[]}>}
+ *   One entry per note, shaped for `icloud-notes-parser.mjs`'s `parseNote`.
+ */
+export function parseExport(text) {
+  return splitNotes(text).map(note => ({
+    title: note.title,
+    date: note.date,
+    ...parseNoteBody(note.body),
+  }))
+}

--- a/scripts/lib/icloud-notes-text.test.ts
+++ b/scripts/lib/icloud-notes-text.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Tests for the Shortcuts-export text parser (#400).
+ *
+ * Fixtures are excerpts of the real export, kept verbatim — including the
+ * trailing spaces, the inline separator, and the blank lines that *are* empty
+ * cells. Normalizing any of that would test a format the data doesn't have.
+ */
+import { describe, expect, it } from 'vitest'
+
+import { parseExport, parseNoteBody, splitNotes } from './icloud-notes-text.mjs'
+
+/** Two notes, the second separator running inline off the end of the first. */
+const INLINE_SEPARATOR = [
+  ' ===  Back Day 2| 2024-03-19=== ',
+  '',
+  'Barbell Bent Over Rows 4 sets',
+  '',
+  'Set',
+  'Weight',
+  'Reps',
+  '1',
+  '100',
+  '10',
+  '',
+  'Workout pace: 35 min ===  Chest Day 2| 2024-03-18=== ',
+  '',
+  'Military Press 4 sets',
+  'Set',
+  'Weight',
+  'Reps',
+  '1',
+  '55',
+  '15',
+].join('\n')
+
+describe('splitNotes', () => {
+  it('splits on the separator even when it runs inline off a previous note', () => {
+    const notes = splitNotes(INLINE_SEPARATOR)
+    expect(notes.map(n => `${n.title}|${n.date}`)).toEqual([
+      'Back Day 2|2024-03-19',
+      'Chest Day 2|2024-03-18',
+    ])
+  })
+
+  it('trims the padding around the title', () => {
+    expect(splitNotes(' ===  Legs Day 1| 2024-04-18=== \nPull ups')[0].title).toBe('Legs Day 1')
+  })
+
+  it('keeps a title that is not one of the six templates', () => {
+    // The user's own warning: an untitled note takes its first line as a name.
+    const notes = splitNotes(' ===  Nov 25| 2023-11-21=== \nBack Day 1\n')
+    expect(notes[0].title).toBe('Nov 25')
+  })
+
+  it('returns nothing for input with no separators', () => {
+    expect(splitNotes('just some text')).toEqual([])
+    expect(splitNotes(undefined as unknown as string)).toEqual([])
+  })
+})
+
+describe('parseNoteBody — tables', () => {
+  // Verbatim from Back Day 1, 2024-04-16.
+  const backDay1 = [
+    'Pull ups 4 sets',
+    'Set',
+    'Weight',
+    'Reps',
+    '1',
+    'BW',
+    '6',
+    '2',
+    'BW',
+    '6',
+    '10',
+    'BW',
+    '',
+    '11',
+    'BW',
+    '',
+    'Seated two arm Row 4 sets',
+    'Set',
+    'Weight',
+    'Reps',
+    '1',
+    '110',
+    '15',
+    '2',
+    '120',
+    '15',
+  ].join('\n')
+
+  it('reads a blank third cell as an empty measure, not a missing row', () => {
+    // Set 10 is BW for *no recorded reps*. Dropping the blank line would slide
+    // set 11's number into set 10's reps and invent a set of 11.
+    const { exercises } = parseNoteBody(backDay1)
+    const pullups = exercises[0]
+    expect(pullups.name).toBe('Pull ups')
+    expect(pullups.declared).toBe('4 sets')
+    expect(pullups.sets).toEqual([
+      { set: 1, weight: 'BW', reps: '6' },
+      { set: 2, weight: 'BW', reps: '6' },
+      { set: 10, weight: 'BW', reps: '' },
+      { set: 11, weight: 'BW', reps: '' },
+    ])
+  })
+
+  it('starts a new exercise when the rows stop', () => {
+    const { exercises } = parseNoteBody(backDay1)
+    expect(exercises.map(e => e.name)).toEqual(['Pull ups', 'Seated two arm Row'])
+    expect(exercises[1].sets).toHaveLength(2)
+  })
+
+  it('captures the weight header verbatim, including (total)', () => {
+    // The sharpest trap in the source: a combined two-dumbbell load.
+    const { exercises } = parseNoteBody(
+      ['Incline barbell press 4 sets', 'Set', 'Weight (total)', 'Reps', '1', '115', '8'].join('\n')
+    )
+    expect(exercises[0].weight_header).toBe('Weight (total)')
+  })
+
+  it('captures a third column that is not reps', () => {
+    // Walking lunges count steps; planks record seconds. Calling either "reps"
+    // would put a step count into the rep total.
+    const lunges = parseNoteBody(
+      ['Walking Lunges 4 sets ', '', 'Set', 'Weight', 'Steps', '1', 'BW', '20'].join('\n')
+    )
+    expect(lunges.exercises[0].measure_header).toBe('Steps')
+
+    const planks = parseNoteBody(
+      ['Planks 4 sets', '', 'Set', 'Weight', 'Time (seconds)', '1', 'BW', '30'].join('\n')
+    )
+    expect(planks.exercises[0].measure_header).toBe('Time (seconds)')
+  })
+
+  it('handles a pluralized Sets header', () => {
+    const { exercises } = parseNoteBody(
+      ['Knee Tucks 4 sets', '', 'Sets', 'Weight', 'Reps', '1', 'Hanging Knee tuck', '10'].join('\n')
+    )
+    expect(exercises[0].name).toBe('Knee Tucks')
+    expect(exercises[0].sets[0].weight).toBe('Hanging Knee tuck')
+  })
+
+  it('steps over a qualifier line between the heading and the table', () => {
+    // `Machine` / `Barbell` / `Did cable curl` describe the movement without
+    // being its name; taking the nearest line would name the exercise "Machine".
+    const { exercises } = parseNoteBody(
+      ['Preacher curls 5 sets', 'Machine', 'Set', 'Weight', 'Reps', '1', '95', '10'].join('\n')
+    )
+    expect(exercises[0].name).toBe('Preacher curls')
+    expect(exercises[0].note).toBe('Machine')
+  })
+
+  it('tolerates trailing spaces in headings and headers', () => {
+    const { exercises } = parseNoteBody(
+      ['Military press ', 'Set ', 'Weight ', 'Reps', '1', '55', '15'].join('\n')
+    )
+    expect(exercises[0].name).toBe('Military press')
+    expect(exercises[0].declared).toBeNull()
+  })
+})
+
+describe('parseNoteBody — rep lists and freeform', () => {
+  it('reads a bare number list as grease-the-groove volume', () => {
+    const { rep_lists, exercises } = parseNoteBody(['Pushups', '10', '10', '12', ''].join('\n'))
+    expect(exercises).toHaveLength(0)
+    expect(rep_lists).toEqual([{ movement: 'Pushups', reps: [10, 10, 12] }])
+  })
+
+  it('reads the older weight - reps shorthand as a real exercise', () => {
+    // Pre-table notes logged `180 - 15`; those are loaded sets, not volume.
+    const { exercises, rep_lists } = parseNoteBody(
+      ['Leg press', '180 - 15', '270 - 12', '270 - 12'].join('\n')
+    )
+    expect(rep_lists).toHaveLength(0)
+    expect(exercises[0].name).toBe('Leg press')
+    expect(exercises[0].sets).toEqual([
+      { set: 1, weight: '180', reps: '15' },
+      { set: 2, weight: '270', reps: '12' },
+      { set: 3, weight: '270', reps: '12' },
+    ])
+  })
+
+  it('keeps prose out of both piles', () => {
+    const { loose_text, rep_lists, exercises } = parseNoteBody(
+      ['Rack Run 35,30,25,20 2 sets', '', 'Set 1: 25, 20, 10', '', 'Workout pace: 35 min'].join(
+        '\n'
+      )
+    )
+    expect(exercises).toHaveLength(0)
+    expect(rep_lists).toHaveLength(0)
+    expect(loose_text).toContain('Workout pace: 35 min')
+  })
+
+  it('does not mistake a table it already consumed for a rep list', () => {
+    const { rep_lists } = parseNoteBody(
+      ['Squats 5 sets', 'Set', 'Weight', 'Reps', '1', '95', '10', '2', '115', '10'].join('\n')
+    )
+    expect(rep_lists).toHaveLength(0)
+  })
+})
+
+describe('parseExport', () => {
+  it('produces one entry per note, shaped for the movement parser', () => {
+    const parsed = parseExport(INLINE_SEPARATOR)
+    expect(parsed).toHaveLength(2)
+    expect(parsed[0]).toMatchObject({ title: 'Back Day 2', date: '2024-03-19' })
+    expect(parsed[0].exercises[0].name).toBe('Barbell Bent Over Rows')
+    expect(parsed[1].exercises[0].name).toBe('Military Press')
+  })
+})

--- a/supabase/migrations/20260808120000_weight_room_icloud_notes_import.sql
+++ b/supabase/migrations/20260808120000_weight_room_icloud_notes_import.sql
@@ -1,0 +1,92 @@
+-- #400 — let workouts transcribed from iCloud Notes land in the Weight Room.
+--
+-- Two years of training (2022-2024) were logged in Apple Notes: one note per
+-- session, titled with the template it ran, holding a `Set | Weight | Reps`
+-- table per exercise. #413 already imported the Apple Health side of those same
+-- sessions — 507 Traditional Strength Training workouts that know *when* and
+-- *how hard* but nothing about what was lifted. The notes are the missing half.
+--
+-- The two halves line up far more tightly than "same day". Spot-checking
+-- 2024-04-16: the Health workout ran 21:39:00-22:10:42 local, and the note was
+-- created 21:40:38 and last edited 22:07:12 — the note window sits entirely
+-- inside the workout window, because the note was typed *during* the session,
+-- one row at a time. So the importer attaches sets to the existing
+-- `apple_health` row whose window overlaps, rather than inventing a second
+-- session for the same hour. `weight-room-supabase.mjs` anticipated exactly
+-- this: an imported session can acquire hand-authored sets later.
+--
+-- 'icloud_notes' as a workout source therefore covers only the residue — a note
+-- with no Health counterpart (watch left on the charger, or a session predating
+-- the watch).
+
+alter table public.weight_room_workouts
+  drop constraint if exists weight_room_workouts_source_check;
+
+alter table public.weight_room_workouts
+  add constraint weight_room_workouts_source_check
+  check (source in ('manual', 'apple_health', 'icloud_notes'));
+
+comment on column public.weight_room_workouts.source is
+  'Where this session came from. ''manual'' — recorded through the app''s live '
+  'recording surface (#374). ''apple_health'' — imported from a Health export '
+  '(#413); knows its window and HR but usually carries no sets, though #400 may '
+  'attach transcribed ones. ''icloud_notes'' — transcribed from an Apple Notes '
+  'session log (#400) that had no Health workout to attach to.';
+
+-- Provenance on the sets themselves, not just their workout.
+--
+-- `resolveAchievements` recomputes every badge from the full set history, and
+-- streaks and all-time bests span the whole log — so backfilling two years of
+-- training silently re-scores everything. That is not wrong (it *is* the
+-- history), but per #400 it has to be a decision the surfaces can make rather
+-- than a surprise on the next page load, and that requires being able to tell
+-- an imported set from a logged one.
+--
+-- A column here rather than a join through `workout_id` because the join cannot
+-- answer it: grease-the-groove rep lists transcribed from these notes are
+-- deliberately *not* attached to a workout (see below), so they would come back
+-- indistinguishable from sets logged in the app today.
+alter table public.weight_room_sets
+  add column if not exists source text not null default 'manual',
+  add column if not exists import_key text;
+
+do $$
+begin
+  alter table public.weight_room_sets
+    add constraint weight_room_sets_source_check
+    check (source in ('manual', 'icloud_notes'));
+exception
+  when duplicate_object then null;
+end $$;
+
+comment on column public.weight_room_sets.source is
+  'Where this set came from. ''manual'' — logged through the app or the '
+  'log-workout skill. ''icloud_notes'' — transcribed from a historical Apple '
+  'Notes session log (#400). Surfaces that recompute over all-time history '
+  '(achievements, streaks, personal bests) can scope on this rather than '
+  'silently re-scoring years of backfilled training.';
+
+-- Idempotency for imported sets.
+--
+-- Unlike workouts, a set has no natural key: the same movement at the same
+-- weight for the same reps legitimately appears several times in one session,
+-- and `logged_at` is derived from the note's window rather than observed, so it
+-- cannot separate them. The importer therefore mints a deterministic key from
+-- the note identity and the set's position within it
+-- (`icloud:<title>:<date>:<exercise>:<n>`), which makes a re-run an upsert
+-- instead of a second copy of the same two years.
+--
+-- Nullable, and unique over the non-null values only — Postgres allows repeated
+-- NULLs in a unique index, so every manually logged set (which has no import
+-- key and never will) stays unconstrained. Full rather than partial for the
+-- same reason as `weight_room_workouts_source_started_at_key`: supabase-js's
+-- `onConflict` names columns and cannot restate a WHERE predicate, so a partial
+-- index fails the upsert outright.
+create unique index if not exists weight_room_sets_import_key_key
+  on public.weight_room_sets (import_key);
+
+comment on column public.weight_room_sets.import_key is
+  'Deterministic natural key for a set transcribed by the #400 importer, of the '
+  'form ''icloud:<note title>:<note date>:<exercise slug>:<index>''. Null for '
+  'every manually logged set. Backs the importer''s upsert so re-running it '
+  'converges instead of duplicating.';

--- a/supabase/migrations/20260809120000_weight_room_box_jump_assisted_pullup.sql
+++ b/supabase/migrations/20260809120000_weight_room_box_jump_assisted_pullup.sql
@@ -1,0 +1,27 @@
+-- #400 — two movements the iCloud Notes archive trains that the catalog lacks.
+--
+-- Both were surfaced by the importer refusing to guess: it reports a movement
+-- it cannot resolve rather than bending it onto the nearest existing slug,
+-- which is how a near-duplicate ends up splitting a movement's history in two.
+--
+-- `box-jump` covers the plyo work that appears at the end of nearly every leg
+-- and chest session ("18 inch plyo", "24 inch plyo", "30 inch plyo"). The box
+-- height is the load, so it rides on the set's `variant` rather than becoming
+-- three separate slugs — the same treatment grip and tempo already get.
+--
+-- `assisted-pullups` is deliberately NOT folded into `pullups`. An assisted rep
+-- moves less than bodyweight, and counting it toward the same movement would
+-- inflate the unassisted pull-up history that the daily ring and the
+-- then-vs-now comparison both read.
+
+insert into public.weight_room_exercises
+  (slug, display_name, equipment, muscle_group, load_multiplier, is_unilateral)
+values
+  ('box-jump', 'Box Jump', 'bodyweight', 'legs', 1, false),
+  ('assisted-pullups', 'Assisted Pull-ups', 'machine', 'back', 1, false)
+on conflict (slug) do nothing;
+
+comment on table public.weight_room_exercises is
+  'Movement roster for the Weight Room (#373). Rows are added when a real '
+  'movement appears with no home — see #400, which added box jumps and assisted '
+  'pull-ups rather than mapping them onto near-duplicate slugs.';

--- a/supabase/migrations/20260809130000_weight_room_sets_duration.sql
+++ b/supabase/migrations/20260809130000_weight_room_sets_duration.sql
@@ -1,0 +1,37 @@
+-- #400 — record isometric holds as time, because reps cannot describe them.
+--
+-- A plank is not performed for repetitions. The notes log it as seconds, in
+-- three different shapes across the years — a `Time (seconds)` table column, a
+-- bare list under `Planks`, and `45 seconds` written out per set. Every one of
+-- those is a duration.
+--
+-- Until now the importer had nowhere to put it. The tabular shape was reported
+-- and skipped; the freeform shape slipped through the generic rep path and
+-- landed 12 sets claiming 35-50 *reps* of plank, which is exactly the silent
+-- mistranslation this column exists to prevent. Those rows are corrected by
+-- re-running the import, which upserts them on their existing keys.
+--
+-- `reps` stays `not null`: a held set is one repetition of the hold, so a plank
+-- is `reps = 1, duration_seconds = 45`. Making `reps` nullable instead would
+-- ripple through every rollup that sums it — the daily ring, tonnage, personal
+-- bests — for a single movement family, and each of those would then have to
+-- decide what a null rep count means.
+
+alter table public.weight_room_sets
+  add column if not exists duration_seconds integer;
+
+do $$
+begin
+  alter table public.weight_room_sets
+    add constraint weight_room_sets_duration_check
+    check (duration_seconds is null or duration_seconds > 0);
+exception
+  when duplicate_object then null;
+end $$;
+
+comment on column public.weight_room_sets.duration_seconds is
+  'How long an isometric set was held, in seconds. Null for the overwhelming '
+  'majority — every set counted in repetitions. Set alongside ''reps = 1'' for a '
+  'hold (a plank of 45 seconds is one repetition lasting 45 seconds), so rollups '
+  'that sum reps keep working without special-casing the movement, and surfaces '
+  'that can say ''45s'' read this instead of printing ''1 rep''.';

--- a/types/weight-room.ts
+++ b/types/weight-room.ts
@@ -95,7 +95,28 @@ export interface StrengthSet {
    * rows are one set of the prescription, so the slot reads `8 / 2`.
    */
   template_slot_step_id?: string
+  /**
+   * Where this set came from (#400). Absent means `'manual'` — logged through
+   * the app or the `log-workout` skill — which is the column default and what
+   * every set predating the import is.
+   *
+   * `'icloud_notes'` marks a set transcribed from a historical Apple Notes
+   * session log. Surfaces that recompute over all-time history (achievements,
+   * streaks, personal bests) can scope on this rather than silently re-scoring
+   * years of backfilled training, and the then-vs-now panel uses it to say
+   * whether the earlier era is imported rather than assuming it.
+   */
+  source?: SetSource
 }
+
+/**
+ * How a {@link StrengthSet} got into the database (#400).
+ *
+ * Narrower than {@link WorkoutSource} on purpose: the Apple Health export
+ * records that a workout happened but never what was done in it, so no set can
+ * originate there.
+ */
+export type SetSource = 'manual' | 'icloud_notes'
 
 /**
  * Where a {@link WeightRoomWorkout} happened (#374). Coarse on purpose — it
@@ -105,14 +126,23 @@ export interface StrengthSet {
 export type WorkoutLocation = 'gym' | 'home' | 'travel' | 'other'
 
 /**
- * How a {@link WeightRoomWorkout} got into the database (#413).
+ * How a {@link WeightRoomWorkout} got into the database (#413, #400).
  *
  * Not cosmetic — it decides what the session can honestly claim. A `'manual'`
  * session was recorded set by set, so its tonnage and adherence are
  * measurements. An `'apple_health'` one knows only that lifting happened and
- * for how long, so the same fields are *unknown* rather than zero.
+ * for how long, so the same fields are *unknown* rather than zero. An
+ * `'icloud_notes'` one was transcribed from a historical Apple Notes session log
+ * (#400) that had no Health workout to attach to; it carries real sets but no
+ * duration or heart rate.
+ *
+ * **Every value the database can hold must appear here and in
+ * `WeightRoomWorkoutRowSchema`.** `assembleWeightRoomWorkouts` validates the
+ * whole array in one pass, so a single row with an unlisted source fails the
+ * entire read — and the callers catch that as `[]`, which renders as "no
+ * workouts recorded yet" over a full history rather than as an error.
  */
-export type WorkoutSource = 'manual' | 'apple_health'
+export type WorkoutSource = 'manual' | 'apple_health' | 'icloud_notes'
 
 /**
  * One bounded training session (#374) — mirrors a row of

--- a/types/weight-room.ts
+++ b/types/weight-room.ts
@@ -107,6 +107,16 @@ export interface StrengthSet {
    * whether the earlier era is imported rather than assuming it.
    */
   source?: SetSource
+  /**
+   * How long an isometric set was held, in seconds (#400).
+   *
+   * Absent for the overwhelming majority — every set counted in repetitions.
+   * Present alongside `reps: 1` for a hold: a 45-second plank is one repetition
+   * lasting 45 seconds, which keeps rep rollups working without special-casing
+   * the movement. Surfaces that can render a hold should prefer this over
+   * printing "1 rep".
+   */
+  duration_seconds?: number
 }
 
 /**


### PR DESCRIPTION
Imports two years of training (2022–2024) that was logged one note per session in Apple Notes, and adds the then-vs-now comparison that was the reason to import it.

Closes #400.

## The discovery that shaped this

#413 already imported the Apple Health half of these sessions — 507 workouts that know *when* and *how hard* but nothing about what was lifted. The notes are the other half.

They line up far more tightly than "same day", because **the notes were typed during the workout**, one table row at a time:

| | window (local) |
|---|---|
| Health session, 2024-04-16 | 21:39:00 – 22:10:42 |
| Note create → last edit | 21:40:38 – 22:07:12 |

The note sits *entirely inside* the session. So the importer **attaches sets to the overlapping `apple_health` row** rather than inventing a second session for the same hour — which is exactly what `weight-room-supabase.mjs` anticipated when it refused to prune imported rows. In the real run, **15 of 17 notes matched by overlap**; the 2 that didn't became their own `icloud_notes` sessions rather than being dropped.

This also supersedes the issue's earlier premise that dating would be guesswork: the dates are exact.

## Traps handled

- **`Weight (total)` columns.** Some tables head the column `Weight` (per hand), others `Weight (total)` (the pair). Importing a `(total)` value verbatim records **double** the real load with nothing downstream looking wrong, so the header is read per table. Visible in the data: `dumbbell-incline-press` landed at `21.25` lb — a correctly halved 42.5.
- **`Squats` means two different movements.** In a table (loaded) it's `barbell-back-squat`; as a bare rep list it's the bodyweight `squats` that feeds the daily ring. Mapping the former onto the latter would dump gym volume into the grease-the-groove streak.
- **Grease-the-groove vs session work.** Bare rep lists are that day's volume, not the workout's — they import with `workout_id` null. The same movement can be both on one day (Chest Day 2 has push-ups in both shapes), so the discriminator is the shape it was written in.
- **Unfilled template rows.** A `Pull ups 4 sets` table runs to 18 numbered rows with `BW` pre-filled and Reps blank. Those are stationery, not training; reps is the discriminator.
- **Re-runs.** Sets carry a deterministic `import_key`, so re-importing converges instead of doubling two years of history.

## Re-scoring decision (the issue's "decide before the first insert")

`weight_room_sets` gains a `source` column. Achievements, streaks and all-time bests recompute over the full history, so a two-year backfill silently re-scores everything; the column makes that a decision the surfaces can take deliberately. A column rather than a join through `workout_id`, because grease-the-groove sets deliberately have no workout to join to.

## Then vs now

The era boundary is **discovered, not configured** — the longest gap in the movement's own history — so a future injury layoff splits eras the same way instead of needing a hardcoded 2024 cutoff. Movements trained continuously render no panel.

Real output for shrugs: `12 × 110 lb` then vs `10 × 120 lb` now → *"Current training has passed the archive's heaviest shrugs by 10 lb."*

Bodyweight movements render em-dashes rather than zeros and get a rep-volume verdict instead, because "not yet surpassed" would be a judgement on training that was never measured in pounds.

## Migration

Applied to **both** staging and production. Additive and idempotent: extends the workouts `source` check with `icloud_notes`, adds `source` + `import_key` to `weight_room_sets`, and a unique index backing the upsert.

## Test plan

- [ ] `/training-facility/weight-room/exercises/shrugs` — Then/Now columns, and the "passed by 10 lb" verdict
- [ ] `/training-facility/weight-room/exercises/pullups` — bodyweight path: em-dashes for load rows, rep-volume verdict
- [ ] `/training-facility/weight-room/exercises/pushups` — same bodyweight path
- [ ] A movement with only current training (e.g. `dumbbell-lateral-raise`) shows **no** Then-vs-now panel
- [ ] Weight Room history/achievements still render — imported sets are present but flagged
- [ ] `npm run import-icloud-notes -- --dry-run --manifest="<export>/Notes Details.csv"` reports the same counts and writes nothing
- [ ] Re-running the real import writes the same rows (idempotent), not duplicates

## Known gaps

- **Only 17 of ~131 notes are imported so far.** Apple's bulk export flattens notes to plain text and every table collapses to a `￼` placeholder (161 of 680 notes affected), so the numbers only exist in the rendered note. Recovering the rest needs a Mac/iPhone export or manual transcription — see the issue thread. The importer is idempotent, so the remainder can be added by re-running.
- Two movements are still unmapped and reported rather than guessed: `24 inch plyo` and `Assisted pull ups`. They need real catalog rows, not near-duplicate slugs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added iCloud Notes workout importing with workout and grease-the-groove sets, date matching, duplicate-safe updates, dry-run support, and unmatched-movement reporting.
  - Added “Then vs. Now” comparisons to exercise pages, including training periods, volume, reps, estimated strength, and progress verdicts.
  - Added provenance tracking for imported workout data.
  - Added support for tracking and displaying timed isometric holds.
  - Added Box Jump and Assisted Pull-Up exercises.

- **Bug Fixes**
  - Improved matching across time zones, daylight-saving changes, incomplete sessions, and ambiguous workout dates.

- **Tests**
  - Added comprehensive coverage for comparisons, note parsing, session matching, imports, and hold formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->