### PR TITLE
fix(weight-room): make session-log filter counts mean what they say (#445)

### DIFF
--- a/app/training-facility/weight-room/workouts/page.tsx
+++ b/app/training-facility/weight-room/workouts/page.tsx
@@ -9,7 +9,6 @@ import {
   WorkoutHistoryList,
   WORKOUTS_ROUTE,
   type TemplateFilterOption,
-  type WorkoutSourceFilter,
 } from '@/components/training-facility/weight-room/WorkoutHistoryList'
 import { WeightRoomSubNav } from '@/components/training-facility/weight-room/WeightRoomSubNav'
 import { isAdminRequest } from '@/lib/auth/admin-session'
@@ -25,6 +24,7 @@ import {
   facetCount,
   filterWorkouts,
   isImported,
+  resolveSourceFilter,
   type WorkoutFilterState,
 } from '@/lib/training-facility/workout-facets'
 import {
@@ -92,16 +92,24 @@ export default async function WeightRoomWorkoutsPage({
     if (id !== undefined) everRun.add(id)
   }
 
-  const requestedSource = firstParam(params.source)
-  const selectedSource: WorkoutSourceFilter | null =
-    requestedSource === 'recorded' || requestedSource === 'imported' ? requestedSource : null
+  // Whether the provenance rail exists at all is a question about the log, not
+  // the current view — and it has to be answered before the param is read, or
+  // `?source=imported` on a log with no imports empties the page while the rail
+  // that would undo it isn't rendered.
+  const hasImported = history.some(isImported)
+  const selectedSource = resolveSourceFilter(firstParam(params.source), hasImported)
 
   const requestedTemplate = firstParam(params.template)
-  // An unknown id falls back to "all" rather than to an empty list — a stale
-  // link naming a deleted template should degrade to the full history. A
-  // template that exists but has nothing under the *current* year stays
-  // selected on purpose: its chip renders at 0 below, so the reader can see why
-  // the list is empty and click out of it.
+  // Validated against what was *run*, not against the current roster. An id no
+  // session ever used falls back to "all" rather than to an empty list, so a
+  // stale link degrades to the full history.
+  //
+  // A template deleted from the roster but still referenced by old sessions
+  // deliberately stays selectable, labelled "Unknown template" further down:
+  // those sessions are real and filtering to them is a true answer, where
+  // dropping the filter would silently discard it. A template that exists but
+  // has nothing under the *current* year also stays selected — its chip renders
+  // at 0, so the reader can see why the list is empty and click out of it.
   const selectedTemplateId =
     requestedTemplate !== null && everRun.has(requestedTemplate) ? requestedTemplate : null
 
@@ -173,8 +181,6 @@ export default async function WeightRoomWorkoutsPage({
   // real set data.
   const recordedCount = facetCount(history, filterState, { source: 'recorded' })
   const importedCount = facetCount(history, filterState, { source: 'imported' })
-  // Whether the rail exists at all is a question about the log, not the view.
-  const hasImported = history.some(isImported)
 
   // Paginate whatever the filters left, not just the all-years view: 2022 alone
   // is 152 sessions, so a year filter on its own still ships a heavy page.

--- a/app/training-facility/weight-room/workouts/page.tsx
+++ b/app/training-facility/weight-room/workouts/page.tsx
@@ -22,9 +22,14 @@ import {
 import { isWeightRoomEnabled } from '@/lib/feature-flags'
 import { isPreviewDemoActive } from '@/lib/training-facility/preview-param'
 import {
+  facetCount,
+  filterWorkouts,
+  isImported,
+  type WorkoutFilterState,
+} from '@/lib/training-facility/workout-facets'
+import {
   buildWorkoutHistory,
   paginateWorkouts,
-  workoutYear,
   workoutYearOptions,
 } from '@/lib/training-facility/workout-stats'
 
@@ -78,63 +83,98 @@ export default async function WeightRoomWorkoutsPage({
 
   const history = buildWorkoutHistory(sourceWorkouts, sourceSets, sourceTemplates, sourceExercises)
 
-  // Chips are built from what has actually been *run*, not from the template
-  // roster: a template nobody has recorded a session against would otherwise
-  // render a chip that filters to an empty list.
-  const counts = new Map<string, number>()
+  // Templates that have actually been *run*, not the roster: a template nobody
+  // has recorded a session against would otherwise render a chip that filters
+  // to an empty list.
+  const everRun = new Set<string>()
   for (const entry of history) {
     const id = entry.workout.template_id
-    if (id !== undefined) counts.set(id, (counts.get(id) ?? 0) + 1)
+    if (id !== undefined) everRun.add(id)
   }
-  const templateById = new Map(sourceTemplates.map(t => [t.id, t]))
-  const filters: TemplateFilterOption[] = [
-    { id: null, name: 'All', color: null, count: history.length },
-    ...[...counts.entries()]
-      .map(([id, count]) => ({
-        id,
-        name: templateById.get(id)?.name ?? 'Unknown template',
-        color: templateById.get(id)?.color ?? null,
-        count,
-      }))
-      .sort((a, b) => a.name.localeCompare(b.name)),
-  ]
 
-  // Provenance is a second, independent filter axis (#413). Hundreds of
-  // imported skeletons would otherwise bury the handful of sessions that carry
-  // real set data.
-  const recordedCount = history.filter(e => e.workout.source !== 'apple_health').length
-  const importedCount = history.length - recordedCount
   const requestedSource = firstParam(params.source)
   const selectedSource: WorkoutSourceFilter | null =
     requestedSource === 'recorded' || requestedSource === 'imported' ? requestedSource : null
 
   const requestedTemplate = firstParam(params.template)
   // An unknown id falls back to "all" rather than to an empty list — a stale
-  // link naming a deleted template should degrade to the full history.
+  // link naming a deleted template should degrade to the full history. A
+  // template that exists but has nothing under the *current* year stays
+  // selected on purpose: its chip renders at 0 below, so the reader can see why
+  // the list is empty and click out of it.
   const selectedTemplateId =
-    requestedTemplate !== null && counts.has(requestedTemplate) ? requestedTemplate : null
+    requestedTemplate !== null && everRun.has(requestedTemplate) ? requestedTemplate : null
+
   // Year is the third filter axis, and the one that keeps the page bounded
   // (#416). Before it, the default view rendered every session ever recorded —
   // 507 rows and 1.4 MB after the Health import landed.
+  //
+  // Resolved *after* the other two axes, because its counts and its default
+  // both depend on them (#445): the year rail under a template filter should
+  // offer the years that template actually ran, and default to one of them.
+  const otherAxes: WorkoutFilterState = {
+    templateId: selectedTemplateId,
+    source: selectedSource,
+    year: null,
+  }
   const years = workoutYearOptions(history)
+    .map(option => ({
+      year: option.year,
+      count: facetCount(history, otherAxes, { year: option.year }),
+    }))
+    .filter(option => option.count > 0)
+
   const requestedYear = firstParam(params.year)
-  // Default to the newest year with sessions rather than to everything. An
-  // unrecognised value also lands here, so a stale link degrades to a small,
-  // useful page instead of the heaviest one.
+  // Default to the newest year that has anything under the other filters,
+  // rather than the newest year overall — which, with a template selected,
+  // routinely isn't a year that template ran. An unrecognised value lands here
+  // too, so a stale link degrades to a small, useful page rather than the
+  // heaviest one.
   const selectedYear: number | null =
     requestedYear === 'all'
       ? null
       : (years.find(y => String(y.year) === requestedYear)?.year ?? years[0]?.year ?? null)
 
-  const filtered = history.filter(entry => {
-    if (selectedTemplateId !== null && entry.workout.template_id !== selectedTemplateId) {
-      return false
-    }
-    if (selectedYear !== null && workoutYear(entry) !== selectedYear) return false
-    if (selectedSource === null) return true
-    const isImported = entry.workout.source === 'apple_health'
-    return selectedSource === 'imported' ? isImported : !isImported
-  })
+  // Every chip's count is measured against the history filtered by the *other*
+  // two axes (#445) — the exact state its own link navigates to. Tallying over
+  // the whole log instead is what put "Apple Health 507" above a list of 22,
+  // since the year axis is always active by default.
+  const filterState: WorkoutFilterState = {
+    templateId: selectedTemplateId,
+    year: selectedYear,
+    source: selectedSource,
+  }
+  const filtered = filterWorkouts(history, filterState)
+
+  const templateById = new Map(sourceTemplates.map(t => [t.id, t]))
+  const filters: TemplateFilterOption[] = [
+    {
+      id: null,
+      name: 'All',
+      color: null,
+      count: facetCount(history, filterState, { templateId: null }),
+    },
+    ...[...everRun]
+      .map(id => ({
+        id,
+        name: templateById.get(id)?.name ?? 'Unknown template',
+        color: templateById.get(id)?.color ?? null,
+        count: facetCount(history, filterState, { templateId: id }),
+      }))
+      // Unreachable chips are dropped rather than shown at 0 — a chip is an
+      // offer, and one that leads nowhere is noise. The selected template is
+      // the exception: it has to stay visible to be undoable.
+      .filter(option => option.count > 0 || option.id === selectedTemplateId)
+      .sort((a, b) => a.name.localeCompare(b.name)),
+  ]
+
+  // Provenance is a second, independent filter axis (#413). Hundreds of
+  // imported skeletons would otherwise bury the handful of sessions that carry
+  // real set data.
+  const recordedCount = facetCount(history, filterState, { source: 'recorded' })
+  const importedCount = facetCount(history, filterState, { source: 'imported' })
+  // Whether the rail exists at all is a question about the log, not the view.
+  const hasImported = history.some(isImported)
 
   // Paginate whatever the filters left, not just the all-years view: 2022 alone
   // is 152 sessions, so a year filter on its own still ships a heavy page.
@@ -196,6 +236,7 @@ export default async function WeightRoomWorkoutsPage({
             selectedSource={selectedSource}
             recordedCount={recordedCount}
             importedCount={importedCount}
+            hasImported={hasImported}
             years={years}
             selectedYear={selectedYear}
             page={pageResult.page}

--- a/components/training-facility/weight-room/WorkoutHistoryList.test.tsx
+++ b/components/training-facility/weight-room/WorkoutHistoryList.test.tsx
@@ -258,6 +258,7 @@ describe('WorkoutHistoryList — imported sessions (#413)', () => {
         selectedSource="imported"
         recordedCount={2}
         importedCount={507}
+        hasImported
       />
     )
     // Switching template must preserve the source filter...
@@ -285,11 +286,63 @@ describe('WorkoutHistoryList — imported sessions (#413)', () => {
         hasAnyWorkouts
         recordedCount={2}
         importedCount={507}
+        hasImported
       />
     )
     expect(screen.getByTestId('workout-source-all')).toHaveTextContent('509')
     expect(screen.getByTestId('workout-source-imported')).toHaveTextContent('507')
     expect(screen.getByTestId('workout-source-recorded')).toHaveTextContent('2')
+  })
+
+  it('drops a source chip that matches nothing under the current filters (#445)', () => {
+    // The counts are faceted by the selected year, so a year with no recorded
+    // sessions gets no Recorded chip — rather than one advertising 0 that, when
+    // clicked, falls back to a year that has some.
+    render(
+      <WorkoutHistoryList
+        entries={[]}
+        filters={[]}
+        selectedTemplateId={null}
+        hasAnyWorkouts
+        recordedCount={0}
+        importedCount={22}
+        hasImported
+      />
+    )
+    expect(screen.queryByTestId('workout-source-recorded')).toBeNull()
+    expect(screen.getByTestId('workout-source-imported')).toHaveTextContent('22')
+  })
+
+  it('keeps the selected source chip even at zero, so the filter is undoable', () => {
+    render(
+      <WorkoutHistoryList
+        entries={[]}
+        filters={[]}
+        selectedTemplateId={null}
+        hasAnyWorkouts
+        selectedSource="recorded"
+        recordedCount={0}
+        importedCount={22}
+        hasImported
+      />
+    )
+    expect(screen.getByTestId('workout-source-recorded')).toHaveTextContent('0')
+    expect(screen.getByTestId('workout-source-all')).toBeInTheDocument()
+  })
+
+  it('hides the rail entirely when the log has nothing imported', () => {
+    // The distinction doesn't apply to this log, so it shouldn't grow a filter.
+    render(
+      <WorkoutHistoryList
+        entries={[]}
+        filters={[]}
+        selectedTemplateId={null}
+        hasAnyWorkouts
+        recordedCount={9}
+        importedCount={0}
+      />
+    )
+    expect(screen.queryByTestId('workout-source-filter')).toBeNull()
   })
 })
 

--- a/components/training-facility/weight-room/WorkoutHistoryList.tsx
+++ b/components/training-facility/weight-room/WorkoutHistoryList.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link'
 
 import { formatDayKey, safePacificDayKey, todayDayKey } from '@/lib/training-facility/day-keys'
 import { describeSetOrHold } from '@/lib/training-facility/strength-format'
+import type { WorkoutSourceFilter } from '@/lib/training-facility/workout-facets'
 import {
   workoutDisplayTitle,
   type WorkoutHistoryEntry,
@@ -21,12 +22,12 @@ export const YEAR_FILTER_PARAM = 'year'
 /**
  * Provenance filter selection (#413).
  *
- * `'recorded'` — sessions logged set by set through the app. `'imported'` —
- * sessions from an Apple Health export, which know only that lifting happened
- * and for how long. `null` — both, in true chronological order, which is the
- * default because the whole point of importing is to see the two eras together.
+ * Re-exported from the faceting module so the rail and the counts that feed it
+ * can't disagree about the vocabulary. `null` means both, in true chronological
+ * order, which is the default because the whole point of importing is to see
+ * the two eras together.
  */
-export type WorkoutSourceFilter = 'recorded' | 'imported'
+export type { WorkoutSourceFilter }
 
 /** One entry in the filter rail. */
 export interface TemplateFilterOption {
@@ -50,10 +51,20 @@ export interface WorkoutHistoryListProps {
   selectedTemplateId: string | null
   /** Currently selected provenance filter, or `null` for both (#413). */
   selectedSource?: WorkoutSourceFilter | null
-  /** How many sessions were recorded in-app; drives the Recorded chip's count. */
+  /**
+   * Sessions the Recorded chip would show — faceted by the year and template
+   * currently selected (#445), so the number is what clicking it returns.
+   */
   recordedCount?: number
-  /** How many were imported from Apple Health; drives the Imported chip's count. */
+  /** Sessions the Apple Health chip would show, faceted the same way (#445). */
   importedCount?: number
+  /**
+   * Whether the log contains *any* imported session, ignoring current filters.
+   * Decides whether the provenance rail exists at all — a distinction that
+   * doesn't apply to this log shouldn't grow a filter, but one that does must
+   * stay reachable even from a year where it happens to match nothing.
+   */
+  hasImported?: boolean
   /** Years that have sessions, newest first (#416). Empty hides the year rail. */
   years?: readonly WorkoutYearOption[]
   /** Selected year, or `null` for all years. */
@@ -98,6 +109,7 @@ export function WorkoutHistoryList({
   selectedSource = null,
   recordedCount = 0,
   importedCount = 0,
+  hasImported = false,
   years = [],
   selectedYear = null,
   page = 1,
@@ -115,7 +127,11 @@ export function WorkoutHistoryList({
     <div className="flex flex-col gap-5">
       {years.length > 1 ? <YearFilterRail years={years} filterState={filterState} /> : null}
 
-      {importedCount > 0 ? (
+      {/* Gated on the whole log, not on the faceted counts (#445): those go to
+          zero for a year with nothing imported, and hiding the rail there would
+          strand anyone who arrived with `?source=imported` — no chip left to
+          undo the filter that emptied the page. */}
+      {hasImported ? (
         <SourceFilterRail
           filterState={filterState}
           recordedCount={recordedCount}
@@ -234,11 +250,20 @@ function SourceFilterRail({
   importedCount,
 }: SourceFilterRailProps): JSX.Element {
   const selectedSource = filterState.selectedSource
-  const options: Array<{ value: WorkoutSourceFilter | null; label: string; count: number }> = [
+  const allOptions: Array<{ value: WorkoutSourceFilter | null; label: string; count: number }> = [
     { value: null, label: 'All', count: recordedCount + importedCount },
     { value: 'recorded', label: 'Recorded', count: recordedCount },
     { value: 'imported', label: 'Apple Health', count: importedCount },
   ]
+  const options = allOptions.filter(
+    // A chip that matches nothing under the current year is dropped rather than
+    // shown at 0 (#445). Not cosmetic: the year axis falls back when the
+    // requested year has nothing for the chosen source, so a "Recorded 0" chip
+    // clicked from 2026 would land on 2024's five sessions — the count broken
+    // in the opposite direction from the bug this all started as. "All" and the
+    // current selection always stay, so the rail can never become a dead end.
+    option => option.count > 0 || option.value === null || option.value === selectedSource
+  )
 
   return (
     <nav aria-label="Filter by source" data-testid="workout-source-filter">

--- a/e2e/workout-filters.spec.ts
+++ b/e2e/workout-filters.spec.ts
@@ -1,0 +1,146 @@
+import { expect, test, type Page } from '@playwright/test'
+
+/**
+ * Pins the session log's filter-count contract (#445).
+ *
+ * A count on a filter chip is a promise about what clicking it returns. The
+ * chips used to tally the whole history while the list was filtered, and the
+ * year axis defaults to the newest year rather than to everything — so the rail
+ * advertised "Apple Health 507" above a list of 22, and clicking "Recorded 15"
+ * from the 2026 view landed on an empty page, because every recorded session
+ * was in 2022-2024.
+ *
+ * The assertions walk the chips that are actually rendered rather than naming
+ * fixed ones, so this holds against both environments: CI has no Supabase
+ * credentials and renders the demo fixture, while a credentialed local run
+ * renders 522 real sessions across six years.
+ */
+
+const WORKOUTS = '/training-facility/weight-room/workouts'
+
+/**
+ * How many sessions the current view actually contains.
+ *
+ * Reads the paginator's "Showing 1–50 of 507" when the result spans pages, and
+ * falls back to counting rendered rows when it doesn't — a single page has no
+ * paginator to read.
+ */
+async function visibleTotal(page: Page): Promise<number> {
+  const paginator = page.getByTestId('workout-pagination')
+  if ((await paginator.count()) > 0) {
+    const text = (await paginator.innerText()).replace(/,/g, '')
+    const match = /of\s+(\d+)/.exec(text)
+    if (match !== null) return Number(match[1])
+  }
+  return page.locator('[data-testid^="workout-row-"]').count()
+}
+
+/** The number a chip advertises, from its trailing count span. */
+async function chipCount(page: Page, testId: string): Promise<number> {
+  const text = await page.getByTestId(testId).innerText()
+  const match = /(\d[\d,]*)\s*$/.exec(text.trim())
+  expect(match, `chip ${testId} has no trailing count`).not.toBeNull()
+  return Number((match as RegExpExecArray)[1].replace(/,/g, ''))
+}
+
+/** Test ids of the chips a rail is currently rendering, in document order. */
+async function renderedChipIds(
+  rail: ReturnType<Page['getByTestId']>,
+  prefix: string
+): Promise<string[]> {
+  return rail
+    .locator(`[data-testid^="${prefix}"]`)
+    .evaluateAll(nodes =>
+      nodes.map(n => n.getAttribute('data-testid')).filter((id): id is string => id !== null)
+    )
+}
+
+/**
+ * Click a chip and wait for the view it selects to actually be on screen.
+ *
+ * These are soft navigations, so the DOM keeps serving the previous filter's
+ * rows for as long as the RSC render takes — long enough on this route that
+ * reading the total straight after the click measures the *old* page. The chip
+ * gaining `aria-current` is the signal that the new render landed.
+ */
+async function clickChip(page: Page, testId: string): Promise<void> {
+  await page.getByTestId(testId).click()
+  await expect(page.getByTestId(testId)).toHaveAttribute('aria-current', 'page', {
+    timeout: 30_000,
+  })
+}
+
+test.describe('session log filter counts', () => {
+  test('every source chip counts what clicking it returns', async ({ page }) => {
+    test.slow() // One render per chip, on a route that carries the full history.
+    await page.goto(`${WORKOUTS}?preview=demo`)
+
+    const rail = page.getByTestId('workout-source-filter')
+    if ((await rail.count()) === 0) {
+      // No imported sessions in this environment's data — the rail correctly
+      // doesn't exist, and there is nothing to assert.
+      test.skip()
+      return
+    }
+
+    // Enumerated rather than hardcoded: a source that matches nothing under the
+    // current year has no chip at all, which is the point.
+    const ids = await renderedChipIds(rail, 'workout-source-')
+
+    for (const id of ids) {
+      await page.goto(`${WORKOUTS}?preview=demo`)
+      const promised = await chipCount(page, id)
+      await clickChip(page, id)
+      expect(await visibleTotal(page), `${id} promised ${promised}`).toBe(promised)
+    }
+  })
+
+  test('every year chip counts what clicking it returns', async ({ page }) => {
+    test.slow()
+    await page.goto(`${WORKOUTS}?preview=demo`)
+
+    const rail = page.getByTestId('workout-year-filter')
+    if ((await rail.count()) === 0) {
+      test.skip()
+      return
+    }
+
+    const ids = await renderedChipIds(rail, 'workout-year-')
+
+    for (const id of ids) {
+      await page.goto(`${WORKOUTS}?preview=demo`)
+      const promised = await chipCount(page, id)
+      await clickChip(page, id)
+      expect(await visibleTotal(page), `${id} promised ${promised}`).toBe(promised)
+    }
+  })
+
+  test('the source rail stays reachable from a year it matches nothing in', async ({ page }) => {
+    // The rail's *existence* is a fact about the log, not the current view.
+    // Gating it on the faceted count would remove the only way to undo a
+    // provenance filter that emptied the page.
+    await page.goto(`${WORKOUTS}?preview=demo&source=imported`)
+
+    const rail = page.getByTestId('workout-source-filter')
+    if ((await rail.count()) === 0) {
+      test.skip()
+      return
+    }
+    await expect(rail).toBeVisible()
+    await expect(page.getByTestId('workout-source-all')).toBeVisible()
+  })
+
+  test('a template chip never offers a year it did not run in', async ({ page }) => {
+    // Template chips are dropped when they have nothing under the current year
+    // and source, so no chip leads to an empty list.
+    await page.goto(`${WORKOUTS}?preview=demo`)
+
+    const chips = page.locator('[data-testid^="workout-filter-"]')
+    const count = await chips.count()
+    for (let i = 0; i < count; i++) {
+      const id = await chips.nth(i).getAttribute('data-testid')
+      if (id === null || id === 'workout-filter-all') continue
+      expect(await chipCount(page, id)).toBeGreaterThan(0)
+    }
+  })
+})

--- a/lib/training-facility/workout-facets.test.ts
+++ b/lib/training-facility/workout-facets.test.ts
@@ -10,7 +10,12 @@ import { describe, expect, it } from 'vitest'
 
 import type { WorkoutHistoryEntry } from './workout-stats'
 
-import { facetCount, filterWorkouts, matchesWorkoutFilters } from './workout-facets'
+import {
+  facetCount,
+  filterWorkouts,
+  matchesWorkoutFilters,
+  resolveSourceFilter,
+} from './workout-facets'
 
 /** A history entry with just the fields the facets read. */
 function entry(
@@ -59,6 +64,25 @@ describe('matchesWorkoutFilters', () => {
 
   it('treats a missing template as matching no template filter', () => {
     expect(matchesWorkoutFilters(HISTORY[3], { ...ALL, templateId: 'chest-1' })).toBe(false)
+  })
+})
+
+describe('resolveSourceFilter', () => {
+  it('reads the two valid selections', () => {
+    expect(resolveSourceFilter('recorded', true)).toBe('recorded')
+    expect(resolveSourceFilter('imported', true)).toBe('imported')
+  })
+
+  it('falls back for an absent or hand-typed value', () => {
+    expect(resolveSourceFilter(null, true)).toBeNull()
+    expect(resolveSourceFilter('everything', true)).toBeNull()
+  })
+
+  it('ignores the param entirely on a log with no imports', () => {
+    // The rail doesn't render for such a log, so honouring `?source=imported`
+    // would filter the page to nothing with no chip left to undo it.
+    expect(resolveSourceFilter('imported', false)).toBeNull()
+    expect(resolveSourceFilter('recorded', false)).toBeNull()
   })
 })
 

--- a/lib/training-facility/workout-facets.test.ts
+++ b/lib/training-facility/workout-facets.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Tests for the session log's filter faceting (#445).
+ *
+ * The bug these pin: every chip counted the whole history while the list was
+ * filtered, and the year axis defaults to the newest year — so the source rail
+ * advertised 507 Apple Health sessions above a list of 22. The cases below are
+ * all about one axis's count respecting the *other* axes.
+ */
+import { describe, expect, it } from 'vitest'
+
+import type { WorkoutHistoryEntry } from './workout-stats'
+
+import { facetCount, filterWorkouts, matchesWorkoutFilters } from './workout-facets'
+
+/** A history entry with just the fields the facets read. */
+function entry(
+  id: string,
+  startedAt: string,
+  source: 'manual' | 'apple_health',
+  templateId?: string
+): WorkoutHistoryEntry {
+  return {
+    workout: {
+      id,
+      started_at: startedAt,
+      source,
+      ...(templateId === undefined ? {} : { template_id: templateId }),
+    },
+  } as unknown as WorkoutHistoryEntry
+}
+
+/**
+ * A log shaped like the real one: a large imported archive across old years,
+ * and a small recorded population in the current year.
+ */
+const HISTORY: WorkoutHistoryEntry[] = [
+  entry('r1', '2026-08-01T18:00:00Z', 'manual', 'chest-1'),
+  entry('r2', '2026-08-03T18:00:00Z', 'manual', 'chest-1'),
+  entry('r3', '2026-07-20T18:00:00Z', 'manual', 'legs'),
+  entry('i1', '2026-02-10T18:00:00Z', 'apple_health'),
+  entry('i2', '2023-05-05T18:00:00Z', 'apple_health'),
+  entry('i3', '2023-06-06T18:00:00Z', 'apple_health'),
+  entry('o1', '2023-04-04T18:00:00Z', 'manual', 'chest-1'),
+]
+
+const ALL = { templateId: null, year: null, source: null } as const
+
+describe('matchesWorkoutFilters', () => {
+  it('matches everything when no axis is set', () => {
+    expect(HISTORY.every(e => matchesWorkoutFilters(e, ALL))).toBe(true)
+  })
+
+  it('places a session in its Pacific year, not its UTC one', () => {
+    // 2026-01-01 03:00 UTC is still Dec 31 2025 in Pacific.
+    const newYear = entry('ny', '2026-01-01T03:00:00Z', 'manual')
+    expect(matchesWorkoutFilters(newYear, { ...ALL, year: 2025 })).toBe(true)
+    expect(matchesWorkoutFilters(newYear, { ...ALL, year: 2026 })).toBe(false)
+  })
+
+  it('treats a missing template as matching no template filter', () => {
+    expect(matchesWorkoutFilters(HISTORY[3], { ...ALL, templateId: 'chest-1' })).toBe(false)
+  })
+})
+
+describe('filterWorkouts', () => {
+  it('applies every axis together', () => {
+    const got = filterWorkouts(HISTORY, { templateId: 'chest-1', year: 2026, source: 'recorded' })
+    expect(got.map(e => e.workout.id)).toEqual(['r1', 'r2'])
+  })
+
+  it('preserves input order', () => {
+    const got = filterWorkouts(HISTORY, { ...ALL, source: 'imported' })
+    expect(got.map(e => e.workout.id)).toEqual(['i1', 'i2', 'i3'])
+  })
+})
+
+describe('facetCount', () => {
+  it('counts a source chip within the selected year, not the whole log', () => {
+    // The reported bug, in miniature: 3 imported sessions exist, but only 1 is
+    // in 2026, and 2026 is what the list is showing.
+    const state = { templateId: null, year: 2026, source: null }
+    expect(facetCount(HISTORY, state, { source: 'imported' })).toBe(1)
+    expect(facetCount(HISTORY, state, { source: 'recorded' })).toBe(3)
+    expect(facetCount(HISTORY, state, { source: null })).toBe(4)
+  })
+
+  it('counts a year chip within the selected source', () => {
+    const state = { templateId: null, year: 2026, source: 'recorded' as const }
+    expect(facetCount(HISTORY, state, { year: 2023 })).toBe(1)
+    expect(facetCount(HISTORY, state, { year: null })).toBe(4)
+  })
+
+  it('counts a template chip within the selected year', () => {
+    const state = { templateId: null, year: 2026, source: null }
+    expect(facetCount(HISTORY, state, { templateId: 'chest-1' })).toBe(2)
+    // Ran only in 2023, so it is unreachable from the 2026 view.
+    expect(facetCount(HISTORY, state, { templateId: 'legs' })).toBe(1)
+  })
+
+  it('reports zero for a template with no sessions under the other axes', () => {
+    const state = { templateId: null, year: 2026, source: 'imported' as const }
+    expect(facetCount(HISTORY, state, { templateId: 'chest-1' })).toBe(0)
+  })
+
+  it('ignores the axis the chip replaces', () => {
+    // A template chip's count must not be narrowed by the template already
+    // selected, or every unselected chip reads zero.
+    const state = { templateId: 'legs', year: null, source: null }
+    expect(facetCount(HISTORY, state, { templateId: 'chest-1' })).toBe(3)
+  })
+
+  it('equals the length of the list the chip navigates to', () => {
+    // The invariant the whole module exists for.
+    const state = { templateId: null, year: 2026, source: null }
+    const override = { source: 'imported' as const }
+    expect(facetCount(HISTORY, state, override)).toBe(
+      filterWorkouts(HISTORY, { ...state, ...override }).length
+    )
+  })
+})

--- a/lib/training-facility/workout-facets.ts
+++ b/lib/training-facility/workout-facets.ts
@@ -1,0 +1,102 @@
+/**
+ * Faceting for the session log's three filter axes (#445).
+ *
+ * The log filters by template (#377), source (#413), and year (#416), and each
+ * chip carries a count. Those counts were tallied over the whole history while
+ * the list was filtered — and because the year axis defaults to the newest year
+ * rather than to everything, the two disagreed on first paint with no
+ * interaction at all: the source rail read "Apple Health 507" above a list of 22.
+ *
+ * A count on a filter chip is a promise about what clicking it returns. Keeping
+ * that promise means counting each chip against the history filtered by the
+ * *other* two axes — which is what {@link facetCount} does, and why the
+ * predicate lives in one place instead of being restated per rail.
+ */
+import { PACIFIC_CLOCK, type DayClock } from './clock'
+import type { WorkoutHistoryEntry } from './workout-stats'
+import { workoutYear } from './workout-stats'
+
+/**
+ * Provenance selection.
+ *
+ * `'recorded'` — logged set by set through the app. `'imported'` — from an
+ * Apple Health export, which knows only that lifting happened and for how long.
+ */
+export type WorkoutSourceFilter = 'recorded' | 'imported'
+
+/** The session log's full filter state. Every axis, `null` meaning unfiltered. */
+export interface WorkoutFilterState {
+  /** Template id, or `null` for every template. */
+  templateId: string | null
+  /** Calendar year, or `null` for every year. */
+  year: number | null
+  /** Provenance, or `null` for both. */
+  source: WorkoutSourceFilter | null
+}
+
+/** Which axes a facet query holds fixed. */
+export type WorkoutFilterAxis = keyof WorkoutFilterState
+
+/** Whether `entry` is an Apple Health import rather than an in-app recording. */
+export function isImported(entry: WorkoutHistoryEntry): boolean {
+  return entry.workout.source === 'apple_health'
+}
+
+/**
+ * Whether an entry survives every axis of `state`.
+ *
+ * @param entry The session to test.
+ * @param state Filter state; a `null` axis matches everything.
+ * @param clock Zone the year boundary is measured in; defaults to Pacific (#429).
+ */
+export function matchesWorkoutFilters(
+  entry: WorkoutHistoryEntry,
+  state: WorkoutFilterState,
+  clock: DayClock = PACIFIC_CLOCK
+): boolean {
+  if (state.templateId !== null && entry.workout.template_id !== state.templateId) return false
+  if (state.year !== null && workoutYear(entry, clock) !== state.year) return false
+  if (state.source !== null && isImported(entry) !== (state.source === 'imported')) return false
+  return true
+}
+
+/**
+ * Apply every axis of `state`.
+ *
+ * @param entries History entries, in any order; order is preserved.
+ * @param state Filter state; a `null` axis matches everything.
+ * @param clock Zone the year boundary is measured in; defaults to Pacific (#429).
+ */
+export function filterWorkouts(
+  entries: readonly WorkoutHistoryEntry[],
+  state: WorkoutFilterState,
+  clock: DayClock = PACIFIC_CLOCK
+): WorkoutHistoryEntry[] {
+  return entries.filter(entry => matchesWorkoutFilters(entry, state, clock))
+}
+
+/**
+ * How many sessions a chip would show if it were clicked.
+ *
+ * The chip's own axis is replaced by the value it selects; the other axes stay
+ * as they are. That is exactly the state the link navigates to, so the number
+ * and the resulting page cannot disagree.
+ *
+ * @param entries The full history, before any filtering.
+ * @param state The currently active filter state.
+ * @param override The single axis this chip changes, e.g. `{ source: 'imported' }`.
+ * @param clock Zone the year boundary is measured in; defaults to Pacific (#429).
+ */
+export function facetCount(
+  entries: readonly WorkoutHistoryEntry[],
+  state: WorkoutFilterState,
+  override: Partial<WorkoutFilterState>,
+  clock: DayClock = PACIFIC_CLOCK
+): number {
+  const next = { ...state, ...override }
+  let count = 0
+  for (const entry of entries) {
+    if (matchesWorkoutFilters(entry, next, clock)) count += 1
+  }
+  return count
+}

--- a/lib/training-facility/workout-facets.ts
+++ b/lib/training-facility/workout-facets.ts
@@ -43,6 +43,25 @@ export function isImported(entry: WorkoutHistoryEntry): boolean {
 }
 
 /**
+ * Resolve the provenance filter from a raw URL param.
+ *
+ * Ignored entirely when the log holds no imports: the rail doesn't render for a
+ * log the distinction doesn't apply to, so honouring `?source=imported` there
+ * would filter the page to nothing with no chip left to undo it. With one
+ * population, neither value means anything anyway.
+ *
+ * @param raw The param value; anything unrecognized resolves to `null`.
+ * @param hasImported Whether the log contains any imported session at all.
+ */
+export function resolveSourceFilter(
+  raw: string | null,
+  hasImported: boolean
+): WorkoutSourceFilter | null {
+  if (!hasImported) return null
+  return raw === 'recorded' || raw === 'imported' ? raw : null
+}
+
+/**
  * Whether an entry survives every axis of `state`.
  *
  * @param entry The session to test.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -42,7 +42,7 @@ export default defineConfig({
     {
       name: 'training-facility-enabled',
       testMatch:
-        /(?:training-facility-enabled|draft-room-enabled|draft-room-live|chart-overflow|heatmap-span)\.spec\.ts/,
+        /(?:training-facility-enabled|draft-room-enabled|draft-room-live|chart-overflow|heatmap-span|workout-filters)\.spec\.ts/,
       use: {
         baseURL: TRAINING_FACILITY_BASE_URL,
       },


### PR DESCRIPTION
## Summary

Every filter chip on the session log counted the **whole** history while the list was **filtered**. The year axis is always active — it defaults to the newest year rather than to everything — so the two disagreed on first paint with no interaction at all.

Measured against the real log before this change:

| Chip | Said | Clicking it gave |
|---|---|---|
| Year 2026 | 22 | 22 ✅ |
| Source · All | 522 | 22 |
| Source · Recorded | 15 | **0 — an empty page** |
| Source · Apple Health | 507 | 22 |

The "Recorded 15" case is the sharp one: all fifteen app-recorded sessions are in 2022–2024, so from the default 2026 view that chip promised fifteen sessions and delivered "No sessions match that filter yet."

A count on a filter chip is a promise about what clicking it returns. Each one is now measured against the history filtered by the *other* axes — the exact state its own link navigates to — via one tested helper (`lib/training-facility/workout-facets.ts`) instead of a predicate restated per rail.

## Three decisions worth a look

**Zero-count chips are dropped, not shown at 0.** Otherwise no chip leads anywhere empty. The currently selected chip is always kept (at 0 if need be) so a filter is never undoable-only-by-editing-the-URL — the same stranding bug #438 had.

**The year axis resolves last.** Its counts *and* its default depend on the other two: with a template selected, the newest year overall routinely isn't a year that template ran, so defaulting there opened on nothing.

**The provenance rail's existence stays keyed to the whole log.** It renders when the log contains any import at all, not when the *current view* does. Gating it on the faceted count would have removed the only way to undo a source filter that had emptied the page — I wrote that bug, and the new e2e caught it.

## Test plan

- [ ] `/training-facility/weight-room/workouts` — source chips now read **All 22 / Apple Health 22**; "Recorded" is absent because 2026 has none
- [ ] Click **All years** — chips become All 522 / Recorded 15 / Apple Health 507, and each matches its result count
- [ ] Click **Recorded** from All years → 15 sessions; the year rail now offers only 2024/2023/2022
- [ ] Pick a template — the year rail narrows to years that template actually ran
- [ ] From a template + year with results, switch source; nothing strands, every rail stays reachable
- [ ] Hand-type `?template=<unknown>` — degrades to the full history rather than an empty list

Verified: `tsc --noEmit` clean, `eslint` clean, `next build` compiles, 2478 vitest tests pass, 79 Playwright tests pass.

Closes #445.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved workout filtering across templates, sources, and years.
  * Filter counts now reflect the results users will see.
  * Unavailable filter options are hidden, while selected options remain accessible.
  * Imported workout filters remain available even when the current selection has no matches.

* **Bug Fixes**
  * Corrected filter behavior for missing templates, zero-result selections, and year boundaries.
  * Improved consistency between displayed counts and filtered workout results.

* **Tests**
  * Added comprehensive automated coverage for workout filtering and filter-count accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->