### PR TITLE
feat(weight-room): import rack runs and 21s as the drop sets they are (#435)

### DIFF
--- a/app/training-facility/weight-room/exercises/[slug]/page.tsx
+++ b/app/training-facility/weight-room/exercises/[slug]/page.tsx
@@ -169,6 +169,7 @@ export default async function WeightRoomExercisePage({
                   comparison={eraComparison}
                   displayName={displayName}
                   earlierEraImported={eraIsImported(eraComparison.then, exercise, sets)}
+                  currentEraImported={eraIsImported(eraComparison.now, exercise, sets)}
                 />
               )}
               <ExerciseProgressionPanel

--- a/components/training-facility/weight-room/ThenVsNowPanel.tsx
+++ b/components/training-facility/weight-room/ThenVsNowPanel.tsx
@@ -22,6 +22,15 @@ export interface ThenVsNowPanelProps {
    * that never happened would put a false provenance on real training.
    */
   earlierEraImported: boolean
+  /**
+   * Whether the *later* era is also imported.
+   *
+   * A movement trained only during the archive still has eras — the archive
+   * contains its own layoffs, and a movement like dumbbell curl splits at a
+   * 254-day one. Both sides are then imported, and saying "the earlier one
+   * comes from Apple Notes" would imply the later one doesn't.
+   */
+  currentEraImported: boolean
 }
 
 /**
@@ -43,9 +52,17 @@ export function ThenVsNowPanel({
   comparison,
   displayName,
   earlierEraImported,
+  currentEraImported,
 }: ThenVsNowPanelProps): JSX.Element {
   const { then, now, gapDays } = comparison
   const gapYears = gapDays / 365
+
+  const provenance =
+    earlierEraImported && currentEraImported
+      ? 'Both stretches come from training logged in Apple Notes and imported into this log.'
+      : earlierEraImported
+        ? 'The earlier one comes from training logged in Apple Notes and imported into this log.'
+        : 'The earlier one is training this log already carried.'
 
   return (
     <section
@@ -61,9 +78,7 @@ export function ThenVsNowPanel({
           {gapYears >= 1
             ? `${gapYears.toFixed(1)} years separate these two stretches of ${displayName.toLowerCase()}.`
             : `${gapDays} days separate these two stretches of ${displayName.toLowerCase()}.`}{' '}
-          {earlierEraImported
-            ? 'The earlier one comes from training logged in Apple Notes and imported into this log.'
-            : 'The earlier one is training this log already carried.'}
+          {provenance}
         </p>
       </header>
 

--- a/lib/data/weight-room-shared.ts
+++ b/lib/data/weight-room-shared.ts
@@ -67,7 +67,7 @@ const EXERCISES_TABLE = 'weight_room_exercises'
  * into a workout without another round trip.
  */
 const SETS_COLUMNS =
-  'id, logged_at, exercise, reps, weight_lbs, variant, workout_id, position, template_slot_id, template_slot_step_id, source, duration_seconds, updated_at'
+  'id, logged_at, exercise, reps, weight_lbs, variant, workout_id, position, template_slot_id, template_slot_step_id, source, duration_seconds, to_failure, updated_at'
 // `load_multiplier` deliberately absent (#373) — it moved to the catalog and is
 // joined on below. The goals column still exists (dropping it while the
 // deployed build still selected it would break the live read) but is dead.

--- a/lib/schemas/weight-room.ts
+++ b/lib/schemas/weight-room.ts
@@ -156,6 +156,8 @@ export const WeightRoomSetRowSchema = z
     source: z.enum(['manual', 'icloud_notes']).nullable().optional(),
     // Seconds a hold lasted (#400); null for every set counted in reps.
     duration_seconds: nonNegativeInt().nullable().optional(),
+    // Set taken to failure with its rep count unrecorded (#435).
+    to_failure: z.boolean().nullable().optional(),
   })
   .strict()
 
@@ -344,6 +346,9 @@ export function setRowToStrengthSet(row: WeightRoomSetRow): StrengthSet {
     // follows for its own source.
     ...(row.source != null && row.source !== 'manual' ? { source: row.source } : {}),
     ...(row.duration_seconds != null ? { duration_seconds: row.duration_seconds } : {}),
+    // `false` is the column default and the absent-field meaning, so only a
+    // true flag is carried — same convention as `source`.
+    ...(row.to_failure === true ? { to_failure: true } : {}),
   }
 }
 

--- a/lib/training-facility/exercise-progression.ts
+++ b/lib/training-facility/exercise-progression.ts
@@ -232,6 +232,7 @@ export function buildExerciseProgression(
         effectiveLoad,
         loggedAt: set.logged_at,
         ...(set.duration_seconds === undefined ? {} : { durationSeconds: set.duration_seconds }),
+        ...(set.to_failure === true ? { toFailure: true } : {}),
       }
 
       reps += set.reps

--- a/lib/training-facility/strength-format.test.ts
+++ b/lib/training-facility/strength-format.test.ts
@@ -97,4 +97,20 @@ describe('describeSetOrHold', () => {
   it('ignores a nonsensical duration rather than rendering it', () => {
     expect(describeSetOrHold({ reps: 12, effectiveLoad: 0, durationSeconds: 0 })).toBe('12 reps')
   })
+
+  it('says what a to-failure set was, not its placeholder rep count', () => {
+    // A rack-run drop stores `reps: 1` meaning "one set" (#435). Printing
+    // "1 rep" would claim a count that was never recorded.
+    expect(describeSetOrHold({ reps: 1, effectiveLoad: 50, toFailure: true })).toBe(
+      '50 lb to failure'
+    )
+  })
+
+  it('describes an unloaded to-failure set without inventing a load', () => {
+    expect(describeSetOrHold({ reps: 1, effectiveLoad: 0, toFailure: true })).toBe('to failure')
+  })
+
+  it('leaves ordinary sets alone when the flag is absent or false', () => {
+    expect(describeSetOrHold({ reps: 8, effectiveLoad: 60, toFailure: false })).toBe('8 × 60 lb')
+  })
 })

--- a/lib/training-facility/strength-format.ts
+++ b/lib/training-facility/strength-format.ts
@@ -85,10 +85,22 @@ export function formatHold(seconds: number): string {
  * @param options Unit label and locale, forwarded to {@link formatLbs}.
  */
 export function describeSetOrHold(
-  set: { reps: number; effectiveLoad: number; durationSeconds?: number | null },
+  set: {
+    reps: number
+    effectiveLoad: number
+    durationSeconds?: number | null
+    toFailure?: boolean | null
+  },
   options: LoadFormatOptions = {}
 ): string {
-  const { reps, effectiveLoad, durationSeconds } = set
+  const { reps, effectiveLoad, durationSeconds, toFailure } = set
+
+  // A to-failure set stores `reps: 1` meaning "one set", so the rep count is
+  // not a number worth printing — say what actually happened instead (#435).
+  if (toFailure === true) {
+    return effectiveLoad > 0 ? `${formatLbs(effectiveLoad, options)} to failure` : 'to failure'
+  }
+
   if (durationSeconds === undefined || durationSeconds === null || durationSeconds <= 0) {
     return describeSet(reps, effectiveLoad, options)
   }

--- a/lib/training-facility/workout-stats.ts
+++ b/lib/training-facility/workout-stats.ts
@@ -120,6 +120,13 @@ export interface WorkoutSetHighlight {
    * `describeSetOrHold`, which says `45s` where `describeSet` would say `1 rep`.
    */
   durationSeconds?: number
+  /**
+   * Whether the set went to failure with its rep count unrecorded (#435).
+   *
+   * When true, `reps` is 1 and means "one set", not one repetition — render
+   * sites should prefer `describeSetOrHold`, which says "to failure".
+   */
+  toFailure?: boolean
 }
 
 /** One movement's contribution to a session. */
@@ -270,6 +277,7 @@ export function buildWorkoutSummary(
         effectiveLoad,
         loggedAt: set.logged_at,
         ...(set.duration_seconds === undefined ? {} : { durationSeconds: set.duration_seconds }),
+        ...(set.to_failure === true ? { toFailure: true } : {}),
       }
       // Heaviest wins; at equal load the one with more reps is the better set.
       if (

--- a/scripts/import-icloud-notes.mjs
+++ b/scripts/import-icloud-notes.mjs
@@ -340,6 +340,11 @@ async function main() {
           weight_lbs: set.weight_lbs,
           ...(set.variant === undefined ? {} : { variant: set.variant }),
           ...(set.duration_seconds === undefined ? {} : { duration_seconds: set.duration_seconds }),
+          // Always sent, never conditionally spread: PostgREST builds one
+          // INSERT from the union of keys across the batch, and a row missing
+          // the key gets NULL rather than the column default — which a
+          // `not null` column rejects, failing the whole batch.
+          to_failure: set.to_failure === true,
           // Grease-the-groove volume is that day's, not the session's — see
           // #400. Leaving `workout_id` null is what keeps it off the workout.
           workout_id: set.disposition === 'workout' ? workoutId : null,

--- a/scripts/lib/icloud-notes-parser.mjs
+++ b/scripts/lib/icloud-notes-parser.mjs
@@ -171,6 +171,22 @@ const RAW_MOVEMENT_ALIASES = {
 }
 
 /**
+ * Reps in one 21s set, counted the way every other two-dumbbell set is (#435).
+ *
+ * The protocol is 7 reps with one arm while the other holds mid-curl, 7 with
+ * the other, then 7 with both — 21 curls in total, but **14 per arm**. Every
+ * other dumbbell movement in this log stores reps *per arm* and lets the
+ * catalog's `load_multiplier` of 2 account for the second one, so a straight
+ * set of 10 curls is `reps = 10` and tonnage comes out as `10 × weight × 2`.
+ *
+ * Storing 21 here would put all 21 through that same doubling and bill 42
+ * arm-reps for work that was 28. 14 keeps the arithmetic honest and consistent;
+ * the `21s` variant preserves that it was the protocol rather than a straight
+ * set of 14.
+ */
+export const TWENTY_ONES_REPS_PER_ARM = 14
+
+/**
  * Box height stated in a plyo movement's name, e.g. `24 inch plyo`.
  *
  * Kept as the set's variant rather than as three near-duplicate slugs: a box
@@ -508,6 +524,76 @@ export function mintImportKey({ title, date, slug, index }) {
 }
 
 /**
+ * Turn a `Set N:` block — a rack run or a set of 21s — into sets (#435).
+ *
+ * Both are dumbbell curls that a `Set | Weight | Reps` table cannot express,
+ * and both record loads where a table would record reps.
+ *
+ * **Rack run.** A drop set: curl the 35s to failure, drop to the 30s, again,
+ * down the rack. `Set 1: 25, 20, 10` is three drops at three loads, and the rep
+ * count was never written because each drop simply went until it couldn't.
+ * Every drop is therefore a set marked `to_failure` — see the #435 migration
+ * for why that stores `reps = 1` rather than null.
+ *
+ * A `Set N:` with nothing after it is the same movement performed with nothing
+ * recorded at all. It still happened — the heading declared it and the label is
+ * there — so it imports as one unloaded to-failure set rather than vanishing.
+ * That is the two shapes the source actually has: one with loads, one without.
+ *
+ * **21s.** One set at one load, for {@link TWENTY_ONES_REPS_PER_ARM} reps.
+ *
+ * @param {{movement: string, planned?: string,
+ *   sets: Array<{set: number, value: string}>}} block A parsed labelled block.
+ * @param {Record<string, number>} [loadMultipliers] Live catalog multipliers.
+ * @returns {Array<{exercise: string, reps: number, weight_lbs: number|null,
+ *   variant: string, to_failure?: boolean}>} Sets in the order they were run.
+ */
+export function parseLabelledBlock(block, loadMultipliers = {}) {
+  const isRackRun = /^rack run/i.test(block.movement)
+  const slug = 'dumbbell-curl'
+  const variant = isRackRun ? 'rack run' : '21s'
+  const out = []
+
+  for (const entry of block.sets ?? []) {
+    // Loads are comma-separated: `25, 20, 10` is three drops, `22.5 DB` is one.
+    const loads = entry.value
+      .split(',')
+      .map(part => part.trim())
+      .filter(part => part !== '')
+
+    if (!isRackRun) {
+      // 21s: a value of bare `DB` names the implement without a load, which is
+      // a set that happened at a weight nobody wrote down.
+      const weight = perImplementWeight(loads[0], 'Weight', slug, loadMultipliers[slug])
+      out.push({
+        exercise: slug,
+        reps: TWENTY_ONES_REPS_PER_ARM,
+        weight_lbs: weight,
+        variant,
+      })
+      continue
+    }
+
+    if (loads.length === 0) {
+      out.push({ exercise: slug, reps: 1, weight_lbs: null, variant, to_failure: true })
+      continue
+    }
+
+    for (const load of loads) {
+      out.push({
+        exercise: slug,
+        reps: 1,
+        weight_lbs: perImplementWeight(load, 'Weight', slug, loadMultipliers[slug]),
+        variant,
+        to_failure: true,
+      })
+    }
+  }
+
+  return out
+}
+
+/**
  * Turn one transcribed note into the sets it records.
  *
  * Splits into two piles, which is the distinction #400 flags as easiest to get
@@ -523,17 +609,24 @@ export function mintImportKey({ title, date, slug, index }) {
  * @param {string} note.title Note title.
  * @param {string} note.date Note date as `YYYY-MM-DD`.
  * @param {Array<{name: string, weight_header?: string|null,
+ *   measure_header?: string|null,
  *   sets?: Array<{set?: number, weight?: unknown, reps?: unknown}>}>} [note.exercises]
- *   Table-backed exercises.
+ *   Table-backed exercises. `measure_header` distinguishes a rep column from a
+ *   duration one — see {@link isRepMeasure}.
  * @param {Array<{movement: string, reps?: unknown[]}>} [note.rep_lists]
  *   Bare rep lists.
+ * @param {Array<{movement: string, planned?: string,
+ *   sets: Array<{set: number, value: string}>}>} [note.labelled_blocks]
+ *   `Set N:` blocks — rack runs and 21s (#435); see {@link parseLabelledBlock}.
  * @param {Record<string, number>} [loadMultipliers] Live catalog multipliers
  *   keyed by slug. Falls back to {@link TWO_IMPLEMENT_SLUGS} when absent.
  * @returns {{sets: Array<{exercise: string, reps: number, weight_lbs: number|null,
+ *   variant?: string, duration_seconds?: number, to_failure?: boolean,
  *   disposition: 'workout'|'gtg', position: number|null, import_key: string}>,
- *   unmapped: string[]}} Parsed sets in note order, plus every movement name
- *   that resolved to nothing — reported so it gets a real catalog row rather
- *   than a near-duplicate slug.
+ *   unmapped: string[], timed: string[]}} Parsed sets in note order; every
+ *   movement name that resolved to nothing — reported so it gets a real catalog
+ *   row rather than a near-duplicate slug; and every duration-measured movement
+ *   skipped for want of a rep count.
  */
 export function parseNote(note, loadMultipliers = {}) {
   const sets = []
@@ -598,6 +691,23 @@ export function parseNote(note, loadMultipliers = {}) {
         }),
       })
     })
+  }
+
+  for (const block of note.labelled_blocks ?? []) {
+    const parsed = parseLabelledBlock(block, loadMultipliers)
+    for (const set of parsed) {
+      sets.push({
+        ...set,
+        disposition: 'workout',
+        position: position++,
+        import_key: mintImportKey({
+          title: note.title,
+          date: note.date,
+          slug: set.exercise,
+          index: nextIndex(set.exercise),
+        }),
+      })
+    }
   }
 
   for (const list of note.rep_lists ?? []) {

--- a/scripts/lib/icloud-notes-parser.test.ts
+++ b/scripts/lib/icloud-notes-parser.test.ts
@@ -12,6 +12,8 @@ import { describe, expect, it } from 'vitest'
 import {
   isPerformedSet,
   mintImportKey,
+  parseLabelledBlock,
+  TWENTY_ONES_REPS_PER_ARM,
   normalizeName,
   parseNote,
   parseNoteDate,
@@ -234,6 +236,106 @@ describe('parseNote', () => {
       unmapped: [],
       timed: [],
     })
+  })
+})
+
+describe('parseLabelledBlock', () => {
+  it('turns a rack run into one to-failure set per drop', () => {
+    // `25, 20, 10` is three drops down the rack, each taken to failure with
+    // the rep count never written down.
+    const sets = parseLabelledBlock({
+      movement: 'Rack Run',
+      planned: '35,30,25,20',
+      sets: [{ set: 1, value: '25, 20, 10' }],
+    })
+    expect(sets).toEqual([
+      { exercise: 'dumbbell-curl', reps: 1, weight_lbs: 25, variant: 'rack run', to_failure: true },
+      { exercise: 'dumbbell-curl', reps: 1, weight_lbs: 20, variant: 'rack run', to_failure: true },
+      { exercise: 'dumbbell-curl', reps: 1, weight_lbs: 10, variant: 'rack run', to_failure: true },
+    ])
+  })
+
+  it('records an empty Set N: as one unloaded to-failure set', () => {
+    // The set was declared and labelled, so it happened — it just recorded
+    // nothing. Dropping it would lose that the movement was performed at all.
+    const sets = parseLabelledBlock({
+      movement: 'Rack Run',
+      planned: '35,30,25,20',
+      sets: [{ set: 1, value: '' }],
+    })
+    expect(sets).toEqual([
+      {
+        exercise: 'dumbbell-curl',
+        reps: 1,
+        weight_lbs: null,
+        variant: 'rack run',
+        to_failure: true,
+      },
+    ])
+  })
+
+  it('never takes loads from the planned rack in the heading', () => {
+    // `35,30,25,20` is what was intended; the body is what was done, and they
+    // routinely disagree.
+    const sets = parseLabelledBlock({
+      movement: 'Rack Run',
+      planned: '35,30,25,20',
+      sets: [{ set: 1, value: '25, 20, 10' }],
+    })
+    expect(sets.map(s => s.weight_lbs)).toEqual([25, 20, 10])
+  })
+
+  it('stores 21s at 14 reps — the per-arm count, not the 21 total', () => {
+    // 7 one arm, 7 the other, 7 both: 21 curls but 14 per arm. Every other
+    // dumbbell set stores reps per arm and doubles for tonnage, so 21 here
+    // would bill 42 arm-reps for work that was 28.
+    const sets = parseLabelledBlock({
+      movement: '21s',
+      sets: [{ set: 1, value: '22.5 DB' }],
+    })
+    expect(sets).toEqual([
+      { exercise: 'dumbbell-curl', reps: 14, weight_lbs: 22.5, variant: '21s' },
+    ])
+    expect(TWENTY_ONES_REPS_PER_ARM).toBe(14)
+  })
+
+  it('keeps a 21s set whose load was never written', () => {
+    // `Set 1: DB` names the implement without a weight.
+    const sets = parseLabelledBlock({ movement: '21s', sets: [{ set: 1, value: 'DB' }] })
+    expect(sets).toEqual([
+      { exercise: 'dumbbell-curl', reps: 14, weight_lbs: null, variant: '21s' },
+    ])
+  })
+
+  it('does not mark 21s as to-failure — its rep count is known', () => {
+    const sets = parseLabelledBlock({ movement: '21s', sets: [{ set: 1, value: '20 DB' }] })
+    expect(sets[0].to_failure).toBeUndefined()
+  })
+})
+
+describe('parseNote — labelled blocks', () => {
+  it('imports rack runs alongside the note’s tables, with unique keys', () => {
+    const { sets } = parseNote({
+      title: 'Back Day 1',
+      date: '2024-03-15',
+      exercises: [
+        {
+          name: 'EZ curl standing',
+          weight_header: 'Weight',
+          measure_header: 'Reps',
+          sets: [{ set: 1, weight: 70, reps: 12 }],
+        },
+      ],
+      labelled_blocks: [
+        { movement: 'Rack Run', planned: '35,30,25,20', sets: [{ set: 1, value: '25, 20' }] },
+      ],
+    })
+
+    const rack = sets.filter(s => s.variant === 'rack run')
+    expect(rack).toHaveLength(2)
+    expect(rack.every(s => s.to_failure === true)).toBe(true)
+    // Keys index per movement across the whole note, so two drops never collide.
+    expect(new Set(sets.map(s => s.import_key)).size).toBe(sets.length)
   })
 })
 

--- a/scripts/lib/icloud-notes-text.mjs
+++ b/scripts/lib/icloud-notes-text.mjs
@@ -87,6 +87,26 @@ const LOAD_LINE =
 const MAX_SET_ROWS = 40
 
 /**
+ * A block written as `Set N:` labels rather than a table (#435).
+ *
+ * Two movements in this log are recorded this way, both because a plain
+ * `Set | Weight | Reps` grid cannot express them:
+ *
+ *     Rack Run 35,30,25,20 2 sets     21s 2 sets
+ *     Set 1: 25, 20, 10               Set 1: 22.5 DB
+ *     Set 2:                          Set 2:  22.5 DB
+ *
+ * The heading names the movement and declares how many sets; each `Set N:` line
+ * carries what that set was, which for a rack run is the loads it ran down and
+ * for 21s is the single load it used. Reps appear in neither, and for a rack run
+ * they never existed — each drop went to failure.
+ */
+const LABELLED_BLOCK = /^(rack run|21s)\b(.*)$/i
+
+/** One `Set N:` line and whatever followed the colon. */
+const SET_LINE = /^set\s*(\d+)\s*:?\s*(.*)$/i
+
+/**
  * Split the Shortcuts output into individual notes.
  *
  * @param {string} text Whole exported file.
@@ -200,13 +220,18 @@ function readRows(lines, start) {
  * @returns {{exercises: Array<{name: string, declared: string|null,
  *   weight_header: string, measure_header: string, note: string|null,
  *   sets: Array<{set: number, weight: string, reps: string}>}>,
- *   rep_lists: Array<{movement: string, reps: number[]}>, loose_text: string[]}}
+ *   rep_lists: Array<{movement: string, reps: number[]}>, loose_text: string[],
+ *   labelled_blocks: Array<{movement: string, declared: string|null,
+ *     planned: string, sets: Array<{set: number, value: string}>}>}}
+ *   `labelled_blocks` holds the `Set N:` shapes — rack runs and 21s — whose
+ *   values are loads rather than reps; see {@link LABELLED_BLOCK}.
  */
 export function parseNoteBody(body) {
   const lines = String(body ?? '').split(/\r?\n/)
   const exercises = []
   const repLists = []
   const looseText = []
+  const labelledBlocks = []
 
   /** Lines already consumed by a table, so the rep-list pass skips them. */
   const consumed = new Set()
@@ -228,7 +253,57 @@ export function parseNoteBody(body) {
     i = next - 1
   }
 
-  // Second pass: headings followed by bare numbers (grease-the-groove volume)
+  // Second pass: `Set N:` blocks, which are not tables and would otherwise fall
+  // through to the loose-text pile — see LABELLED_BLOCK.
+  for (let i = 0; i < lines.length; i += 1) {
+    if (consumed.has(i)) continue
+    const block = (lines[i] ?? '').trim().match(LABELLED_BLOCK)
+    if (!block) continue
+
+    const [, movement, rest] = block
+    const declared = rest.match(/(\d+\s*sets?)/i)?.[1] ?? null
+    // Everything before the set count is the planned rack (`35,30,25,20`) —
+    // what was *intended*, which the body below routinely disagrees with.
+    const planned = rest
+      .replace(/\d+\s*sets?\b/i, '')
+      .trim()
+      .replace(/^[,\s]+|[,\s]+$/g, '')
+
+    const setLines = []
+    let j = i + 1
+    // Scan to the next movement, tolerating the blank lines between labels.
+    while (j < lines.length) {
+      const line = (lines[j] ?? '').trim()
+      if (line === '') {
+        j += 1
+        continue
+      }
+      const setLine = line.match(SET_LINE)
+      if (!setLine) break
+      // A label's value sits either after the colon or on the following line.
+      let value = setLine[2].trim()
+      let consumedThrough = j
+      if (value === '') {
+        let k = j + 1
+        while (k < lines.length && (lines[k] ?? '').trim() === '') k += 1
+        const following = (lines[k] ?? '').trim()
+        if (following !== '' && !SET_LINE.test(following) && /[\d.]/.test(following)) {
+          value = following
+          consumedThrough = k
+        }
+      }
+      setLines.push({ set: Number(setLine[1]), value })
+      j = consumedThrough + 1
+    }
+
+    if (setLines.length === 0) continue
+    for (let k = i; k < j; k += 1) consumed.add(k)
+
+    labelledBlocks.push({ movement: movement.trim(), declared, planned, sets: setLines })
+    i = j - 1
+  }
+
+  // Third pass: headings followed by bare numbers (grease-the-groove volume)
   // or `weight - reps` pairs (the older freeform shorthand).
   //
   // `lastHeading` carries the most recent line that actually named a movement,
@@ -312,7 +387,12 @@ export function parseNoteBody(body) {
     i = j - 1
   }
 
-  return { exercises, rep_lists: repLists, loose_text: looseText }
+  return {
+    exercises,
+    rep_lists: repLists,
+    loose_text: looseText,
+    labelled_blocks: labelledBlocks,
+  }
 }
 
 /**

--- a/scripts/lib/icloud-notes-text.test.ts
+++ b/scripts/lib/icloud-notes-text.test.ts
@@ -199,6 +199,63 @@ describe('parseNoteBody — rep lists and freeform', () => {
   })
 })
 
+describe('parseNoteBody — labelled Set N: blocks', () => {
+  it('reads a rack run with its loads, keeping the planned rack separate', () => {
+    // Verbatim from Back Day 1, 2024-03-15. The heading states the intended
+    // rack; the body records what was actually run, and they disagree.
+    const { labelled_blocks, loose_text } = parseNoteBody(
+      ['Rack Run 35,30,25,20 2 sets', '', 'Set 1: 25, 20, 10', '', 'Set 2:', ''].join('\n')
+    )
+    expect(labelled_blocks).toHaveLength(1)
+    expect(labelled_blocks[0]).toMatchObject({
+      movement: 'Rack Run',
+      declared: '2 sets',
+      planned: '35,30,25,20',
+    })
+    expect(labelled_blocks[0].sets).toEqual([
+      { set: 1, value: '25, 20, 10' },
+      { set: 2, value: '' },
+    ])
+    // It no longer falls through to the loose-text pile.
+    expect(loose_text.join(' ')).not.toContain('Rack Run')
+  })
+
+  it('reads loads written on the line after the label', () => {
+    // The 2023-01-08 shape: `Set 1:` with its loads underneath.
+    const { labelled_blocks } = parseNoteBody(
+      ['Rack Run 35,30,25,20 2 sets', '', 'Set 1:', '30, 15', 'Set 2:', '30, 27.5, 22.5'].join('\n')
+    )
+    expect(labelled_blocks[0].sets).toEqual([
+      { set: 1, value: '30, 15' },
+      { set: 2, value: '30, 27.5, 22.5' },
+    ])
+  })
+
+  it('does not swallow the next movement as a set value', () => {
+    const { labelled_blocks, rep_lists } = parseNoteBody(
+      ['Rack Run 35,30,25,20 2 sets', '', 'Set 1:', '', 'Set 2:', '', 'Push ups:', '12', '10'].join(
+        '\n'
+      )
+    )
+    expect(labelled_blocks[0].sets).toEqual([
+      { set: 1, value: '' },
+      { set: 2, value: '' },
+    ])
+    expect(rep_lists).toEqual([{ movement: 'Push ups:', reps: [12, 10] }])
+  })
+
+  it('reads a 21s block and its per-set load', () => {
+    const { labelled_blocks } = parseNoteBody(
+      ['21s 2 sets', '', 'Set 1: 22.5 DB', 'Set 2:  20 DB'].join('\n')
+    )
+    expect(labelled_blocks[0]).toMatchObject({ movement: '21s', declared: '2 sets' })
+    expect(labelled_blocks[0].sets).toEqual([
+      { set: 1, value: '22.5 DB' },
+      { set: 2, value: '20 DB' },
+    ])
+  })
+})
+
 describe('parseExport', () => {
   it('produces one entry per note, shaped for the movement parser', () => {
     const parsed = parseExport(INLINE_SEPARATOR)

--- a/supabase/migrations/20260809140000_weight_room_sets_to_failure.sql
+++ b/supabase/migrations/20260809140000_weight_room_sets_to_failure.sql
@@ -1,0 +1,29 @@
+-- #435 — mark a set whose rep count was never recorded because it went to failure.
+--
+-- A rack run is a drop set of dumbbell curls: pick up the 35s, curl to failure,
+-- drop to the 30s, again, and so on down the rack. The notes record the loads
+-- that were run (`Set 1: 25, 20, 10`) and never the reps, because the rep count
+-- isn't the point — the point is that each drop went until it couldn't.
+--
+-- `weight_room_sets.reps` is `not null check (reps > 0)`, so until now such a
+-- set had nowhere to live and #400 dropped all 25 of them. Making `reps`
+-- nullable would model it purely but ripples through 87 call sites across 21
+-- files — every ring, streak, tonnage and achievement rollup would have to
+-- decide what a null rep count means, for the sake of ~32 sets.
+--
+-- So the same shape the duration column already uses: `reps = 1` meaning "one
+-- set was performed", and a flag saying the count is unrecorded. Rep totals are
+-- then understated by a known, small amount rather than wrong in an unbounded
+-- way, and every existing rollup keeps working untouched. Surfaces read the
+-- flag and print "to failure" instead of "1 rep".
+
+alter table public.weight_room_sets
+  add column if not exists to_failure boolean not null default false;
+
+comment on column public.weight_room_sets.to_failure is
+  'True when the set was taken to failure and its rep count was never recorded '
+  '(#435). Such a set stores ''reps = 1'', meaning one set happened rather than '
+  'one repetition — so rep rollups understate it by a known amount instead of '
+  'counting a number nobody wrote down. Surfaces should render ''to failure'' '
+  'rather than the literal rep count. Mirrors how ''duration_seconds'' handles '
+  'isometric holds.';

--- a/types/weight-room.ts
+++ b/types/weight-room.ts
@@ -117,6 +117,17 @@ export interface StrengthSet {
    * printing "1 rep".
    */
   duration_seconds?: number
+  /**
+   * Whether the set went to failure with its rep count unrecorded (#435).
+   *
+   * A rack run's drops are the case this exists for: the notes record the loads
+   * run down the rack and never the reps, because each drop simply went until
+   * it couldn't. Such a set stores `reps: 1` — meaning *one set happened*, not
+   * one repetition — so rep rollups understate it by a known amount rather than
+   * counting a number nobody wrote down. Render sites should say "to failure"
+   * instead of the literal count.
+   */
+  to_failure?: boolean
 }
 
 /**


### PR DESCRIPTION
Both are dumbbell curls written as `Set N:` labels rather than tables, because a `Set | Weight | Reps` grid can't express either. #400 reported them as unmapped and dropped all 50 blocks.

Closes #435.

## The issue had a factual error, now corrected

I wrote #435 assuming those comma-separated numbers were reps. **They're loads** — `30, 27.5, 22.5` are dumbbell sizes, and the heading's `35,30,25,20` is the rack. Reps were never recorded for a rack run, which inverted the two halves of the work:

| | occurrences | recoverable |
|---|---|---|
| Rack Run | 25 | 7 have loads; **no reps, ever** |
| 21s | 25 | ~24 have loads; reps known from the protocol |

## Rack run — `to_failure`

Curl the 35s to failure, drop to the 30s, again, down the rack. The rep count isn't the point, which is why it was never written.

`weight_room_sets.reps` is `not null check (reps > 0)`, so these had nowhere to live. The new `to_failure` flag carries it: each drop stores `reps = 1` meaning *one set happened*, with the flag saying the count is unrecorded, and surfaces render `50 lb to failure` instead of `1 rep`.

Making `reps` nullable would model it more purely, but it ripples through **87 call sites across 21 files** — every ring, streak, tonnage and achievement rollup would have to decide what a null rep count means, for ~32 sets. A known, small understatement beats an unbounded refactor. Same shape `duration_seconds` already uses for holds.

Both source shapes import: with loads (`Set 1: 25, 20, 10` → three drops), and bare (`Set 1:` → one unloaded to-failure set, since the label says it happened).

## 21s — 14 reps, not 21

Per your correction: 7 with one arm, 7 with the other, 7 with both — 21 curls, but **14 per arm**.

Every other dumbbell movement stores reps *per arm* and lets the catalog's ×2 multiplier account for the second. Storing 21 would push all 21 through that doubling and bill 42 arm-reps for work that was 28. `reps = 14, variant = '21s'` keeps tonnage exact and the protocol legible.

## A claim the richer data exposed

With the full archive in, a movement trained *only* during it — dumbbell curl — splits at an internal 254-day layoff, so both eras are imported. The panel still said "the earlier one comes from Apple Notes," implying the later one didn't. Now it says "Both stretches come from…" when that's the case.

## Result

| | |
|---|---|
| Sets | 5,209 → **5,323** |
| Rack run | 70 sets, all `to_failure`, 31 with loads (10–30 lb) |
| 21s | 44 sets, 24 with loads (15–30 lb), all 14 reps |
| Unmapped | `Rack Run` and `21s` gone; only `(Did military press)`, `Left`, `Right` remain — annotations, not movements |

Import re-runs converge at 5,323. Migration applied to staging and production.

One bug worth noting for future schema work: `to_failure` is `not null`, and PostgREST builds one INSERT from the union of keys across a batch — so a conditionally-spread key becomes `NULL` on rows that omit it and fails the whole batch. It's now always sent.

## Test plan

- [ ] `/training-facility/weight-room/exercises/dumbbell-curl` — heaviest set reads `60 lb to failure`; provenance says "Both stretches…"
- [ ] Same page — "Both stretches top out at the same dumbbell curl — 60 lb" (the tie branch)
- [ ] A Back Day 1 session (e.g. 2024-03-15) shows rack-run drops at 25/20/10
- [ ] A Back Day 2 session shows a 21s set at 14 reps
- [ ] Other movements unaffected — spot-check `/exercises/shrugs` and `/exercises/plank`
- [ ] `npm run import-icloud-notes -- --dry-run --from-text=<export> --manifest=<csv>` reports 5,323 and writes nothing

All checks green locally: 2,396 unit tests, `tsc` clean, `next build` compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
