### PR TITLE
feat(weight-room): an all-time range for the History heatmaps (#438)

### DIFF
--- a/app/training-facility/weight-room/history/page.tsx
+++ b/app/training-facility/weight-room/history/page.tsx
@@ -11,6 +11,7 @@ import { FocusLaneHeatmap } from '@/components/training-facility/weight-room/Foc
 import { LoadManagementPanel } from '@/components/training-facility/weight-room/LoadManagementPanel'
 import { PastFocusCard } from '@/components/training-facility/weight-room/PastFocusCard'
 import { HeatmapSpanToggle } from '@/components/training-facility/weight-room/HeatmapSpanToggle'
+import { ScrollToEnd } from '@/components/training-facility/weight-room/ScrollToEnd'
 import { StrengthHeatmap } from '@/components/training-facility/weight-room/StrengthHeatmap'
 import { ExerciseStatCard } from '@/components/training-facility/weight-room/StrengthStats'
 import { StrengthVsBodyweightChart } from '@/components/training-facility/weight-room/StrengthVsBodyweightChart'
@@ -23,9 +24,9 @@ import { getCardioDataServer } from '@/lib/data/cardio-server'
 import { getWeightRoomDataServer } from '@/lib/data/weight-room-server'
 import { isWeightRoomEnabled } from '@/lib/feature-flags'
 import {
+  DEFAULT_HEATMAP_SPAN,
   HEATMAP_SPAN_PARAM,
-  heatmapCellMetrics,
-  heatmapWindowStart,
+  heatmapWindow,
   parseHeatmapSpan,
 } from '@/lib/training-facility/heatmap-span'
 import {
@@ -71,12 +72,16 @@ import type { ExerciseGoal } from '@/types/weight-room'
 const HISTORY_PATH = '/training-facility/weight-room/history'
 
 /**
- * Query params the filter chips must preserve when toggling. Only the
- * Training-Facility preview flag today — an allowlist rather than a
- * pass-through so a chip href can't be turned into an open redirect vector by
- * an arbitrary param riding along.
+ * Query params the filter chips must preserve when toggling — the
+ * Training-Facility preview flag and the heatmap range (#438). An allowlist
+ * rather than a pass-through, so a chip href can't be turned into an open
+ * redirect vector by an arbitrary param riding along.
+ *
+ * The range is *not* carried from here: it's re-emitted from the parsed value
+ * below, so a junk `?span=` normalizes away on first render instead of sticking
+ * to every subsequent href.
  */
-const CARRIED_PARAMS = [TRAINING_FACILITY_PREVIEW_PARAM, HEATMAP_SPAN_PARAM] as const
+const CARRIED_PARAMS = [TRAINING_FACILITY_PREVIEW_PARAM] as const
 
 export default async function WeightRoomHistoryPage({
   searchParams,
@@ -151,8 +156,7 @@ export default async function WeightRoomHistoryPage({
   // mostly for — but it renders the 2022-2024 archive as nothing at all, so
   // all-time is reachable rather than absent.
   const heatmapSpan = parseHeatmapSpan(params[HEATMAP_SPAN_PARAM])
-  const heatmapFrom = heatmapWindowStart(heatmapSpan, sets)
-  const heatmapCells = heatmapCellMetrics(heatmapSpan)
+  const heatmap = heatmapWindow(heatmapSpan, sets)
 
   const carryParams: Record<string, string> = {}
   for (const key of CARRIED_PARAMS) {
@@ -160,17 +164,21 @@ export default async function WeightRoomHistoryPage({
     const value = Array.isArray(raw) ? raw[0] : raw
     if (typeof value === 'string' && value !== '') carryParams[key] = value
   }
+  // Re-emitted from the parsed value, not copied from the URL, so `?span=junk`
+  // renders the default view *and* disappears from every href it feeds.
+  if (heatmapSpan !== DEFAULT_HEATMAP_SPAN) carryParams[HEATMAP_SPAN_PARAM] = heatmapSpan
 
-  // The span toggle additionally carries the exercise filter, which the chips'
+  // The range toggle additionally carries the exercise filter, which the chips'
   // own allowlist can't include — a chip href has to *rewrite* that param, not
   // preserve it. Copied raw rather than through the loop above because
   // `?exercises=` (present, empty) means "nothing selected" and is distinct
   // from absent (#367); dropping the empty string would reset the filter to
-  // everything on a span switch.
+  // everything on a range switch.
   const spanCarryParams: Record<string, string> = { ...carryParams }
   const rawExercises = params[EXERCISE_FILTER_PARAM]
   const exercisesParam = Array.isArray(rawExercises) ? rawExercises[0] : rawExercises
   if (typeof exercisesParam === 'string') spanCarryParams[EXERCISE_FILTER_PARAM] = exercisesParam
+
   // The catalog classifies each movement as load- or rep-driven from its
   // equipment (#384); without it the panel falls back to guessing from the
   // share of weighted sets.
@@ -315,17 +323,23 @@ export default async function WeightRoomHistoryPage({
               carryParams={carryParams}
             />
 
+            {/* Outside the heatmap section on purpose: nested inside it, emptying
+                the exercise filter took the range control away with the charts,
+                stranding a reader in the all-time view with no way back. */}
+            <div className="mt-6">
+              <HeatmapSpanToggle
+                span={heatmapSpan}
+                pathname={HISTORY_PATH}
+                carryParams={spanCarryParams}
+              />
+            </div>
+
             {visibleGoals.length > 0 ? (
               <section
                 aria-label="Per-exercise heatmaps"
                 data-testid="weight-room-heatmaps"
-                className="mt-10 space-y-8"
+                className="mt-6 space-y-8"
               >
-                <HeatmapSpanToggle
-                  span={heatmapSpan}
-                  pathname={HISTORY_PATH}
-                  carryParams={spanCarryParams}
-                />
                 {visibleGoals.map(goal => (
                   <article
                     key={goal.exercise}
@@ -342,15 +356,19 @@ export default async function WeightRoomHistoryPage({
                         goal {goal.daily_target}/day
                       </span>
                     </header>
-                    <div className="overflow-x-auto">
+                    <ScrollToEnd
+                      className="overflow-x-auto"
+                      enabled={heatmap.dateFrom !== null}
+                      label={`${exerciseLabel(goal)} heatmap, scrollable`}
+                    >
                       <StrengthHeatmap
                         sets={sets}
                         goal={goal}
-                        dateFrom={heatmapFrom}
-                        cellSize={heatmapCells.cellSize}
-                        cellGap={heatmapCells.cellGap}
+                        dateFrom={heatmap.dateFrom}
+                        cellSize={heatmap.cellSize}
+                        cellGap={heatmap.cellGap}
                       />
-                    </div>
+                    </ScrollToEnd>
                     <div className="mt-5 border-t border-white/10 pt-4">
                       <p className="mb-2 font-mono text-[10px] uppercase tracking-[0.22em] text-[#e8d5be]/60">
                         Weekly volume · last 12 weeks

--- a/app/training-facility/weight-room/history/page.tsx
+++ b/app/training-facility/weight-room/history/page.tsx
@@ -10,6 +10,7 @@ import { exerciseTrendHref } from '@/components/training-facility/weight-room/Ex
 import { FocusLaneHeatmap } from '@/components/training-facility/weight-room/FocusLaneHeatmap'
 import { LoadManagementPanel } from '@/components/training-facility/weight-room/LoadManagementPanel'
 import { PastFocusCard } from '@/components/training-facility/weight-room/PastFocusCard'
+import { HeatmapSpanToggle } from '@/components/training-facility/weight-room/HeatmapSpanToggle'
 import { StrengthHeatmap } from '@/components/training-facility/weight-room/StrengthHeatmap'
 import { ExerciseStatCard } from '@/components/training-facility/weight-room/StrengthStats'
 import { StrengthVsBodyweightChart } from '@/components/training-facility/weight-room/StrengthVsBodyweightChart'
@@ -21,6 +22,12 @@ import { isAdminRequest } from '@/lib/auth/admin-session'
 import { getCardioDataServer } from '@/lib/data/cardio-server'
 import { getWeightRoomDataServer } from '@/lib/data/weight-room-server'
 import { isWeightRoomEnabled } from '@/lib/feature-flags'
+import {
+  HEATMAP_SPAN_PARAM,
+  heatmapCellMetrics,
+  heatmapWindowStart,
+  parseHeatmapSpan,
+} from '@/lib/training-facility/heatmap-span'
 import {
   EXERCISE_FILTER_PARAM,
   parseExerciseSelection,
@@ -69,7 +76,7 @@ const HISTORY_PATH = '/training-facility/weight-room/history'
  * pass-through so a chip href can't be turned into an open redirect vector by
  * an arbitrary param riding along.
  */
-const CARRIED_PARAMS = [TRAINING_FACILITY_PREVIEW_PARAM] as const
+const CARRIED_PARAMS = [TRAINING_FACILITY_PREVIEW_PARAM, HEATMAP_SPAN_PARAM] as const
 
 export default async function WeightRoomHistoryPage({
   searchParams,
@@ -139,12 +146,31 @@ export default async function WeightRoomHistoryPage({
   const visibleGoals = permanentGoals.filter(g => selectedSet.has(g.exercise))
   const visibleStats = stats.filter(s => selectedSet.has(s.exercise))
 
+  // How much history the heatmaps draw (#438). The trailing year stays the
+  // default — it answers "how am I doing lately", which is what the page is
+  // mostly for — but it renders the 2022-2024 archive as nothing at all, so
+  // all-time is reachable rather than absent.
+  const heatmapSpan = parseHeatmapSpan(params[HEATMAP_SPAN_PARAM])
+  const heatmapFrom = heatmapWindowStart(heatmapSpan, sets)
+  const heatmapCells = heatmapCellMetrics(heatmapSpan)
+
   const carryParams: Record<string, string> = {}
   for (const key of CARRIED_PARAMS) {
     const raw = params[key]
     const value = Array.isArray(raw) ? raw[0] : raw
     if (typeof value === 'string' && value !== '') carryParams[key] = value
   }
+
+  // The span toggle additionally carries the exercise filter, which the chips'
+  // own allowlist can't include — a chip href has to *rewrite* that param, not
+  // preserve it. Copied raw rather than through the loop above because
+  // `?exercises=` (present, empty) means "nothing selected" and is distinct
+  // from absent (#367); dropping the empty string would reset the filter to
+  // everything on a span switch.
+  const spanCarryParams: Record<string, string> = { ...carryParams }
+  const rawExercises = params[EXERCISE_FILTER_PARAM]
+  const exercisesParam = Array.isArray(rawExercises) ? rawExercises[0] : rawExercises
+  if (typeof exercisesParam === 'string') spanCarryParams[EXERCISE_FILTER_PARAM] = exercisesParam
   // The catalog classifies each movement as load- or rep-driven from its
   // equipment (#384); without it the panel falls back to guessing from the
   // share of weighted sets.
@@ -295,6 +321,11 @@ export default async function WeightRoomHistoryPage({
                 data-testid="weight-room-heatmaps"
                 className="mt-10 space-y-8"
               >
+                <HeatmapSpanToggle
+                  span={heatmapSpan}
+                  pathname={HISTORY_PATH}
+                  carryParams={spanCarryParams}
+                />
                 {visibleGoals.map(goal => (
                   <article
                     key={goal.exercise}
@@ -312,7 +343,13 @@ export default async function WeightRoomHistoryPage({
                       </span>
                     </header>
                     <div className="overflow-x-auto">
-                      <StrengthHeatmap sets={sets} goal={goal} />
+                      <StrengthHeatmap
+                        sets={sets}
+                        goal={goal}
+                        dateFrom={heatmapFrom}
+                        cellSize={heatmapCells.cellSize}
+                        cellGap={heatmapCells.cellGap}
+                      />
                     </div>
                     <div className="mt-5 border-t border-white/10 pt-4">
                       <p className="mb-2 font-mono text-[10px] uppercase tracking-[0.22em] text-[#e8d5be]/60">

--- a/components/training-facility/weight-room/ExerciseFilterChips.tsx
+++ b/components/training-facility/weight-room/ExerciseFilterChips.tsx
@@ -6,6 +6,9 @@ import {
   serializeExerciseSelection,
   toggleExercise,
 } from '@/lib/training-facility/exercise-filter'
+import { buildFilterHref } from '@/lib/training-facility/filter-href'
+
+import { CHIP_BASE_CLASS, CHIP_INACTIVE_CLASS } from './chip-class'
 
 /** One selectable exercise, in render order. */
 export interface FilterableExercise {
@@ -94,10 +97,8 @@ export function ExerciseFilterChips({
               data-testid={`exercise-chip-${exercise}`}
               data-selected={isOn}
               aria-label={`${isOn ? 'Hide' : 'Show'} ${displayName ?? exercise}`}
-              className={`rounded-full border px-3 py-1 font-mono text-[11px] tracking-[0.12em] transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-300 ${
-                isOn
-                  ? 'border-transparent text-[#0a0a0a]'
-                  : 'border-white/20 text-white/45 hover:text-white/70'
+              className={`${CHIP_BASE_CLASS} ${
+                isOn ? 'border-transparent text-[#0a0a0a]' : CHIP_INACTIVE_CLASS
               }`}
               style={isOn ? { backgroundColor: color } : undefined}
             >
@@ -134,8 +135,5 @@ function buildHref(
   pathname: string,
   carryParams: Readonly<Record<string, string>>
 ): string {
-  const params = new URLSearchParams(carryParams)
-  if (encoded !== null) params.set(EXERCISE_FILTER_PARAM, encoded)
-  const query = params.toString()
-  return query === '' ? pathname : `${pathname}?${query}`
+  return buildFilterHref(pathname, { ...carryParams, [EXERCISE_FILTER_PARAM]: encoded })
 }

--- a/components/training-facility/weight-room/HeatmapSpanToggle.tsx
+++ b/components/training-facility/weight-room/HeatmapSpanToggle.tsx
@@ -1,0 +1,102 @@
+import type { JSX } from 'react'
+import Link from 'next/link'
+
+import {
+  DEFAULT_HEATMAP_SPAN,
+  HEATMAP_SPAN_PARAM,
+  type HeatmapSpan,
+} from '@/lib/training-facility/heatmap-span'
+
+/** Props for {@link HeatmapSpanToggle}. */
+export interface HeatmapSpanToggleProps {
+  /** The span currently drawn. */
+  span: HeatmapSpan
+  /** Route the links point back to, e.g. `/training-facility/weight-room/history`. */
+  pathname: string
+  /**
+   * Other search params to preserve, so switching range doesn't silently drop
+   * the exercise filter or a preview tour.
+   */
+  carryParams?: Readonly<Record<string, string>>
+}
+
+/** The two spans, in display order. */
+const OPTIONS: readonly { value: HeatmapSpan; label: string }[] = [
+  { value: 'year', label: 'Last 12 months' },
+  { value: 'all', label: 'All time' },
+]
+
+/**
+ * Switch the History heatmaps between a trailing year and the whole log (#438).
+ *
+ * Links rather than buttons, and resolved on the server like the exercise
+ * filter beside it: the route is already dynamic, so a *linked* all-time view
+ * paints correctly on first byte with no flash of the trailing year and no
+ * dependence on JS having loaded.
+ *
+ * A Server Component.
+ */
+export function HeatmapSpanToggle({
+  span,
+  pathname,
+  carryParams = {},
+}: HeatmapSpanToggleProps): JSX.Element {
+  return (
+    <div className="flex flex-wrap items-center gap-2" data-testid="heatmap-span-toggle">
+      <span
+        id="heatmap-span-label"
+        className="font-mono text-[10px] uppercase tracking-[0.28em] text-amber-300/70"
+      >
+        Range
+      </span>
+      <nav aria-labelledby="heatmap-span-label" className="flex flex-wrap gap-2">
+        {OPTIONS.map(({ value, label }) => {
+          const isOn = value === span
+          return (
+            <Link
+              key={value}
+              href={buildHref(value, pathname, carryParams)}
+              scroll={false}
+              data-testid={`heatmap-span-${value}`}
+              data-selected={isOn}
+              aria-current={isOn ? 'true' : undefined}
+              className={`rounded-full border px-3 py-1 font-mono text-[11px] tracking-[0.12em] transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-300 ${
+                isOn
+                  ? 'border-amber-300/50 bg-amber-300/15 text-amber-100'
+                  : 'border-white/20 text-white/45 hover:text-white/70'
+              }`}
+            >
+              {label}
+            </Link>
+          )
+        })}
+      </nav>
+    </div>
+  )
+}
+
+/**
+ * Compose the href that switches to `span`.
+ *
+ * An absolute `pathname` rather than a bare `?query`: Next's `<Link>` does not
+ * resolve a query-only relative href against the current route, so the chips
+ * beside this render one too.
+ *
+ * @param span The range this link switches to.
+ * @param pathname Route to link to.
+ * @param carryParams Unrelated params to preserve.
+ * @returns A route-relative URL; the default range is spelled as the *absence*
+ *   of the param, so the canonical view keeps a clean URL and a link shared
+ *   without one lands where a reader starts.
+ */
+function buildHref(
+  span: HeatmapSpan,
+  pathname: string,
+  carryParams: Readonly<Record<string, string>>
+): string {
+  const params = new URLSearchParams(carryParams)
+  if (span === DEFAULT_HEATMAP_SPAN) params.delete(HEATMAP_SPAN_PARAM)
+  else params.set(HEATMAP_SPAN_PARAM, span)
+  const query = params.toString()
+  return query === '' ? pathname : `${pathname}?${query}`
+}

--- a/components/training-facility/weight-room/HeatmapSpanToggle.tsx
+++ b/components/training-facility/weight-room/HeatmapSpanToggle.tsx
@@ -1,11 +1,14 @@
 import type { JSX } from 'react'
 import Link from 'next/link'
 
+import { buildFilterHref } from '@/lib/training-facility/filter-href'
 import {
   DEFAULT_HEATMAP_SPAN,
   HEATMAP_SPAN_PARAM,
   type HeatmapSpan,
 } from '@/lib/training-facility/heatmap-span'
+
+import { CHIP_BASE_CLASS, CHIP_INACTIVE_CLASS } from './chip-class'
 
 /** Props for {@link HeatmapSpanToggle}. */
 export interface HeatmapSpanToggleProps {
@@ -55,15 +58,13 @@ export function HeatmapSpanToggle({
           return (
             <Link
               key={value}
-              href={buildHref(value, pathname, carryParams)}
+              href={hrefFor(value, pathname, carryParams)}
               scroll={false}
               data-testid={`heatmap-span-${value}`}
               data-selected={isOn}
               aria-current={isOn ? 'true' : undefined}
-              className={`rounded-full border px-3 py-1 font-mono text-[11px] tracking-[0.12em] transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-300 ${
-                isOn
-                  ? 'border-amber-300/50 bg-amber-300/15 text-amber-100'
-                  : 'border-white/20 text-white/45 hover:text-white/70'
+              className={`${CHIP_BASE_CLASS} ${
+                isOn ? 'border-amber-300/50 bg-amber-300/15 text-amber-100' : CHIP_INACTIVE_CLASS
               }`}
             >
               {label}
@@ -78,25 +79,18 @@ export function HeatmapSpanToggle({
 /**
  * Compose the href that switches to `span`.
  *
- * An absolute `pathname` rather than a bare `?query`: Next's `<Link>` does not
- * resolve a query-only relative href against the current route, so the chips
- * beside this render one too.
- *
  * @param span The range this link switches to.
  * @param pathname Route to link to.
  * @param carryParams Unrelated params to preserve.
- * @returns A route-relative URL; the default range is spelled as the *absence*
- *   of the param, so the canonical view keeps a clean URL and a link shared
- *   without one lands where a reader starts.
  */
-function buildHref(
+function hrefFor(
   span: HeatmapSpan,
   pathname: string,
   carryParams: Readonly<Record<string, string>>
 ): string {
-  const params = new URLSearchParams(carryParams)
-  if (span === DEFAULT_HEATMAP_SPAN) params.delete(HEATMAP_SPAN_PARAM)
-  else params.set(HEATMAP_SPAN_PARAM, span)
-  const query = params.toString()
-  return query === '' ? pathname : `${pathname}?${query}`
+  return buildFilterHref(pathname, {
+    ...carryParams,
+    // `null` removes it: the default range is spelled as the param's absence.
+    [HEATMAP_SPAN_PARAM]: span === DEFAULT_HEATMAP_SPAN ? null : span,
+  })
 }

--- a/components/training-facility/weight-room/ScrollToEnd.tsx
+++ b/components/training-facility/weight-room/ScrollToEnd.tsx
@@ -1,0 +1,67 @@
+'use client'
+
+import { useEffect, useRef, type JSX, type ReactNode } from 'react'
+
+/** Props for {@link ScrollToEnd}. */
+export interface ScrollToEndProps {
+  /** Content to scroll; usually a chart wider than the container. */
+  children: ReactNode
+  /**
+   * Whether to jump to the right edge. `false` leaves the container at its
+   * natural left-aligned start, which is correct whenever the content fits.
+   */
+  enabled: boolean
+  /** Classes for the scroll container itself. */
+  className?: string
+  /** Accessible label, since a scrollable region is focusable. */
+  label?: string
+}
+
+/**
+ * A horizontal scroller that opens at its **right** edge (#438).
+ *
+ * The all-time heatmap is ~1,400px inside a ~900px column, and a scroller
+ * starts at `scrollLeft: 0` — so switching to All time landed every chart on
+ * 2022 with the current week off the right edge. For a movement whose archive
+ * is sparse (squats has a single 2022 cell) that opens on a blank grid, which
+ * reads as "the all-time view is broken" — the very misperception the range was
+ * added to correct.
+ *
+ * Anchoring right keeps the invariant the trailing-year view had for free:
+ * today is always on screen, and the history extends back to the left.
+ *
+ * Client-only, and deliberately the *only* client code in this feature — the
+ * range itself resolves on the server. Without JS the container simply stays
+ * left-aligned and scrollable by hand, which is the pre-existing behavior
+ * rather than a broken one.
+ */
+export function ScrollToEnd({
+  children,
+  enabled,
+  className,
+  label,
+}: ScrollToEndProps): JSX.Element {
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const el = ref.current
+    if (el === null || !enabled) return
+    // Jump, not smooth-scroll: this is the initial position, and animating it
+    // would read as the page drifting on load.
+    el.scrollLeft = el.scrollWidth
+  }, [enabled])
+
+  return (
+    <div
+      ref={ref}
+      className={className}
+      // A scrollable region needs to be reachable and named for keyboard and
+      // screen-reader users; without JS it is still both.
+      tabIndex={enabled ? 0 : undefined}
+      role={enabled ? 'region' : undefined}
+      aria-label={enabled ? label : undefined}
+    >
+      {children}
+    </div>
+  )
+}

--- a/components/training-facility/weight-room/chip-class.ts
+++ b/components/training-facility/weight-room/chip-class.ts
@@ -1,0 +1,16 @@
+/**
+ * Shared pill styling for the History view's filter controls (#438).
+ *
+ * The exercise chips and the heatmap range toggle render side by side, so a
+ * focus ring or padding tweak applied to one and not the other is visible on
+ * the same row. The *active* treatment deliberately stays with each control —
+ * chips tint with the exercise's own colour, the range toggle uses the page's
+ * amber accent — because that difference is the point, not drift.
+ */
+
+/** Shape, type, spacing, and focus ring shared by every filter pill. */
+export const CHIP_BASE_CLASS =
+  'rounded-full border px-3 py-1 font-mono text-[11px] tracking-[0.12em] transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-300'
+
+/** The unselected treatment, identical across both controls. */
+export const CHIP_INACTIVE_CLASS = 'border-white/20 text-white/45 hover:text-white/70'

--- a/e2e/chart-overflow.spec.ts
+++ b/e2e/chart-overflow.spec.ts
@@ -74,22 +74,34 @@ test.describe('chart overflow behaviour', () => {
     expect(doc.scrollWidth).toBeLessThanOrEqual(doc.clientWidth + 1)
   })
 
-  test('the all-time heatmap range does not widen the document either', async ({ page }) => {
-    // `?span=all` (#438) is the widest thing this page can draw — on real data
-    // a ~1,400px grid inside a ~900px column. It's *meant* to scroll inside its
-    // card; the document must still not move.
+  test('the all-time range never renders smaller than the default (#438)', async ({ page }) => {
+    // Two full renders of the slowest route on the site, one of them all-time.
+    test.slow()
+    // The bug: the window start came from the data while the cell size came
+    // from the span *name*, so on a log shorter than a year "All time" drew a
+    // two-column sliver of 6px cells — narrower and less legible than the view
+    // it replaced, and narrow enough to clip the legend out of the SVG.
     //
-    // The demo fixture spans a couple of weeks, so this can't assert the grid
-    // actually overflows — but the invariant it does check is the one that
-    // breaks if the toggle's markup ever escapes the scroll container.
-    await page.goto('/training-facility/weight-room/history?preview=demo&span=all')
-    await expect(page.getByTestId('weight-room-heatmaps')).toBeVisible()
+    // Width, not equality, and not height: all-time is deliberately *shorter*
+    // (seven rows of 6px beats seven of 14px) while being much wider. Width is
+    // the axis the range actually widens, and "never narrower" is the one claim
+    // that holds in both environments — CI renders the ~9-day demo fixture,
+    // where all-time correctly collapses to the default, while a credentialed
+    // local run renders four real years.
+    const widthOf = async (url: string): Promise<number> => {
+      await page.goto(url)
+      await expect(page.getByTestId('weight-room-heatmaps')).toBeVisible()
+      return page
+        .getByRole('img', { name: 'Pushups heatmap' })
+        .evaluate(svg => Number(svg.getAttribute('width')))
+    }
 
-    const doc = await page.evaluate(() => ({
-      scrollWidth: document.documentElement.scrollWidth,
-      clientWidth: document.documentElement.clientWidth,
-    }))
-    expect(doc.scrollWidth).toBeLessThanOrEqual(doc.clientWidth + 1)
+    const base = '/training-facility/weight-room/history?preview=demo'
+    const year = await widthOf(base)
+    const all = await widthOf(`${base}&span=all`)
+
+    expect(year).toBeGreaterThan(0)
+    expect(all).toBeGreaterThanOrEqual(year)
   })
 
   test('the per-exercise trend keeps its charts inside the page', async ({ page }) => {
@@ -102,6 +114,11 @@ test.describe('chart overflow behaviour', () => {
     // fixture, while a local run has real credentials — which *suppresses* the
     // fixture — and has to find real pull-up sets instead. A demo-only movement
     // renders the empty state locally and the assertion never runs.
+    //
+    // Slow for the same reason: on real data this route's render was already
+    // near the default budget, and the all-time cases added alongside it (#438)
+    // compete for the same dev server.
+    test.slow()
     await page.goto('/training-facility/weight-room/exercises/pullups?preview=demo')
     await expect(page.getByTestId('exercise-progression-pullups')).toBeVisible()
 

--- a/e2e/chart-overflow.spec.ts
+++ b/e2e/chart-overflow.spec.ts
@@ -74,6 +74,24 @@ test.describe('chart overflow behaviour', () => {
     expect(doc.scrollWidth).toBeLessThanOrEqual(doc.clientWidth + 1)
   })
 
+  test('the all-time heatmap range does not widen the document either', async ({ page }) => {
+    // `?span=all` (#438) is the widest thing this page can draw — on real data
+    // a ~1,400px grid inside a ~900px column. It's *meant* to scroll inside its
+    // card; the document must still not move.
+    //
+    // The demo fixture spans a couple of weeks, so this can't assert the grid
+    // actually overflows — but the invariant it does check is the one that
+    // breaks if the toggle's markup ever escapes the scroll container.
+    await page.goto('/training-facility/weight-room/history?preview=demo&span=all')
+    await expect(page.getByTestId('weight-room-heatmaps')).toBeVisible()
+
+    const doc = await page.evaluate(() => ({
+      scrollWidth: document.documentElement.scrollWidth,
+      clientWidth: document.documentElement.clientWidth,
+    }))
+    expect(doc.scrollWidth).toBeLessThanOrEqual(doc.clientWidth + 1)
+  })
+
   test('the per-exercise trend keeps its charts inside the page', async ({ page }) => {
     // The trend panels (#412) are fixed-width SVGs — 760px, wider than a phone —
     // so they carry the same two obligations: scroll inside their own card, and

--- a/e2e/heatmap-span.spec.ts
+++ b/e2e/heatmap-span.spec.ts
@@ -59,6 +59,16 @@ test.describe('heatmap range toggle', () => {
     await expect(toggle.getByTestId('heatmap-span-year')).not.toHaveAttribute('href', /span=/)
   })
 
+  test('the range control survives an empty exercise filter', async ({ page }) => {
+    // It used to live inside the heatmap section, so deselecting everything
+    // took away the only way back out of the all-time view.
+    await page.goto(`${HISTORY}?preview=demo&exercises=&span=all`)
+
+    await expect(page.getByTestId('weight-room-heatmaps')).toHaveCount(0)
+    await expect(page.getByTestId('heatmap-span-toggle')).toBeVisible()
+    await expect(page.getByTestId('heatmap-span-year')).toHaveAttribute('href', /exercises=/)
+  })
+
   test('the exercise chips carry the range back', async ({ page }) => {
     await page.goto(`${HISTORY}?preview=demo&span=all`)
 

--- a/e2e/heatmap-span.spec.ts
+++ b/e2e/heatmap-span.spec.ts
@@ -1,0 +1,84 @@
+import { expect, test } from '@playwright/test'
+
+/**
+ * Pins the History view's heatmap range toggle (#438).
+ *
+ * The toggle is a pair of server-resolved links, so the contract worth
+ * defending is the URL: switching range must carry the exercise filter across,
+ * and the filter chips must carry the range back. Get either wrong and the two
+ * controls silently reset each other — which reads as the page losing your
+ * place rather than as a bug.
+ *
+ * Most of that is asserted on the rendered `href`s rather than by clicking.
+ * This route is the slowest on the site against real data, and a soft
+ * navigation doesn't move the address bar until the RSC payload lands — so a
+ * click-per-assertion spec spends a minute proving something the markup already
+ * states, and flakes under parallel workers while doing it. One test does
+ * navigate, because an href can look correct and still not resolve.
+ *
+ * Deliberately *not* asserted here: how wide the all-time grid draws. CI has no
+ * Supabase credentials and falls through to `?preview=demo`, whose fixture is a
+ * couple of weeks of days — so an all-time window there is narrower than the
+ * trailing year, and any width assertion would pass by measuring the opposite
+ * of the real case. The span arithmetic is unit-tested against a 2022 start in
+ * `lib/training-facility/heatmap-span.test.ts` instead, and the one width claim
+ * the fixture *can* support — that the document never widens — lives with the
+ * rest of that invariant in `chart-overflow.spec.ts`, which also runs on phone
+ * WebKit.
+ */
+
+const HISTORY = '/training-facility/weight-room/history'
+
+/**
+ * Budget for the one assertion that waits on a navigation.
+ *
+ * `test.slow()` raises the *test* timeout but not `expect`'s, which defaults to
+ * 5s — nowhere near a cold all-time render on a dev server under parallel
+ * workers. Both have to be raised or the test passes alone and fails in the
+ * suite, which reads as a broken link rather than a slow one.
+ */
+const NAV_TIMEOUT = 60_000
+
+test.describe('heatmap range toggle', () => {
+  test('the range links carry the exercise filter', async ({ page }) => {
+    await page.goto(`${HISTORY}?preview=demo&exercises=pullups`)
+
+    const toggle = page.getByTestId('heatmap-span-toggle')
+    await expect(toggle).toBeVisible()
+
+    // All time adds the param; the trailing year spells itself as the param's
+    // absence, so the default view keeps a clean, shareable URL.
+    await expect(toggle.getByTestId('heatmap-span-all')).toHaveAttribute(
+      'href',
+      /exercises=pullups.*span=all|span=all.*exercises=pullups/
+    )
+    await expect(toggle.getByTestId('heatmap-span-year')).toHaveAttribute(
+      'href',
+      /exercises=pullups/
+    )
+    await expect(toggle.getByTestId('heatmap-span-year')).not.toHaveAttribute('href', /span=/)
+  })
+
+  test('the exercise chips carry the range back', async ({ page }) => {
+    await page.goto(`${HISTORY}?preview=demo&span=all`)
+
+    const chip = page.getByTestId('exercise-chip-pullups')
+    await expect(chip).toBeVisible()
+    await expect(chip).toHaveAttribute('href', /span=all/)
+  })
+
+  test('following the all-time link lands on the all-time view', async ({ page }) => {
+    // The one navigation in this spec. An href can read correctly and still not
+    // resolve — a query-only `?span=all` looks right in the markup but Next's
+    // <Link> won't resolve it against the current route, and only a real click
+    // catches that.
+    test.slow() // Slowest route on the site; the RSC render dominates.
+    await page.goto(`${HISTORY}?preview=demo`)
+
+    await page.getByTestId('heatmap-span-all').click()
+
+    await expect(page).toHaveURL(/span=all/, { timeout: NAV_TIMEOUT })
+    await expect(page.getByTestId('weight-room-heatmaps')).toBeVisible()
+    await expect(page.getByTestId('heatmap-span-all')).toHaveAttribute('data-selected', 'true')
+  })
+})

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -121,6 +121,7 @@ const eslintConfig = [
     files: [
       'lib/training-facility/achievements.ts',
       'lib/training-facility/exercise-progression.ts',
+      'lib/training-facility/heatmap-span.ts',
       'lib/training-facility/load-management.ts',
       'lib/training-facility/monthly-focus.ts',
       'lib/training-facility/strength-streaks.ts',

--- a/lib/training-facility/clock-threading.test.ts
+++ b/lib/training-facility/clock-threading.test.ts
@@ -29,6 +29,7 @@ import {
   localNoonIsoForDay,
   toLocalDateKey,
 } from './strength-today'
+import { firstLoggedDate, heatmapWindow } from './heatmap-span'
 import {
   buildStrengthHeatmap,
   buildWeeklyVolume,
@@ -86,6 +87,11 @@ const SPLIT_LATE = '2026-07-14T12:00:00Z'
 const WEEK_STRADDLE = '2026-07-12T12:00:00Z'
 /** Pacific Dec 31 2026 · Kiritimati Jan 1 2027. */
 const YEAR_STRADDLE = '2026-12-31T12:00:00Z'
+/**
+ * Pacific Mar 3 2022 · Kiritimati Mar 4 2022 — and old enough to be outside
+ * the heatmaps' default trailing-year window (#438).
+ */
+const ARCHIVE_STRADDLE = '2022-03-04T05:00:00Z'
 /** "Now", late enough that every fixture day has elapsed in both zones. */
 const NOW = new Date('2026-07-16T20:00:00Z')
 
@@ -196,6 +202,23 @@ describe('every zone-consuming entry point honors its clock', () => {
         .filter(cell => cell.reps > 0)
         .map(cell => `${cell.dayKey}:${cell.reps}`)
     )
+  })
+
+  it('heatmapWindow', () => {
+    // The all-time start is a day bucket like any other (#438): read in the
+    // wrong zone it lands a day early, and the grid's first column with it.
+    //
+    // Needs a set older than the default window, or `heatmapWindow` correctly
+    // returns the component default for both zones and the comparison is
+    // vacuous — the archive is the whole point of the branch under test.
+    const archived = [...SETS, set({ id: 'archive', logged_at: ARCHIVE_STRADDLE, reps: 20 })]
+    dependsOnZone(
+      clock => heatmapWindow('all', archived, clock, NOW).dateFrom?.toISOString() ?? null
+    )
+  })
+
+  it('firstLoggedDate', () => {
+    dependsOnZone(clock => firstLoggedDate(SETS, clock)?.toISOString() ?? null)
   })
 
   it('computeStrengthStats', () => {

--- a/lib/training-facility/filter-href.test.ts
+++ b/lib/training-facility/filter-href.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Tests for the shared filter-href builder (#438).
+ *
+ * The rule that matters is `null` meaning *remove*, not "write empty" — the
+ * exercise filter distinguishes `?exercises=` (nothing selected) from an absent
+ * param (everything selected), so conflating the two silently resets a filter.
+ */
+import { describe, expect, it } from 'vitest'
+
+import { buildFilterHref } from './filter-href'
+
+const PATH = '/training-facility/weight-room/history'
+
+describe('buildFilterHref', () => {
+  it('returns a bare pathname when nothing survives', () => {
+    expect(buildFilterHref(PATH, { span: null })).toBe(PATH)
+    expect(buildFilterHref(PATH, {})).toBe(PATH)
+  })
+
+  it('links an absolute pathname, not a query-only relative href', () => {
+    // Next's <Link> does not resolve `?span=all` against the current route.
+    expect(buildFilterHref(PATH, { span: 'all' })).toBe(`${PATH}?span=all`)
+  })
+
+  it('drops null params and keeps empty-string ones', () => {
+    // Present-but-empty is a meaningful state for the exercise filter.
+    expect(buildFilterHref(PATH, { exercises: '', span: null })).toBe(`${PATH}?exercises=`)
+  })
+
+  it('encodes values that need it', () => {
+    expect(buildFilterHref(PATH, { exercises: 'pullups,squats' })).toBe(
+      `${PATH}?exercises=pullups%2Csquats`
+    )
+  })
+
+  it('preserves carried params alongside the one being written', () => {
+    const href = buildFilterHref(PATH, { preview: 'demo', span: 'all' })
+    expect(href).toContain('preview=demo')
+    expect(href).toContain('span=all')
+  })
+})

--- a/lib/training-facility/filter-href.ts
+++ b/lib/training-facility/filter-href.ts
@@ -1,0 +1,31 @@
+/**
+ * Shared href construction for the History view's URL-state controls (#438).
+ *
+ * The exercise chips and the heatmap range toggle sit next to each other and
+ * both encode their state as search params, both carry the *other's* params
+ * through, and both spell their default as the param's absence. Written twice
+ * they drifted immediately — the second copy went in with a query-only `?…`
+ * href that Next's `<Link>` doesn't resolve against the current route, a bug
+ * the first copy had already avoided by linking an absolute pathname.
+ */
+
+/**
+ * Compose a route-relative href from a pathname and a set of params.
+ *
+ * @param pathname Route to link to, e.g. `/training-facility/weight-room/history`.
+ * @param params Params to write. A `null` value **removes** the param, which is
+ *   how a default is spelled — it keeps the canonical URL clean and means a
+ *   link shared without the param lands where a reader starts.
+ * @returns The pathname alone when no params survive, otherwise `path?query`.
+ */
+export function buildFilterHref(
+  pathname: string,
+  params: Readonly<Record<string, string | null>>
+): string {
+  const search = new URLSearchParams()
+  for (const [key, value] of Object.entries(params)) {
+    if (value !== null) search.set(key, value)
+  }
+  const query = search.toString()
+  return query === '' ? pathname : `${pathname}?${query}`
+}

--- a/lib/training-facility/heatmap-labels.test.ts
+++ b/lib/training-facility/heatmap-labels.test.ts
@@ -109,6 +109,39 @@ describe('thinMonthLabels', () => {
     }
   })
 
+  it('never thins away a pinned label, even against a wider month', () => {
+    // A pinned marker is the only thing carrying a year on a multi-year grid
+    // (#438), so losing it to the ordinary wider-month rule leaves four
+    // indistinguishable Jan-Dec runs.
+    const labels: HeatmapMonthLabel[] = [
+      { col: 0, label: 'Dec' },
+      { col: 1, label: "Jan '23", pinned: true },
+      { col: 2, label: 'Feb' },
+      { col: 20, label: 'Mar' },
+    ]
+    const kept = thinMonthLabels(labels, { cellSize: 6, totalCols: 40 })
+    expect(kept.map(k => k.label)).toContain("Jan '23")
+  })
+
+  it('lets a pinned label displace the neighbour it collides with', () => {
+    const labels: HeatmapMonthLabel[] = [
+      { col: 0, label: 'Dec' },
+      { col: 1, label: "Jan '23", pinned: true },
+    ]
+    const kept = thinMonthLabels(labels, { cellSize: 6, totalCols: 40 })
+    expect(kept).toEqual([{ col: 1, label: "Jan '23", pinned: true }])
+  })
+
+  it('does not let an unpinned label displace a pinned one', () => {
+    const labels: HeatmapMonthLabel[] = [
+      { col: 0, label: "Jan '23", pinned: true },
+      // Wider month, which would normally win the collision.
+      { col: 1, label: 'Feb' },
+    ]
+    const kept = thinMonthLabels(labels, { cellSize: 6, totalCols: 40 })
+    expect(kept).toEqual([{ col: 0, label: "Jan '23", pinned: true }])
+  })
+
   it('preserves ascending column order', () => {
     const labels: HeatmapMonthLabel[] = [
       { col: 0, label: 'Jun' },

--- a/lib/training-facility/heatmap-labels.ts
+++ b/lib/training-facility/heatmap-labels.ts
@@ -15,8 +15,15 @@
 export interface HeatmapMonthLabel {
   /** Zero-based grid column the label is drawn above. */
   col: number
-  /** Short month name, e.g. `"Jul"`. */
+  /** Short month name, e.g. `"Jul"` — or `"Jan '23"` where a year begins. */
   label: string
+  /**
+   * Never thin this label away (#438). Set on the markers that carry a year on
+   * a multi-year grid: bare month names repeat every twelve columns-worth, so
+   * an all-time grid whose year markers got thinned is four indistinguishable
+   * Jan–Dec runs, and the range exists precisely to tell 2022 from 2025.
+   */
+  pinned?: boolean
 }
 
 /** Options for {@link thinMonthLabels}. */
@@ -72,6 +79,11 @@ export function estimateTextWidth(text: string, fontSize: number): number {
  * rotation `Jul`, not `Jun`. Keeping the earlier marker unconditionally
  * would name the whole chart after its first three days.
  *
+ * A {@link HeatmapMonthLabel.pinned} marker is exempt: it wins every collision
+ * and is never dropped, because on a multi-year grid it is the only thing
+ * carrying a year. Pinned markers are twelve months apart, so they cannot
+ * collide with each other.
+ *
  * @param labels Month markers in ascending column order.
  * @returns The subset to render, in the same order.
  */
@@ -95,9 +107,17 @@ export function thinMonthLabels(
       continue
     }
 
-    // Colliding: swap in the wider month, or drop this one. A replacement
-    // only ever moves the label right, and `prev` already cleared the entry
-    // before it, so the swap cannot re-collide further left.
+    // Colliding. A pinned marker displaces whatever it lands on, and nothing
+    // displaces a pinned marker — otherwise the year vanishes from the axis.
+    if (prev.label.pinned === true) continue
+    if (entry.label.pinned === true) {
+      kept[kept.length - 1] = entry
+      continue
+    }
+
+    // Otherwise the wider month wins. A replacement only ever moves the label
+    // right, and `prev` already cleared the entry before it, so the swap cannot
+    // re-collide further left.
     if (entry.span > prev.span) kept[kept.length - 1] = entry
   }
 

--- a/lib/training-facility/heatmap-span.test.ts
+++ b/lib/training-facility/heatmap-span.test.ts
@@ -1,11 +1,14 @@
 /**
- * Tests for the History view's heatmap span (#438).
+ * Tests for the History view's heatmap range (#438).
  *
  * The heatmaps drew a trailing year, which was the whole log until #400
  * backfilled 2022-2024 — after which the archive was invisible on the only
- * calendar surface in the room. These pin the two things that would break the
- * all-time view quietly: a bad param taking the page down, and a start date
- * landing a day early because of a midnight boundary.
+ * calendar surface in the room.
+ *
+ * The cases that matter are the ones where the window and the cell size have to
+ * agree. Deciding them separately is what produced an "All time" view that was
+ * *narrower* than the default on a short log, so most of this file is about
+ * that pairing rather than about either number alone.
  */
 import { describe, expect, it } from 'vitest'
 
@@ -14,10 +17,12 @@ import type { StrengthSet } from '@/types/weight-room'
 import {
   DEFAULT_HEATMAP_SPAN,
   firstLoggedDate,
-  heatmapCellMetrics,
-  heatmapWindowStart,
+  heatmapWindow,
   parseHeatmapSpan,
 } from './heatmap-span'
+
+/** Fixed "today" for every window case, so column counts are stable. */
+const NOW = new Date('2026-08-09T20:00:00Z')
 
 /** A set logged at a given Pacific-local day. */
 function loggedOn(dayKey: string, hourUtc = 20): StrengthSet {
@@ -30,7 +35,7 @@ function loggedOn(dayKey: string, hourUtc = 20): StrengthSet {
 }
 
 describe('parseHeatmapSpan', () => {
-  it('reads the all-time span', () => {
+  it('reads the all-time range', () => {
     expect(parseHeatmapSpan('all')).toBe('all')
   })
 
@@ -52,7 +57,6 @@ describe('parseHeatmapSpan', () => {
 describe('firstLoggedDate', () => {
   it('finds the earliest training day', () => {
     const date = firstLoggedDate([loggedOn('2026-08-09'), loggedOn('2022-03-03')])
-    expect(date).not.toBeNull()
     expect(date?.toISOString().slice(0, 10)).toBe('2022-03-03')
   })
 
@@ -68,38 +72,65 @@ describe('firstLoggedDate', () => {
   })
 })
 
-describe('heatmapWindowStart', () => {
-  it('leaves the component on its own default for the trailing year', () => {
-    expect(heatmapWindowStart('year', [loggedOn('2022-03-03')])).toBeNull()
+describe('heatmapWindow', () => {
+  it('leaves the trailing year on the component defaults', () => {
+    expect(heatmapWindow('year', [loggedOn('2022-03-03')], undefined, NOW)).toEqual({
+      dateFrom: null,
+      cellSize: 14,
+      cellGap: 2,
+    })
   })
 
   it('starts at the first logged day for all-time', () => {
-    const start = heatmapWindowStart('all', [loggedOn('2024-04-16'), loggedOn('2022-03-03')])
-    expect(start?.toISOString().slice(0, 10)).toBe('2022-03-03')
+    const { dateFrom } = heatmapWindow(
+      'all',
+      [loggedOn('2024-04-16'), loggedOn('2022-03-03')],
+      undefined,
+      NOW
+    )
+    expect(dateFrom?.toISOString().slice(0, 10)).toBe('2022-03-03')
   })
 
-  it('is null for an all-time view of an empty log', () => {
-    // Nothing to widen to; the component's default is the honest fallback.
-    expect(heatmapWindowStart('all', [])).toBeNull()
-  })
-})
-
-describe('heatmapCellMetrics', () => {
-  it('tightens the cell for the all-time view', () => {
-    // ~210 columns at the default stride is nearly 3,000px, wide enough that
-    // the shape of the history is lost to panning.
-    expect(heatmapCellMetrics('all').cellSize).toBeLessThan(heatmapCellMetrics('year').cellSize)
+  it('tightens the cell in proportion to the widened grid', () => {
+    const { cellSize, cellGap } = heatmapWindow('all', [loggedOn('2022-03-03')], undefined, NOW)
+    expect(cellSize).toBeLessThan(14)
+    expect(cellGap).toBe(1)
   })
 
-  it('keeps the whole log within a couple of screens of panning', () => {
-    // Nothing legible fits the ~900px content column outright, so the budget is
-    // how far you have to pan: two screens, not the three and a half the
-    // default stride would cost.
-    const { cellSize } = heatmapCellMetrics('all')
-    expect(232 * cellSize).toBeLessThan(2 * 900)
+  it('keeps four years of columns within a couple of screens of panning', () => {
+    // Not a fit — the content column is ~900px and four years cannot fit it at
+    // any legible size. The budget is how far you have to pan.
+    const { dateFrom, cellSize } = heatmapWindow('all', [loggedOn('2022-08-23')], undefined, NOW)
+    const cols = Math.ceil((NOW.getTime() - (dateFrom?.getTime() ?? 0)) / (7 * 86_400_000))
+    expect(cols * cellSize).toBeLessThan(2 * 900)
   })
 
-  it('leaves the trailing year at the established size', () => {
-    expect(heatmapCellMetrics('year')).toEqual({ cellSize: 14, cellGap: 2 })
+  it('never renders all-time smaller than the default it replaces', () => {
+    // The bug this pairing exists to prevent: the start came from the data
+    // while the cell size came from the span *name*, so a log shorter than the
+    // default window produced a two-column sliver of 6px cells — narrower and
+    // less legible than the view it replaced, showing no extra data.
+    const shortLog = [loggedOn('2026-07-20'), loggedOn('2026-08-05')]
+    expect(heatmapWindow('all', shortLog, undefined, NOW)).toEqual({
+      dateFrom: null,
+      cellSize: 14,
+      cellGap: 2,
+    })
+  })
+
+  it('falls back to the component default for an all-time view of an empty log', () => {
+    expect(heatmapWindow('all', [], undefined, NOW)).toEqual({
+      dateFrom: null,
+      cellSize: 14,
+      cellGap: 2,
+    })
+  })
+
+  it('holds the cell above the floor even for an absurdly old first set', () => {
+    // A corrupt `logged_at` shouldn't shrink the grid to invisibility; the
+    // column cap in buildStrengthHeatmap handles the width, this handles the
+    // cell.
+    const { cellSize } = heatmapWindow('all', [loggedOn('1970-01-05')], undefined, NOW)
+    expect(cellSize).toBeGreaterThanOrEqual(6)
   })
 })

--- a/lib/training-facility/heatmap-span.test.ts
+++ b/lib/training-facility/heatmap-span.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Tests for the History view's heatmap span (#438).
+ *
+ * The heatmaps drew a trailing year, which was the whole log until #400
+ * backfilled 2022-2024 — after which the archive was invisible on the only
+ * calendar surface in the room. These pin the two things that would break the
+ * all-time view quietly: a bad param taking the page down, and a start date
+ * landing a day early because of a midnight boundary.
+ */
+import { describe, expect, it } from 'vitest'
+
+import type { StrengthSet } from '@/types/weight-room'
+
+import {
+  DEFAULT_HEATMAP_SPAN,
+  firstLoggedDate,
+  heatmapCellMetrics,
+  heatmapWindowStart,
+  parseHeatmapSpan,
+} from './heatmap-span'
+
+/** A set logged at a given Pacific-local day. */
+function loggedOn(dayKey: string, hourUtc = 20): StrengthSet {
+  return {
+    id: dayKey,
+    logged_at: `${dayKey}T${String(hourUtc).padStart(2, '0')}:00:00Z`,
+    exercise: 'pullups',
+    reps: 5,
+  }
+}
+
+describe('parseHeatmapSpan', () => {
+  it('reads the all-time span', () => {
+    expect(parseHeatmapSpan('all')).toBe('all')
+  })
+
+  it('defaults to the trailing year', () => {
+    expect(parseHeatmapSpan(undefined)).toBe('year')
+    expect(parseHeatmapSpan('year')).toBe('year')
+  })
+
+  it('falls back rather than erroring on a stale or hand-typed value', () => {
+    expect(parseHeatmapSpan('everything')).toBe(DEFAULT_HEATMAP_SPAN)
+    expect(parseHeatmapSpan('')).toBe(DEFAULT_HEATMAP_SPAN)
+  })
+
+  it('takes the first value when the param arrives repeated', () => {
+    expect(parseHeatmapSpan(['all', 'year'])).toBe('all')
+  })
+})
+
+describe('firstLoggedDate', () => {
+  it('finds the earliest training day', () => {
+    const date = firstLoggedDate([loggedOn('2026-08-09'), loggedOn('2022-03-03')])
+    expect(date).not.toBeNull()
+    expect(date?.toISOString().slice(0, 10)).toBe('2022-03-03')
+  })
+
+  it('is null for an empty log', () => {
+    expect(firstLoggedDate([])).toBeNull()
+  })
+
+  it('uses the local day, not the UTC one', () => {
+    // 2022-03-04 01:00 UTC is still 2022-03-03 in Pacific. Bucketing on UTC
+    // would start the grid a day — and therefore possibly a column — late.
+    const date = firstLoggedDate([loggedOn('2022-03-04', 1)])
+    expect(date?.toISOString().slice(0, 10)).toBe('2022-03-03')
+  })
+})
+
+describe('heatmapWindowStart', () => {
+  it('leaves the component on its own default for the trailing year', () => {
+    expect(heatmapWindowStart('year', [loggedOn('2022-03-03')])).toBeNull()
+  })
+
+  it('starts at the first logged day for all-time', () => {
+    const start = heatmapWindowStart('all', [loggedOn('2024-04-16'), loggedOn('2022-03-03')])
+    expect(start?.toISOString().slice(0, 10)).toBe('2022-03-03')
+  })
+
+  it('is null for an all-time view of an empty log', () => {
+    // Nothing to widen to; the component's default is the honest fallback.
+    expect(heatmapWindowStart('all', [])).toBeNull()
+  })
+})
+
+describe('heatmapCellMetrics', () => {
+  it('tightens the cell for the all-time view', () => {
+    // ~210 columns at the default stride is nearly 3,000px, wide enough that
+    // the shape of the history is lost to panning.
+    expect(heatmapCellMetrics('all').cellSize).toBeLessThan(heatmapCellMetrics('year').cellSize)
+  })
+
+  it('keeps the whole log within a couple of screens of panning', () => {
+    // Nothing legible fits the ~900px content column outright, so the budget is
+    // how far you have to pan: two screens, not the three and a half the
+    // default stride would cost.
+    const { cellSize } = heatmapCellMetrics('all')
+    expect(232 * cellSize).toBeLessThan(2 * 900)
+  })
+
+  it('leaves the trailing year at the established size', () => {
+    expect(heatmapCellMetrics('year')).toEqual({ cellSize: 14, cellGap: 2 })
+  })
+})

--- a/lib/training-facility/heatmap-span.ts
+++ b/lib/training-facility/heatmap-span.ts
@@ -1,0 +1,102 @@
+import type { StrengthSet } from '@/types/weight-room'
+
+import { PACIFIC_CLOCK, type DayClock } from './clock'
+
+/**
+ * How much history the History view's heatmaps show (#438).
+ *
+ * They have always drawn a trailing year, which was the whole log when the log
+ * began in May 2026. #400 backfilled 2022-2024, and a rolling twelve-month
+ * window renders that entire archive as nothing at all — the only surface in
+ * the room where four years of training is invisible rather than merely
+ * summarized.
+ *
+ * The trailing year stays the default, because it is the right answer to "how
+ * am I doing lately" and that is what the page is mostly for. All-time is a
+ * deliberate second view rather than a replacement.
+ */
+
+/** Search-param name carrying the chosen span. */
+export const HEATMAP_SPAN_PARAM = 'span'
+
+/** Which window the heatmaps draw. */
+export type HeatmapSpan = 'year' | 'all'
+
+/** The default — a trailing year, as the heatmaps have always drawn. */
+export const DEFAULT_HEATMAP_SPAN: HeatmapSpan = 'year'
+
+/**
+ * Read the span out of a search param.
+ *
+ * Anything unrecognized falls back to the default rather than erroring: a
+ * hand-typed or stale URL should render the normal page, not a broken one.
+ *
+ * @param raw The param value, which Next may hand over repeated.
+ * @returns The span to draw.
+ */
+export function parseHeatmapSpan(raw: string | string[] | undefined): HeatmapSpan {
+  const value = Array.isArray(raw) ? raw[0] : raw
+  return value === 'all' ? 'all' : DEFAULT_HEATMAP_SPAN
+}
+
+/**
+ * The earliest day any set was logged, as a `Date` at local noon.
+ *
+ * Noon rather than midnight for the same reason the progression charts use it:
+ * a midnight boundary read in the wrong zone slides onto the previous day, and
+ * the heatmap's first column would start a week early.
+ *
+ * @param sets Every logged set.
+ * @param clock Zone each day is measured in; defaults to Pacific (#429).
+ * @returns The first training day, or `null` when nothing is logged.
+ */
+export function firstLoggedDate(
+  sets: readonly StrengthSet[],
+  clock: DayClock = PACIFIC_CLOCK
+): Date | null {
+  let earliest = ''
+  for (const set of sets) {
+    const dayKey = clock.safeDayKey(set.logged_at)
+    if (dayKey === '') continue
+    if (earliest === '' || dayKey < earliest) earliest = dayKey
+  }
+  return earliest === '' ? null : clock.toNoon(earliest)
+}
+
+/**
+ * Where a heatmap should start drawing.
+ *
+ * @param span The chosen span.
+ * @param sets Every logged set, for the all-time start.
+ * @param clock Zone each day is measured in; defaults to Pacific (#429).
+ * @returns The window start, or `null` to leave the component on its own
+ *   trailing-year default. Null is also the answer for an all-time view of an
+ *   empty log — there is no history to widen to.
+ */
+export function heatmapWindowStart(
+  span: HeatmapSpan,
+  sets: readonly StrengthSet[],
+  clock: DayClock = PACIFIC_CLOCK
+): Date | null {
+  return span === 'all' ? firstLoggedDate(sets, clock) : null
+}
+
+/**
+ * Cell stride for a span, in pixels.
+ *
+ * The log runs to ~232 columns, which at the default 14px stride is over
+ * 3,000px per heatmap. The card scrolls horizontally, so that renders — but the
+ * point of an all-time view is the *shape*: where the gaps are, where the
+ * density is, and shape read through a quarter-width window is no shape at all.
+ *
+ * Nothing legible fits the ~900px content column outright — that would need a
+ * 4px stride — so this is a panning budget, not a fit. 6px puts the whole log
+ * in about one and a half screens with cells still individually visible, where
+ * 8px needs two and the default needs three and a half.
+ *
+ * @param span The chosen span.
+ * @returns `{ cellSize, cellGap }` to hand the heatmap.
+ */
+export function heatmapCellMetrics(span: HeatmapSpan): { cellSize: number; cellGap: number } {
+  return span === 'all' ? { cellSize: 6, cellGap: 1 } : { cellSize: 14, cellGap: 2 }
+}

--- a/lib/training-facility/heatmap-span.ts
+++ b/lib/training-facility/heatmap-span.ts
@@ -63,40 +63,96 @@ export function firstLoggedDate(
   return earliest === '' ? null : clock.toNoon(earliest)
 }
 
+/** Columns in the heatmaps' established trailing-year window. */
+const DEFAULT_COLS = 52
+
+/** Cell stride the heatmaps have always drawn at, and the widest this returns. */
+const DEFAULT_CELL = { cellSize: 14, cellGap: 2 } as const
+
 /**
- * Where a heatmap should start drawing.
+ * Pixel width the all-time grid aims for.
+ *
+ * Not a fit — the content column is ~900px, and fitting four years inside it
+ * would need a 4px stride. It's a panning budget: ~1,400px is a screen and a
+ * half, where the default stride over the same span would be three and a half.
+ */
+const ALL_TIME_TARGET_WIDTH = 1400
+
+/** Floor on the stride, below which a cell stops reading as its own square. */
+const MIN_CELL_SIZE = 6
+
+/** How a heatmap should draw one span. */
+export interface HeatmapWindow {
+  /**
+   * Inclusive start to hand the heatmap, or `null` to leave it on its own
+   * trailing-year default.
+   */
+  dateFrom: Date | null
+  /** Pixel stride per column, including the gap. */
+  cellSize: number
+  /** Pixel gap between cells. */
+  cellGap: number
+}
+
+/**
+ * Resolve the window *and* the cell size a heatmap should draw a span at.
+ *
+ * One function rather than two, because the two answers have to agree. When
+ * they were decided separately — the start derived from the data, the stride
+ * from the span *name* — a log shorter than a year rendered "All time" as a
+ * two-column sliver of 6px cells: narrower and less legible than the default
+ * while showing no more data, and narrow enough that
+ * {@link import('@/components/training-facility/weight-room/StrengthHeatmap').StrengthHeatmap}
+ * clipped its own legend off the right edge of the SVG.
+ *
+ * So all-time is defined as a *superset* of the trailing year: it never starts
+ * later than the default window would, and the stride shrinks only in
+ * proportion to how much wider the resulting grid actually is.
  *
  * @param span The chosen span.
  * @param sets Every logged set, for the all-time start.
  * @param clock Zone each day is measured in; defaults to Pacific (#429).
- * @returns The window start, or `null` to leave the component on its own
- *   trailing-year default. Null is also the answer for an all-time view of an
- *   empty log — there is no history to widen to.
+ * @param now Clock reading for "today"; injectable for tests.
  */
-export function heatmapWindowStart(
+export function heatmapWindow(
   span: HeatmapSpan,
   sets: readonly StrengthSet[],
-  clock: DayClock = PACIFIC_CLOCK
-): Date | null {
-  return span === 'all' ? firstLoggedDate(sets, clock) : null
+  clock: DayClock = PACIFIC_CLOCK,
+  now: Date = new Date()
+): HeatmapWindow {
+  if (span !== 'all') return { dateFrom: null, ...DEFAULT_CELL }
+
+  const first = firstLoggedDate(sets, clock)
+  if (first === null) return { dateFrom: null, ...DEFAULT_CELL }
+
+  // A log that doesn't reach back past the default window has no archive to
+  // reveal. Returning `null` hands the component its own trailing year, so
+  // "All time" degrades to the same picture rather than to a worse one.
+  const cols = columnsSince(first, clock, now)
+  if (cols <= DEFAULT_COLS) return { dateFrom: null, ...DEFAULT_CELL }
+
+  const cellSize = Math.max(
+    MIN_CELL_SIZE,
+    Math.min(DEFAULT_CELL.cellSize, Math.floor(ALL_TIME_TARGET_WIDTH / cols))
+  )
+  // A 1px gap below the default stride: 2px of a 6px cell is a third of it,
+  // and the squares stop reading as squares.
+  return { dateFrom: first, cellSize, cellGap: cellSize >= 10 ? 2 : 1 }
 }
 
 /**
- * Cell stride for a span, in pixels.
+ * Whole weeks from `start` through today, which is what the grid draws as
+ * columns.
  *
- * The log runs to ~232 columns, which at the default 14px stride is over
- * 3,000px per heatmap. The card scrolls horizontally, so that renders — but the
- * point of an all-time view is the *shape*: where the gaps are, where the
- * density is, and shape read through a quarter-width window is no shape at all.
- *
- * Nothing legible fits the ~900px content column outright — that would need a
- * 4px stride — so this is a panning budget, not a fit. 6px puts the whole log
- * in about one and a half screens with cells still individually visible, where
- * 8px needs two and the default needs three and a half.
- *
- * @param span The chosen span.
- * @returns `{ cellSize, cellGap }` to hand the heatmap.
+ * Day keys rather than milliseconds (#319): a DST week is 23 or 25 hours long,
+ * so dividing an elapsed-ms span by a week drifts twice a year.
  */
-export function heatmapCellMetrics(span: HeatmapSpan): { cellSize: number; cellGap: number } {
-  return span === 'all' ? { cellSize: 6, cellGap: 1 } : { cellSize: 14, cellGap: 2 }
+function columnsSince(start: Date, clock: DayClock, now: Date): number {
+  const startKey = clock.safeDayKey(start)
+  const endKey = clock.safeDayKey(now)
+  if (startKey === '' || endKey === '') return DEFAULT_COLS
+  const days = Math.round(
+    (Date.parse(`${endKey}T12:00:00Z`) - Date.parse(`${startKey}T12:00:00Z`)) / 86_400_000
+  )
+  return Math.max(1, Math.ceil((days + 1) / 7))
 }

--- a/lib/training-facility/weight-room-history.test.ts
+++ b/lib/training-facility/weight-room-history.test.ts
@@ -116,6 +116,35 @@ describe('buildStrengthHeatmap', () => {
     expect(clamped[0].length).toBeLessThanOrEqual(419)
   })
 
+  it('dates a multi-year axis, and pins the years against thinning (#438)', () => {
+    // Bare month names repeat, so on a four-year grid they identify nothing.
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 3, 15))
+    const { monthLabels } = buildStrengthHeatmap(
+      [],
+      PUSHUPS,
+      new Date(2022, 7, 23),
+      new Date(2026, 3, 15)
+    )
+    const years = monthLabels.filter(m => m.pinned === true)
+    expect(years.map(m => m.label)).toEqual(["Aug '22", "Jan '23", "Jan '24", "Jan '25", "Jan '26"])
+  })
+
+  it('leaves a single-year axis on bare month names', () => {
+    // The trailing-year default reads fine without years, and adding them
+    // there would be noise on every existing chart.
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 3, 15))
+    const { monthLabels } = buildStrengthHeatmap(
+      [],
+      PUSHUPS,
+      new Date(2026, 0, 5),
+      new Date(2026, 3, 15)
+    )
+    expect(monthLabels.every(m => m.pinned !== true)).toBe(true)
+    expect(monthLabels.map(m => m.label)).not.toContain("Jan '26")
+  })
+
   it('draws the whole log for an all-time range, archive included (#438)', () => {
     // The cap used to be ~2 years, so an all-time window starting at the 2022
     // archive was silently redrawn as starting in 2024 — and a clamped grid is

--- a/lib/training-facility/weight-room-history.test.ts
+++ b/lib/training-facility/weight-room-history.test.ts
@@ -110,10 +110,27 @@ describe('buildStrengthHeatmap', () => {
     const { grid: clamped } = buildStrengthHeatmap(
       [],
       PUSHUPS,
-      new Date(2018, 0, 1),
+      new Date(1970, 0, 1),
       new Date(2026, 3, 15)
     )
-    expect(clamped[0].length).toBeLessThanOrEqual(105)
+    expect(clamped[0].length).toBeLessThanOrEqual(419)
+  })
+
+  it('draws the whole log for an all-time range, archive included (#438)', () => {
+    // The cap used to be ~2 years, so an all-time window starting at the 2022
+    // archive was silently redrawn as starting in 2024 — and a clamped grid is
+    // indistinguishable from a complete one, so the truncation read as "there
+    // was no training back then".
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 3, 15))
+    const { grid } = buildStrengthHeatmap(
+      [set('2022-08-23', 'pushups', 50)],
+      PUSHUPS,
+      new Date(2022, 7, 23),
+      new Date(2026, 3, 15)
+    )
+    expect(grid[0][0].dayKey <= '2022-08-23').toBe(true)
+    expect(grid.flat().reduce((acc, c) => acc + c.reps, 0)).toBe(50)
   })
 
   it('skips sets with unparseable timestamps', () => {

--- a/lib/training-facility/weight-room-history.ts
+++ b/lib/training-facility/weight-room-history.ts
@@ -176,8 +176,18 @@ export interface StrengthExerciseStats {
   focus?: FocusCampaignSummary
 }
 
-/** Cap at ~2 years to limit DOM node count when a wide range is requested. */
-const MAX_COLS = 104
+/**
+ * Cap on rendered columns, to bound DOM node count when a wide range is
+ * requested.
+ *
+ * This was ~2 years, which silently truncated the all-time view (#438): the
+ * log starts in 2022 and a 104-column clamp redrew it as starting in 2024,
+ * hiding the archive it was widened to show — and hiding it *convincingly*,
+ * since a clamped grid looks like a complete one. ~8 years is well past the
+ * log's span, so the cap now only fires on a hand-typed or corrupt bound
+ * rather than on real data.
+ */
+const MAX_COLS = 418
 /** Days in a calendar week — heatmap column height, and the week-key stride. */
 const DAYS_PER_WEEK = 7
 
@@ -214,7 +224,7 @@ export function intensityFromPct(pct: number): 0 | 1 | 2 | 3 {
  * is Monday so a year reads top-down as Mon→Sun. The grid spans the
  * supplied range when both `dateFrom` and `dateTo` are provided;
  * otherwise it falls back to the trailing 52 weeks ending at the
- * current week. Capped at ~2 years to keep the DOM small.
+ * current week. Capped at {@link MAX_COLS} weeks to keep the DOM small.
  *
  * Each cell carries the day's rep total, set count, and `pct = reps /
  * dailyTarget` so the renderer can pick a color via
@@ -231,8 +241,8 @@ export function intensityFromPct(pct: number): 0 | 1 | 2 | 3 {
  * @param goal the {@link ExerciseGoal} for the target exercise; supplies
  *   the per-day `daily_target` denominator for `pct` via its
  *   `target_history` (falling back to `daily_target` when absent).
- * @param dateFrom optional inclusive start of the range; clamped to ~2
- *   years before `dateTo` if longer.
+ * @param dateFrom optional inclusive start of the range; clamped to
+ *   {@link MAX_COLS} weeks before `dateTo` if longer.
  * @param dateTo optional inclusive end; defaults to today.
  */
 export function buildStrengthHeatmap(

--- a/lib/training-facility/weight-room-history.ts
+++ b/lib/training-facility/weight-room-history.ts
@@ -16,6 +16,7 @@ import {
   targetForDay,
   targetResolverFor,
 } from './goal-targets'
+import type { HeatmapMonthLabel } from './heatmap-labels'
 import { type StreakCounts, streakFromDailyReps } from './hit-day-streaks'
 import {
   type FocusCampaignSummary,
@@ -82,7 +83,7 @@ export interface StrengthHeatmapGrid {
   /** 7-row × N-column grid; row 0 is Monday, row 6 is Sunday. */
   grid: StrengthHeatmapCell[][]
   /** First-of-month markers for the column header labels. */
-  monthLabels: { col: number; label: string }[]
+  monthLabels: HeatmapMonthLabel[]
 }
 
 /**
@@ -296,8 +297,15 @@ export function buildStrengthHeatmap(
       (inclusiveDaySpan(startMondayKey, shiftDayKey(endMondayKey, 6)) - 1) / DAYS_PER_WEEK
     ) + 1
   const grid: StrengthHeatmapCell[][] = Array.from({ length: 7 }, () => [])
-  const monthLabels: { col: number; label: string }[] = []
+  const monthLabels: HeatmapMonthLabel[] = []
   let lastMonth = -1
+  let lastYear = ''
+
+  // Bare month names repeat, so they only identify a column while the grid
+  // stays inside one span of twelve (#438). Past that, each year's first
+  // rendered marker carries the year and is pinned against thinning — without
+  // it an all-time grid is four indistinguishable Jan-Dec runs.
+  const multiYear = startMondayKey.slice(0, 4) !== shiftDayKey(endMondayKey, 6).slice(0, 4)
 
   for (let col = 0; col < totalCols; col++) {
     for (let row = 0; row < 7; row++) {
@@ -320,7 +328,14 @@ export function buildStrengthHeatmap(
       const month = monthIndexOfDayKey(key)
       if (month !== lastMonth) {
         lastMonth = month
-        monthLabels.push({ col, label: MONTH_LABELS[month] })
+        const year = key.slice(0, 4)
+        const startsYear = multiYear && year !== lastYear
+        lastYear = year
+        monthLabels.push(
+          startsYear
+            ? { col, label: `${MONTH_LABELS[month]} '${year.slice(2)}`, pinned: true }
+            : { col, label: MONTH_LABELS[month] }
+        )
       }
     }
   }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -42,7 +42,7 @@ export default defineConfig({
     {
       name: 'training-facility-enabled',
       testMatch:
-        /(?:training-facility-enabled|draft-room-enabled|draft-room-live|chart-overflow)\.spec\.ts/,
+        /(?:training-facility-enabled|draft-room-enabled|draft-room-live|chart-overflow|heatmap-span)\.spec\.ts/,
       use: {
         baseURL: TRAINING_FACILITY_BASE_URL,
       },


### PR DESCRIPTION
## Summary

The History heatmaps drew a trailing 52 weeks, which *was* the whole log until #400 backfilled 2022–2024. Since then the archive has been invisible on the only calendar surface in the Weight Room — and invisible convincingly, because an empty rolling window looks exactly like no training.

This adds a **Range** toggle above the heatmaps. `?span=all` starts each grid at the first logged day and tightens the cell stride from 14px to 6px, which brings ~232 columns down to ~1,400px — about a screen and a half of panning instead of three and a half.

The trailing year stays the default. It's the right answer to "how am I doing lately", which is what the page is mostly for; all-time is a deliberate second view, not a replacement.

### Two things worth a closer look

**The cap had to move.** `buildStrengthHeatmap` clamped any requested window to 104 columns. So the first version of this shipped an "all time" view that silently redrew a 2022 start as a 2024 start — the same failure as the bug, one layer down, and just as hard to see. `MAX_COLS` is now 418 (~8 years), well past the log, so it only fires on a corrupt or hand-typed bound.

**The two controls carry each other.** Switching range preserves `?exercises=`, and toggling a chip preserves `?span=`. The exercise param is copied raw rather than through the page's allowlist loop, because `?exercises=` present-but-empty means "nothing selected" and is distinct from absent (#367) — dropping the empty string would reset the filter to everything on a range switch.

### What this does *not* do

Investigating #438 turned up that the rest of the archive-visibility concern was already handled: all-time totals, streaks, and the trophy wall all read the full log correctly (the longest 4-day pullup streak is tied three ways, one of them 2023-02-07 → 02-10; the trophy wall already renders "first Aug 23 2022"). The heatmap was the only surface that was actually wrong.

## Test plan

- [ ] `/training-facility/weight-room/history` — heatmaps still show a trailing year by default, cells unchanged in size, no `span` in the URL
- [ ] Click **All time** — grids widen back to early 2022; the 2022–2024 archive is visible, then the gap, then the 2026 density
- [ ] Filter to one exercise, then switch range — the filter survives
- [ ] Switch to All time, then toggle a chip — the range survives
- [ ] Click **Last 12 months** — the `span` param disappears rather than being pinned to `year`
- [ ] Hand-type `?span=nonsense` — renders the default view, doesn't error
- [ ] On a phone, the all-time grid scrolls inside its card and the page itself does not slide sideways

Verified locally: `tsc --noEmit` clean, `eslint` clean, `next build` compiles, 2451 vitest tests pass, 74 Playwright tests pass.

Closes #438.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added “Last 12 months” and “All time” views for weight-room history heatmaps.
  * Added range controls that preserve selected exercise filters while navigating.
  * All-time views now include archived training data and support expanded history.

* **Bug Fixes**
  * Improved heatmap sizing to prevent horizontal overflow in all-time views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->