### PR TITLE
fix(weight-room): stop calling a 2024 stretch "Now" (#441)

### DIFF
--- a/app/training-facility/weight-room/exercises/[slug]/page.tsx
+++ b/app/training-facility/weight-room/exercises/[slug]/page.tsx
@@ -16,7 +16,12 @@ import {
   getWeightRoomWorkoutsServer,
 } from '@/lib/data/weight-room-server'
 import { isWeightRoomEnabled } from '@/lib/feature-flags'
-import { buildEraComparison, eraIsImported } from '@/lib/training-facility/era-comparison'
+import {
+  buildEraComparison,
+  eraIsImported,
+  isCurrentEra,
+  latestLoggedDay,
+} from '@/lib/training-facility/era-comparison'
 import {
   buildExerciseProgression,
   buildSetDetailCoverage,
@@ -106,6 +111,10 @@ export default async function WeightRoomExercisePage({
   // only appears where the imported archive actually gives something to compare
   // the current stretch against (#400).
   const eraComparison = progression === null ? null : buildEraComparison(progression)
+  // Currency is judged against the whole log's most recent training day, not
+  // this movement's own — otherwise every movement would look current relative
+  // to itself, which is exactly the claim #441 is about.
+  const latestDay = latestLoggedDay(sets)
   // The movement's own color where it has a daily goal, so the trend matches the
   // ring and heatmap it's already drawn in elsewhere. Gym lifts have no goal and
   // fall back to the panel's default.
@@ -170,6 +179,7 @@ export default async function WeightRoomExercisePage({
                   displayName={displayName}
                   earlierEraImported={eraIsImported(eraComparison.then, exercise, sets)}
                   currentEraImported={eraIsImported(eraComparison.now, exercise, sets)}
+                  laterEraIsCurrent={isCurrentEra(eraComparison.now, latestDay)}
                 />
               )}
               <ExerciseProgressionPanel

--- a/app/training-facility/weight-room/exercises/[slug]/page.tsx
+++ b/app/training-facility/weight-room/exercises/[slug]/page.tsx
@@ -114,7 +114,7 @@ export default async function WeightRoomExercisePage({
   // Currency is judged against the whole log's most recent training day, not
   // this movement's own — otherwise every movement would look current relative
   // to itself, which is exactly the claim #441 is about.
-  const latestDay = latestLoggedDay(sets)
+  const latestDay = latestLoggedDay(sets, workouts)
   // The movement's own color where it has a daily goal, so the trend matches the
   // ring and heatmap it's already drawn in elsewhere. Gym lifts have no goal and
   // fall back to the panel's default.

--- a/components/training-facility/weight-room/ThenVsNowPanel.tsx
+++ b/components/training-facility/weight-room/ThenVsNowPanel.tsx
@@ -31,6 +31,17 @@ export interface ThenVsNowPanelProps {
    * comes from Apple Notes" would imply the later one doesn't.
    */
   currentEraImported: boolean
+  /**
+   * Whether the later era is what the log is currently doing, as answered by
+   * `isCurrentEra`.
+   *
+   * False for most movements here: barbell, machine and sled work stopped in
+   * 2024, so their later era is two years old. Splitting the archive against
+   * itself is still worth showing, but calling the later half "Now" — and
+   * saying "current training has passed" about it — would be a claim about the
+   * present that the log contradicts.
+   */
+  laterEraIsCurrent: boolean
 }
 
 /**
@@ -53,13 +64,15 @@ export function ThenVsNowPanel({
   displayName,
   earlierEraImported,
   currentEraImported,
+  laterEraIsCurrent,
 }: ThenVsNowPanelProps): JSX.Element {
   const { then, now, gapDays } = comparison
   const gapYears = gapDays / 365
+  const movement = displayName.toLowerCase()
 
   const provenance =
     earlierEraImported && currentEraImported
-      ? 'Both stretches come from training logged in Apple Notes and imported into this log.'
+      ? 'Both come from training logged in Apple Notes and imported into this log.'
       : earlierEraImported
         ? 'The earlier one comes from training logged in Apple Notes and imported into this log.'
         : 'The earlier one is training this log already carried.'
@@ -68,26 +81,44 @@ export function ThenVsNowPanel({
     <section
       data-testid="then-vs-now"
       className="rounded-[1.4rem] border border-white/10 bg-white/[0.04] p-5 sm:p-6"
-      aria-label={`${displayName}: then versus now`}
+      aria-label={`${displayName}: ${laterEraIsCurrent ? 'then versus now' : 'two stretches compared'}`}
     >
       <header>
         <h2 className="font-mono text-[11px] uppercase tracking-[0.28em] text-amber-300/80">
-          Then vs now
+          {laterEraIsCurrent ? 'Then vs now' : 'Two stretches'}
         </h2>
         <p className="mt-2 text-sm leading-6 text-[#e8d5be]/75">
           {gapYears >= 1
-            ? `${gapYears.toFixed(1)} years separate these two stretches of ${displayName.toLowerCase()}.`
-            : `${gapDays} days separate these two stretches of ${displayName.toLowerCase()}.`}{' '}
+            ? `${gapYears.toFixed(1)} years separate these two stretches of ${movement}.`
+            : `${gapDays} days separate these two stretches of ${movement}.`}{' '}
           {provenance}
+          {laterEraIsCurrent ? null : (
+            <>
+              {' '}
+              Last trained{' '}
+              <strong className="font-black text-[#fff7ec]">
+                {formatDayKey(now.endDayKey, ERA_DATE)}
+              </strong>
+              .
+            </>
+          )}
         </p>
       </header>
 
       <div className="mt-5 grid gap-3 sm:grid-cols-2">
-        <EraColumn era={then} label="Then" />
-        <EraColumn era={now} label="Now" isCurrent />
+        <EraColumn era={then} label={laterEraIsCurrent ? 'Then' : 'Earlier'} />
+        <EraColumn
+          era={now}
+          label={laterEraIsCurrent ? 'Now' : 'Later'}
+          isCurrent={laterEraIsCurrent}
+        />
       </div>
 
-      <Verdict comparison={comparison} displayName={displayName} />
+      <Verdict
+        comparison={comparison}
+        displayName={displayName}
+        laterEraIsCurrent={laterEraIsCurrent}
+      />
     </section>
   )
 }
@@ -180,6 +211,8 @@ interface VerdictProps {
   comparison: EraComparison
   /** Movement name, for the sentence. */
   displayName: string
+  /** Whether the later era is the present — see {@link ThenVsNowPanelProps}. */
+  laterEraIsCurrent: boolean
 }
 
 /** The verdict's shared shell, so every branch gets the same box and test id. */
@@ -204,7 +237,7 @@ function Sentence({ children }: { children: ReactNode }): JSX.Element {
  * and a dead heat is neither "passed" nor "still above", both of which would
  * render as "by 0 lb".
  */
-function Verdict({ comparison, displayName }: VerdictProps): JSX.Element | null {
+function Verdict({ comparison, displayName, laterEraIsCurrent }: VerdictProps): JSX.Element | null {
   const { heaviestDelta, surpassedHeaviest, then, now } = comparison
   const movement = displayName.toLowerCase()
   const repsDelta = now.reps - then.reps
@@ -221,7 +254,12 @@ function Verdict({ comparison, displayName }: VerdictProps): JSX.Element | null 
     const bothBodyweight = then.heaviestSet === null && now.heaviestSet === null
 
     if (!bothBodyweight) {
-      const loadedSide = now.heaviestSet !== null ? 'the current stretch' : 'the earlier stretch'
+      const loadedSide =
+        now.heaviestSet !== null
+          ? laterEraIsCurrent
+            ? 'the current stretch'
+            : 'the later stretch'
+          : 'the earlier stretch'
       if (repsDelta === 0) {
         return (
           <Sentence>
@@ -262,16 +300,22 @@ function Verdict({ comparison, displayName }: VerdictProps): JSX.Element | null 
 
   const magnitude = formatLbs(Math.abs(heaviestDelta))
 
+  // "Current training" is only true when the later era *is* current. For a
+  // movement last trained in 2024 the same sentence describes two archive
+  // stretches as if one were the present.
+  const later = laterEraIsCurrent ? 'Current training' : 'The later stretch'
+  const earlierLeads = laterEraIsCurrent ? 'the current one' : 'the later one'
+
   return (
     <Sentence>
       {surpassedHeaviest ? (
         <>
-          Current training has passed the earlier stretch&rsquo;s heaviest {movement} by{' '}
+          {later} has passed the earlier stretch&rsquo;s heaviest {movement} by{' '}
           <strong className="font-black text-[#fff7ec]">{magnitude}</strong>.
         </>
       ) : (
         <>
-          The earlier stretch&rsquo;s heaviest {movement} still leads the current one by{' '}
+          The earlier stretch&rsquo;s heaviest {movement} still leads {earlierLeads} by{' '}
           <strong className="font-black text-[#fff7ec]">{magnitude}</strong>.
         </>
       )}

--- a/lib/training-facility/era-comparison.test.ts
+++ b/lib/training-facility/era-comparison.test.ts
@@ -7,7 +7,7 @@
  */
 import { describe, expect, it } from 'vitest'
 
-import type { StrengthSet } from '@/types/weight-room'
+import type { StrengthSet, WeightRoomWorkout } from '@/types/weight-room'
 
 import {
   buildEraComparison,
@@ -238,6 +238,29 @@ describe('latestLoggedDay', () => {
   it('is empty for an empty log', () => {
     expect(latestLoggedDay([])).toBe('')
   })
+
+  it('keeps a past-midnight set on the session that started it', () => {
+    // `buildExerciseProgression` dates a session's sets by the session's own
+    // day. Reading raw `logged_at` here would measure currency on a different
+    // calendar than the eras were built on and shift the cutoff by a day.
+    const workout = {
+      id: 'late-night',
+      started_at: '2026-08-10T04:30:00Z', // 2026-08-09 21:30 Pacific
+      ended_at: '2026-08-10T06:10:00Z',
+    } as WeightRoomWorkout
+    const pastMidnight: StrengthSet = {
+      id: 's',
+      // 2026-08-10 00:05 Pacific — the next calendar day by its own stamp.
+      logged_at: '2026-08-10T07:05:00Z',
+      exercise: 'pullups',
+      reps: 5,
+      workout_id: 'late-night',
+    }
+
+    expect(latestLoggedDay([pastMidnight], [workout])).toBe('2026-08-09')
+    // Without the session, the set dates itself and lands a day later.
+    expect(latestLoggedDay([pastMidnight])).toBe('2026-08-10')
+  })
 })
 
 describe('isCurrentEra', () => {
@@ -272,9 +295,24 @@ describe('isCurrentEra', () => {
   })
 
   it('draws the line at the same silence that separates two eras', () => {
-    expect(isCurrentEra(eraEnding('2026-02-10'), '2026-08-09', 180)).toBe(true)
-    expect(isCurrentEra(eraEnding('2026-02-08'), '2026-08-09', 180)).toBe(false)
+    // Exclusive at the boundary, matching buildEraComparison: a gap of exactly
+    // 180 days already divides two eras, so it cannot also be the present —
+    // otherwise the shared threshold would mean two things one day apart.
+    expect(daysBetween('2026-02-10', '2026-08-09')).toBe(180)
+    expect(isCurrentEra(eraEnding('2026-02-10'), '2026-08-09', 180)).toBe(false)
+    expect(isCurrentEra(eraEnding('2026-02-11'), '2026-08-09', 180)).toBe(true)
     expect(DEFAULT_CURRENT_WITHIN_DAYS).toBe(DEFAULT_MIN_GAP_DAYS)
+  })
+
+  it('agrees with the era split at the exact threshold', () => {
+    // The invariant stated in the doc comment, pinned end to end: a silence
+    // that splits eras never leaves the later one called current.
+    const endedAt = '2026-02-10'
+    const latest = '2026-08-09'
+    const gap = daysBetween(endedAt, latest)
+    const splitsEras = gap >= DEFAULT_MIN_GAP_DAYS
+    expect(splitsEras).toBe(true)
+    expect(isCurrentEra(eraEnding(endedAt), latest)).toBe(false)
   })
 
   it('refuses to claim currency with nothing to measure against', () => {

--- a/lib/training-facility/era-comparison.test.ts
+++ b/lib/training-facility/era-comparison.test.ts
@@ -11,10 +11,14 @@ import type { StrengthSet } from '@/types/weight-room'
 
 import {
   buildEraComparison,
+  DEFAULT_CURRENT_WITHIN_DAYS,
   DEFAULT_MIN_GAP_DAYS,
   daysBetween,
   eraIsImported,
+  isCurrentEra,
+  latestLoggedDay,
   median,
+  type TrainingEra,
 } from './era-comparison'
 import type { ExerciseDayPoint, ExerciseProgression } from './exercise-progression'
 import type { WorkoutSetHighlight } from './workout-stats'
@@ -216,6 +220,74 @@ describe('buildEraComparison', () => {
     const comparison = buildEraComparison(tied)
     expect(comparison?.heaviestDelta).toBe(0)
     expect(comparison?.surpassedHeaviest).toBe(false)
+  })
+})
+
+describe('latestLoggedDay', () => {
+  /** A set on a given day, at midday Pacific so the UTC instant stays on it. */
+  function loggedOn(dayKey: string): StrengthSet {
+    return { id: dayKey, logged_at: `${dayKey}T20:00:00Z`, exercise: 'pullups', reps: 5 }
+  }
+
+  it('finds the most recent day across every movement', () => {
+    expect(
+      latestLoggedDay([loggedOn('2024-04-16'), loggedOn('2026-08-09'), loggedOn('2023-01-08')])
+    ).toBe('2026-08-09')
+  })
+
+  it('is empty for an empty log', () => {
+    expect(latestLoggedDay([])).toBe('')
+  })
+})
+
+describe('isCurrentEra', () => {
+  /** An era ending on the given day; the rest is irrelevant here. */
+  function eraEnding(endDayKey: string): TrainingEra {
+    return {
+      startDayKey: '2023-01-01',
+      endDayKey,
+      trainingDays: 1,
+      sets: 1,
+      reps: 1,
+      tonnage: 0,
+      heaviestSet: null,
+      bestOneRepMax: null,
+      typicalTopSet: null,
+    }
+  }
+
+  it('is true when the era reaches the end of the log', () => {
+    expect(isCurrentEra(eraEnding('2026-08-09'), '2026-08-09')).toBe(true)
+  })
+
+  it('is true for a movement trained recently but not last', () => {
+    // Trained three weeks before the newest entry anywhere — still current.
+    expect(isCurrentEra(eraEnding('2026-07-19'), '2026-08-09')).toBe(true)
+  })
+
+  it('is false for a movement that stopped two years ago', () => {
+    // The real case: barbell and machine work ended in 2024 while the log
+    // continued, so calling its later era "Now" is a false claim.
+    expect(isCurrentEra(eraEnding('2024-04-16'), '2026-08-09')).toBe(false)
+  })
+
+  it('draws the line at the same silence that separates two eras', () => {
+    expect(isCurrentEra(eraEnding('2026-02-10'), '2026-08-09', 180)).toBe(true)
+    expect(isCurrentEra(eraEnding('2026-02-08'), '2026-08-09', 180)).toBe(false)
+    expect(DEFAULT_CURRENT_WITHIN_DAYS).toBe(DEFAULT_MIN_GAP_DAYS)
+  })
+
+  it('refuses to claim currency with nothing to measure against', () => {
+    expect(isCurrentEra(eraEnding('2026-08-09'), '')).toBe(false)
+  })
+
+  it('does not go stale as the log grows — it moves with it', () => {
+    // The whole point of measuring against the log rather than the wall clock:
+    // pick a movement back up and its era becomes current again, with no
+    // hardcoded date to revisit.
+    const era = eraEnding('2026-08-09')
+    expect(isCurrentEra(era, '2026-08-09')).toBe(true)
+    expect(isCurrentEra(era, '2027-06-01')).toBe(false)
   })
 })
 

--- a/lib/training-facility/era-comparison.ts
+++ b/lib/training-facility/era-comparison.ts
@@ -30,6 +30,16 @@ import type { WorkoutSetHighlight } from './workout-stats'
 /** How long a silence has to be before it separates two eras, in days. */
 export const DEFAULT_MIN_GAP_DAYS = 180
 
+/**
+ * How recently a movement must have been trained for its later era to count as
+ * the present.
+ *
+ * Deliberately the same figure as {@link DEFAULT_MIN_GAP_DAYS}: if a movement
+ * has been quiet for long enough that the silence would itself divide two eras,
+ * it is not what the log is currently doing. One threshold, one meaning.
+ */
+export const DEFAULT_CURRENT_WITHIN_DAYS = DEFAULT_MIN_GAP_DAYS
+
 /** One continuous stretch of training, bounded by a long layoff. */
 export interface TrainingEra {
   /** First training day in the era, `YYYY-MM-DD`. */
@@ -231,6 +241,64 @@ export function buildEraComparison(
     typicalTopSetDelta: delta(then.typicalTopSet, now.typicalTopSet),
     surpassedHeaviest: heaviestDelta === null ? null : heaviestDelta > 0,
   }
+}
+
+/**
+ * Whether a movement's later era is what the log is currently doing (#441).
+ *
+ * "Then" and "Now" are a claim about the present, and for most movements in
+ * this log it is false: barbell work, machine work and sled pushes stopped in
+ * 2024, so their later era is two years old. Splitting the archive against
+ * itself is still worth showing — 2023 dips against 2024 dips is a real
+ * comparison — but calling the 2024 half "Now" is not.
+ *
+ * Measured against **the log's own most recent training day**, not the wall
+ * clock. That keeps the answer stable when the page is rendered, makes it
+ * testable without freezing time, and means the whole thing self-corrects: pick
+ * a movement back up and its later era becomes current again, stop training for
+ * six months and every movement goes quiet together rather than one page
+ * disagreeing with the rest.
+ *
+ * @param era The later era, from {@link buildEraComparison}.
+ * @param latestLoggedDayKey The most recent training day anywhere in the log,
+ *   `YYYY-MM-DD`. An empty string yields `false` — with nothing to compare
+ *   against, claiming currency would be a guess.
+ * @param withinDays How recent counts; defaults to
+ *   {@link DEFAULT_CURRENT_WITHIN_DAYS}.
+ * @returns True when the era reaches close enough to the end of the log.
+ */
+export function isCurrentEra(
+  era: TrainingEra,
+  latestLoggedDayKey: string,
+  withinDays: number = DEFAULT_CURRENT_WITHIN_DAYS
+): boolean {
+  if (latestLoggedDayKey === '') return false
+  const behind = daysBetween(era.endDayKey, latestLoggedDayKey)
+  if (!Number.isFinite(behind)) return false
+  return behind <= withinDays
+}
+
+/**
+ * The most recent training day anywhere in the log.
+ *
+ * The reference point {@link isCurrentEra} measures against — "recent" has to
+ * mean recent *relative to the training*, not to whenever someone loads the
+ * page, or a site left alone for a year would declare its own history stale.
+ *
+ * @param sets Every logged set.
+ * @param clock Zone each day is measured in; defaults to Pacific (#429).
+ * @returns `YYYY-MM-DD`, or `''` when nothing is logged.
+ */
+export function latestLoggedDay(
+  sets: readonly StrengthSet[],
+  clock: DayClock = PACIFIC_CLOCK
+): string {
+  let latest = ''
+  for (const set of sets) {
+    const dayKey = clock.safeDayKey(set.logged_at)
+    if (dayKey !== '' && dayKey > latest) latest = dayKey
+  }
+  return latest
 }
 
 /**

--- a/lib/training-facility/era-comparison.ts
+++ b/lib/training-facility/era-comparison.ts
@@ -1,7 +1,8 @@
-import type { StrengthSet } from '@/types/weight-room'
+import type { StrengthSet, WeightRoomWorkout } from '@/types/weight-room'
 
 import { PACIFIC_CLOCK, type DayClock } from './clock'
 import type { ExerciseProgression } from './exercise-progression'
+import { workoutDayKey } from './workout-sessions'
 import type { WorkoutSetHighlight } from './workout-stats'
 
 /**
@@ -266,6 +267,10 @@ export function buildEraComparison(
  * @param withinDays How recent counts; defaults to
  *   {@link DEFAULT_CURRENT_WITHIN_DAYS}.
  * @returns True when the era reaches close enough to the end of the log.
+ *   Exclusive at the boundary, matching {@link buildEraComparison}, which
+ *   treats a gap of exactly `minGapDays` as era-separating. A silence long
+ *   enough to divide two eras cannot also be the present, or the shared
+ *   threshold would mean two different things one day apart.
  */
 export function isCurrentEra(
   era: TrainingEra,
@@ -275,7 +280,7 @@ export function isCurrentEra(
   if (latestLoggedDayKey === '') return false
   const behind = daysBetween(era.endDayKey, latestLoggedDayKey)
   if (!Number.isFinite(behind)) return false
-  return behind <= withinDays
+  return behind < withinDays
 }
 
 /**
@@ -285,17 +290,35 @@ export function isCurrentEra(
  * mean recent *relative to the training*, not to whenever someone loads the
  * page, or a site left alone for a year would declare its own history stale.
  *
+ * Uses the same day-mapping as `buildExerciseProgression`: a set belonging to a
+ * session takes the session's day, so a workout running past midnight stays on
+ * the evening that started it. Reading raw `logged_at` here instead would
+ * measure currency on a different calendar than the eras were built on, and
+ * shift the cutoff by a day for exactly the movement sitting on the boundary.
+ *
  * @param sets Every logged set.
+ * @param workouts Recorded sessions, for that mapping. Omitting them dates
+ *   every set by its own timestamp, which is right only when no session
+ *   crossed midnight.
  * @param clock Zone each day is measured in; defaults to Pacific (#429).
  * @returns `YYYY-MM-DD`, or `''` when nothing is logged.
  */
 export function latestLoggedDay(
   sets: readonly StrengthSet[],
+  workouts: readonly WeightRoomWorkout[] = [],
   clock: DayClock = PACIFIC_CLOCK
 ): string {
+  const sessionDay = new Map<string, string>()
+  for (const workout of workouts) {
+    const dayKey = workoutDayKey(workout, clock)
+    if (dayKey !== null) sessionDay.set(workout.id, dayKey)
+  }
+
   let latest = ''
   for (const set of sets) {
-    const dayKey = clock.safeDayKey(set.logged_at)
+    const dayKey =
+      (set.workout_id === undefined ? undefined : sessionDay.get(set.workout_id)) ??
+      clock.safeDayKey(set.logged_at)
     if (dayKey !== '' && dayKey > latest) latest = dayKey
   }
   return latest


### PR DESCRIPTION
"Then" and "Now" are a claim about the present, and for seven movements it's false — they split the archive against *itself* at an internal layoff and label the later half "Now", then say "Current training has passed…" about two stretches that both ended in 2024.

Closes #441.

## Scope, corrected

The issue said this affects most movement pages. The real number is **7**, not 39 — only 13 movements have a gap long enough to render the panel at all:

| | movements |
|---|---|
| **Current** (correct today) | shrugs, pullups, pushups, squats, lunges, dumbbell-lateral-raise |
| **Stale** (mislabelled) | assisted-pullups, sled-push, dips, step-ups, back-extension, ez-bar-curl, decline-crunch |

`dumbbell-curl` — the example in the issue — dropped off the list entirely: its 2022 era was the Strength Cycle note, removed in #436.

## What changed

A movement whose later era isn't current now reads:

> **TWO STRETCHES**
> 275 days separate these two stretches of ez bar curl. Both come from training logged in Apple Notes and imported into this log. **Last trained Apr 2024.**
>
> **EARLIER** · Apr 2022 – Apr 2022  **LATER** · Jan 2023 – Apr 2024
>
> *The later stretch has passed the earlier stretch's heaviest ez bar curl by 25 lb.*

The verdict needed fixing too — it said "Current training has passed…" in one branch and "the current stretch" in another, both equally wrong for these seven. The accent treatment on the right-hand column is also dropped, since it exists to mark the present.

The six current movements are untouched and still read Then / Now.

## Currency is measured against the log, not the clock

`isCurrentEra` compares an era's end against **the log's own most recent training day**. That's deliberate over `Date.now()`:

- Stable at render time, and testable without freezing time.
- A site left alone for a year doesn't declare its own history stale.
- It self-corrects **in both directions**. Resume dips and the era boundary relocates on its own — the 2024→2026 gap becomes the longest silence, so "Earlier" becomes the whole archive and "Later" becomes the new training, with the labels flipping back to Then / Now. Stop training shrugs for six months and it goes the other way. Nothing to maintain.

The threshold is the same 180 days that separates two eras in the first place — if a movement has been quiet long enough for the silence to divide eras, it isn't what the log is currently doing. One number, one meaning.

One known rough edge, not worth fixing: right after resuming a movement, "Now" is a single training day, so its median is thin. Honest, and it settles after a few sessions.

## Test plan

- [ ] `/training-facility/weight-room/exercises/ez-bar-curl` — "Two stretches", Earlier / Later, "Last trained Apr 2024", verdict says "The later stretch"
- [ ] `/training-facility/weight-room/exercises/shrugs` — still "Then vs now", Then / Now, "Current training has passed… by 10 lb", accent on the Now column
- [ ] `/exercises/dips` and `/exercises/back-extension` — also read as two stretches
- [ ] `/exercises/pullups` — bodyweight current movement, still Then / Now with the rep-volume verdict
- [ ] A movement with no long gap (e.g. `barbell-bench-press`) shows no panel at all
- [ ] No horizontal scroll on mobile

All green locally: 2,435 unit tests, 69 e2e, `tsc` clean, `next build` compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
