### PR TITLE
feat(weight-room): surface the training rotation the archive reveals (#436)

### DIFF
--- a/app/training-facility/weight-room/program/page.tsx
+++ b/app/training-facility/weight-room/program/page.tsx
@@ -31,13 +31,24 @@ import { buildProgramSummary } from '@/lib/training-facility/training-program'
 export default async function WeightRoomProgramPage(): Promise<JSX.Element> {
   if (!isWeightRoomEnabled()) notFound()
 
-  const [workouts, templates, isAdmin] = await Promise.all([
-    getWeightRoomWorkoutsServer().catch(() => []),
-    getWorkoutTemplatesServer().catch(() => []),
+  // Falling back to an empty read matches every other Weight Room page, but
+  // this one's empty state makes a *claim* — that training isn't run against a
+  // programme — and a failed read must not be allowed to assert it. Settled
+  // results keep the difference between "nothing to show" and "couldn't look".
+  const [workoutsRead, templatesRead, isAdmin] = await Promise.all([
+    getWeightRoomWorkoutsServer().then(
+      value => ({ ok: true as const, value }),
+      () => ({ ok: false as const, value: [] })
+    ),
+    getWorkoutTemplatesServer().then(
+      value => ({ ok: true as const, value }),
+      () => ({ ok: false as const, value: [] })
+    ),
     isAdminRequest().catch(() => false),
   ])
 
-  const summary = buildProgramSummary(workouts, templates)
+  const readFailed = !workoutsRead.ok || !templatesRead.ok
+  const summary = buildProgramSummary(workoutsRead.value, templatesRead.value)
 
   return (
     <div className="relative min-h-svh overflow-hidden bg-[#120d0a] text-[#f7ead9]">
@@ -68,7 +79,15 @@ export default async function WeightRoomProgramPage(): Promise<JSX.Element> {
         </header>
 
         <div className="mt-8 pb-16">
-          {summary === null ? (
+          {readFailed && summary === null ? (
+            <p
+              data-testid="program-unavailable"
+              className="rounded-[1.2rem] border border-white/10 bg-white/5 p-6 text-center text-sm text-[#e8d5be]/70"
+            >
+              Couldn&rsquo;t load the training log just now, so there&rsquo;s nothing to describe
+              yet. Try again in a moment.
+            </p>
+          ) : summary === null ? (
             <p
               data-testid="program-empty"
               className="rounded-[1.2rem] border border-white/10 bg-white/5 p-6 text-center text-sm text-[#e8d5be]/70"

--- a/app/training-facility/weight-room/program/page.tsx
+++ b/app/training-facility/weight-room/program/page.tsx
@@ -1,0 +1,86 @@
+import type { JSX } from 'react'
+import { notFound } from 'next/navigation'
+
+import { BackToCourtButton } from '@/components/common/BackToCourtButton'
+import { FacilityBackLink } from '@/components/training-facility/FacilityBackLink'
+import { ProgramPanel } from '@/components/training-facility/weight-room/ProgramPanel'
+import { WeightRoomSubNav } from '@/components/training-facility/weight-room/WeightRoomSubNav'
+import { isAdminRequest } from '@/lib/auth/admin-session'
+import {
+  getWeightRoomWorkoutsServer,
+  getWorkoutTemplatesServer,
+} from '@/lib/data/weight-room-server'
+import { isWeightRoomEnabled } from '@/lib/feature-flags'
+import { buildProgramSummary } from '@/lib/training-facility/training-program'
+
+/**
+ * The training programme (#436) — which template ran when, and how well the
+ * rotation held.
+ *
+ * A different altitude from every other Weight Room surface: not one session,
+ * not one movement, but the *plan* behind sixteen months of them. It only
+ * became answerable with #400, which imported 133 templated sessions from the
+ * Apple Notes archive.
+ *
+ * Deliberately says nothing about the current era. Today's training is
+ * grease-the-groove with no template at all, so there is no rotation to report
+ * — and the page says that outright rather than drawing an empty one.
+ *
+ * Public and read-only, like the rest of the room.
+ */
+export default async function WeightRoomProgramPage(): Promise<JSX.Element> {
+  if (!isWeightRoomEnabled()) notFound()
+
+  const [workouts, templates, isAdmin] = await Promise.all([
+    getWeightRoomWorkoutsServer().catch(() => []),
+    getWorkoutTemplatesServer().catch(() => []),
+    isAdminRequest().catch(() => false),
+  ])
+
+  const summary = buildProgramSummary(workouts, templates)
+
+  return (
+    <div className="relative min-h-svh overflow-hidden bg-[#120d0a] text-[#f7ead9]">
+      <div
+        aria-hidden="true"
+        className="absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(248,214,170,0.16),transparent_30%),linear-gradient(180deg,#241811_0%,#120d0a_55%,#0b0806_100%)]"
+      />
+
+      <div className="relative z-10 mx-auto flex min-h-svh w-full max-w-5xl flex-col px-4 py-6 sm:px-6 sm:py-8 lg:px-10">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <BackToCourtButton />
+          <FacilityBackLink />
+        </div>
+
+        <header className="mt-12">
+          <p className="font-mono text-[11px] uppercase tracking-[0.32em] text-amber-300/80">
+            Weight Room · Program
+          </p>
+          <h1 className="mt-2 text-3xl font-black uppercase tracking-[0.06em] text-[#fff7ec] sm:text-5xl">
+            The Rotation
+          </h1>
+          <p className="mt-3 max-w-xl text-sm leading-7 text-[#e8d5be] sm:text-base">
+            Six templates on a cycle, run across sixteen months and written down one note per
+            session. This is the programme those notes describe — how often it ran, how strictly the
+            order held, and how long each kind of day actually took.
+          </p>
+          <WeightRoomSubNav active="program" className="mt-5" isAdmin={isAdmin} />
+        </header>
+
+        <div className="mt-8 pb-16">
+          {summary === null ? (
+            <p
+              data-testid="program-empty"
+              className="rounded-[1.2rem] border border-white/10 bg-white/5 p-6 text-center text-sm text-[#e8d5be]/70"
+            >
+              No session names a template yet. Current training is logged set by set rather than
+              against a programme, so there is no rotation to describe.
+            </p>
+          ) : (
+            <ProgramPanel summary={summary} />
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/training-facility/weight-room/ProgramPanel.tsx
+++ b/components/training-facility/weight-room/ProgramPanel.tsx
@@ -41,7 +41,12 @@ export function ProgramPanel({ summary }: ProgramPanelProps): JSX.Element {
             title="How often the next session was the next template in the rotation"
           />
         )}
-        <Stat label="Median session" value={medianOfMedians(templates)} detail="across templates" />
+        <Stat
+          label="Median session"
+          value={medianOfMedians(templates)}
+          detail="as the watch measured it"
+          title="From Apple Health session windows. Sessions whose only timing came from when the note was written are excluded — that window runs short."
+        />
       </dl>
 
       {rotation.length === 0 ? null : <RotationStrip rotation={rotation} />}

--- a/components/training-facility/weight-room/ProgramPanel.tsx
+++ b/components/training-facility/weight-room/ProgramPanel.tsx
@@ -1,0 +1,239 @@
+import type { JSX } from 'react'
+
+import { formatDayKey } from '@/lib/training-facility/day-keys'
+import type { ProgramSummary, TemplateSummary } from '@/lib/training-facility/training-program'
+
+/** Date style for the programme's endpoints. */
+const SPAN_DATE: Intl.DateTimeFormatOptions = { month: 'short', year: 'numeric' }
+
+/** Props for {@link ProgramPanel}. */
+export interface ProgramPanelProps {
+  /** The programme as the templated sessions record it. */
+  summary: ProgramSummary
+}
+
+/**
+ * The training programme behind the archive (#436).
+ *
+ * Answers a question no other Weight Room surface does: not "how did that
+ * session go" or "is the bench going up", but *what the plan was and how well
+ * it held*. Six templates, cycled, across sixteen months.
+ *
+ * A Server Component — no state, no effects.
+ */
+export function ProgramPanel({ summary }: ProgramPanelProps): JSX.Element {
+  const { templates, rotation, adherence, months, totalSessions, firstDayKey, lastDayKey } = summary
+  const span =
+    firstDayKey === null || lastDayKey === null
+      ? null
+      : `${formatDayKey(firstDayKey, SPAN_DATE)} – ${formatDayKey(lastDayKey, SPAN_DATE)}`
+
+  return (
+    <div className="flex flex-col gap-8" data-testid="program-panel">
+      <dl className="grid grid-cols-2 gap-3 sm:grid-cols-4" aria-label="Programme at a glance">
+        <Stat label="Sessions" value={totalSessions.toLocaleString('en-US')} detail={span} />
+        <Stat label="Templates" value={String(templates.length)} detail="on rotation" />
+        {adherence.total === 0 ? null : (
+          <Stat
+            label="Cycle held"
+            value={`${Math.round(adherence.rate * 100)}%`}
+            detail={`${adherence.followed} of ${adherence.total} in order`}
+            title="How often the next session was the next template in the rotation"
+          />
+        )}
+        <Stat label="Median session" value={medianOfMedians(templates)} detail="across templates" />
+      </dl>
+
+      {rotation.length === 0 ? null : <RotationStrip rotation={rotation} />}
+
+      <TemplateTable templates={templates} />
+
+      <CadenceChart months={months} />
+    </div>
+  )
+}
+
+/** Props for one headline figure. */
+interface StatProps {
+  /** What the number is. */
+  label: string
+  /** The number itself. */
+  value: string
+  /** Optional smaller line beneath. */
+  detail?: string | null
+  /** Optional hover explanation. */
+  title?: string
+}
+
+/** One headline figure. */
+function Stat({ label, value, detail, title }: StatProps): JSX.Element {
+  return (
+    <div className="rounded-[1rem] border border-white/10 bg-white/[0.04] px-4 py-3" title={title}>
+      <dt className="font-mono text-[10px] uppercase tracking-[0.22em] text-[#e8d5be]/60">
+        {label}
+      </dt>
+      <dd className="mt-1.5 text-lg font-black tabular-nums text-[#fff7ec]">{value}</dd>
+      {detail ? (
+        <dd className="mt-0.5 font-mono text-[10px] tracking-[0.12em] text-[#e8d5be]/50">
+          {detail}
+        </dd>
+      ) : null}
+    </div>
+  )
+}
+
+/** The cycle, rendered in the order it was run. */
+function RotationStrip({ rotation }: { rotation: readonly string[] }): JSX.Element {
+  return (
+    <section
+      data-testid="program-rotation"
+      className="rounded-[1.2rem] border border-white/10 bg-white/[0.04] p-5"
+      aria-label="Rotation order"
+    >
+      <h2 className="font-mono text-[11px] uppercase tracking-[0.28em] text-amber-300/80">
+        The rotation
+      </h2>
+      <p className="mt-2 text-sm leading-6 text-[#e8d5be]/75">
+        Read from the sessions themselves rather than from a configured order — this is what the log
+        says was run, in the order it was run.
+      </p>
+      <ol className="mt-4 flex flex-wrap items-center gap-x-2 gap-y-2">
+        {rotation.map((name, index) => (
+          <li key={name} className="flex items-center gap-2">
+            <span className="rounded-full border border-amber-300/25 bg-amber-300/[0.07] px-3 py-1 text-xs font-semibold text-[#fff7ec]">
+              {name}
+            </span>
+            <span aria-hidden="true" className="text-[#e8d5be]/35">
+              {index === rotation.length - 1 ? '↺' : '→'}
+            </span>
+          </li>
+        ))}
+      </ol>
+    </section>
+  )
+}
+
+/** Per-template records. */
+function TemplateTable({ templates }: { templates: readonly TemplateSummary[] }): JSX.Element {
+  return (
+    <section
+      data-testid="program-templates"
+      className="overflow-hidden rounded-[1.2rem] border border-white/10 bg-[#f7ead9]"
+    >
+      <h2 className="px-5 pt-4 font-mono text-[11px] uppercase tracking-[0.28em] text-[#0a0a0a]/60">
+        By template
+      </h2>
+      <div className="overflow-x-auto">
+        <table className="mt-3 w-full min-w-[34rem] border-collapse text-sm text-[#0a0a0a]">
+          <thead>
+            <tr className="border-b border-[#0a0a0a]/10 font-mono text-[10px] uppercase tracking-[0.18em] text-[#0a0a0a]/55">
+              <th scope="col" className="px-5 py-2 text-left font-normal">
+                Template
+              </th>
+              <th scope="col" className="px-3 py-2 text-right font-normal">
+                Sessions
+              </th>
+              <th scope="col" className="px-3 py-2 text-right font-normal">
+                Median
+              </th>
+              <th scope="col" className="px-5 py-2 text-right font-normal">
+                Span
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {templates.map(template => (
+              <tr key={template.id} className="border-b border-[#0a0a0a]/5 last:border-0">
+                <th scope="row" className="px-5 py-2.5 text-left font-semibold">
+                  {template.name}
+                </th>
+                <td className="px-3 py-2.5 text-right tabular-nums">{template.sessions}</td>
+                <td className="px-3 py-2.5 text-right tabular-nums">
+                  {template.medianMinutes === null ? (
+                    <span className="text-[#0a0a0a]/35">—</span>
+                  ) : (
+                    `${Math.round(template.medianMinutes)} min`
+                  )}
+                </td>
+                <td className="px-5 py-2.5 text-right font-mono text-[11px] text-[#0a0a0a]/60">
+                  {formatDayKey(template.firstDayKey, SPAN_DATE)} –{' '}
+                  {formatDayKey(template.lastDayKey, SPAN_DATE)}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  )
+}
+
+/**
+ * Sessions per month, as a bar per month.
+ *
+ * Deliberately includes months with none — a gap in training is the most
+ * informative thing this chart has to show, and skipping empty months would
+ * draw a continuous run straight over a layoff.
+ */
+function CadenceChart({ months }: { months: ProgramSummary['months'] }): JSX.Element {
+  const peak = months.reduce((max, month) => Math.max(max, month.sessions), 0)
+
+  return (
+    <section
+      data-testid="program-cadence"
+      className="rounded-[1.2rem] border border-white/10 bg-white/[0.04] p-5"
+      aria-label="Sessions per month"
+    >
+      <h2 className="font-mono text-[11px] uppercase tracking-[0.28em] text-amber-300/80">
+        Cadence
+      </h2>
+      <p className="mt-2 text-sm leading-6 text-[#e8d5be]/75">
+        Templated sessions per month. Months with none are shown as gaps rather than skipped.
+      </p>
+      <ol className="mt-5 flex items-end gap-1.5" style={{ height: '7rem' }}>
+        {months.map(month => (
+          <li
+            key={month.monthKey}
+            className="flex h-full flex-1 flex-col justify-end"
+            title={`${month.monthKey}: ${month.sessions} session${month.sessions === 1 ? '' : 's'}`}
+          >
+            <div
+              className={
+                month.sessions === 0
+                  ? 'w-full rounded-t-[3px] bg-white/[0.06]'
+                  : 'w-full rounded-t-[3px] bg-amber-300/60'
+              }
+              // A zero month still draws a hairline, so the gap reads as a
+              // measured zero rather than as missing data.
+              style={{
+                height:
+                  month.sessions === 0 || peak === 0 ? '2px' : `${(month.sessions / peak) * 100}%`,
+              }}
+            />
+          </li>
+        ))}
+      </ol>
+      <div className="mt-2 flex justify-between font-mono text-[10px] tracking-[0.12em] text-[#e8d5be]/45">
+        <span>{months[0]?.monthKey}</span>
+        <span>peak {peak}/mo</span>
+        <span>{months[months.length - 1]?.monthKey}</span>
+      </div>
+    </section>
+  )
+}
+
+/**
+ * The median of the per-template medians, as a one-line "how long a session takes".
+ *
+ * @returns A formatted figure, or an em-dash when nothing was ever timed.
+ */
+function medianOfMedians(templates: readonly TemplateSummary[]): string {
+  const values = templates
+    .map(template => template.medianMinutes)
+    .filter((value): value is number => value !== null)
+    .sort((a, b) => a - b)
+  if (values.length === 0) return '—'
+  const mid = Math.floor(values.length / 2)
+  const value = values.length % 2 === 0 ? (values[mid - 1] + values[mid]) / 2 : values[mid]
+  return `${Math.round(value)} min`
+}

--- a/components/training-facility/weight-room/WeightRoomSubNav.tsx
+++ b/components/training-facility/weight-room/WeightRoomSubNav.tsx
@@ -14,7 +14,7 @@ import Link from 'next/link'
  * isn't on.
  */
 export type WeightRoomSubNavSection =
-  'today' | 'history' | 'workouts' | 'exercises' | 'achievements' | 'settings' | 'log'
+  'today' | 'history' | 'workouts' | 'program' | 'exercises' | 'achievements' | 'settings' | 'log'
 
 /** Props for {@link WeightRoomSubNav}. */
 export interface WeightRoomSubNavProps {
@@ -68,6 +68,7 @@ const ITEMS: readonly SubNavItem[] = [
   { section: 'today', label: 'Today', href: '/training-facility/weight-room' },
   { section: 'history', label: 'History', href: '/training-facility/weight-room/history' },
   { section: 'workouts', label: 'Workouts', href: '/training-facility/weight-room/workouts' },
+  { section: 'program', label: 'Program', href: '/training-facility/weight-room/program' },
   {
     section: 'achievements',
     label: 'Trophies',

--- a/e2e/training-facility-disabled.spec.ts
+++ b/e2e/training-facility-disabled.spec.ts
@@ -19,6 +19,7 @@ const gatedRoutes = [
   '/training-facility/weight-room',
   '/training-facility/weight-room/achievements',
   '/training-facility/weight-room/history',
+  '/training-facility/weight-room/program',
   '/training-facility/weight-room/exercises/pullups',
 ]
 

--- a/lib/training-facility/training-program.test.ts
+++ b/lib/training-facility/training-program.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Tests for the training-programme summary (#436).
+ *
+ * The cases pin the two things that would quietly mislead: reading a rotation
+ * out of sessions that have none, and reporting adherence against an order the
+ * log never followed. The rotation fixture is the real one — Chest 1 → Back 1 →
+ * Legs 1 → Chest 2 → Back 2 → Legs 2 — which is deliberately *not* the order
+ * `weight_room_workout_templates.position` lists the six in.
+ */
+import { describe, expect, it } from 'vitest'
+
+import type { WeightRoomWorkout, WorkoutTemplate } from '@/types/weight-room'
+
+import { buildProgramSummary, inferRotation, rotationAdherence } from './training-program'
+
+/** The six templates, in the order the catalog lists them (not the rotation). */
+const TEMPLATES: WorkoutTemplate[] = [
+  'Chest Day 1',
+  'Chest Day 2',
+  'Back Day 1',
+  'Back Day 2',
+  'Legs Day 1',
+  'Legs Day 2',
+].map((name, index) => ({
+  id: `t${index}`,
+  name,
+  position: index,
+  archived: false,
+  slots: [],
+}))
+
+const ID_BY_NAME = new Map(TEMPLATES.map(t => [t.name, t.id]))
+
+/** The cycle the sessions actually record. */
+const CYCLE = ['Chest Day 1', 'Back Day 1', 'Legs Day 1', 'Chest Day 2', 'Back Day 2', 'Legs Day 2']
+
+/** A templated session on a given day, optionally with a duration. */
+function session(name: string, dayKey: string, minutes?: number): WeightRoomWorkout {
+  const started = `${dayKey}T18:00:00Z`
+  return {
+    id: `${name}-${dayKey}`,
+    started_at: started,
+    template_id: ID_BY_NAME.get(name) as string,
+    ...(minutes === undefined
+      ? {}
+      : { ended_at: new Date(Date.parse(started) + minutes * 60_000).toISOString() }),
+  } as WeightRoomWorkout
+}
+
+/** `n` full turns of the cycle, one session every two days from 2023-01-02. */
+function cycleSessions(turns: number): WeightRoomWorkout[] {
+  const out: WeightRoomWorkout[] = []
+  let day = Date.parse('2023-01-02T00:00:00Z')
+  for (let turn = 0; turn < turns; turn += 1) {
+    for (const name of CYCLE) {
+      out.push(session(name, new Date(day).toISOString().slice(0, 10)))
+      day += 2 * 86_400_000
+    }
+  }
+  return out
+}
+
+describe('inferRotation', () => {
+  it('reads the cycle out of the order sessions were run', () => {
+    const sequence = [...CYCLE, ...CYCLE, ...CYCLE]
+    expect(inferRotation(sequence)).toEqual(CYCLE)
+  })
+
+  it('ignores the catalog position order, which is not the rotation', () => {
+    // Positions list them Chest 1, Chest 2, Back 1, Back 2, Legs 1, Legs 2.
+    // The log says otherwise, and the log wins.
+    const inferred = inferRotation([...CYCLE, ...CYCLE])
+    expect(inferred).not.toEqual(TEMPLATES.map(t => t.name))
+    expect(inferred).toEqual(CYCLE)
+  })
+
+  it('outvotes the occasional deviation rather than breaking the chain', () => {
+    // One repeated day and one skip, in a log that otherwise cycles.
+    const sequence = [...CYCLE, 'Chest Day 1', 'Chest Day 1', ...CYCLE, ...CYCLE]
+    expect(inferRotation(sequence)).toEqual(CYCLE)
+  })
+
+  it('treats a genuine two-template alternation as the cycle it is', () => {
+    // A → B → A is a rotation of period two, not noise.
+    expect(inferRotation(['A', 'B', 'A', 'B'])).toEqual(['A', 'B'])
+  })
+
+  it('returns nothing when the chain never closes into a cycle', () => {
+    // A → B → C → nowhere. Reporting a partial chain would make adherence
+    // measure against an order the log never repeated.
+    expect(inferRotation(['A', 'B', 'C'])).toEqual([])
+  })
+
+  it('starts the cycle where the log starts, not alphabetically', () => {
+    // A cycle has no inherent beginning; showing it from the first session
+    // matches the order someone scrolling the log actually meets.
+    expect(inferRotation([...CYCLE, ...CYCLE])[0]).toBe('Chest Day 1')
+    const startedElsewhere = [...CYCLE.slice(2), ...CYCLE, ...CYCLE]
+    expect(inferRotation(startedElsewhere)[0]).toBe('Legs Day 1')
+  })
+
+  it('returns nothing for too few sessions to show an order', () => {
+    expect(inferRotation([])).toEqual([])
+    expect(inferRotation(['Chest Day 1'])).toEqual([])
+  })
+})
+
+describe('rotationAdherence', () => {
+  it('scores a perfectly followed cycle at 1', () => {
+    const result = rotationAdherence([...CYCLE, ...CYCLE], CYCLE)
+    expect(result.followed).toBe(result.total)
+    expect(result.rate).toBe(1)
+  })
+
+  it('counts a deviation against the rate', () => {
+    // Six transitions, one of which skips Back Day 1.
+    const sequence = ['Chest Day 1', 'Legs Day 1', 'Chest Day 2', 'Back Day 2']
+    const result = rotationAdherence(sequence, CYCLE)
+    expect(result.total).toBe(3)
+    expect(result.followed).toBe(2)
+    expect(result.rate).toBeCloseTo(2 / 3)
+  })
+
+  it('is zero rather than NaN when there is no rotation', () => {
+    expect(rotationAdherence(CYCLE, [])).toEqual({ followed: 0, total: 0, rate: 0 })
+    expect(rotationAdherence([], CYCLE)).toEqual({ followed: 0, total: 0, rate: 0 })
+  })
+})
+
+describe('buildProgramSummary', () => {
+  it('summarizes templates in rotation order, not catalog order', () => {
+    const summary = buildProgramSummary(cycleSessions(3), TEMPLATES)
+    expect(summary?.templates.map(t => t.name)).toEqual(CYCLE)
+    expect(summary?.totalSessions).toBe(18)
+    expect(summary?.adherence.rate).toBe(1)
+  })
+
+  it('ignores sessions with no template', () => {
+    // The current era is untemplated grease-the-groove; folding it in would
+    // dilute both cadence and adherence.
+    const untemplated = {
+      id: 'loose',
+      started_at: '2026-06-01T18:00:00Z',
+    } as WeightRoomWorkout
+    const summary = buildProgramSummary([...cycleSessions(2), untemplated], TEMPLATES)
+    expect(summary?.totalSessions).toBe(12)
+    expect(summary?.lastDayKey?.startsWith('2023')).toBe(true)
+  })
+
+  it('returns null when nothing names a template', () => {
+    const loose = { id: 'a', started_at: '2026-06-01T18:00:00Z' } as WeightRoomWorkout
+    expect(buildProgramSummary([loose], TEMPLATES)).toBeNull()
+  })
+
+  it('takes the median session length, so one forgotten stop cannot redefine it', () => {
+    const sessions = [
+      session('Back Day 1', '2023-01-02', 40),
+      session('Back Day 1', '2023-01-09', 44),
+      // Watch left running.
+      session('Back Day 1', '2023-01-16', 600),
+    ]
+    const summary = buildProgramSummary(sessions, TEMPLATES)
+    expect(summary?.templates[0].medianMinutes).toBe(44)
+  })
+
+  it('leaves the duration absent when no session was ever timed', () => {
+    const summary = buildProgramSummary(
+      [session('Back Day 1', '2023-01-02'), session('Back Day 1', '2023-01-09')],
+      TEMPLATES
+    )
+    expect(summary?.templates[0].medianMinutes).toBeNull()
+  })
+
+  it('includes months with no sessions, so a layoff renders as one', () => {
+    const sessions = [session('Chest Day 1', '2023-01-10'), session('Back Day 1', '2023-04-10')]
+    const summary = buildProgramSummary(sessions, TEMPLATES)
+    expect(summary?.months.map(m => m.monthKey)).toEqual([
+      '2023-01',
+      '2023-02',
+      '2023-03',
+      '2023-04',
+    ])
+    expect(summary?.months.map(m => m.sessions)).toEqual([1, 0, 0, 1])
+  })
+
+  it('reports the span of templated training', () => {
+    // 12 sessions, one every two days from 2023-01-02.
+    const summary = buildProgramSummary(cycleSessions(2), TEMPLATES)
+    expect(summary?.firstDayKey).toBe('2023-01-02')
+    expect(summary?.lastDayKey).toBe('2023-01-24')
+  })
+})

--- a/lib/training-facility/training-program.test.ts
+++ b/lib/training-facility/training-program.test.ts
@@ -163,6 +163,32 @@ describe('buildProgramSummary', () => {
     expect(summary?.templates[0].medianMinutes).toBe(44)
   })
 
+  it('ignores a duration derived from when the note was written', () => {
+    // An icloud_notes window is when the *note* was created and last edited,
+    // which runs short of the session it describes. Averaging it in drags the
+    // median toward how long it takes to write a note.
+    const measured = session('Back Day 1', '2023-01-02', 44)
+    const noteDerived = {
+      ...session('Back Day 1', '2023-01-09', 20),
+      source: 'icloud_notes',
+    } as WeightRoomWorkout
+
+    const summary = buildProgramSummary([measured, noteDerived], TEMPLATES)
+    expect(summary?.templates[0].medianMinutes).toBe(44)
+    expect(summary?.templates[0].timedSessions).toBe(1)
+    // The session still counts as a session — only its clock is discounted.
+    expect(summary?.templates[0].sessions).toBe(2)
+  })
+
+  it('keeps a manually recorded duration, which is measured too', () => {
+    const manual = {
+      ...session('Back Day 1', '2023-01-02', 50),
+      source: 'manual',
+    } as WeightRoomWorkout
+    const summary = buildProgramSummary([manual], TEMPLATES)
+    expect(summary?.templates[0].medianMinutes).toBe(50)
+  })
+
   it('leaves the duration absent when no session was ever timed', () => {
     const summary = buildProgramSummary(
       [session('Back Day 1', '2023-01-02'), session('Back Day 1', '2023-01-09')],

--- a/lib/training-facility/training-program.ts
+++ b/lib/training-facility/training-program.ts
@@ -42,14 +42,18 @@ export interface TemplateSummary {
   /** Last day it was run, `YYYY-MM-DD`. */
   lastDayKey: string
   /**
-   * Median session length in minutes, or `null` when no session of this
-   * template has both a start and an end.
+   * Median session length in minutes, from **observed** windows only, or
+   * `null` when no session of this template has one.
    *
    * Median rather than mean: a session left running on the watch skews an
    * average badly, and one forgotten stop should not redefine how long a
    * Back Day takes.
+   *
+   * `icloud_notes` sessions are excluded — see {@link isMeasuredWindow}.
    */
   medianMinutes: number | null
+  /** How many sessions contributed a measured duration to {@link medianMinutes}. */
+  timedSessions: number
 }
 
 /** How faithfully the sessions followed the rotation. */
@@ -91,6 +95,28 @@ export interface ProgramSummary {
   /** First and last templated day, `YYYY-MM-DD`; both `null` when there are none. */
   firstDayKey: string | null
   lastDayKey: string | null
+}
+
+/**
+ * Whether a session's window was observed rather than inferred.
+ *
+ * An `apple_health` session's start and end come off the watch, and a `manual`
+ * one is stamped as the session is recorded — both are measurements of the
+ * workout itself.
+ *
+ * An `icloud_notes` session's window is neither: it is when the *note* was
+ * created and last edited, which is a proxy that systematically runs short.
+ * The notes were typed during training, starting a minute or two in and
+ * stopping before the last set — on 2024-04-16 the note spanned
+ * 21:40:38-22:07:12 inside a workout of 21:39:00-22:10:42. Averaging those in
+ * would quietly drag every template's median down toward how long it takes to
+ * write a note.
+ *
+ * @param workout The session.
+ * @returns True when its duration means what a duration should mean.
+ */
+export function isMeasuredWindow(workout: Pick<WeightRoomWorkout, 'source'>): boolean {
+  return workout.source !== 'icloud_notes'
 }
 
 /**
@@ -263,6 +289,7 @@ export function buildProgramSummary(
     const id = entries[0].workout.template_id as string
     const days = entries.map(entry => entry.dayKey).sort()
     const minutes = entries
+      .filter(entry => isMeasuredWindow(entry.workout))
       .map(entry => workoutDurationMinutes(entry.workout))
       .filter((value): value is number => value !== null && value > 0)
 
@@ -273,6 +300,7 @@ export function buildProgramSummary(
       firstDayKey: days[0],
       lastDayKey: days[days.length - 1],
       medianMinutes: median(minutes),
+      timedSessions: minutes.length,
     })
   }
 

--- a/lib/training-facility/training-program.ts
+++ b/lib/training-facility/training-program.ts
@@ -1,0 +1,307 @@
+import type { WeightRoomWorkout, WorkoutTemplate } from '@/types/weight-room'
+
+import { PACIFIC_CLOCK, type DayClock } from './clock'
+import { workoutDurationMinutes } from './workout-sessions'
+
+/**
+ * The training programme behind the sessions (#436).
+ *
+ * Every other Weight Room surface works at the altitude of a session or a
+ * movement. This one works at the altitude of the *plan*: which template ran
+ * when, how strictly the rotation held, and how long each kind of session
+ * actually took.
+ *
+ * That question only became answerable with #400. The archive is 133 sessions
+ * across 2023-2024, each titled with the template it ran and most carrying an
+ * Apple Health duration because the note was typed during the workout. The
+ * current log has no templates at all, so this says nothing about it — which is
+ * itself worth stating rather than rendering as an empty rotation.
+ *
+ * **The rotation is inferred, not configured.** `weight_room_workout_templates`
+ * has a `position`, but it orders the six as Chest 1, Chest 2, Back 1, Back 2,
+ * Legs 1, Legs 2 — which is a sensible way to *list* them and not the order they
+ * were *run*. The sessions say the cycle was Chest 1 → Back 1 → Legs 1 →
+ * Chest 2 → Back 2 → Legs 2, and reading it off the data means the answer stays
+ * right if the programme changes, and never contradicts the log to match a
+ * column nobody maintained for this purpose.
+ *
+ * Pure and isomorphic, like its siblings — no Supabase client, no React, and no
+ * clock beyond the zone it is handed.
+ */
+
+/** One template's record across the archive. */
+export interface TemplateSummary {
+  /** Template id, for keying and links. */
+  id: string
+  /** Human-readable name, e.g. `Back Day 1`. */
+  name: string
+  /** Sessions that ran it. */
+  sessions: number
+  /** First day it was run, `YYYY-MM-DD`. */
+  firstDayKey: string
+  /** Last day it was run, `YYYY-MM-DD`. */
+  lastDayKey: string
+  /**
+   * Median session length in minutes, or `null` when no session of this
+   * template has both a start and an end.
+   *
+   * Median rather than mean: a session left running on the watch skews an
+   * average badly, and one forgotten stop should not redefine how long a
+   * Back Day takes.
+   */
+  medianMinutes: number | null
+}
+
+/** How faithfully the sessions followed the rotation. */
+export interface RotationAdherence {
+  /** Transitions that went to the next template in the cycle. */
+  followed: number
+  /** Transitions considered — one fewer than the number of templated sessions. */
+  total: number
+  /** {@link followed} over {@link total}, `0` when there are no transitions. */
+  rate: number
+}
+
+/** Sessions in one calendar month. */
+export interface ProgramMonth {
+  /** `YYYY-MM`. */
+  monthKey: string
+  /** Templated sessions that month. */
+  sessions: number
+}
+
+/** The programme as the sessions actually record it. */
+export interface ProgramSummary {
+  /** Per-template records, in rotation order. */
+  templates: TemplateSummary[]
+  /**
+   * Template names in the order the log says they were cycled.
+   *
+   * Empty when no repeating order could be read — a handful of sessions with no
+   * consistent successor is not a rotation, and inventing one from noise would
+   * make the adherence figure meaningless.
+   */
+  rotation: string[]
+  /** How closely the sessions followed {@link rotation}. */
+  adherence: RotationAdherence
+  /** Templated sessions per month, oldest first, including months with none. */
+  months: ProgramMonth[]
+  /** Total templated sessions. */
+  totalSessions: number
+  /** First and last templated day, `YYYY-MM-DD`; both `null` when there are none. */
+  firstDayKey: string | null
+  lastDayKey: string | null
+}
+
+/**
+ * The middle value of a list, averaging the two middles when it is even.
+ *
+ * @param values Numbers to summarize; not mutated.
+ * @returns The median, or `null` for an empty list.
+ */
+function median(values: readonly number[]): number | null {
+  if (values.length === 0) return null
+  const sorted = [...values].sort((a, b) => a - b)
+  const mid = Math.floor(sorted.length / 2)
+  return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid]
+}
+
+/**
+ * Read the repeating cycle out of the order templates were actually run.
+ *
+ * Each template's most frequent successor is taken as its place in the cycle,
+ * then the chain is walked from the most-used template until it returns to
+ * where it started. Deviations — a repeated day, a skipped one — are outvoted
+ * rather than breaking the chain, which is what makes this robust on a log that
+ * followed the plan about 92% of the time.
+ *
+ * @param sequence Template names in the order they were run, oldest first.
+ * @returns The cycle as an ordered list, or `[]` when the walk does not close
+ *   into one. A programme with no repeating order genuinely has no rotation,
+ *   and a partial chain would make adherence measure nothing.
+ */
+export function inferRotation(sequence: readonly string[]): string[] {
+  if (sequence.length < 2) return []
+
+  const successors = new Map<string, Map<string, number>>()
+  const distinct = new Set<string>()
+  for (let i = 0; i < sequence.length; i += 1) {
+    const name = sequence[i]
+    distinct.add(name)
+    const next = sequence[i + 1]
+    if (next === undefined || next === name) continue
+    const counts = successors.get(name) ?? new Map<string, number>()
+    counts.set(next, (counts.get(next) ?? 0) + 1)
+    successors.set(name, counts)
+  }
+
+  /** The successor a template most often had, ties broken alphabetically. */
+  const bestSuccessor = (name: string): string | null => {
+    const counts = successors.get(name)
+    if (!counts || counts.size === 0) return null
+    return [...counts.entries()].sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))[0][0]
+  }
+
+  // Start where the log starts. A cycle has no inherent beginning, so any
+  // rotation of it is equally true — but reading it from the first session
+  // means the order shown matches the order someone scrolling the log meets,
+  // rather than an alphabetical accident.
+  const start = sequence[0]
+
+  const cycle: string[] = [start]
+  const seen = new Set([start])
+  let current = start
+  while (cycle.length <= distinct.size) {
+    const next = bestSuccessor(current)
+    if (next === null) return []
+    // Closed the loop — a genuine rotation.
+    if (next === start) return cycle
+    // Re-entered somewhere other than the start: the chain forks, so there is
+    // no single cycle to report.
+    if (seen.has(next)) return []
+    cycle.push(next)
+    seen.add(next)
+    current = next
+  }
+  return []
+}
+
+/**
+ * Count how many transitions followed the rotation.
+ *
+ * @param sequence Template names in the order they were run, oldest first.
+ * @param rotation The cycle, as produced by {@link inferRotation}.
+ * @returns Followed, total, and the rate. All zero when there is no rotation.
+ */
+export function rotationAdherence(
+  sequence: readonly string[],
+  rotation: readonly string[]
+): RotationAdherence {
+  if (rotation.length === 0 || sequence.length < 2) {
+    return { followed: 0, total: 0, rate: 0 }
+  }
+  const nextOf = new Map(rotation.map((name, i) => [name, rotation[(i + 1) % rotation.length]]))
+
+  let followed = 0
+  let total = 0
+  for (let i = 0; i + 1 < sequence.length; i += 1) {
+    const expected = nextOf.get(sequence[i])
+    if (expected === undefined) continue
+    total += 1
+    if (sequence[i + 1] === expected) followed += 1
+  }
+  return { followed, total, rate: total === 0 ? 0 : followed / total }
+}
+
+/**
+ * Every `YYYY-MM` from one month to another, inclusive.
+ *
+ * Months with no sessions are included deliberately: a gap in training is the
+ * most interesting thing a cadence chart can show, and omitting empty months
+ * would draw a continuous line straight over it.
+ */
+function monthRange(firstMonth: string, lastMonth: string): string[] {
+  const [startYear, startMonth] = firstMonth.split('-').map(Number)
+  const [endYear, endMonth] = lastMonth.split('-').map(Number)
+  const months: string[] = []
+  let year = startYear
+  let month = startMonth
+  while (year < endYear || (year === endYear && month <= endMonth)) {
+    months.push(`${year}-${String(month).padStart(2, '0')}`)
+    month += 1
+    if (month > 12) {
+      month = 1
+      year += 1
+    }
+  }
+  return months
+}
+
+/**
+ * Summarize the programme the templated sessions record.
+ *
+ * @param workouts Every session. Ones with no `template_id` are ignored — the
+ *   current era's grease-the-groove logging has no programme to describe, and
+ *   folding it in would dilute both the cadence and the adherence.
+ * @param templates The template roster, for names.
+ * @param clock Zone every day and month is measured in; defaults to Pacific (#429).
+ * @returns The summary, or `null` when no session names a template.
+ */
+export function buildProgramSummary(
+  workouts: readonly WeightRoomWorkout[],
+  templates: readonly WorkoutTemplate[],
+  clock: DayClock = PACIFIC_CLOCK
+): ProgramSummary | null {
+  const nameById = new Map(templates.map(template => [template.id, template.name]))
+
+  const templated = workouts
+    .filter(workout => workout.template_id !== undefined && nameById.has(workout.template_id))
+    .map(workout => ({
+      workout,
+      name: nameById.get(workout.template_id as string) as string,
+      dayKey: clock.safeDayKey(workout.started_at),
+    }))
+    .filter(entry => entry.dayKey !== '')
+    // `started_at` is an instant, so string comparison orders it correctly.
+    .sort((a, b) => a.workout.started_at.localeCompare(b.workout.started_at))
+
+  if (templated.length === 0) return null
+
+  const sequence = templated.map(entry => entry.name)
+  const rotation = inferRotation(sequence)
+  const adherence = rotationAdherence(sequence, rotation)
+
+  const byTemplate = new Map<string, typeof templated>()
+  for (const entry of templated) {
+    const list = byTemplate.get(entry.name)
+    if (list) list.push(entry)
+    else byTemplate.set(entry.name, [entry])
+  }
+
+  const summaries: TemplateSummary[] = []
+  for (const [name, entries] of byTemplate) {
+    const id = entries[0].workout.template_id as string
+    const days = entries.map(entry => entry.dayKey).sort()
+    const minutes = entries
+      .map(entry => workoutDurationMinutes(entry.workout))
+      .filter((value): value is number => value !== null && value > 0)
+
+    summaries.push({
+      id,
+      name,
+      sessions: entries.length,
+      firstDayKey: days[0],
+      lastDayKey: days[days.length - 1],
+      medianMinutes: median(minutes),
+    })
+  }
+
+  // Rotation order where there is one, so the table reads as the cycle rather
+  // than as an arbitrary list; alphabetical otherwise.
+  const rank = new Map(rotation.map((name, i) => [name, i]))
+  summaries.sort(
+    (a, b) =>
+      (rank.get(a.name) ?? Number.MAX_SAFE_INTEGER) -
+        (rank.get(b.name) ?? Number.MAX_SAFE_INTEGER) || a.name.localeCompare(b.name)
+  )
+
+  const countByMonth = new Map<string, number>()
+  for (const entry of templated) {
+    const monthKey = entry.dayKey.slice(0, 7)
+    countByMonth.set(monthKey, (countByMonth.get(monthKey) ?? 0) + 1)
+  }
+  const allDays = templated.map(entry => entry.dayKey).sort()
+  const months = monthRange(allDays[0].slice(0, 7), allDays[allDays.length - 1].slice(0, 7)).map(
+    monthKey => ({ monthKey, sessions: countByMonth.get(monthKey) ?? 0 })
+  )
+
+  return {
+    templates: summaries,
+    rotation,
+    adherence,
+    months,
+    totalSessions: templated.length,
+    firstDayKey: allDays[0],
+    lastDayKey: allDays[allDays.length - 1],
+  }
+}

--- a/scripts/import-icloud-notes.mjs
+++ b/scripts/import-icloud-notes.mjs
@@ -40,12 +40,19 @@ import path from 'node:path'
 
 import { createServiceRoleClient, loadEnv } from './lib/cardio-supabase.mjs'
 import { matchNoteToSession, noteWindow, parseNotesCsvStamp } from './lib/icloud-notes-match.mjs'
-import { parseNote, parseNoteDate } from './lib/icloud-notes-parser.mjs'
+import {
+  isSessionNote,
+  parseNote,
+  parseNoteDate,
+  templateNameForNote,
+} from './lib/icloud-notes-parser.mjs'
 import { parseExport } from './lib/icloud-notes-text.mjs'
 import {
   fetchExerciseSlugs,
   fetchLoadMultipliers,
   fetchSessionsInRange,
+  fetchTemplateIdsByName,
+  linkSessionTemplates,
   upsertNoteSession,
   upsertNoteSets,
 } from './lib/icloud-notes-supabase.mjs'
@@ -248,16 +255,23 @@ async function main() {
     )
   }
 
-  const [multipliers, catalogSlugs] = await Promise.all([
+  const [multipliers, catalogSlugs, templateIdByName] = await Promise.all([
     fetchLoadMultipliers(supabase),
     fetchExerciseSlugs(supabase),
+    fetchTemplateIdsByName(supabase),
   ])
 
   // Resolve each note's day first so the session read can be scoped to the
   // range the notes actually cover.
   const dated = []
   const undatable = []
+  const skipped = []
   for (const note of notes) {
+    // A programme document is not a session — see NON_SESSION_NOTES.
+    if (!isSessionNote(note.title)) {
+      skipped.push(note.title)
+      continue
+    }
     const day = parseNoteDate(note.date)
     if (!day) {
       undatable.push(note)
@@ -276,6 +290,7 @@ async function main() {
   )
 
   const rows = []
+  const templateLinks = new Map()
   const unmappedMovements = new Map()
   const timedMovements = new Map()
   const unknownSlugs = new Map()
@@ -283,6 +298,7 @@ async function main() {
     overlap: 0,
     sameDay: 0,
     ownSession: 0,
+    noSession: 0,
     missingManifest: 0,
     clampedWindow: 0,
   }
@@ -306,9 +322,27 @@ async function main() {
     // first note's sets, silently merging two distinct workouts into one.
     const noteKey = `${note.title}|${window.start.toISOString()}`
 
+    // Which of the six templates this note ran, where it ran one. Keyed by the
+    // session it landed on — or by `noteKey` when the session doesn't exist yet
+    // and gets created below.
+    const templateName = templateNameForNote(note.title)
+    const templateId = templateName ? (templateIdByName.get(templateName) ?? null) : null
+    if (templateId !== null) templateLinks.set(workoutId ?? noteKey, templateId)
+
+    const { sets, unmapped, timed } = parseNote({ ...note, date: note.day }, multipliers)
+
+    // Parsed before the session decision, because whether a note deserves its
+    // own session depends on whether it produced any. A note whose content is
+    // all grease-the-groove rep lists — most `Pull ups` and `Squat` notes — has
+    // no session work at all, and one that isn't about training (`Jared`, a
+    // list of names; `Lucas - 0792`, a locker number) has nothing whatsoever.
+    // Minting a session for those leaves the session log full of empty
+    // workouts that were never performed.
+    const hasWorkoutSets = sets.some(set => set.disposition === 'workout')
+
     if (match?.method === 'overlap') report.overlap += 1
     else if (match?.method === 'same-day') report.sameDay += 1
-    else {
+    else if (hasWorkoutSets) {
       report.ownSession += 1
       createdSessions.push({
         startedAt: window.start.toISOString(),
@@ -316,9 +350,10 @@ async function main() {
         title: note.title,
         noteKey,
       })
+    } else {
+      report.noSession += 1
     }
 
-    const { sets, unmapped, timed } = parseNote({ ...note, date: note.day }, multipliers)
     for (const name of unmapped) {
       unmappedMovements.set(name, (unmappedMovements.get(name) ?? 0) + 1)
     }
@@ -362,10 +397,13 @@ async function main() {
   console.log(`Notes read              ${notes.length}`)
   console.log(`  dated                 ${dated.length}`)
   console.log(`  undatable (skipped)   ${undatable.length}`)
+  console.log(`  not a session         ${skipped.length}`)
+  console.log(`Templates linked        ${templateLinks.size}`)
   console.log(`Attribution`)
   console.log(`  matched by overlap    ${report.overlap}`)
   console.log(`  matched by same day   ${report.sameDay}`)
   console.log(`  own icloud session    ${report.ownSession}`)
+  console.log(`  loose volume only     ${report.noSession}`)
   console.log(`  no manifest row       ${report.missingManifest}`)
   console.log(`  late edit discarded   ${report.clampedWindow}`)
   console.log(`Sets parsed             ${rows.length}`)
@@ -409,8 +447,19 @@ async function main() {
   )
 
   const { upserted } = await upsertNoteSets(supabase, prepared)
+
+  // Templates last: a note that needed its own session only has an id now.
+  const resolvedLinks = new Map()
+  for (const [key, templateId] of templateLinks) {
+    const workoutId = sessionIdByNote.get(key) ?? key
+    if (typeof workoutId === 'string' && workoutId.includes('|')) continue
+    resolvedLinks.set(workoutId, templateId)
+  }
+  const { linked } = await linkSessionTemplates(supabase, resolvedLinks)
+
   console.log('')
   console.log(`Wrote ${createdSessions.length} sessions and ${upserted} sets.`)
+  console.log(`Linked ${linked} sessions to their template.`)
 }
 
 main().catch(error => {

--- a/scripts/import-icloud-notes.mjs
+++ b/scripts/import-icloud-notes.mjs
@@ -53,6 +53,7 @@ import {
   fetchSessionsInRange,
   fetchTemplateIdsByName,
   linkSessionTemplates,
+  pruneNoteImports,
   upsertNoteSession,
   upsertNoteSets,
 } from './lib/icloud-notes-supabase.mjs'
@@ -432,6 +433,15 @@ async function main() {
     console.log('')
     console.log('--dry-run: nothing written.')
     return
+  }
+
+  // Anything previously imported from a note now classed as a programme
+  // document has to be removed, not merely left out of this payload — see
+  // pruneNoteImports.
+  const pruned = await pruneNoteImports(supabase, skipped)
+  if (pruned.sets > 0 || pruned.sessions > 0) {
+    console.log('')
+    console.log(`Pruned ${pruned.sets} sets and ${pruned.sessions} sessions from skipped notes.`)
   }
 
   // Sessions first: a note that matched nothing needs its own row before its

--- a/scripts/lib/icloud-notes-parser.mjs
+++ b/scripts/lib/icloud-notes-parser.mjs
@@ -171,6 +171,69 @@ const RAW_MOVEMENT_ALIASES = {
 }
 
 /**
+ * Notes that describe training without being a record of a session (#436).
+ *
+ * `Strength Cycle` is the program itself — all six templates in one note, with
+ * example numbers, a `Workout pace` line per template, and app feature notes at
+ * the bottom. Imported as a session it became a single 30-minute workout of
+ * 163 sets and 1,523 reps across 32 movements, which is not a thing that
+ * happened: it distorted that day's totals, the all-time biggest session, and
+ * every density figure at once.
+ *
+ * Its metadata says the same thing — created 2022-04-29 and last modified
+ * 2025-03-09, a document revised for three years rather than a log written
+ * during a workout. The sets in it are also not the author's.
+ *
+ * Matched on title, so both copies of the note are covered.
+ */
+export const NON_SESSION_NOTES = Object.freeze(new Set(['strength cycle']))
+
+/**
+ * Whether a note records a session at all.
+ *
+ * @param {string} title Note title.
+ * @returns {boolean} False for reference documents — see {@link NON_SESSION_NOTES}.
+ */
+export function isSessionNote(title) {
+  return !NON_SESSION_NOTES.has(
+    String(title ?? '')
+      .trim()
+      .toLowerCase()
+  )
+}
+
+/**
+ * Note titles to the workout template they ran (#436).
+ *
+ * The six templates are seeded in `weight_room_workout_templates` under exactly
+ * the names the notes use, so this only has to cover the spellings that drift:
+ * `Leg Day 2` for `Legs Day 2` across three sessions in early 2023.
+ *
+ * Titles absent here are genuinely untemplated — standalone pull-up, leg-press
+ * and plyo days that were never part of the rotation — and stay unlinked rather
+ * than being forced onto the nearest template.
+ */
+const TEMPLATE_TITLE_ALIASES = Object.freeze({
+  'leg day 2': 'Legs Day 2',
+})
+
+/**
+ * Resolve the template a note's title names.
+ *
+ * @param {string} title Note title, as written.
+ * @returns {string|null} The canonical template name, or null when the note is
+ *   not one of the six — which most standalone notes are not.
+ */
+export function templateNameForNote(title) {
+  const trimmed = String(title ?? '').trim()
+  const canonical = TEMPLATE_TITLE_ALIASES[trimmed.toLowerCase()]
+  if (canonical) return canonical
+  return /^(chest|back|legs) day [12]$/i.test(trimmed)
+    ? trimmed.replace(/\b\w/g, char => char.toUpperCase()).replace(/Day/i, 'Day')
+    : null
+}
+
+/**
  * Reps in one 21s set, counted the way every other two-dumbbell set is (#435).
  *
  * The protocol is 7 reps with one arm while the other holds mid-curl, 7 with

--- a/scripts/lib/icloud-notes-parser.test.ts
+++ b/scripts/lib/icloud-notes-parser.test.ts
@@ -11,7 +11,9 @@ import { describe, expect, it } from 'vitest'
 
 import {
   isPerformedSet,
+  isSessionNote,
   mintImportKey,
+  templateNameForNote,
   parseLabelledBlock,
   TWENTY_ONES_REPS_PER_ARM,
   normalizeName,
@@ -236,6 +238,46 @@ describe('parseNote', () => {
       unmapped: [],
       timed: [],
     })
+  })
+})
+
+describe('isSessionNote', () => {
+  it('rejects the Strength Cycle programme document', () => {
+    // All six templates in one note, revised 2022-2025. Imported as a session
+    // it became one 30-minute workout of 163 sets and 1,523 reps.
+    expect(isSessionNote('Strength Cycle')).toBe(false)
+    expect(isSessionNote('  strength cycle  ')).toBe(false)
+  })
+
+  it('accepts real session notes', () => {
+    expect(isSessionNote('Back Day 1')).toBe(true)
+    expect(isSessionNote('Pull ups')).toBe(true)
+  })
+})
+
+describe('templateNameForNote', () => {
+  it('resolves the six seeded templates from their note titles', () => {
+    expect(templateNameForNote('Back Day 1')).toBe('Back Day 1')
+    expect(templateNameForNote('Chest Day 2')).toBe('Chest Day 2')
+    expect(templateNameForNote('Legs Day 2')).toBe('Legs Day 2')
+  })
+
+  it('folds the Leg Day 2 spelling onto Legs Day 2', () => {
+    // Three sessions in early 2023 drop the plural.
+    expect(templateNameForNote('Leg Day 2')).toBe('Legs Day 2')
+  })
+
+  it('is case-insensitive about the title', () => {
+    expect(templateNameForNote('chest day 1')).toBe('Chest Day 1')
+  })
+
+  it('leaves genuinely untemplated notes unlinked', () => {
+    // Standalone pull-up, leg-press and plyo days were never in the rotation;
+    // forcing them onto the nearest template would invent adherence.
+    expect(templateNameForNote('Pull ups')).toBeNull()
+    expect(templateNameForNote('Workout')).toBeNull()
+    expect(templateNameForNote('Leg press')).toBeNull()
+    expect(templateNameForNote('Nov 25')).toBeNull()
   })
 })
 

--- a/scripts/lib/icloud-notes-supabase.mjs
+++ b/scripts/lib/icloud-notes-supabase.mjs
@@ -134,6 +134,55 @@ export async function upsertNoteSets(supabase, rows) {
 }
 
 /**
+ * Read the workout templates by name.
+ *
+ * The six seeded templates (#375) carry exactly the names the notes title
+ * themselves with, which is what makes linking a session to its template a name
+ * match rather than an inference.
+ *
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase Service-role client.
+ * @returns {Promise<Map<string, string>>} Template id keyed by name.
+ * @throws when the read fails.
+ */
+export async function fetchTemplateIdsByName(supabase) {
+  const { data, error } = await supabase.from('weight_room_workout_templates').select('id, name')
+  if (error) {
+    throw new Error(`Failed to read workout templates: ${error.message}`)
+  }
+  return new Map((data ?? []).map(row => [row.name, row.id]))
+}
+
+/**
+ * Record which template each imported session ran (#436).
+ *
+ * Only fills a template in where the session has none. A session that already
+ * names its template was either recorded live against it or corrected by hand,
+ * and neither is this importer's to overwrite — the same "never clobber what
+ * the app recorded" rule the set upsert follows.
+ *
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase Service-role client.
+ * @param {Map<string, string>} links Template id keyed by workout id.
+ * @returns {Promise<{linked: number}>} How many sessions were updated.
+ * @throws when an update fails, naming the workout.
+ */
+export async function linkSessionTemplates(supabase, links) {
+  let linked = 0
+  for (const [workoutId, templateId] of links) {
+    const { data, error } = await supabase
+      .from(WORKOUTS_TABLE)
+      .update({ template_id: templateId })
+      .eq('id', workoutId)
+      .is('template_id', null)
+      .select('id')
+    if (error) {
+      throw new Error(`Failed to link template for workout ${workoutId}: ${error.message}`)
+    }
+    linked += data?.length ?? 0
+  }
+  return { linked }
+}
+
+/**
  * Read the movement catalog's load multipliers.
  *
  * Taken live rather than hardcoded so a `Weight (total)` column is halved by

--- a/scripts/lib/icloud-notes-supabase.mjs
+++ b/scripts/lib/icloud-notes-supabase.mjs
@@ -134,6 +134,73 @@ export async function upsertNoteSets(supabase, rows) {
 }
 
 /**
+ * Delete rows imported from a note that is no longer treated as a session.
+ *
+ * Skipping a note only keeps it out of the *next* upsert. Nothing here prunes
+ * absent keys — deliberately, since an imported session can acquire
+ * hand-authored data — so a note reclassified as a programme document would
+ * otherwise leave its rows behind forever, still corrupting the totals that
+ * reclassifying it was meant to fix.
+ *
+ * Scoped to the importer's own rows: only sets whose `import_key` names the
+ * note, and only `icloud_notes` sessions left with nothing in them afterwards.
+ * A Health session that happened to overlap is never removed — it existed
+ * before this import and is not ours to delete.
+ *
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase Service-role client.
+ * @param {Iterable<string>} titles Note titles to purge, lowercase-insensitive
+ *   only in as much as the keys were minted from the original casing.
+ * @returns {Promise<{sets: number, sessions: number}>} What was removed.
+ * @throws when a delete fails, naming the title.
+ */
+export async function pruneNoteImports(supabase, titles) {
+  let sets = 0
+  const touched = new Set()
+
+  for (const title of titles) {
+    const { data, error } = await supabase
+      .from(SETS_TABLE)
+      .delete()
+      .like('import_key', `icloud:${title}:%`)
+      .select('workout_id')
+    if (error) {
+      throw new Error(`Failed to prune imported sets for "${title}": ${error.message}`)
+    }
+    sets += data?.length ?? 0
+    for (const row of data ?? []) {
+      if (row.workout_id) touched.add(row.workout_id)
+    }
+  }
+
+  let sessions = 0
+  for (const workoutId of touched) {
+    // Only if nothing else survives on it — a session shared with other notes
+    // or with app-logged sets stays.
+    const { count, error: countError } = await supabase
+      .from(SETS_TABLE)
+      .select('id', { count: 'exact', head: true })
+      .eq('workout_id', workoutId)
+    if (countError) {
+      throw new Error(`Failed to check workout ${workoutId}: ${countError.message}`)
+    }
+    if ((count ?? 0) > 0) continue
+
+    const { data, error } = await supabase
+      .from(WORKOUTS_TABLE)
+      .delete()
+      .eq('id', workoutId)
+      .eq('source', ICLOUD_NOTES_SOURCE)
+      .select('id')
+    if (error) {
+      throw new Error(`Failed to prune workout ${workoutId}: ${error.message}`)
+    }
+    sessions += data?.length ?? 0
+  }
+
+  return { sets, sessions }
+}
+
+/**
  * Read the workout templates by name.
  *
  * The six seeded templates (#375) carry exactly the names the notes title

--- a/scripts/lib/icloud-notes-supabase.test.ts
+++ b/scripts/lib/icloud-notes-supabase.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from 'vitest'
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+import { pruneNoteImports } from './icloud-notes-supabase.mjs'
+
+/**
+ * Coverage for the destructive half of the iCloud Notes import (#436).
+ *
+ * Everything else this module does is an upsert, which fails loudly and
+ * converges on a re-run. `pruneNoteImports` deletes, and it exists precisely
+ * because reclassifying a note as a programme document has to remove what a
+ * previous run already wrote — so the two things worth pinning are that it
+ * removes what it should and, much more importantly, nothing else.
+ */
+
+/** A row the stub will hand back from a `.delete()` or count. */
+interface StubSet {
+  workout_id: string | null
+}
+
+/**
+ * Minimal Supabase stub covering the three chains the pruner uses:
+ * `.delete().like().select()`, `.select(count, head)`, and
+ * `.delete().eq().eq().select()`.
+ *
+ * Cast rather than mocked wholesale, following `weight-room-supabase.test.ts`:
+ * standing up the rest of `SupabaseClient` would bury the three calls that
+ * matter.
+ */
+function stubClient(options: {
+  /** Sets returned per `like` pattern. */
+  setsByPattern: Record<string, StubSet[]>
+  /** Remaining set count per workout id, consulted after the delete. */
+  remainingByWorkout: Record<string, number>
+  /** Workout ids the stub will admit to deleting. */
+  deletableWorkouts: string[]
+}) {
+  const deletedPatterns: string[] = []
+  const deletedWorkouts: string[] = []
+  const countedWorkouts: string[] = []
+
+  const client = {
+    from(table: string) {
+      return {
+        delete() {
+          return {
+            // Sets: .delete().like(...).select(...)
+            like(_column: string, pattern: string) {
+              deletedPatterns.push(pattern)
+              return {
+                select() {
+                  return Promise.resolve({
+                    data: options.setsByPattern[pattern] ?? [],
+                    error: null,
+                  })
+                },
+              }
+            },
+            // Workouts: .delete().eq('id', …).eq('source', …).select(…)
+            eq(_column: string, id: string) {
+              return {
+                eq() {
+                  return {
+                    select() {
+                      const deletable = options.deletableWorkouts.includes(id)
+                      if (deletable) deletedWorkouts.push(id)
+                      return Promise.resolve({
+                        data: deletable ? [{ id }] : [],
+                        error: null,
+                      })
+                    },
+                  }
+                },
+              }
+            },
+          }
+        },
+        select(_columns: string, _opts: unknown) {
+          return {
+            eq(_column: string, workoutId: string) {
+              countedWorkouts.push(workoutId)
+              return Promise.resolve({
+                count: options.remainingByWorkout[workoutId] ?? 0,
+                error: null,
+              })
+            },
+          }
+        },
+        _table: table,
+      }
+    },
+  } as unknown as SupabaseClient
+
+  return { client, deletedPatterns, deletedWorkouts, countedWorkouts }
+}
+
+describe('pruneNoteImports', () => {
+  it('deletes only sets whose import key names the note', () => {
+    const { client, deletedPatterns } = stubClient({
+      setsByPattern: { 'icloud:Strength Cycle:%': [] },
+      remainingByWorkout: {},
+      deletableWorkouts: [],
+    })
+
+    return pruneNoteImports(client, ['Strength Cycle']).then(result => {
+      expect(deletedPatterns).toEqual(['icloud:Strength Cycle:%'])
+      expect(result).toEqual({ sets: 0, sessions: 0 })
+    })
+  })
+
+  it('removes the session once nothing is left on it', async () => {
+    const { client, deletedWorkouts } = stubClient({
+      setsByPattern: {
+        'icloud:Strength Cycle:%': [{ workout_id: 'w1' }, { workout_id: 'w1' }],
+      },
+      remainingByWorkout: { w1: 0 },
+      deletableWorkouts: ['w1'],
+    })
+
+    const result = await pruneNoteImports(client, ['Strength Cycle'])
+    expect(result).toEqual({ sets: 2, sessions: 1 })
+    expect(deletedWorkouts).toEqual(['w1'])
+  })
+
+  it('keeps a session that still holds other sets', async () => {
+    // A Health session shared with a real note, or one carrying app-logged
+    // sets, must survive having some of its rows pruned.
+    const { client, deletedWorkouts } = stubClient({
+      setsByPattern: { 'icloud:Strength Cycle:%': [{ workout_id: 'shared' }] },
+      remainingByWorkout: { shared: 12 },
+      deletableWorkouts: ['shared'],
+    })
+
+    const result = await pruneNoteImports(client, ['Strength Cycle'])
+    expect(result.sets).toBe(1)
+    expect(result.sessions).toBe(0)
+    expect(deletedWorkouts).toEqual([])
+  })
+
+  it('never deletes a workout that is not an icloud_notes session', async () => {
+    // The `source` filter is what stops it reaching an Apple Health row that
+    // existed before this import and is not ours to remove.
+    const { client, deletedWorkouts } = stubClient({
+      setsByPattern: { 'icloud:Strength Cycle:%': [{ workout_id: 'health-row' }] },
+      remainingByWorkout: { 'health-row': 0 },
+      // The stub refuses it, standing in for the `source` predicate not matching.
+      deletableWorkouts: [],
+    })
+
+    const result = await pruneNoteImports(client, ['Strength Cycle'])
+    expect(result.sessions).toBe(0)
+    expect(deletedWorkouts).toEqual([])
+  })
+
+  it('ignores sets that were never attached to a session', async () => {
+    const { client, countedWorkouts } = stubClient({
+      setsByPattern: { 'icloud:Strength Cycle:%': [{ workout_id: null }] },
+      remainingByWorkout: {},
+      deletableWorkouts: [],
+    })
+
+    const result = await pruneNoteImports(client, ['Strength Cycle'])
+    expect(result).toEqual({ sets: 1, sessions: 0 })
+    expect(countedWorkouts).toEqual([])
+  })
+
+  it('does nothing when there is nothing to skip', async () => {
+    const { client, deletedPatterns } = stubClient({
+      setsByPattern: {},
+      remainingByWorkout: {},
+      deletableWorkouts: [],
+    })
+
+    expect(await pruneNoteImports(client, [])).toEqual({ sets: 0, sessions: 0 })
+    expect(deletedPatterns).toEqual([])
+  })
+})


### PR DESCRIPTION
133 sessions across 2023–2024 ran a deliberate six-template cycle, each note titled with the template it ran and most carrying an Apple Health duration. The Weight Room shows sessions and movements; it never showed the **plan**.

Closes #436.

## The rotation is inferred, not configured

`weight_room_workout_templates` has a `position`, but it orders the six as Chest 1, Chest 2, Back 1, Back 2, Legs 1, Legs 2 — a sensible way to *list* them, and not the order they were *run*.

The sessions disagree, unambiguously:

| transition | count |
|---|---|
| Chest 1 → Back 1 | 22 |
| Back 1 → Legs 1 | 21 |
| Legs 1 → Chest 2 | 20 |
| Chest 2 → Back 2 | 19 |
| Back 2 → Legs 2 | 19 |
| Legs 2 → Chest 1 | 21 |

`inferRotation` reads the cycle off the sequence by most-frequent successor, so the occasional repeated or skipped day is outvoted rather than breaking the chain. It returns `[]` when the chain doesn't close into a cycle — a partial chain would make adherence measure against an order the log never repeated.

It starts the cycle **where the log starts** rather than alphabetically, so the order shown matches what someone scrolling the log meets.

## What it shows

**133 sessions · 6 templates · cycle held 92% (122 of 132) · 41 min median**, Jan 2023 – Apr 2024.

Plus per-template records (Back Day 1 is the quick one at 38 min; Chest Day 1 the long one at 46) and a cadence chart. Cadence renders months with **no** sessions rather than skipping them — a gap is the most informative thing that chart can show, and omitting empty months would draw a continuous run straight over a layoff.

The current era is untemplated grease-the-groove, so it's excluded rather than diluting cadence and adherence, and the page says so outright when nothing names a template.

## Two data problems fixed on the way

Both surfaced by looking at real rows rather than by the issue:

**`Strength Cycle` is the programme document, not a session.** All six templates in one note, created 2022-04-29 and last modified **2025-03-09** — revised for three years — and per Lucas not his sets. It had imported as a single 30-minute session of **163 sets, 32 movements, 1,523 reps**, distorting that day's totals, the all-time biggest session, and every density figure. Now skipped by name, and its 214 rows removed.

**Empty sessions.** A session was minted for every unmatched note even when the note produced no workout sets, leaving **22 empty workouts** in the session log — including notes that aren't training at all (`Jared`, a list of names; `Lucas - 0792`, a locker number). Sessions are now created only where there is session work to put in them; those notes' rep lists still import as loose volume.

## Also

The importer sets `template_id`, so this is a join rather than string-parsing `import_key` in a render path — and it's the same linkage #440 needs for rack-run slot steps. `Leg Day 2` folds onto `Legs Day 2` (3 sessions). Genuinely untemplated notes stay unlinked rather than being forced onto the nearest template.

Import result: 207 notes, 1 skipped, **133 sessions linked**, 5,109 sets, idempotent on re-run.

## Not in this PR

The issue's fourth AC — comparing the Health duration against the `Workout pace` the note claimed — needs the claimed pace stored, and it currently isn't. Actual duration ships; the comparison doesn't. Worth a follow-up if you want it, since the two disagree interestingly (Back Day 2 notes claim 35 min; the watch says 44).

## Test plan

- [ ] `/training-facility/weight-room/program` — 133 sessions, 92% cycle, rotation strip reads Back Day 1 → Legs Day 1 → Chest Day 2 → Back Day 2 → Legs Day 2 → Chest Day 1 ↺
- [ ] Per-template table — six rows, sessions and medians plausible
- [ ] Cadence chart spans 2023-01 → 2024-04 with no horizontal page scroll on mobile
- [ ] The **Program** pill appears in the sub-nav on every Weight Room page and marks itself active here
- [ ] `/training-facility/weight-room/workouts` — no empty sessions in the log any more
- [ ] Nothing on 2022-04-29 shows a 163-set session
- [ ] With the Weight Room flag off, `/program` 404s (covered by the e2e gated-routes spec)

All green locally: 2,419 unit tests, 69 e2e, `tsc` clean, `next build` compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a read-only Weight Room Program page with workout totals, date ranges, template breakdowns, adherence, session duration, rotation order, and monthly activity.
  - Added Program navigation within the Weight Room.
- **Improvements**
  - Improved iCloud workout imports by recognizing templates, linking sessions, excluding reference notes, and reporting skipped entries.
- **Bug Fixes**
  - Improved handling of empty programs, missing dates, untimed sessions, inactive months, alternate title formats, and corrected imported records.
- **Tests**
  - Added coverage for program summaries, adherence, rotations, imports, and template matching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->