### PR TITLE
feat(weight-room): a per-template view — the workout, trended as a workout (#446)

### DIFF
--- a/app/training-facility/weight-room/templates/[slug]/page.tsx
+++ b/app/training-facility/weight-room/templates/[slug]/page.tsx
@@ -1,0 +1,216 @@
+import type { JSX } from 'react'
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+
+import { BackToCourtButton } from '@/components/common/BackToCourtButton'
+import { FacilityBackLink } from '@/components/training-facility/FacilityBackLink'
+import { PreviewModeBadge } from '@/components/training-facility/shared/PreviewModeBadge'
+import {
+  ExerciseProgressionPanel,
+  exerciseTrendHref,
+} from '@/components/training-facility/weight-room/ExerciseProgressionPanel'
+import { TemplateCompositionPanel } from '@/components/training-facility/weight-room/TemplateCompositionPanel'
+import { TemplateRunCharts } from '@/components/training-facility/weight-room/TemplateRunCharts'
+import { WeightRoomSubNav } from '@/components/training-facility/weight-room/WeightRoomSubNav'
+import { buildWorkoutDemoData } from '@/constants/weight-room-demo-fixture'
+import { isAdminRequest } from '@/lib/auth/admin-session'
+import {
+  getWeightRoomDataServer,
+  getWeightRoomWorkoutsServer,
+  getWorkoutTemplatesServer,
+} from '@/lib/data/weight-room-server'
+import { isWeightRoomEnabled } from '@/lib/feature-flags'
+import { formatDayKey } from '@/lib/training-facility/day-keys'
+import {
+  buildExerciseProgression,
+  buildSetDetailCoverage,
+} from '@/lib/training-facility/exercise-progression'
+import { buildExerciseLabels, slugLabel } from '@/lib/training-facility/exercise-labels'
+import { isPreviewDemoActive } from '@/lib/training-facility/preview-param'
+import {
+  buildTemplateHistory,
+  resolveTemplate,
+  templateRunIds,
+} from '@/lib/training-facility/template-history'
+import { buildWorkoutHistory } from '@/lib/training-facility/workout-stats'
+
+/** Route + search params for the per-template view. */
+interface PageProps {
+  /** Async per-request route params (Next 15+). `slug` names the template. */
+  params: Promise<{ slug: string }>
+  /** Async per-request search params; only `preview` is consumed. */
+  searchParams: Promise<Record<string, string | string[] | undefined>>
+}
+
+/** Session log route, for the breadcrumb back-link. */
+const WORKOUTS_ROUTE = '/training-facility/weight-room/workouts'
+
+/**
+ * A movement needs two training days before a trend means anything; below that
+ * the panel renders its own single-day note instead of a collapsed axis.
+ */
+const MIN_PANEL_DAYS = 2
+
+/**
+ * Per-template view (#446) — one workout, trended as a workout.
+ *
+ * The room could already show a movement over time (#412) and a single session
+ * in detail (#377), but the unit training is actually *planned* in sat between
+ * them: "how is Chest Day 1 going" meant opening four movement pages and doing
+ * the joining by eye.
+ *
+ * Two halves. The whole-workout charts treat each run as one point — tonnage,
+ * volume, duration — and the per-movement panels below reuse the #412 trend,
+ * narrowed to the sets logged *in this workout*, so a lift that also appears
+ * elsewhere trends here only on the days this session ran it.
+ *
+ * A leaf page, like the per-exercise view: no sub-nav pill, because it's about
+ * one workout rather than a section of the room.
+ */
+export default async function WeightRoomTemplatePage({
+  params,
+  searchParams,
+}: PageProps): Promise<JSX.Element> {
+  if (!isWeightRoomEnabled()) notFound()
+
+  const [{ slug }, query, realWorkouts, data, realTemplates, isAdmin] = await Promise.all([
+    params,
+    searchParams,
+    getWeightRoomWorkoutsServer().catch(() => []),
+    getWeightRoomDataServer().catch(() => null),
+    getWorkoutTemplatesServer().catch(() => []),
+    isAdminRequest().catch(() => false),
+  ])
+
+  // Same contract as every other Weight Room surface: the fixture stands in
+  // only when the real read is empty, so it can never sit in front of real
+  // training.
+  const isPreviewMode = realWorkouts.length === 0 && isPreviewDemoActive(query.preview)
+  const demo = isPreviewMode ? buildWorkoutDemoData() : null
+
+  const workouts = demo?.workouts ?? realWorkouts
+  const sets = demo?.sets ?? data?.sets ?? []
+  const templates = demo?.templates ?? realTemplates
+  const exercises = demo?.exercises ?? data?.exercises ?? []
+
+  // Slugs are derived from the name at request time, so match case-insensitively
+  // — a hand-typed `/templates/Chest-Day-1` should find the same workout.
+  const template = resolveTemplate(slug.toLowerCase(), templates)
+  if (template === null) notFound()
+
+  const history = buildWorkoutHistory(workouts, sets, templates, exercises)
+  const templateHistory = buildTemplateHistory(template, history)
+  const runIds = templateRunIds(templateHistory)
+
+  // Narrowed to this workout's own sessions, so a movement that also runs
+  // elsewhere trends here only on the days this template ran it. Loose sets
+  // carry no `workout_id` and are excluded by the same test.
+  const templateSets = sets.filter(
+    set => set.workout_id !== undefined && runIds.has(set.workout_id)
+  )
+  const exerciseLabels = buildExerciseLabels(exercises)
+
+  const panels = templateHistory.movements
+    .map(movement => ({
+      movement,
+      progression: buildExerciseProgression(
+        movement.exercise,
+        templateSets,
+        exercises,
+        workouts.filter(workout => runIds.has(workout.id))
+      ),
+    }))
+    .filter(entry => (entry.progression?.points.length ?? 0) >= MIN_PANEL_DAYS)
+
+  const ranged =
+    templateHistory.firstDayKey === ''
+      ? null
+      : `${formatDayKey(templateHistory.firstDayKey, { month: 'short', year: 'numeric' })} – ${formatDayKey(
+          templateHistory.lastDayKey,
+          { month: 'short', year: 'numeric' }
+        )}`
+
+  return (
+    <div className="relative min-h-svh overflow-hidden bg-[#120d0a] text-[#f7ead9]">
+      <div
+        aria-hidden="true"
+        className="absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(248,214,170,0.16),transparent_30%),linear-gradient(180deg,#241811_0%,#120d0a_55%,#0b0806_100%)]"
+      />
+
+      <div className="relative z-10 mx-auto flex min-h-svh w-full max-w-5xl flex-col px-4 py-6 sm:px-6 sm:py-8 lg:px-10">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <BackToCourtButton />
+          <FacilityBackLink />
+        </div>
+
+        <header className="mt-12">
+          <p className="font-mono text-[11px] uppercase tracking-[0.32em] text-amber-300/80">
+            Weight Room ·{' '}
+            {/* Keeps the preview alive on the way back — without the param the
+                read is empty again and the demo vanishes mid-tour. */}
+            <Link
+              href={isPreviewMode ? `${WORKOUTS_ROUTE}?preview=demo` : WORKOUTS_ROUTE}
+              className="underline-offset-4 hover:underline"
+            >
+              Session log
+            </Link>
+          </p>
+          <h1
+            className="mt-2 text-3xl font-black uppercase tracking-[0.06em] text-[#fff7ec] sm:text-5xl"
+            style={template.color === undefined ? undefined : { color: template.color }}
+          >
+            {template.name}
+          </h1>
+          <p className="mt-3 max-w-xl text-sm leading-7 text-[#e8d5be] sm:text-base">
+            {templateHistory.runs.length === 0
+              ? 'This workout has no recorded sessions yet. Its charts start at the first one.'
+              : `${templateHistory.runs.length} sessions${ranged === null ? '' : ` · ${ranged}`} — the workout as a whole, then each movement in it.`}
+          </p>
+          <WeightRoomSubNav active="workouts" className="mt-5" isAdmin={isAdmin} />
+        </header>
+
+        {isPreviewMode ? (
+          <div className="mt-6">
+            <PreviewModeBadge description="These sessions are illustrative — not Lucas’s real training log." />
+          </div>
+        ) : null}
+
+        <div className="mt-8 flex flex-col gap-8 pb-16" data-testid={`template-${template.id}`}>
+          <TemplateRunCharts
+            history={templateHistory}
+            {...(template.color === undefined ? {} : { accentColor: template.color })}
+          />
+
+          <TemplateCompositionPanel
+            history={templateHistory}
+            exerciseLabels={exerciseLabels}
+            exerciseHref={slug => exerciseTrendHref(slug, isPreviewMode)}
+          />
+
+          {panels.length > 0 ? (
+            <section className="flex flex-col gap-8" data-testid="template-movement-panels">
+              <h2 className="font-mono text-[11px] uppercase tracking-[0.28em] text-amber-300/80">
+                Movement by movement
+              </h2>
+              {panels.map(({ movement, progression }) =>
+                progression === null ? null : (
+                  <ExerciseProgressionPanel
+                    key={movement.exercise}
+                    progression={progression}
+                    displayName={slugLabel(movement.exercise, undefined, exerciseLabels)}
+                    coverage={buildSetDetailCoverage(
+                      progression.points[0]?.dayKey ?? null,
+                      workouts.filter(workout => runIds.has(workout.id)),
+                      templateSets
+                    )}
+                    {...(template.color === undefined ? {} : { accentColor: template.color })}
+                  />
+                )
+              )}
+            </section>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/training-facility/weight-room/TemplateCompositionPanel.test.tsx
+++ b/components/training-facility/weight-room/TemplateCompositionPanel.test.tsx
@@ -1,0 +1,135 @@
+/**
+ * Tests for the template composition panel (#446).
+ *
+ * This panel replaced a prescribed-vs-actual adherence score, which no session
+ * in the log can support — none carries a frozen prescription, so the only
+ * thing to grade against is today's template. The cases below pin the two
+ * claims it makes instead: a movement that ran is listed even after the
+ * template drops it, and one the template prescribes but never ran is named as
+ * such rather than silently absent.
+ */
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import type { WorkoutTemplate } from '@/types/weight-room'
+
+import { buildExerciseLabels } from '@/lib/training-facility/exercise-labels'
+import type { TemplateHistory, TemplateMovement } from '@/lib/training-facility/template-history'
+
+import { TemplateCompositionPanel } from './TemplateCompositionPanel'
+
+const TEMPLATE: WorkoutTemplate = {
+  id: 't-chest',
+  name: 'Chest Day 1',
+  position: 0,
+  slots: [],
+}
+
+function movement(exercise: string, prescribed: boolean, runs = 5): TemplateMovement {
+  return { exercise, runs, sets: runs * 3, reps: runs * 24, tonnage: runs * 1000, prescribed }
+}
+
+function history(overrides: Partial<TemplateHistory> = {}): TemplateHistory {
+  return {
+    template: TEMPLATE,
+    runs: Array.from({ length: 8 }, (_, i) => ({
+      dayKey: `2024-01-0${i + 1}`,
+      date: new Date(`2024-01-0${i + 1}T20:00:00Z`),
+      workoutId: `w${i}`,
+      tonnage: 1000,
+      totalSets: 10,
+      totalReps: 80,
+      durationMinutes: 45,
+    })),
+    durations: [],
+    movements: [],
+    neverRun: [],
+    firstDayKey: '2024-01-01',
+    lastDayKey: '2024-01-08',
+    ...overrides,
+  }
+}
+
+const LABELS = buildExerciseLabels([
+  { slug: 'barbell-bench-press', display_name: 'Barbell Bench Press' },
+  { slug: 'barbell-overhead-press', display_name: 'Barbell Overhead Press' },
+  { slug: 'sled-push', display_name: 'Sled Push' },
+])
+
+describe('TemplateCompositionPanel', () => {
+  it('lists a movement the template no longer prescribes, and marks it', () => {
+    render(
+      <TemplateCompositionPanel
+        history={history({
+          movements: [
+            movement('barbell-bench-press', true),
+            movement('barbell-overhead-press', false),
+          ],
+        })}
+        exerciseLabels={LABELS}
+      />
+    )
+    expect(screen.getByText('Barbell Overhead Press')).toBeInTheDocument()
+    expect(
+      screen.getByTestId('template-movement-retired-barbell-overhead-press')
+    ).toBeInTheDocument()
+    // The still-prescribed one carries no badge.
+    expect(screen.queryByTestId('template-movement-retired-barbell-bench-press')).toBeNull()
+  })
+
+  it('names a prescribed movement that has never run', () => {
+    render(
+      <TemplateCompositionPanel
+        history={history({
+          movements: [movement('barbell-bench-press', true)],
+          neverRun: ['sled-push'],
+        })}
+        exerciseLabels={LABELS}
+      />
+    )
+    expect(screen.getByTestId('template-never-run')).toHaveTextContent('Sled Push')
+  })
+
+  it('omits the never-run note when everything prescribed has run', () => {
+    render(
+      <TemplateCompositionPanel
+        history={history({ movements: [movement('barbell-bench-press', true)] })}
+        exerciseLabels={LABELS}
+      />
+    )
+    expect(screen.queryByTestId('template-never-run')).toBeNull()
+  })
+
+  it('reports each movement against the number of runs', () => {
+    render(
+      <TemplateCompositionPanel
+        history={history({ movements: [movement('barbell-bench-press', true, 6)] })}
+        exerciseLabels={LABELS}
+      />
+    )
+    expect(screen.getByTestId('template-movement-barbell-bench-press')).toHaveTextContent(
+      '6 of 8 runs'
+    )
+  })
+
+  it('links a movement to its own trend when a href builder is supplied', () => {
+    render(
+      <TemplateCompositionPanel
+        history={history({ movements: [movement('barbell-bench-press', true)] })}
+        exerciseLabels={LABELS}
+        exerciseHref={slug => `/exercises/${slug}`}
+      />
+    )
+    expect(screen.getByRole('link', { name: 'Barbell Bench Press' })).toHaveAttribute(
+      'href',
+      '/exercises/barbell-bench-press'
+    )
+  })
+
+  it('says so plainly when nothing has been logged', () => {
+    render(<TemplateCompositionPanel history={history()} exerciseLabels={LABELS} />)
+    expect(screen.getByTestId('template-composition')).toHaveTextContent(
+      'No sets have been logged under this workout yet.'
+    )
+  })
+})

--- a/components/training-facility/weight-room/TemplateCompositionPanel.test.tsx
+++ b/components/training-facility/weight-room/TemplateCompositionPanel.test.tsx
@@ -42,6 +42,8 @@ function history(overrides: Partial<TemplateHistory> = {}): TemplateHistory {
       durationMinutes: 45,
     })),
     durations: [],
+    noteTimedRuns: 0,
+    untimedRuns: 0,
     movements: [],
     neverRun: [],
     firstDayKey: '2024-01-01',

--- a/components/training-facility/weight-room/TemplateCompositionPanel.tsx
+++ b/components/training-facility/weight-room/TemplateCompositionPanel.tsx
@@ -1,0 +1,119 @@
+import type { JSX } from 'react'
+import Link from 'next/link'
+
+import { slugLabel, type ExerciseLabels } from '@/lib/training-facility/exercise-labels'
+import type { TemplateHistory } from '@/lib/training-facility/template-history'
+
+/** Props for {@link TemplateCompositionPanel}. */
+export interface TemplateCompositionPanelProps {
+  /** The template's aggregated run history. */
+  history: TemplateHistory
+  /** Slug → human-readable movement name, from `buildExerciseLabels`. */
+  exerciseLabels: ExerciseLabels
+  /** Link to a movement's own trend; omit to render names as plain text. */
+  exerciseHref?: (slug: string) => string
+}
+
+/**
+ * What actually ran under a template, over its whole history (#446).
+ *
+ * This is the page's answer to "prescribed vs actual", and it deliberately
+ * isn't an adherence score. No session in the log carries a frozen
+ * prescription, so the only thing to score against is *today's* template — and
+ * templates drift, heavily: across this log fifteen movements were logged under
+ * templates that no longer list them. A percentage computed that way would
+ * grade a 2023 session against a 2026 plan and present the result as fact.
+ *
+ * So it reports rather than grades: every movement that ran, how often, with
+ * the ones the template has since dropped marked as such. That is checkable
+ * against the sessions themselves.
+ *
+ * A Server Component.
+ */
+export function TemplateCompositionPanel({
+  history,
+  exerciseLabels,
+  exerciseHref,
+}: TemplateCompositionPanelProps): JSX.Element {
+  const { movements, neverRun, runs } = history
+  const mostRuns = movements.reduce((max, m) => Math.max(max, m.runs), 0)
+
+  return (
+    <section
+      data-testid="template-composition"
+      className="rounded-[1.2rem] border border-white/10 bg-white/[0.04] p-5"
+    >
+      <h2 className="font-mono text-[11px] uppercase tracking-[0.28em] text-amber-300/80">
+        What actually ran
+      </h2>
+      <p className="mt-1.5 text-sm leading-6 text-[#e8d5be]/75">
+        Every movement logged under this workout, most load moved first — not what the template
+        prescribes today. Sessions from before an edit still happened.
+      </p>
+
+      {movements.length === 0 ? (
+        <p className="mt-4 text-sm leading-6 text-[#e8d5be]/60">
+          No sets have been logged under this workout yet.
+        </p>
+      ) : (
+        <ul className="mt-4 flex flex-col gap-2.5">
+          {movements.map(movement => {
+            const label = slugLabel(movement.exercise, undefined, exerciseLabels)
+            const share = mostRuns === 0 ? 0 : movement.runs / mostRuns
+            return (
+              <li key={movement.exercise} data-testid={`template-movement-${movement.exercise}`}>
+                <div className="flex flex-wrap items-baseline justify-between gap-x-3 gap-y-1">
+                  <span className="font-mono text-[11px] uppercase tracking-[0.14em] text-[#f7ead9]">
+                    {exerciseHref === undefined ? (
+                      label
+                    ) : (
+                      <Link
+                        href={exerciseHref(movement.exercise)}
+                        className="underline decoration-white/25 underline-offset-4 hover:decoration-white/60"
+                      >
+                        {label}
+                      </Link>
+                    )}
+                    {!movement.prescribed ? (
+                      <span
+                        data-testid={`template-movement-retired-${movement.exercise}`}
+                        className="ml-2 rounded bg-white/10 px-1.5 py-0.5 font-mono text-[0.55rem] uppercase tracking-[0.1em] text-[#e8d5be]/70"
+                      >
+                        no longer in this workout
+                      </span>
+                    ) : null}
+                  </span>
+                  <span className="font-mono text-[11px] text-[#e8d5be]/60">
+                    {movement.runs} of {runs.length} runs · {movement.sets} sets ·{' '}
+                    {movement.tonnage.toLocaleString()} lb
+                  </span>
+                </div>
+                <div
+                  aria-hidden="true"
+                  className="mt-1.5 h-1.5 w-full overflow-hidden rounded-full bg-white/8"
+                >
+                  <div
+                    className={
+                      movement.prescribed ? 'h-full bg-amber-300/70' : 'h-full bg-[#e8d5be]/30'
+                    }
+                    style={{ width: `${Math.round(share * 100)}%` }}
+                  />
+                </div>
+              </li>
+            )
+          })}
+        </ul>
+      )}
+
+      {neverRun.length > 0 ? (
+        <p
+          data-testid="template-never-run"
+          className="mt-4 border-t border-white/10 pt-3 text-xs leading-5 text-[#e8d5be]/60"
+        >
+          Prescribed but never logged under this workout:{' '}
+          {neverRun.map(slug => slugLabel(slug, undefined, exerciseLabels)).join(', ')}.
+        </p>
+      ) : null}
+    </section>
+  )
+}

--- a/components/training-facility/weight-room/TemplateRunCharts.test.tsx
+++ b/components/training-facility/weight-room/TemplateRunCharts.test.tsx
@@ -1,0 +1,87 @@
+/**
+ * Tests for the whole-workout charts (#446).
+ *
+ * Two things worth pinning: a single run can't be a trend and must say so
+ * rather than render a collapsed axis, and the duration chart has to account
+ * for the runs it leaves out — an `icloud_notes` session's window measures
+ * note-taking, so silently dropping it would understate how often this workout
+ * was actually timed.
+ */
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import type { WorkoutTemplate } from '@/types/weight-room'
+
+import type { TemplateHistory, TemplateRunPoint } from '@/lib/training-facility/template-history'
+
+import { TemplateRunCharts } from './TemplateRunCharts'
+
+const TEMPLATE: WorkoutTemplate = { id: 't', name: 'Chest Day 1', position: 0, slots: [] }
+
+function run(day: number, minutes: number | null = 45): TemplateRunPoint {
+  const dayKey = `2024-01-${String(day).padStart(2, '0')}`
+  return {
+    dayKey,
+    date: new Date(`${dayKey}T20:00:00Z`),
+    workoutId: `w${day}`,
+    tonnage: 10_000 + day * 100,
+    totalSets: 12,
+    totalReps: 96,
+    durationMinutes: minutes,
+  }
+}
+
+function history(runs: TemplateRunPoint[], durations = runs): TemplateHistory {
+  return {
+    template: TEMPLATE,
+    runs,
+    durations,
+    movements: [],
+    neverRun: [],
+    firstDayKey: runs[0]?.dayKey ?? '',
+    lastDayKey: runs[runs.length - 1]?.dayKey ?? '',
+  }
+}
+
+describe('TemplateRunCharts', () => {
+  it('renders the trends once there are two runs', () => {
+    render(<TemplateRunCharts history={history([run(1), run(8)])} />)
+    expect(screen.getByTestId('template-run-charts')).toBeInTheDocument()
+    expect(screen.queryByTestId('template-single-run-note')).toBeNull()
+  })
+
+  it('plots reps and sets on separate axes, not one shared scale', () => {
+    // Reps run an order of magnitude above sets; overlaying them flattens the
+    // set line into a smear along the baseline (#266).
+    render(<TemplateRunCharts history={history([run(1), run(8)])} />)
+    expect(screen.getByRole('img', { name: /reps per session/i })).toBeInTheDocument()
+    expect(screen.getByRole('img', { name: /sets per session/i })).toBeInTheDocument()
+  })
+
+  it('explains a single run instead of drawing a collapsed axis', () => {
+    render(<TemplateRunCharts history={history([run(1)])} />)
+    expect(screen.getByTestId('template-single-run-note')).toHaveTextContent('Ran once so far')
+    expect(screen.queryByTestId('template-run-charts')).toBeNull()
+  })
+
+  it('says so when the workout has never run', () => {
+    render(<TemplateRunCharts history={history([])} />)
+    expect(screen.getByTestId('template-single-run-note')).toHaveTextContent(
+      'No sessions have run this workout yet.'
+    )
+  })
+
+  it('accounts for runs left out of the duration series', () => {
+    const runs = [run(1), run(8), run(15)]
+    render(<TemplateRunCharts history={history(runs, [run(1), run(8)])} />)
+    expect(screen.getByRole('img', { name: /duration per session/i })).toBeInTheDocument()
+    expect(screen.getByTestId('template-run-charts')).toHaveTextContent('1 of 3 runs are left out')
+  })
+
+  it('drops the duration chart when too few runs recorded a real one', () => {
+    render(<TemplateRunCharts history={history([run(1), run(8)], [run(1)])} />)
+    expect(screen.queryByRole('img', { name: /duration per session/i })).toBeNull()
+    // The other two charts still render.
+    expect(screen.getByRole('img', { name: /tonnage per session/i })).toBeInTheDocument()
+  })
+})

--- a/components/training-facility/weight-room/TemplateRunCharts.test.tsx
+++ b/components/training-facility/weight-room/TemplateRunCharts.test.tsx
@@ -31,11 +31,20 @@ function run(day: number, minutes: number | null = 45): TemplateRunPoint {
   }
 }
 
-function history(runs: TemplateRunPoint[], durations = runs): TemplateHistory {
+function history(
+  runs: TemplateRunPoint[],
+  durations = runs,
+  excluded: { noteTimedRuns?: number; untimedRuns?: number } = {}
+): TemplateHistory {
+  const missing = runs.length - durations.length
   return {
     template: TEMPLATE,
     runs,
     durations,
+    // Default the whole shortfall to the note-timed cause, which is what the
+    // real log looks like; a case that cares states both explicitly.
+    noteTimedRuns: excluded.noteTimedRuns ?? missing - (excluded.untimedRuns ?? 0),
+    untimedRuns: excluded.untimedRuns ?? 0,
     movements: [],
     neverRun: [],
     firstDayKey: runs[0]?.dayKey ?? '',
@@ -76,6 +85,33 @@ describe('TemplateRunCharts', () => {
     render(<TemplateRunCharts history={history(runs, [run(1), run(8)])} />)
     expect(screen.getByRole('img', { name: /duration per session/i })).toBeInTheDocument()
     expect(screen.getByTestId('template-run-charts')).toHaveTextContent('1 of 3 runs are left out')
+  })
+
+  it('names each reason a run is missing, not just the note-timed one', () => {
+    // Two distinct causes reach the same subtraction. Blaming both on note
+    // timestamps would be a plausible-sounding lie about the untimed run.
+    const runs = [run(1), run(8), run(15), run(22)]
+    render(
+      <TemplateRunCharts
+        history={history(runs, [run(1), run(8)], { noteTimedRuns: 1, untimedRuns: 1 })}
+      />
+    )
+    const charts = screen.getByTestId('template-run-charts')
+    expect(charts).toHaveTextContent('2 of 4 runs are left out')
+    expect(charts).toHaveTextContent('when a note was written')
+    expect(charts).toHaveTextContent('1 recorded no end time')
+  })
+
+  it('says only the untimed reason when no run is note-timed', () => {
+    const runs = [run(1), run(8), run(15)]
+    render(
+      <TemplateRunCharts
+        history={history(runs, [run(1), run(8)], { noteTimedRuns: 0, untimedRuns: 1 })}
+      />
+    )
+    const charts = screen.getByTestId('template-run-charts')
+    expect(charts).toHaveTextContent('1 recorded no end time')
+    expect(charts).not.toHaveTextContent('when a note was written')
   })
 
   it('drops the duration chart when too few runs recorded a real one', () => {

--- a/components/training-facility/weight-room/TemplateRunCharts.tsx
+++ b/components/training-facility/weight-room/TemplateRunCharts.tsx
@@ -108,14 +108,39 @@ export function TemplateRunCharts({ history, accentColor }: TemplateRunChartsPro
           />
           {durations.length < runs.length ? (
             <p className="mt-3 text-xs leading-5 text-[#e8d5be]/60">
-              {runs.length - durations.length} of {runs.length} runs are left out: their start and
-              end times come from when a note was written, not from the session itself.
+              {runs.length - durations.length} of {runs.length} runs are left out:{' '}
+              {describeExclusions(history.noteTimedRuns, history.untimedRuns)}.
             </p>
           ) : null}
         </ChartCard>
       ) : null}
     </div>
   )
+}
+
+/**
+ * Say why runs are missing from the duration series, naming each reason that
+ * applies.
+ *
+ * Two distinct causes reach the same subtraction — a window that measures
+ * note-taking rather than training, and a session that recorded no end at all.
+ * Attributing both to the first would be a plausible-sounding lie about the
+ * second, which is the failure mode this whole page is trying to avoid.
+ *
+ * @param noteTimed Runs whose start and end come from a note's timestamps.
+ * @param untimed Runs carrying no duration at all.
+ */
+function describeExclusions(noteTimed: number, untimed: number): string {
+  const reasons: string[] = []
+  if (noteTimed > 0) {
+    reasons.push(
+      `${noteTimed} took ${noteTimed === 1 ? 'its' : 'their'} start and end from when a note was written, not from the session`
+    )
+  }
+  if (untimed > 0) {
+    reasons.push(`${untimed} recorded no end time`)
+  }
+  return reasons.length === 0 ? 'no duration was recorded' : reasons.join('; ')
 }
 
 /** Props for {@link ChartCard}. */

--- a/components/training-facility/weight-room/TemplateRunCharts.tsx
+++ b/components/training-facility/weight-room/TemplateRunCharts.tsx
@@ -1,0 +1,193 @@
+import type { JSX } from 'react'
+
+import { RoughLine, chartPalette } from '@/components/training-facility/shared/charts'
+import { formatDayKey } from '@/lib/training-facility/day-keys'
+import type { TemplateHistory, TemplateRunPoint } from '@/lib/training-facility/template-history'
+
+/** Cream axis ink that reads on the Weight Room's dark page surface. */
+const AXIS_COLOR = 'rgba(247, 234, 217, 0.55)'
+
+/** A trend needs two anchored points; below that `scaleTime`'s domain collapses. */
+const MIN_TREND_POINTS = 2
+
+/** Chart geometry, matching the per-movement trends (#412). */
+const CHART_WIDTH = 760
+const CHART_HEIGHT = 240
+
+/** Props for {@link TemplateRunCharts}. */
+export interface TemplateRunChartsProps {
+  /** The template's aggregated run history. */
+  history: TemplateHistory
+  /** Line color; defaults to the template's own chip color where it has one. */
+  accentColor?: string
+}
+
+/**
+ * Whole-workout trends for one template (#446) — how the *session* is going,
+ * rather than any single movement in it.
+ *
+ * Three series, each answering a different question about the same runs:
+ * tonnage (is the work going up), volume (is that more sets or heavier ones),
+ * and duration (is it taking longer to do it).
+ *
+ * A Server Component; rough.js emits its paths without a DOM.
+ */
+export function TemplateRunCharts({ history, accentColor }: TemplateRunChartsProps): JSX.Element {
+  const stroke = accentColor ?? chartPalette.rimOrange
+  const { runs, durations } = history
+
+  if (runs.length < MIN_TREND_POINTS) {
+    return (
+      <p
+        data-testid="template-single-run-note"
+        className="rounded-[1.2rem] border border-white/10 bg-white/[0.04] p-5 text-sm leading-6 text-[#e8d5be]/75"
+      >
+        {runs.length === 0
+          ? 'No sessions have run this workout yet.'
+          : 'Ran once so far — a second session is what turns these numbers into a trend.'}
+      </p>
+    )
+  }
+
+  return (
+    <div className="space-y-6" data-testid="template-run-charts">
+      <ChartCard
+        title="Tonnage per session"
+        subtitle="Total load moved each time this workout ran. The clearest single read on whether the session is progressing."
+      >
+        <RunChart
+          data={runs}
+          y={run => run.tonnage}
+          stroke={stroke}
+          yLabel="lb"
+          yTickFormat={value => `${Math.round(value / 1000)}k`}
+          ariaLabel={`${history.template.name} tonnage per session`}
+        />
+      </ChartCard>
+
+      <ChartCard
+        title="Volume per session"
+        subtitle="Sets and reps recorded each run. Read against tonnage: rising load on flat volume is heavier work, not more of it."
+      >
+        {/* Two charts on a shared x-axis rather than two series on a shared
+            y-axis. Reps run an order of magnitude above sets, so overlaying
+            them flattens the set line into a smear along the baseline — the
+            same trap the OTF machine card avoided (#266). */}
+        <div className="flex flex-col gap-4">
+          <RunChart
+            data={runs}
+            y={run => run.totalReps}
+            stroke={stroke}
+            yLabel="reps"
+            yTickFormat={value => String(Math.round(value))}
+            ariaLabel={`${history.template.name} reps per session`}
+          />
+          <RunChart
+            data={runs}
+            y={run => run.totalSets}
+            stroke={stroke}
+            yLabel="sets"
+            yTickFormat={value => String(Math.round(value))}
+            ariaLabel={`${history.template.name} sets per session`}
+          />
+        </div>
+      </ChartCard>
+
+      {durations.length >= MIN_TREND_POINTS ? (
+        <ChartCard
+          title="Duration per session"
+          subtitle="Wall-clock minutes, from sessions that recorded a real one."
+        >
+          <RunChart
+            data={durations}
+            y={run => run.durationMinutes ?? 0}
+            stroke={stroke}
+            yLabel="min"
+            yTickFormat={value => String(Math.round(value))}
+            ariaLabel={`${history.template.name} duration per session`}
+          />
+          {durations.length < runs.length ? (
+            <p className="mt-3 text-xs leading-5 text-[#e8d5be]/60">
+              {runs.length - durations.length} of {runs.length} runs are left out: their start and
+              end times come from when a note was written, not from the session itself.
+            </p>
+          ) : null}
+        </ChartCard>
+      ) : null}
+    </div>
+  )
+}
+
+/** Props for {@link ChartCard}. */
+interface ChartCardProps {
+  /** Short, all-caps section label. */
+  title: string
+  /** One line saying what the series actually is. */
+  subtitle: string
+  /** The chart, plus any note beneath it. */
+  children: React.ReactNode
+}
+
+/** Titled, horizontally scrollable frame around one chart. */
+function ChartCard({ title, subtitle, children }: ChartCardProps): JSX.Element {
+  return (
+    <section className="rounded-[1.2rem] border border-white/10 bg-white/[0.04] p-5">
+      <h2 className="font-mono text-[11px] uppercase tracking-[0.28em] text-amber-300/80">
+        {title}
+      </h2>
+      <p className="mt-1.5 text-sm leading-6 text-[#e8d5be]/75">{subtitle}</p>
+      {/* Fixed-width SVG: the page scrolls it on a phone rather than squashing
+          a year of sessions into 350 px. */}
+      <div className="mt-4 overflow-x-auto">{children}</div>
+    </section>
+  )
+}
+
+/** Props for {@link RunChart}. */
+interface RunChartProps {
+  /** Runs to plot, oldest first. */
+  data: readonly TemplateRunPoint[]
+  /** The value to plot for a run. */
+  y: (run: TemplateRunPoint) => number
+  /** Line color. */
+  stroke: string
+  /** Left-axis unit label. */
+  yLabel: string
+  /** Tick formatter for the left axis. */
+  yTickFormat: (value: number) => string
+  /** Accessible name for the chart. */
+  ariaLabel: string
+}
+
+/** One session-over-session line, on a shared time axis. */
+function RunChart({ data, y, stroke, yLabel, yTickFormat, ariaLabel }: RunChartProps): JSX.Element {
+  return (
+    <RoughLine
+      data={[...data]}
+      x={run => run.date}
+      y={y}
+      stroke={stroke}
+      width={CHART_WIDTH}
+      height={CHART_HEIGHT}
+      yLabel={yLabel}
+      yTickFormat={yTickFormat}
+      xTickFormat={tick => formatDayKey(toDayKey(tick), { month: 'short', year: '2-digit' })}
+      axisColor={AXIS_COLOR}
+      ariaLabel={ariaLabel}
+    />
+  )
+}
+
+/**
+ * A tick value from the time axis as a `YYYY-MM-DD` key.
+ *
+ * The points are built at Pacific noon, so the calendar fields of the tick are
+ * already the right day — reading them back through `toISOString` would shift
+ * a UTC-rendered server onto the wrong side of midnight.
+ */
+function toDayKey(tick: Date | number): string {
+  const date = tick instanceof Date ? tick : new Date(tick)
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${date.getFullYear()}-${month}-${day}`
+}

--- a/components/training-facility/weight-room/WorkoutHistoryList.tsx
+++ b/components/training-facility/weight-room/WorkoutHistoryList.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link'
 
 import { formatDayKey, safePacificDayKey, todayDayKey } from '@/lib/training-facility/day-keys'
 import { describeSetOrHold } from '@/lib/training-facility/strength-format'
+import { templateSlug } from '@/lib/training-facility/template-history'
 import type { WorkoutSourceFilter } from '@/lib/training-facility/workout-facets'
 import {
   workoutDisplayTitle,
@@ -18,6 +19,21 @@ export const SOURCE_FILTER_PARAM = 'source'
 
 /** URL param naming the year filter (#416). Value is a year, or `all`. */
 export const YEAR_FILTER_PARAM = 'year'
+
+/** Route base for the per-template view (#446). */
+export const TEMPLATES_ROUTE = '/training-facility/weight-room/templates'
+
+/**
+ * Link to one workout's trends over time.
+ *
+ * @param name Template name; slugified to match the route's own resolution.
+ * @param isPreviewMode Carry `?preview=demo` through, so a preview tour doesn't
+ *   dead-end on a page whose own read is empty.
+ */
+export function templateTrendHref(name: string, isPreviewMode = false): string {
+  const path = `${TEMPLATES_ROUTE}/${encodeURIComponent(templateSlug(name))}`
+  return isPreviewMode ? `${path}?preview=demo` : path
+}
 
 /**
  * Provenance filter selection (#413).
@@ -293,6 +309,7 @@ function SourceFilterRail({
 
 function TemplateFilterRail({ filters, filterState }: TemplateFilterRailProps): JSX.Element {
   const selectedTemplateId = filterState.selectedTemplateId
+  const selected = filters.find(option => option.id === selectedTemplateId)
   return (
     <nav aria-label="Filter by template" data-testid="workout-template-filter">
       <ul className="flex flex-wrap gap-2">
@@ -322,6 +339,18 @@ function TemplateFilterRail({ filters, filterState }: TemplateFilterRailProps): 
           )
         })}
       </ul>
+      {/* A separate link rather than repurposing the chip: the chip's job is to
+          filter this list, and a reader who wants the trends is asking a
+          different question (#446). */}
+      {selected !== undefined && selected.id !== null ? (
+        <Link
+          href={templateTrendHref(selected.name, filterState.isPreviewMode)}
+          data-testid="template-trends-link"
+          className="mt-2 inline-block font-mono text-[10px] uppercase tracking-[0.2em] text-amber-300/80 underline underline-offset-4 hover:text-amber-200"
+        >
+          {selected.name} over time →
+        </Link>
+      ) : null}
     </nav>
   )
 }

--- a/components/training-facility/weight-room/WorkoutHistoryList.tsx
+++ b/components/training-facility/weight-room/WorkoutHistoryList.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link'
 
 import { formatDayKey, safePacificDayKey, todayDayKey } from '@/lib/training-facility/day-keys'
 import { describeSetOrHold } from '@/lib/training-facility/strength-format'
-import { templateSlug } from '@/lib/training-facility/template-history'
+import { templateSegment } from '@/lib/training-facility/template-history'
 import type { WorkoutSourceFilter } from '@/lib/training-facility/workout-facets'
 import {
   workoutDisplayTitle,
@@ -26,12 +26,22 @@ export const TEMPLATES_ROUTE = '/training-facility/weight-room/templates'
 /**
  * Link to one workout's trends over time.
  *
- * @param name Template name; slugified to match the route's own resolution.
+ * Addresses the template through {@link templateSegment} rather than its name
+ * alone: names are editable and not unique, so a shared or empty slug has to
+ * fall back to the id or the link opens a different workout — or no route at
+ * all.
+ *
+ * @param template The template to link to; only `id` and `name` are read.
+ * @param all Every template in the rail, to detect a shared slug.
  * @param isPreviewMode Carry `?preview=demo` through, so a preview tour doesn't
  *   dead-end on a page whose own read is empty.
  */
-export function templateTrendHref(name: string, isPreviewMode = false): string {
-  const path = `${TEMPLATES_ROUTE}/${encodeURIComponent(templateSlug(name))}`
+export function templateTrendHref(
+  template: { id: string; name: string },
+  all: readonly { id: string; name: string }[],
+  isPreviewMode = false
+): string {
+  const path = `${TEMPLATES_ROUTE}/${encodeURIComponent(templateSegment(template, all))}`
   return isPreviewMode ? `${path}?preview=demo` : path
 }
 
@@ -344,7 +354,13 @@ function TemplateFilterRail({ filters, filterState }: TemplateFilterRailProps): 
           different question (#446). */}
       {selected !== undefined && selected.id !== null ? (
         <Link
-          href={templateTrendHref(selected.name, filterState.isPreviewMode)}
+          href={templateTrendHref(
+            { id: selected.id, name: selected.name },
+            filters.flatMap(option =>
+              option.id === null ? [] : [{ id: option.id, name: option.name }]
+            ),
+            filterState.isPreviewMode
+          )}
           data-testid="template-trends-link"
           className="mt-2 inline-block font-mono text-[10px] uppercase tracking-[0.2em] text-amber-300/80 underline underline-offset-4 hover:text-amber-200"
         >

--- a/e2e/template-detail.spec.ts
+++ b/e2e/template-detail.spec.ts
@@ -1,0 +1,73 @@
+import { expect, test } from '@playwright/test'
+
+/**
+ * Pins the per-template view (#446).
+ *
+ * The route resolves its `[slug]` by slugifying template names at request time
+ * — there is no slug column — so the things worth guarding are that the address
+ * works at all, that a bad one 404s rather than rendering an empty shell, and
+ * that the charts stay inside their cards. The aggregation itself is unit
+ * tested in `lib/training-facility/template-history.test.ts`.
+ *
+ * Deliberately one navigation test rather than three. Reaching this page means
+ * rendering the all-years session log and then the template itself — two of the
+ * heaviest renders in the app — and repeating that per assertion pushed the
+ * suite past its budget under parallel workers without covering anything new.
+ *
+ * CI has no Supabase credentials and falls through to `?preview=demo`, whose
+ * fixture carries one template. The spec discovers the template from the
+ * session log rather than naming one, so it holds in both environments.
+ */
+
+const WORKOUTS = '/training-facility/weight-room/workouts'
+const TEMPLATES = '/training-facility/weight-room/templates'
+
+/** Budget for a render of the session log or the template page under load. */
+const RENDER_TIMEOUT = 60_000
+
+test.describe('per-template view', () => {
+  test('is reachable from the session log and keeps its charts inside the page', async ({
+    page,
+  }) => {
+    test.slow() // Two of the heaviest renders in the app, back to back.
+
+    // All years, because templates only ran in past years — the default view
+    // faceting (#445) correctly offers no template chips for the current one.
+    await page.goto(`${WORKOUTS}?preview=demo&year=all`)
+
+    const ids = await page
+      .locator('[data-testid^="workout-filter-"]')
+      .evaluateAll(nodes =>
+        nodes
+          .map(n => n.getAttribute('data-testid'))
+          .filter((id): id is string => id !== null && id !== 'workout-filter-all')
+      )
+    if (ids.length === 0) {
+      // No template has been run in this environment's data — nothing to link.
+      test.skip()
+      return
+    }
+
+    await page.getByTestId(ids[0]).click()
+    const link = page.getByTestId('template-trends-link')
+    await expect(link).toBeVisible({ timeout: RENDER_TIMEOUT })
+
+    await link.click()
+    await expect(page).toHaveURL(new RegExp(`${TEMPLATES}/`), { timeout: RENDER_TIMEOUT })
+    await expect(page.getByTestId('template-composition')).toBeVisible({
+      timeout: RENDER_TIMEOUT,
+    })
+
+    // A chart is meant to scroll inside its own card; the document must not.
+    const doc = await page.evaluate(() => ({
+      scrollWidth: document.documentElement.scrollWidth,
+      clientWidth: document.documentElement.clientWidth,
+    }))
+    expect(doc.scrollWidth).toBeLessThanOrEqual(doc.clientWidth + 1)
+  })
+
+  test('404s on a template that does not exist', async ({ page }) => {
+    const response = await page.goto(`${TEMPLATES}/not-a-real-workout?preview=demo`)
+    expect(response?.status()).toBe(404)
+  })
+})

--- a/e2e/template-detail.spec.ts
+++ b/e2e/template-detail.spec.ts
@@ -48,12 +48,20 @@ test.describe('per-template view', () => {
       return
     }
 
-    await page.getByTestId(ids[0]).click()
+    // Re-entered by URL rather than by clicking the chip, then followed by
+    // `goto` rather than by clicking the link. Both are soft navigations, and
+    // chaining two of the heaviest renders in the app through them exceeded the
+    // budget under parallel workers — while proving nothing the href and a
+    // direct load don't.
+    const templateId = ids[0].replace('workout-filter-', '')
+    await page.goto(`${WORKOUTS}?preview=demo&year=all&template=${templateId}`)
+
     const link = page.getByTestId('template-trends-link')
     await expect(link).toBeVisible({ timeout: RENDER_TIMEOUT })
+    const href = await link.getAttribute('href')
+    expect(href).toContain(`${TEMPLATES}/`)
 
-    await link.click()
-    await expect(page).toHaveURL(new RegExp(`${TEMPLATES}/`), { timeout: RENDER_TIMEOUT })
+    await page.goto(href as string)
     await expect(page.getByTestId('template-composition')).toBeVisible({
       timeout: RENDER_TIMEOUT,
     })

--- a/lib/training-facility/template-history.test.ts
+++ b/lib/training-facility/template-history.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Tests for per-template aggregation (#446).
+ *
+ * The cases that matter are the ones where the template and the log disagree:
+ * a movement that ran but is no longer prescribed, one prescribed but never
+ * run, and a session whose "duration" measures note-taking rather than
+ * training. Getting any of those wrong makes the page quietly wrong rather
+ * than visibly broken.
+ */
+import { describe, expect, it } from 'vitest'
+
+import type { WorkoutTemplate } from '@/types/weight-room'
+
+import {
+  buildTemplateHistory,
+  resolveTemplate,
+  templateRunIds,
+  templateSlug,
+} from './template-history'
+import type { WorkoutHistoryEntry } from './workout-stats'
+
+/** A template with the given prescribed movements. */
+function template(id: string, name: string, exercises: string[], position = 0): WorkoutTemplate {
+  return {
+    id,
+    name,
+    position,
+    slots: exercises.map((exercise, i) => ({
+      id: `${id}-slot-${i}`,
+      position: i,
+      exercise,
+      target_sets: 3,
+      steps: [],
+      alternates: [],
+    })),
+  }
+}
+
+/** A history entry for one run, with a per-exercise breakdown. */
+function run(
+  id: string,
+  templateId: string,
+  startedAt: string,
+  breakdown: { exercise: string; sets: number; reps: number; tonnage: number }[],
+  options: { source?: 'manual' | 'apple_health' | 'icloud_notes'; minutes?: number | null } = {}
+): WorkoutHistoryEntry {
+  const { source = 'apple_health', minutes = 45 } = options
+  return {
+    workout: { id, started_at: startedAt, template_id: templateId, source },
+    summary: {
+      durationMinutes: minutes,
+      tonnage: breakdown.reduce((n, b) => n + b.tonnage, 0),
+      totalSets: breakdown.reduce((n, b) => n + b.sets, 0),
+      totalReps: breakdown.reduce((n, b) => n + b.reps, 0),
+      exercises: breakdown,
+    },
+  } as unknown as WorkoutHistoryEntry
+}
+
+const CHEST = template('t-chest', 'Chest Day 1', ['barbell-bench-press', 'sled-push'])
+
+describe('templateSlug', () => {
+  it('lowercases and hyphenates', () => {
+    expect(templateSlug('Chest Day 1')).toBe('chest-day-1')
+  })
+
+  it('drops apostrophes rather than turning them into separators', () => {
+    expect(templateSlug("Farmer's Day")).toBe('farmers-day')
+  })
+
+  it('trims separator runs at both ends', () => {
+    expect(templateSlug('  Legs / Day 2!  ')).toBe('legs-day-2')
+  })
+})
+
+describe('resolveTemplate', () => {
+  const templates = [template('t-a', 'Chest Day 1', [], 1), template('t-b', 'Legs Day 2', [], 2)]
+
+  it('finds a template by its derived slug', () => {
+    expect(resolveTemplate('chest-day-1', templates)?.id).toBe('t-a')
+  })
+
+  it('falls back to the raw id, so a renamed template stays addressable', () => {
+    expect(resolveTemplate('t-b', templates)?.id).toBe('t-b')
+  })
+
+  it('is null for a segment matching neither', () => {
+    expect(resolveTemplate('nope', templates)).toBeNull()
+  })
+
+  it('breaks a slug collision by position, not by fetch order', () => {
+    const collide = [
+      template('t-late', 'Chest Day 1', [], 5),
+      template('t-early', 'Chest Day 1', [], 2),
+    ]
+    expect(resolveTemplate('chest-day-1', collide)?.id).toBe('t-early')
+    // The loser is still reachable by id.
+    expect(resolveTemplate('t-late', collide)?.id).toBe('t-late')
+  })
+})
+
+describe('buildTemplateHistory', () => {
+  it('keeps only this template’s runs, oldest first', () => {
+    const history = buildTemplateHistory(CHEST, [
+      run('w2', 't-chest', '2024-03-02T18:00:00Z', [
+        { exercise: 'barbell-bench-press', sets: 3, reps: 24, tonnage: 4000 },
+      ]),
+      run('w-other', 't-legs', '2024-03-03T18:00:00Z', [
+        { exercise: 'leg-press', sets: 3, reps: 30, tonnage: 9000 },
+      ]),
+      run('w1', 't-chest', '2024-01-05T18:00:00Z', [
+        { exercise: 'barbell-bench-press', sets: 3, reps: 21, tonnage: 3600 },
+      ]),
+    ])
+    expect(history.runs.map(r => r.workoutId)).toEqual(['w1', 'w2'])
+    expect(history.firstDayKey).toBe('2024-01-05')
+    expect(history.lastDayKey).toBe('2024-03-02')
+  })
+
+  it('keeps a movement that ran but is no longer prescribed, and marks it', () => {
+    // The drift case: fifteen movements in the real log ran under templates
+    // that have since dropped them. Deriving panels from the current slots
+    // would erase them the day someone edits a template.
+    const history = buildTemplateHistory(CHEST, [
+      run('w1', 't-chest', '2024-01-05T18:00:00Z', [
+        { exercise: 'barbell-bench-press', sets: 3, reps: 21, tonnage: 3600 },
+        { exercise: 'barbell-overhead-press', sets: 3, reps: 18, tonnage: 1800 },
+      ]),
+    ])
+    const overhead = history.movements.find(m => m.exercise === 'barbell-overhead-press')
+    expect(overhead).toBeDefined()
+    expect(overhead?.prescribed).toBe(false)
+    expect(history.movements.find(m => m.exercise === 'barbell-bench-press')?.prescribed).toBe(true)
+  })
+
+  it('reports a prescribed movement that has never been logged', () => {
+    const history = buildTemplateHistory(CHEST, [
+      run('w1', 't-chest', '2024-01-05T18:00:00Z', [
+        { exercise: 'barbell-bench-press', sets: 3, reps: 21, tonnage: 3600 },
+      ]),
+    ])
+    expect(history.neverRun).toEqual(['sled-push'])
+  })
+
+  it('totals a movement across every run and orders by tonnage', () => {
+    const history = buildTemplateHistory(CHEST, [
+      run('w1', 't-chest', '2024-01-05T18:00:00Z', [
+        { exercise: 'barbell-bench-press', sets: 3, reps: 21, tonnage: 3600 },
+        { exercise: 'cable-fly', sets: 3, reps: 30, tonnage: 900 },
+      ]),
+      run('w2', 't-chest', '2024-01-12T18:00:00Z', [
+        { exercise: 'barbell-bench-press', sets: 4, reps: 28, tonnage: 5000 },
+      ]),
+    ])
+    const bench = history.movements[0]
+    expect(bench.exercise).toBe('barbell-bench-press')
+    expect(bench).toMatchObject({ runs: 2, sets: 7, reps: 49, tonnage: 8600 })
+    expect(history.movements[1].exercise).toBe('cable-fly')
+  })
+
+  it('excludes an icloud_notes session from the duration series but not the run series', () => {
+    // Its start and end are the note's create and edit times, so the "duration"
+    // measures typing. It is still a real session and still counts everywhere
+    // else.
+    const history = buildTemplateHistory(CHEST, [
+      run(
+        'w-notes',
+        't-chest',
+        '2024-01-05T18:00:00Z',
+        [{ exercise: 'barbell-bench-press', sets: 3, reps: 21, tonnage: 3600 }],
+        { source: 'icloud_notes', minutes: 27 }
+      ),
+      run(
+        'w-watch',
+        't-chest',
+        '2024-01-12T18:00:00Z',
+        [{ exercise: 'barbell-bench-press', sets: 3, reps: 21, tonnage: 3600 }],
+        { source: 'apple_health', minutes: 52 }
+      ),
+    ])
+    expect(history.runs.map(r => r.workoutId)).toEqual(['w-notes', 'w-watch'])
+    expect(history.durations.map(r => r.workoutId)).toEqual(['w-watch'])
+  })
+
+  it('excludes a session with no duration at all', () => {
+    const history = buildTemplateHistory(CHEST, [
+      run('w1', 't-chest', '2024-01-05T18:00:00Z', [], { minutes: null }),
+    ])
+    expect(history.runs).toHaveLength(1)
+    expect(history.durations).toHaveLength(0)
+  })
+
+  it('buckets a run on its Pacific day, not its UTC one', () => {
+    // 2024-01-06 03:00 UTC is still Jan 5 in Pacific.
+    const history = buildTemplateHistory(CHEST, [run('w1', 't-chest', '2024-01-06T03:00:00Z', [])])
+    expect(history.runs[0].dayKey).toBe('2024-01-05')
+  })
+
+  it('is empty but well-formed for a template never run', () => {
+    const history = buildTemplateHistory(CHEST, [])
+    expect(history.runs).toEqual([])
+    expect(history.movements).toEqual([])
+    expect(history.firstDayKey).toBe('')
+    expect(history.neverRun).toEqual(['barbell-bench-press', 'sled-push'])
+  })
+})
+
+describe('templateRunIds', () => {
+  it('collects the sessions that ran the template', () => {
+    const history = buildTemplateHistory(CHEST, [
+      run('w1', 't-chest', '2024-01-05T18:00:00Z', []),
+      run('w2', 't-chest', '2024-01-12T18:00:00Z', []),
+    ])
+    expect([...templateRunIds(history)].sort()).toEqual(['w1', 'w2'])
+  })
+})

--- a/lib/training-facility/template-history.test.ts
+++ b/lib/training-facility/template-history.test.ts
@@ -15,6 +15,7 @@ import {
   buildTemplateHistory,
   resolveTemplate,
   templateRunIds,
+  templateSegment,
   templateSlug,
 } from './template-history'
 import type { WorkoutHistoryEntry } from './workout-stats'
@@ -96,6 +97,47 @@ describe('resolveTemplate', () => {
     expect(resolveTemplate('chest-day-1', collide)?.id).toBe('t-early')
     // The loser is still reachable by id.
     expect(resolveTemplate('t-late', collide)?.id).toBe('t-late')
+  })
+})
+
+describe('templateSegment', () => {
+  const all = [
+    { id: 't-a', name: 'Chest Day 1' },
+    { id: 't-b', name: 'Legs Day 2' },
+  ]
+
+  it('prefers the readable slug', () => {
+    expect(templateSegment(all[0], all)).toBe('chest-day-1')
+  })
+
+  it('falls back to the id when two templates share a slug', () => {
+    // Names are explicitly not unique. Linking by slug would send both chips to
+    // whichever template resolves first.
+    const collide = [
+      { id: 't-a', name: 'Chest Day 1' },
+      { id: 't-b', name: 'chest day 1' },
+    ]
+    expect(templateSegment(collide[0], collide)).toBe('t-a')
+    expect(templateSegment(collide[1], collide)).toBe('t-b')
+  })
+
+  it('falls back to the id when the name has no slug-able characters', () => {
+    // `'!!!'` slugifies to `''`, which builds a href matching no route at all.
+    const odd = [{ id: 't-odd', name: '!!!' }]
+    expect(templateSegment(odd[0], odd)).toBe('t-odd')
+  })
+
+  it('round-trips through resolveTemplate in every case', () => {
+    const templates = [
+      template('t-a', 'Chest Day 1', [], 1),
+      template('t-b', 'chest day 1', [], 2),
+      template('t-c', '!!!', [], 3),
+      template('t-d', 'Legs Day 2', [], 4),
+    ]
+    for (const one of templates) {
+      const segment = templateSegment(one, templates)
+      expect(resolveTemplate(segment, templates)?.id).toBe(one.id)
+    }
   })
 })
 
@@ -188,6 +230,34 @@ describe('buildTemplateHistory', () => {
     ])
     expect(history.runs).toHaveLength(1)
     expect(history.durations).toHaveLength(0)
+  })
+
+  it('reports the two exclusion reasons separately', () => {
+    // A caller that says "N runs left out" has to be able to say *why* — the
+    // note-timed and the never-ended cases reach the same subtraction.
+    const history = buildTemplateHistory(CHEST, [
+      run('w-notes', 't-chest', '2024-01-05T18:00:00Z', [], {
+        source: 'icloud_notes',
+        minutes: 27,
+      }),
+      run('w-open', 't-chest', '2024-01-12T18:00:00Z', [], { minutes: null }),
+      run('w-good', 't-chest', '2024-01-19T18:00:00Z', [], { minutes: 52 }),
+    ])
+    expect(history.noteTimedRuns).toBe(1)
+    expect(history.untimedRuns).toBe(1)
+    expect(history.durations.map(r => r.workoutId)).toEqual(['w-good'])
+    // The two reasons account for the whole shortfall, with no double-count.
+    expect(history.noteTimedRuns + history.untimedRuns).toBe(
+      history.runs.length - history.durations.length
+    )
+  })
+
+  it('counts a note-timed run once, even when it also has no duration', () => {
+    const history = buildTemplateHistory(CHEST, [
+      run('w', 't-chest', '2024-01-05T18:00:00Z', [], { source: 'icloud_notes', minutes: null }),
+    ])
+    expect(history.noteTimedRuns).toBe(1)
+    expect(history.untimedRuns).toBe(0)
   })
 
   it('buckets a run on its Pacific day, not its UTC one', () => {

--- a/lib/training-facility/template-history.ts
+++ b/lib/training-facility/template-history.ts
@@ -1,0 +1,209 @@
+/**
+ * Per-template aggregation for the template detail page (#446).
+ *
+ * The Weight Room could show a movement's trend (#412) and a single session's
+ * breakdown (#377), but nothing answered "how is *Chest Day 1* going" — which
+ * is the unit training is actually planned in. This turns the run history of
+ * one template into the two things that question needs: a per-session series
+ * for the workout as a whole, and the roster of movements that actually ran
+ * under it.
+ *
+ * **Composition comes from the log, not the prescription.** Templates drift —
+ * across this log fifteen movements were logged under templates that no longer
+ * list them, and one is prescribed but was never run. Deriving the movement
+ * panels from the current slots would erase most of the history the page exists
+ * to show, and would do it silently, the day someone edits a template.
+ */
+import type { WorkoutTemplate } from '@/types/weight-room'
+
+import { PACIFIC_CLOCK, type DayClock } from './clock'
+import { isMeasuredWindow } from './training-program'
+import type { WorkoutHistoryEntry } from './workout-stats'
+
+/**
+ * Derive a URL slug from a template name — lowercase, non-alphanumeric runs
+ * collapsed to single hyphens, ends trimmed. `Chest Day 1` → `chest-day-1`.
+ *
+ * Mirrors the exercise catalog's own slug rule so the two read alike in a URL.
+ */
+export function templateSlug(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/['’]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}
+
+/**
+ * Find the template a URL segment names.
+ *
+ * Matches the derived slug first, then falls back to the raw id — template
+ * names are not guaranteed unique and are editable, so the UUID stays a valid
+ * address for a template whose name has changed or collided.
+ *
+ * @param segment The `[slug]` route param, already lowercased by the caller.
+ * @param templates Every template, in roster order.
+ * @returns The match, or `null`. On a slug collision the earliest by
+ *   `position` wins, so the choice is stable across requests rather than
+ *   dependent on fetch order; the loser stays reachable by id.
+ */
+export function resolveTemplate(
+  segment: string,
+  templates: readonly WorkoutTemplate[]
+): WorkoutTemplate | null {
+  const bySlug = templates
+    .filter(t => templateSlug(t.name) === segment)
+    .sort((a, b) => a.position - b.position)
+  return bySlug[0] ?? templates.find(t => t.id === segment) ?? null
+}
+
+/** One run of a template, as a point on the whole-workout series. */
+export interface TemplateRunPoint {
+  /** Pacific day the session belongs to. */
+  dayKey: string
+  /** That day at local noon, for a time axis. */
+  date: Date
+  /** Session id, for linking to its summary. */
+  workoutId: string
+  /** Total load moved, in pounds. */
+  tonnage: number
+  /** Sets recorded. */
+  totalSets: number
+  /** Reps recorded. */
+  totalReps: number
+  /**
+   * Wall-clock minutes, or `null` when the session doesn't carry a trustworthy
+   * one. See {@link TemplateHistory.durations} for which sessions qualify.
+   */
+  durationMinutes: number | null
+}
+
+/** One movement that has run under a template. */
+export interface TemplateMovement {
+  /** Catalog slug. */
+  exercise: string
+  /** Sessions of this template that included it. */
+  runs: number
+  /** Sets across those sessions. */
+  sets: number
+  /** Reps across those sessions. */
+  reps: number
+  /** Load moved across those sessions, in pounds. */
+  tonnage: number
+  /**
+   * Whether the template still prescribes it. `false` means it ran historically
+   * but has since been dropped — kept and labelled rather than hidden, because
+   * those sessions happened.
+   */
+  prescribed: boolean
+}
+
+/** Everything the template detail page renders. */
+export interface TemplateHistory {
+  /** The template these runs belong to. */
+  template: WorkoutTemplate
+  /** Every run, oldest first — the x-axis of every whole-workout chart. */
+  runs: TemplateRunPoint[]
+  /**
+   * Runs carrying a trustworthy duration, oldest first. A subset of
+   * {@link runs}: an `icloud_notes` session's start and end are the *note's*
+   * create and edit times, so its "duration" measures typing, not training.
+   */
+  durations: TemplateRunPoint[]
+  /** Movements that ran, most total tonnage first. */
+  movements: TemplateMovement[]
+  /** Movements the template prescribes that have never been logged under it. */
+  neverRun: string[]
+  /** Pacific day of the earliest run, or `''` when there are none. */
+  firstDayKey: string
+  /** Pacific day of the most recent run, or `''` when there are none. */
+  lastDayKey: string
+}
+
+/**
+ * Aggregate one template's run history.
+ *
+ * @param template The template to summarize.
+ * @param history Every session, from `buildWorkoutHistory`; filtered to this
+ *   template internally so callers can build the history once per page.
+ * @param clock Zone each day is measured in; defaults to Pacific (#429).
+ */
+export function buildTemplateHistory(
+  template: WorkoutTemplate,
+  history: readonly WorkoutHistoryEntry[],
+  clock: DayClock = PACIFIC_CLOCK
+): TemplateHistory {
+  const runs: TemplateRunPoint[] = []
+  const durations: TemplateRunPoint[] = []
+  const byMovement = new Map<string, TemplateMovement>()
+
+  const mine = history.filter(entry => entry.workout.template_id === template.id)
+  for (const entry of mine) {
+    const dayKey = clock.safeDayKey(entry.workout.started_at)
+    if (dayKey === '') continue
+    const date = clock.toNoon(dayKey)
+    if (date === null) continue
+
+    const point: TemplateRunPoint = {
+      dayKey,
+      date,
+      workoutId: entry.workout.id,
+      tonnage: entry.summary.tonnage,
+      totalSets: entry.summary.totalSets,
+      totalReps: entry.summary.totalReps,
+      durationMinutes: entry.summary.durationMinutes,
+    }
+    runs.push(point)
+    if (point.durationMinutes !== null && isMeasuredWindow(entry.workout)) durations.push(point)
+
+    for (const breakdown of entry.summary.exercises) {
+      const existing = byMovement.get(breakdown.exercise) ?? {
+        exercise: breakdown.exercise,
+        runs: 0,
+        sets: 0,
+        reps: 0,
+        tonnage: 0,
+        prescribed: false,
+      }
+      existing.runs += 1
+      existing.sets += breakdown.sets
+      existing.reps += breakdown.reps
+      existing.tonnage += breakdown.tonnage
+      byMovement.set(breakdown.exercise, existing)
+    }
+  }
+
+  runs.sort((a, b) => a.dayKey.localeCompare(b.dayKey))
+  durations.sort((a, b) => a.dayKey.localeCompare(b.dayKey))
+
+  const prescribed = new Set(template.slots.map(slot => slot.exercise))
+  for (const movement of byMovement.values()) {
+    movement.prescribed = prescribed.has(movement.exercise)
+  }
+
+  const movements = [...byMovement.values()].sort(
+    (a, b) => b.tonnage - a.tonnage || b.reps - a.reps || a.exercise.localeCompare(b.exercise)
+  )
+  const neverRun = [...prescribed].filter(slug => !byMovement.has(slug)).sort()
+
+  return {
+    template,
+    runs,
+    durations,
+    movements,
+    neverRun,
+    firstDayKey: runs[0]?.dayKey ?? '',
+    lastDayKey: runs[runs.length - 1]?.dayKey ?? '',
+  }
+}
+
+/**
+ * Ids of the sessions that ran a template.
+ *
+ * Used to narrow the global set list before handing it to
+ * `buildExerciseProgression`, so a movement's panel on this page trends only
+ * the work done *in this workout* rather than everywhere it appears.
+ */
+export function templateRunIds(history: TemplateHistory): Set<string> {
+  return new Set(history.runs.map(run => run.workoutId))
+}

--- a/lib/training-facility/template-history.ts
+++ b/lib/training-facility/template-history.ts
@@ -35,6 +35,32 @@ export function templateSlug(name: string): string {
 }
 
 /**
+ * The URL segment that unambiguously addresses one template.
+ *
+ * Prefers the readable slug, but only when it actually resolves *back* to this
+ * template. Names are editable and explicitly not unique, so two failure modes
+ * are real rather than theoretical: two templates sharing a name would both
+ * slugify the same way and {@link resolveTemplate} would hand every link to
+ * whichever has the lower position, and a name with no alphanumerics at all
+ * slugifies to the empty string, producing a href that matches no route.
+ *
+ * Either case falls back to the id, which {@link resolveTemplate} also accepts.
+ * Ugly beats wrong.
+ *
+ * @param template The template to address; only `id` and `name` are read.
+ * @param all Every template in scope, to detect a shared slug.
+ */
+export function templateSegment(
+  template: { id: string; name: string },
+  all: readonly { id: string; name: string }[]
+): string {
+  const slug = templateSlug(template.name)
+  if (slug === '') return template.id
+  const shared = all.some(other => other.id !== template.id && templateSlug(other.name) === slug)
+  return shared ? template.id : slug
+}
+
+/**
  * Find the template a URL segment names.
  *
  * Matches the derived slug first, then falls back to the raw id — template
@@ -106,10 +132,22 @@ export interface TemplateHistory {
   runs: TemplateRunPoint[]
   /**
    * Runs carrying a trustworthy duration, oldest first. A subset of
-   * {@link runs}: an `icloud_notes` session's start and end are the *note's*
-   * create and edit times, so its "duration" measures typing, not training.
+   * {@link runs}, narrowed for two distinct reasons — see
+   * {@link noteTimedRuns} and {@link untimedRuns}, which are reported
+   * separately so a caller can say *why* rather than guess.
    */
   durations: TemplateRunPoint[]
+  /**
+   * Runs left out of {@link durations} because their window isn't a
+   * measurement: an `icloud_notes` session's start and end are the *note's*
+   * create and edit times, so its "duration" measures typing, not training.
+   */
+  noteTimedRuns: number
+  /**
+   * Runs left out of {@link durations} because they carry no duration at all —
+   * a session still in progress, or one abandoned without an end.
+   */
+  untimedRuns: number
   /** Movements that ran, most total tonnage first. */
   movements: TemplateMovement[]
   /** Movements the template prescribes that have never been logged under it. */
@@ -136,6 +174,8 @@ export function buildTemplateHistory(
   const runs: TemplateRunPoint[] = []
   const durations: TemplateRunPoint[] = []
   const byMovement = new Map<string, TemplateMovement>()
+  let noteTimedRuns = 0
+  let untimedRuns = 0
 
   const mine = history.filter(entry => entry.workout.template_id === template.id)
   for (const entry of mine) {
@@ -154,7 +194,11 @@ export function buildTemplateHistory(
       durationMinutes: entry.summary.durationMinutes,
     }
     runs.push(point)
-    if (point.durationMinutes !== null && isMeasuredWindow(entry.workout)) durations.push(point)
+    // Order matters for the tally: an unmeasured window is the more specific
+    // reason, so a note-timed session is counted there rather than twice.
+    if (!isMeasuredWindow(entry.workout)) noteTimedRuns += 1
+    else if (point.durationMinutes === null) untimedRuns += 1
+    else durations.push(point)
 
     for (const breakdown of entry.summary.exercises) {
       const existing = byMovement.get(breakdown.exercise) ?? {
@@ -190,6 +234,8 @@ export function buildTemplateHistory(
     template,
     runs,
     durations,
+    noteTimedRuns,
+    untimedRuns,
     movements,
     neverRun,
     firstDayKey: runs[0]?.dayKey ?? '',

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -42,7 +42,7 @@ export default defineConfig({
     {
       name: 'training-facility-enabled',
       testMatch:
-        /(?:training-facility-enabled|draft-room-enabled|draft-room-live|chart-overflow|heatmap-span|workout-filters)\.spec\.ts/,
+        /(?:training-facility-enabled|draft-room-enabled|draft-room-live|chart-overflow|heatmap-span|workout-filters|template-detail)\.spec\.ts/,
       use: {
         baseURL: TRAINING_FACILITY_BASE_URL,
       },


### PR DESCRIPTION
## Summary

`/training-facility/weight-room/templates/[slug]` — one workout, trended as a workout.

The room could already show a movement over time (#412) and a single session in detail (#377), but the unit training is actually *planned* in sat between them. Answering "how is Chest Day 1 going" meant opening four movement pages and doing the joining by eye.

Two halves:

- **Whole-workout charts** treat each run as one point — tonnage, reps, sets, duration.
- **Per-movement panels** reuse the #412 trend, narrowed to the sets logged *in this workout*, so a lift that also runs elsewhere trends here only on the days this session ran it.

Reached from the session log: selecting a template reveals a "*Chest Day 1* over time →" link. The chips keep filtering — that's a different question from wanting the trends.

## Decisions worth reviewing

**Composition comes from the log, not the prescription.** Templates drift hard. In this log **fifteen movements ran under templates that no longer list them** — Chest Day 1 alone has six, including overhead press at 12 of 24 runs and 36,105 lb moved — and `sled-push` is prescribed but was never run. Deriving the panels from current slots would erase most of the history the page exists to show, silently, the day someone edits a template.

**No adherence score.** The issue asked for prescribed-vs-actual, and I cut it. Zero runs carry a frozen prescription (`with_prescription = 0` across all 133 template-linked sessions), so the only thing to grade against is *today's* template. A percentage computed that way grades a 2023 session against a 2026 plan and presents the result as fact. The "what actually ran" panel reports instead — every movement, how often, with dropped ones marked. That's checkable against the sessions.

**Reps and sets get separate axes.** They started on one shared scale and the set line rendered as a flat smear along the baseline — reps run an order of magnitude higher. Same trap as the OTF machine card (#266).

**Duration excludes `icloud_notes` runs** — their window is when a *note* was written, not when training happened — and the chart says how many runs that left out rather than quietly narrowing.

**Slug, not UUID.** There's no slug column, so `[slug]` is the template name slugified at request time, matched case-insensitively, with the raw id still accepted. On a name collision the earliest by `position` wins so the choice is stable, and the loser stays reachable by id.

## Test plan

- [ ] Session log → **All years** → pick a template → "over time →" link appears
- [ ] `/templates/chest-day-1` — 24 sessions, Jan 2023 – Apr 2024; tonnage/reps/sets/duration all trend
- [ ] "What actually ran" lists overhead press, incline press etc. tagged **no longer in this workout**
- [ ] Duration card notes the 1 of 24 runs it left out
- [ ] `/templates/CHEST-DAY-1` resolves; `/templates/not-a-real-workout` 404s
- [ ] On a phone, charts scroll inside their cards and the page doesn't slide sideways
- [ ] Movement panels link through to each movement's own full history

Verified: `tsc --noEmit` clean, `eslint` clean, `next build` compiles, 2509 vitest tests pass under `TZ=UTC`, 81 Playwright tests pass.

Closes #446.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detailed workout-template pages with composition summaries, movement usage, navigation, preview mode, and not-found handling.
  * Added template trend charts for tonnage, reps, sets, and available duration data.
  * Added historical movement metrics, including run counts, set totals, tonnage, retired movements, and prescribed movements without logged activity.
  * Added template links and filtering support from workout history.

* **Bug Fixes**
  * Improved template matching and trend navigation across capitalization and preview URLs.

* **Tests**
  * Added unit and end-to-end coverage for template history, charts, composition details, navigation, and invalid template URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->