### PR TITLE
feat(weight-room): two eras of the whole log, stated side by side (#437)

### DIFF
--- a/app/training-facility/weight-room/eras/page.tsx
+++ b/app/training-facility/weight-room/eras/page.tsx
@@ -1,0 +1,137 @@
+import type { JSX } from 'react'
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+
+import { BackToCourtButton } from '@/components/common/BackToCourtButton'
+import { FacilityBackLink } from '@/components/training-facility/FacilityBackLink'
+import { PreviewModeBadge } from '@/components/training-facility/shared/PreviewModeBadge'
+import { EraCadenceChart } from '@/components/training-facility/weight-room/EraCadenceChart'
+import { EraContrastPanel } from '@/components/training-facility/weight-room/EraContrastPanel'
+import { WeightRoomSubNav } from '@/components/training-facility/weight-room/WeightRoomSubNav'
+import { buildWeightRoomDemoData, buildWorkoutDemoData } from '@/constants/weight-room-demo-fixture'
+import { isAdminRequest } from '@/lib/auth/admin-session'
+import {
+  getWeightRoomDataServer,
+  getWeightRoomExercisesServer,
+} from '@/lib/data/weight-room-server'
+import { isWeightRoomEnabled } from '@/lib/feature-flags'
+import { buildExerciseLabels } from '@/lib/training-facility/exercise-labels'
+import { buildLogEras } from '@/lib/training-facility/log-eras'
+import { isPreviewDemoActive } from '@/lib/training-facility/preview-param'
+
+/** Search params for the eras view. */
+interface PageProps {
+  /** Async per-request search params; only `preview` is consumed. */
+  searchParams: Promise<Record<string, string | string[] | undefined>>
+}
+
+/** History route, for the breadcrumb back-link. */
+const HISTORY_ROUTE = '/training-facility/weight-room/history'
+
+/**
+ * Two eras of the whole log (#437).
+ *
+ * #400 shipped a then-vs-now comparison, but per movement, and only for the six
+ * that span both stretches — leaving 42 archive movements with no comparative
+ * surface and no way to ask the more interesting question: not "is my bench
+ * better", but "what did training look like then versus now".
+ *
+ * The answer is mostly that it changed in *kind*. A barbell gym rotation became
+ * bodyweight grease-the-groove, which is why this page states each era on its
+ * own terms and never subtracts one from the other. There is deliberately no
+ * headline figure: over a dataset this heterogeneous, a single percentage would
+ * be invented precision.
+ *
+ * A leaf page like the per-exercise and per-template views — no sub-nav pill of
+ * its own, reached from History.
+ */
+export default async function WeightRoomErasPage({
+  searchParams,
+}: PageProps): Promise<JSX.Element> {
+  if (!isWeightRoomEnabled()) notFound()
+
+  const [query, data, realExercises, isAdmin] = await Promise.all([
+    searchParams,
+    getWeightRoomDataServer().catch(() => null),
+    getWeightRoomExercisesServer().catch(() => []),
+    isAdminRequest().catch(() => false),
+  ])
+
+  const realSets = data?.sets ?? []
+  // Same contract as every other Weight Room surface: the fixture stands in
+  // only when the real read is empty.
+  const isPreviewMode = realSets.length === 0 && isPreviewDemoActive(query.preview)
+  const grooveDemo = isPreviewMode ? buildWeightRoomDemoData() : null
+  const workoutDemo = isPreviewMode ? buildWorkoutDemoData() : null
+
+  const sets = isPreviewMode
+    ? [...(grooveDemo?.sets ?? []), ...(workoutDemo?.sets ?? [])]
+    : realSets
+  const exercises = workoutDemo?.exercises ?? data?.exercises ?? realExercises
+
+  const eras = buildLogEras(sets, exercises)
+  const exerciseLabels = buildExerciseLabels(exercises)
+
+  return (
+    <div className="relative min-h-svh overflow-hidden bg-[#120d0a] text-[#f7ead9]">
+      <div
+        aria-hidden="true"
+        className="absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(248,214,170,0.16),transparent_30%),linear-gradient(180deg,#241811_0%,#120d0a_55%,#0b0806_100%)]"
+      />
+
+      <div className="relative z-10 mx-auto flex min-h-svh w-full max-w-5xl flex-col px-4 py-6 sm:px-6 sm:py-8 lg:px-10">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <BackToCourtButton />
+          <FacilityBackLink />
+        </div>
+
+        <header className="mt-12">
+          <p className="font-mono text-[11px] uppercase tracking-[0.32em] text-amber-300/80">
+            Weight Room ·{' '}
+            {/* Keeps the preview alive on the way back — without the param the
+                read is empty again and the demo vanishes mid-tour. */}
+            <Link
+              href={isPreviewMode ? `${HISTORY_ROUTE}?preview=demo` : HISTORY_ROUTE}
+              className="underline-offset-4 hover:underline"
+            >
+              History
+            </Link>
+          </p>
+          <h1 className="mt-2 text-3xl font-black uppercase tracking-[0.06em] text-[#fff7ec] sm:text-5xl">
+            Two eras
+          </h1>
+          <p className="mt-3 max-w-xl text-sm leading-7 text-[#e8d5be] sm:text-base">
+            The whole log, either side of the layoff — what the training was, not just how much of
+            it there was. The kind of work changed more than the amount did, so nothing here
+            averages one era against the other.
+          </p>
+          <WeightRoomSubNav active="history" className="mt-5" isAdmin={isAdmin} />
+        </header>
+
+        {isPreviewMode ? (
+          <div className="mt-6">
+            <PreviewModeBadge description="This history is illustrative — not Lucas’s real training log." />
+          </div>
+        ) : null}
+
+        <div className="mt-8 flex flex-col gap-8 pb-16">
+          {eras === null ? (
+            <p
+              data-testid="era-empty"
+              className="rounded-[1.2rem] border border-white/10 bg-white/5 p-6 text-center text-sm text-[#e8d5be]/70"
+            >
+              This view needs two stretches of training separated by a long layoff. The log is one
+              continuous run so far — there is no “then” to compare against, and drawing a boundary
+              anyway would invent the comparison.
+            </p>
+          ) : (
+            <>
+              <EraContrastPanel eras={eras} exerciseLabels={exerciseLabels} />
+              <EraCadenceChart months={eras.months} />
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/training-facility/weight-room/eras/page.tsx
+++ b/app/training-facility/weight-room/eras/page.tsx
@@ -105,7 +105,10 @@ export default async function WeightRoomErasPage({
             it there was. The kind of work changed more than the amount did, so nothing here
             averages one era against the other.
           </p>
-          <WeightRoomSubNav active="history" className="mt-5" isAdmin={isAdmin} />
+          {/* `eras` has no pill of its own — a leaf about the log rather than a
+              section of the room. Naming it anyway means no pill is marked
+              current, which beats highlighting History on a page that isn't it. */}
+          <WeightRoomSubNav active="eras" className="mt-5" isAdmin={isAdmin} />
         </header>
 
         {isPreviewMode ? (
@@ -120,9 +123,15 @@ export default async function WeightRoomErasPage({
               data-testid="era-empty"
               className="rounded-[1.2rem] border border-white/10 bg-white/5 p-6 text-center text-sm text-[#e8d5be]/70"
             >
-              This view needs two stretches of training separated by a long layoff. The log is one
-              continuous run so far — there is no “then” to compare against, and drawing a boundary
-              anyway would invent the comparison.
+              {/* `buildLogEras` answers null for two different reasons, and they
+                  must not share copy. "One continuous run" is a claim about the
+                  training log; saying it when the read came back empty would
+                  assert a fact nothing here actually established. */}
+              {sets.length === 0
+                ? 'No sets to read right now — either nothing is logged yet, or the log could not be loaded. Either way there is nothing to compare.'
+                : isPreviewMode
+                  ? 'The sample data covers a couple of recent weeks, so there is no layoff in it to split on. This view needs two stretches of training separated by a long break.'
+                  : 'This view needs two stretches of training separated by a long layoff. The log is one continuous run so far — there is no “then” to compare against, and drawing a boundary anyway would invent the comparison.'}
             </p>
           ) : (
             <>

--- a/app/training-facility/weight-room/history/page.tsx
+++ b/app/training-facility/weight-room/history/page.tsx
@@ -246,6 +246,29 @@ export default async function WeightRoomHistoryPage({
           </div>
         ) : null}
 
+        {/* The whole-log era view (#437) — the counterpart to the per-movement
+            then-vs-now panels, for the 42 archive movements with no current-era
+            side to compare against.
+
+            Outside the has-goals branch on purpose: deleting a goal keeps its
+            logged sets (#373), so a log with years of history and no configured
+            goals is a supported state — and the eras page renders fine from
+            sets alone. Nested in that branch, it was the only entry point and
+            it disappeared exactly when it was most useful.
+
+            Wrapped rather than `inline-block`: this is a flex item, and a flex
+            item's `inline-block` computes to `block` and then stretches, so the
+            anchor's hit target silently spanned the full row. */}
+        <div className="mt-8">
+          <Link
+            href={isPreviewMode ? `${ERAS_ROUTE}?preview=demo` : ERAS_ROUTE}
+            data-testid="eras-link"
+            className="font-mono text-[10px] uppercase tracking-[0.2em] text-amber-300/80 underline underline-offset-4 hover:text-amber-200"
+          >
+            Two eras · then vs now across the whole log →
+          </Link>
+        </div>
+
         {permanentGoals.length === 0 && focuses.length === 0 ? (
           <section
             data-testid="weight-room-history-empty"
@@ -313,17 +336,6 @@ export default async function WeightRoomHistoryPage({
                 </div>
               </section>
             )}
-
-            {/* The whole-log era view (#437) — the counterpart to the
-                per-movement then-vs-now panels, for the 42 archive movements
-                that have no current-era side to be compared against. */}
-            <Link
-              href={isPreviewMode ? `${ERAS_ROUTE}?preview=demo` : ERAS_ROUTE}
-              data-testid="eras-link"
-              className="mt-8 inline-block font-mono text-[10px] uppercase tracking-[0.2em] text-amber-300/80 underline underline-offset-4 hover:text-amber-200"
-            >
-              Two eras · then vs now across the whole log →
-            </Link>
 
             <ExerciseFilterChips
               exercises={goals.map(goal => ({

--- a/app/training-facility/weight-room/history/page.tsx
+++ b/app/training-facility/weight-room/history/page.tsx
@@ -71,6 +71,9 @@ import type { ExerciseGoal } from '@/types/weight-room'
 /** Route the filter chips link back to. */
 const HISTORY_PATH = '/training-facility/weight-room/history'
 
+/** Route for the whole-log era comparison (#437). */
+const ERAS_ROUTE = '/training-facility/weight-room/eras'
+
 /**
  * Query params the filter chips must preserve when toggling — the
  * Training-Facility preview flag and the heatmap range (#438). An allowlist
@@ -310,6 +313,17 @@ export default async function WeightRoomHistoryPage({
                 </div>
               </section>
             )}
+
+            {/* The whole-log era view (#437) — the counterpart to the
+                per-movement then-vs-now panels, for the 42 archive movements
+                that have no current-era side to be compared against. */}
+            <Link
+              href={isPreviewMode ? `${ERAS_ROUTE}?preview=demo` : ERAS_ROUTE}
+              data-testid="eras-link"
+              className="mt-8 inline-block font-mono text-[10px] uppercase tracking-[0.2em] text-amber-300/80 underline underline-offset-4 hover:text-amber-200"
+            >
+              Two eras · then vs now across the whole log →
+            </Link>
 
             <ExerciseFilterChips
               exercises={goals.map(goal => ({

--- a/components/training-facility/shared/charts/RoughBar.test.tsx
+++ b/components/training-facility/shared/charts/RoughBar.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * Tests for {@link RoughBar}'s axis labelling.
+ *
+ * `xTickLabel` was added for a five-year monthly series whose category labels
+ * would otherwise render as one illegible smear (#437). It is a prop on a
+ * primitive several other charts use, so it's tested here rather than only
+ * through the one chart that currently passes it — a break would otherwise
+ * surface as a mislabelled axis on whichever chart adopts it next.
+ */
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { RoughBar } from './RoughBar'
+
+const DATA = [
+  { key: '2022-01', value: 3 },
+  { key: '2022-02', value: 5 },
+  { key: '2022-03', value: 8 },
+]
+
+function renderBar(xTickLabel?: (category: string, index: number) => string | null) {
+  return render(
+    <RoughBar
+      data={DATA}
+      x={d => d.key}
+      y={d => d.value}
+      width={400}
+      height={200}
+      ariaLabel="test chart"
+      {...(xTickLabel === undefined ? {} : { xTickLabel })}
+    />
+  )
+}
+
+describe('RoughBar xTickLabel', () => {
+  it('labels every category when the prop is omitted', () => {
+    // The default the dozen-bar charts this started with rely on.
+    renderBar()
+    for (const row of DATA) expect(screen.getByText(row.key)).toBeInTheDocument()
+  })
+
+  it('relabels a tick', () => {
+    renderBar(category => category.slice(0, 4))
+    expect(screen.getAllByText('2022')).toHaveLength(DATA.length)
+    expect(screen.queryByText('2022-01')).toBeNull()
+  })
+
+  it('omits a tick whose label is null, without dropping its bar', () => {
+    const { container } = renderBar(category => (category === '2022-02' ? null : category))
+    expect(screen.queryByText('2022-02')).toBeNull()
+    expect(screen.getByText('2022-01')).toBeInTheDocument()
+    expect(screen.getByText('2022-03')).toBeInTheDocument()
+    // Same bar count as the unlabelled render — omitting a label must not
+    // remove data.
+    const { container: all } = renderBar()
+    expect(container.querySelectorAll('path').length).toBeGreaterThanOrEqual(
+      all.querySelectorAll('path').length - 2
+    )
+  })
+
+  it('passes the category index, so a caller can label the first tick specially', () => {
+    const seen: number[] = []
+    renderBar((category, index) => {
+      seen.push(index)
+      return index === 0 ? 'first' : null
+    })
+    expect(seen).toEqual([0, 1, 2])
+    expect(screen.getByText('first')).toBeInTheDocument()
+  })
+})

--- a/components/training-facility/shared/charts/RoughBar.tsx
+++ b/components/training-facility/shared/charts/RoughBar.tsx
@@ -15,6 +15,14 @@ export interface RoughBarProps<T> extends ChartCommonProps {
   /** Inner padding between bars (0–1). */
   padding?: number
   xLabel?: string
+  /**
+   * Relabel or drop a category tick. Returning `null` omits that tick's label
+   * while the bar still renders — the escape hatch for a band scale with more
+   * categories than the axis can legibly name, e.g. five years of months where
+   * only January should be written (#437). Defaults to labelling every
+   * category, which is right for the dozen-bar charts this started with.
+   */
+  xTickLabel?: (category: string, index: number) => string | null
   yLabel?: string
   yTickCount?: number
   yTickFormat?: (value: number) => string
@@ -36,6 +44,7 @@ export function RoughBar<T>({
   fontFamily = 'inherit',
   axisColor = chartPalette.inkBlack,
   xLabel,
+  xTickLabel,
   yLabel,
   yTickCount = 5,
   yTickFormat,
@@ -70,10 +79,11 @@ export function RoughBar<T>({
 
   const gen = getGenerator()
 
-  const xTicks: AxisTick[] = categories.map(c => ({
-    value: c,
-    offset: (xScale(c) ?? 0) + xScale.bandwidth() / 2,
-  }))
+  const xTicks: AxisTick[] = categories.flatMap((c, i) => {
+    const label = xTickLabel === undefined ? c : xTickLabel(c, i)
+    if (label === null) return []
+    return [{ value: label, offset: (xScale(c) ?? 0) + xScale.bandwidth() / 2 }]
+  })
 
   const yTicks: AxisTick[] = yScale.ticks(yTickCount).map(tick => ({
     value: yTickFormat ? yTickFormat(tick) : String(tick),

--- a/components/training-facility/weight-room/EraCadenceChart.test.tsx
+++ b/components/training-facility/weight-room/EraCadenceChart.test.tsx
@@ -1,0 +1,62 @@
+/**
+ * Tests for the cadence chart (#437).
+ *
+ * The acceptance criterion this defends is "the gap renders as a gap": the
+ * empty months have to reach the chart and be named, not be filtered out on the
+ * way in — a series that skips them draws the two eras shoulder to shoulder.
+ */
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import type { EraMonth } from '@/lib/training-facility/log-eras'
+
+import { EraCadenceChart } from './EraCadenceChart'
+
+function month(monthKey: string, era: EraMonth['era'], trainingDays = 0): EraMonth {
+  return { monthKey, trainingDays, era }
+}
+
+const MONTHS: EraMonth[] = [
+  month('2024-03', 'then', 8),
+  month('2024-04', 'then', 6),
+  month('2024-05', 'gap'),
+  month('2024-06', 'gap'),
+  month('2024-07', 'gap'),
+  month('2026-05', 'now', 4),
+  month('2026-06', 'now', 22),
+]
+
+describe('EraCadenceChart', () => {
+  it('renders a bar for every month, empty ones included', () => {
+    const { container } = render(<EraCadenceChart months={MONTHS} />)
+    // Each bar emits at least one path; the count only has to grow with the
+    // months, which is what proves the gap wasn't filtered out.
+    const withGap = container.querySelectorAll('path').length
+    const { container: noGap } = render(
+      <EraCadenceChart months={MONTHS.filter(m => m.era !== 'gap')} />
+    )
+    expect(withGap).toBeGreaterThan(noGap.querySelectorAll('path').length)
+  })
+
+  it('names the layoff beneath the chart', () => {
+    render(<EraCadenceChart months={MONTHS} />)
+    const note = screen.getByTestId('era-gap-note')
+    expect(note).toHaveTextContent('2024-05')
+    expect(note).toHaveTextContent('2024-07')
+    expect(note).toHaveTextContent('3 months')
+  })
+
+  it('omits the note when the log has no layoff', () => {
+    render(<EraCadenceChart months={MONTHS.filter(m => m.era !== 'gap')} />)
+    expect(screen.queryByTestId('era-gap-note')).toBeNull()
+  })
+
+  it('widens with the span so a long log stays legible when scrolled', () => {
+    const many = Array.from({ length: 60 }, (_, i) =>
+      month(`2020-${String((i % 12) + 1).padStart(2, '0')}-${i}`, 'then', 5)
+    )
+    const { container } = render(<EraCadenceChart months={many} />)
+    const svg = container.querySelector('svg')
+    expect(Number(svg?.getAttribute('width'))).toBeGreaterThan(1000)
+  })
+})

--- a/components/training-facility/weight-room/EraCadenceChart.test.tsx
+++ b/components/training-facility/weight-room/EraCadenceChart.test.tsx
@@ -38,12 +38,14 @@ describe('EraCadenceChart', () => {
     expect(withGap).toBeGreaterThan(noGap.querySelectorAll('path').length)
   })
 
-  it('names the layoff beneath the chart', () => {
+  it('names the layoff beneath the chart, in prose rather than sort keys', () => {
     render(<EraCadenceChart months={MONTHS} />)
     const note = screen.getByTestId('era-gap-note')
-    expect(note).toHaveTextContent('2024-05')
-    expect(note).toHaveTextContent('2024-07')
+    expect(note).toHaveTextContent('May 2024')
+    expect(note).toHaveTextContent('July 2024')
     expect(note).toHaveTextContent('3 months')
+    // The raw `YYYY-MM` keys are sort keys, not something a reader should see.
+    expect(note).not.toHaveTextContent('2024-05')
   })
 
   it('omits the note when the log has no layoff', () => {

--- a/components/training-facility/weight-room/EraCadenceChart.tsx
+++ b/components/training-facility/weight-room/EraCadenceChart.tsx
@@ -1,6 +1,7 @@
 import type { JSX } from 'react'
 
 import { RoughBar, chartPalette } from '@/components/training-facility/shared/charts'
+import { formatDayKey } from '@/lib/training-facility/day-keys'
 import type { EraMonth } from '@/lib/training-facility/log-eras'
 
 /** Cream axis ink that reads on the Weight Room's dark page surface. */
@@ -25,12 +26,14 @@ export interface EraCadenceChartProps {
  * training reads as "none" rather than vanishing — and a long flat stretch is
  * suggestive rather than precise.
  */
-function gapBounds(months: readonly EraMonth[]): { from: string; to: string } | null {
+function gapBounds(
+  months: readonly EraMonth[]
+): { from: string; to: string; months: number } | null {
   const gaps = months.filter(month => month.era === 'gap')
   const first = gaps[0]
   const last = gaps[gaps.length - 1]
   if (first === undefined || last === undefined) return null
-  return { from: first.monthKey, to: last.monthKey }
+  return { from: first.monthKey, to: last.monthKey, months: gaps.length }
 }
 
 /**
@@ -79,8 +82,16 @@ export function EraCadenceChart({ months, height = 220 }: EraCadenceChartProps):
           // Only January carries a label, plus the first month so the axis
           // opens with a date. Naming all ~54 months renders them as one
           // illegible smear.
+          //
+          // The first tick keeps its month: the log starts in March, and a bare
+          // "2022" anchored on the March band dates the era's start to January
+          // and shifts every reading in that first year.
           xTickLabel={(monthKey, index) =>
-            index === 0 || monthKey.endsWith('-01') ? monthKey.slice(0, 4) : null
+            index === 0
+              ? formatMonthKey(monthKey, { month: 'short', year: 'numeric' })
+              : monthKey.endsWith('-01')
+                ? monthKey.slice(0, 4)
+                : null
           }
           yLabel="days"
           yTickFormat={value => String(Math.round(value))}
@@ -91,15 +102,25 @@ export function EraCadenceChart({ months, height = 220 }: EraCadenceChartProps):
 
       {gap === null ? null : (
         <p data-testid="era-gap-note" className="mt-3 text-xs leading-5 text-[#e8d5be]/60">
-          Nothing logged from {gap.from} through {gap.to} — {monthCount(months)} months of the span
-          with no training recorded.
+          Nothing logged from {formatMonthKey(gap.from)} through {formatMonthKey(gap.to)} —{' '}
+          {gap.months} months of the span with no training recorded.
         </p>
       )}
     </section>
   )
 }
 
-/** How many months of the span carry no training at all. */
-function monthCount(months: readonly EraMonth[]): number {
-  return months.filter(month => month.era === 'gap').length
+/**
+ * A `YYYY-MM` key as prose.
+ *
+ * Month keys are sort keys, not dates a reader should see: printing `2024-05`
+ * in a sentence next to "Mar 2022 – Apr 2024" reads as unfinished. Resolved
+ * through the Pacific day formatter on the first of the month, like every other
+ * date on the page.
+ */
+function formatMonthKey(
+  monthKey: string,
+  options: Intl.DateTimeFormatOptions = { month: 'long', year: 'numeric' }
+): string {
+  return formatDayKey(`${monthKey}-01`, options)
 }

--- a/components/training-facility/weight-room/EraCadenceChart.tsx
+++ b/components/training-facility/weight-room/EraCadenceChart.tsx
@@ -1,0 +1,105 @@
+import type { JSX } from 'react'
+
+import { RoughBar, chartPalette } from '@/components/training-facility/shared/charts'
+import type { EraMonth } from '@/lib/training-facility/log-eras'
+
+/** Cream axis ink that reads on the Weight Room's dark page surface. */
+const AXIS_COLOR = 'rgba(247, 234, 217, 0.55)'
+
+/** Pixels per month column, sized so a five-year span stays legible when scrolled. */
+const MONTH_WIDTH = 20
+
+/** Props for {@link EraCadenceChart}. */
+export interface EraCadenceChartProps {
+  /** Every month from the log's first to its last, gaps included. */
+  months: readonly EraMonth[]
+  /** Chart height in px. */
+  height?: number
+}
+
+/**
+ * The `YYYY-MM` bounds of the layoff, or `null` when there isn't one.
+ *
+ * Named explicitly beneath the chart because the gap is drawn as a run of
+ * zero-height bars — deliberately still present on the axis, so a month with no
+ * training reads as "none" rather than vanishing — and a long flat stretch is
+ * suggestive rather than precise.
+ */
+function gapBounds(months: readonly EraMonth[]): { from: string; to: string } | null {
+  const gaps = months.filter(month => month.era === 'gap')
+  const first = gaps[0]
+  const last = gaps[gaps.length - 1]
+  if (first === undefined || last === undefined) return null
+  return { from: first.monthKey, to: last.monthKey }
+}
+
+/**
+ * Training days per month across the whole log (#437).
+ *
+ * The one requirement that shapes everything: **the layoff has to occupy
+ * space**. `buildLogEras` emits every calendar month between the first and last
+ * training day, including the ~25 empty ones, and this draws them all — so the
+ * gap is a visibly empty stretch of axis rather than two eras rendered
+ * shoulder to shoulder.
+ *
+ * A bar per month rather than a line for the same reason: a line drawn across
+ * the layoff would imply a continuous quantity declining through it, when what
+ * actually happened is that nothing was logged at all.
+ *
+ * A Server Component; rough.js emits its paths without a DOM.
+ */
+export function EraCadenceChart({ months, height = 220 }: EraCadenceChartProps): JSX.Element {
+  const width = Math.max(560, months.length * MONTH_WIDTH + 96)
+  const gap = gapBounds(months)
+
+  return (
+    <section
+      data-testid="era-cadence"
+      className="rounded-[1.2rem] border border-white/10 bg-white/[0.04] p-5"
+    >
+      <h2 className="font-mono text-[11px] uppercase tracking-[0.28em] text-amber-300/80">
+        Days trained per month
+      </h2>
+      <p className="mt-1.5 text-sm leading-6 text-[#e8d5be]/75">
+        Every month between the first logged set and the last. The empty stretch in the middle is
+        the layoff — drawn rather than skipped, because a chart that closed the gap would say the
+        two eras ran back to back.
+      </p>
+
+      <div className="mt-4 overflow-x-auto">
+        <RoughBar
+          data={[...months]}
+          x={month => month.monthKey}
+          y={month => month.trainingDays}
+          fill={chartPalette.rimOrange}
+          stroke={chartPalette.rimOrange}
+          fillStyle="hachure"
+          width={width}
+          height={height}
+          // Only January carries a label, plus the first month so the axis
+          // opens with a date. Naming all ~54 months renders them as one
+          // illegible smear.
+          xTickLabel={(monthKey, index) =>
+            index === 0 || monthKey.endsWith('-01') ? monthKey.slice(0, 4) : null
+          }
+          yLabel="days"
+          yTickFormat={value => String(Math.round(value))}
+          axisColor={AXIS_COLOR}
+          ariaLabel="Days trained per month across the whole log"
+        />
+      </div>
+
+      {gap === null ? null : (
+        <p data-testid="era-gap-note" className="mt-3 text-xs leading-5 text-[#e8d5be]/60">
+          Nothing logged from {gap.from} through {gap.to} — {monthCount(months)} months of the span
+          with no training recorded.
+        </p>
+      )}
+    </section>
+  )
+}
+
+/** How many months of the span carry no training at all. */
+function monthCount(months: readonly EraMonth[]): number {
+  return months.filter(month => month.era === 'gap').length
+}

--- a/components/training-facility/weight-room/EraContrastPanel.test.tsx
+++ b/components/training-facility/weight-room/EraContrastPanel.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * Tests for the two-era contrast panel (#437).
+ *
+ * The panel's whole reason for existing is that it *doesn't* subtract one era
+ * from the other, so the cases here are about each side being stated on its own
+ * terms — and about the roster buckets, where an empty one ("nothing new since")
+ * is itself the finding rather than an absence to hide.
+ */
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { buildExerciseLabels } from '@/lib/training-facility/exercise-labels'
+import type { LogEra, LogEras } from '@/lib/training-facility/log-eras'
+
+import { EraContrastPanel } from './EraContrastPanel'
+
+const LABELS = buildExerciseLabels([
+  { slug: 'barbell-bench-press', display_name: 'Barbell Bench Press' },
+  { slug: 'pushups', display_name: 'Pushups' },
+  { slug: 'pullups', display_name: 'Pullups' },
+])
+
+function era(overrides: Partial<LogEra> = {}): LogEra {
+  return {
+    startDayKey: '2022-03-03',
+    endDayKey: '2024-04-18',
+    trainingDays: 181,
+    sets: 5109,
+    reps: 53_459,
+    loadedSets: 2778,
+    loadedShare: 2778 / 5109,
+    movements: 48,
+    ...overrides,
+  }
+}
+
+function eras(overrides: Partial<LogEras> = {}): LogEras {
+  return {
+    then: era(),
+    now: era({
+      startDayKey: '2026-05-25',
+      endDayKey: '2026-08-09',
+      trainingDays: 65,
+      sets: 1564,
+      reps: 16_212,
+      loadedSets: 214,
+      loadedShare: 214 / 1564,
+      movements: 6,
+    }),
+    gapDays: 767,
+    months: [],
+    roster: { thenOnly: ['barbell-bench-press'], shared: ['pullups'], nowOnly: [] },
+    ...overrides,
+  }
+}
+
+describe('EraContrastPanel', () => {
+  it('states each era on its own terms', () => {
+    render(<EraContrastPanel eras={eras()} exerciseLabels={LABELS} />)
+    expect(screen.getByTestId('era-then')).toHaveTextContent('5,109')
+    expect(screen.getByTestId('era-then')).toHaveTextContent('48')
+    expect(screen.getByTestId('era-now')).toHaveTextContent('1,564')
+    expect(screen.getByTestId('era-now')).toHaveTextContent('6')
+  })
+
+  it('shows the loaded share, which is where the change in kind lives', () => {
+    render(<EraContrastPanel eras={eras()} exerciseLabels={LABELS} />)
+    expect(screen.getByTestId('era-then')).toHaveTextContent('54%')
+    expect(screen.getByTestId('era-now')).toHaveTextContent('14%')
+  })
+
+  it('describes the layoff in months', () => {
+    render(<EraContrastPanel eras={eras()} exerciseLabels={LABELS} />)
+    expect(screen.getByTestId('era-contrast')).toHaveTextContent('25 months')
+  })
+
+  it('names the movements in each bucket rather than only counting them', () => {
+    render(<EraContrastPanel eras={eras()} exerciseLabels={LABELS} />)
+    expect(screen.getByTestId('era-roster-then-only')).toHaveTextContent('Barbell Bench Press')
+    expect(screen.getByTestId('era-roster-shared')).toHaveTextContent('Pullups')
+  })
+
+  it('says so when an era added nothing new, instead of rendering blank', () => {
+    render(<EraContrastPanel eras={eras()} exerciseLabels={LABELS} />)
+    expect(screen.getByTestId('era-roster-now-only')).toHaveTextContent(
+      'Nothing new has been added since.'
+    )
+  })
+
+  it('states no combined figure across the two eras', () => {
+    // The panel must not present a single number spanning both — barbell
+    // tonnage and push-up reps don't add up to anything.
+    render(<EraContrastPanel eras={eras()} exerciseLabels={LABELS} />)
+    const text = screen.getByTestId('era-contrast').textContent ?? ''
+    const combinedSets = (5109 + 1564).toLocaleString()
+    expect(text).not.toContain(combinedSets)
+  })
+})

--- a/components/training-facility/weight-room/EraContrastPanel.test.tsx
+++ b/components/training-facility/weight-room/EraContrastPanel.test.tsx
@@ -48,7 +48,19 @@ function eras(overrides: Partial<LogEras> = {}): LogEras {
       movements: 6,
     }),
     gapDays: 767,
-    months: [],
+    // Two trained months either side of a 24-month layoff. The panel counts the
+    // gap off these rather than dividing `gapDays` by an average month, so a
+    // fixture without them has no layoff to describe.
+    months: [
+      { monthKey: '2024-03', trainingDays: 6, era: 'then' as const },
+      { monthKey: '2024-04', trainingDays: 4, era: 'then' as const },
+      ...Array.from({ length: 24 }, (_, i) => ({
+        monthKey: `gap-${String(i).padStart(2, '0')}`,
+        trainingDays: 0,
+        era: 'gap' as const,
+      })),
+      { monthKey: '2026-05', trainingDays: 5, era: 'now' as const },
+    ],
     roster: { thenOnly: ['barbell-bench-press'], shared: ['pullups'], nowOnly: [] },
     ...overrides,
   }
@@ -69,9 +81,13 @@ describe('EraContrastPanel', () => {
     expect(screen.getByTestId('era-now')).toHaveTextContent('14%')
   })
 
-  it('describes the layoff in months', () => {
+  it('counts the layoff off the drawn months, not off an average month length', () => {
+    // 767 days ÷ 30.44 rounds to 25, while the calendar shows 24 empty months.
+    // Both used to render on the same screen; the drawn count is the one the
+    // reader can check against the chart.
     render(<EraContrastPanel eras={eras()} exerciseLabels={LABELS} />)
-    expect(screen.getByTestId('era-contrast')).toHaveTextContent('25 months')
+    expect(screen.getByTestId('era-contrast')).toHaveTextContent('24 months')
+    expect(screen.getByTestId('era-contrast')).not.toHaveTextContent('25 months')
   })
 
   it('names the movements in each bucket rather than only counting them', () => {

--- a/components/training-facility/weight-room/EraContrastPanel.tsx
+++ b/components/training-facility/weight-room/EraContrastPanel.tsx
@@ -34,9 +34,9 @@ export function EraContrastPanel({ eras, exerciseLabels }: EraContrastPanelProps
         Then and now
       </h2>
       <p className="mt-1.5 text-sm leading-6 text-[#e8d5be]/75">
-        Two stretches of training with {formatGap(eras.gapDays)} between them. Read them side by
-        side rather than as a difference — they aren’t the same kind of training, so subtracting one
-        from the other would produce a number about nothing.
+        Two stretches of training with {formatGap(eras)} between them. Read them side by side rather
+        than as a difference — they aren’t the same kind of training, so subtracting one from the
+        other would produce a number about nothing.
       </p>
 
       <div className="mt-5 grid gap-4 sm:grid-cols-2">
@@ -174,9 +174,17 @@ function RosterRow({ testId, term, slugs, labels, empty }: RosterRowProps): JSX.
   )
 }
 
-/** A layoff in months where that reads better than days. */
-function formatGap(days: number): string {
-  if (days < 60) return `${days} days`
-  const months = Math.round(days / 30.44)
+/**
+ * A layoff in months where that reads better than days.
+ *
+ * Counted from the months the cadence chart actually draws as empty, not by
+ * dividing `gapDays` by an average month. The two disagree — 767 days rounds to
+ * 25 while the calendar shows 24 — and both were on screen at once, which is a
+ * poor look for a page whose whole argument is that it won't state a number it
+ * can't support.
+ */
+function formatGap(eras: LogEras): string {
+  if (eras.gapDays < 60) return `${eras.gapDays} days`
+  const months = eras.months.filter(month => month.era === 'gap').length
   return `${months} months`
 }

--- a/components/training-facility/weight-room/EraContrastPanel.tsx
+++ b/components/training-facility/weight-room/EraContrastPanel.tsx
@@ -1,0 +1,182 @@
+import type { JSX } from 'react'
+
+import { formatDayKey } from '@/lib/training-facility/day-keys'
+import { slugLabel, type ExerciseLabels } from '@/lib/training-facility/exercise-labels'
+import type { LogEra, LogEras } from '@/lib/training-facility/log-eras'
+
+/** Props for {@link EraContrastPanel}. */
+export interface EraContrastPanelProps {
+  /** The split log. */
+  eras: LogEras
+  /** Slug → movement name, from `buildExerciseLabels`. */
+  exerciseLabels: ExerciseLabels
+}
+
+/**
+ * The two eras of the log, side by side (#437).
+ *
+ * Deliberately **not** a diff. The archive is a barbell gym rotation and the
+ * current log is mostly bodyweight grease-the-groove, so a subtraction across
+ * them would be arithmetic on incompatible things — "volume is down" assembled
+ * from barbell tonnage on one side and push-up reps on the other. Each column
+ * states what that era was; the reader does the comparing, which is the only
+ * honest way to compare training that changed in kind.
+ *
+ * A Server Component.
+ */
+export function EraContrastPanel({ eras, exerciseLabels }: EraContrastPanelProps): JSX.Element {
+  return (
+    <section
+      data-testid="era-contrast"
+      className="rounded-[1.2rem] border border-white/10 bg-white/[0.04] p-5"
+    >
+      <h2 className="font-mono text-[11px] uppercase tracking-[0.28em] text-amber-300/80">
+        Then and now
+      </h2>
+      <p className="mt-1.5 text-sm leading-6 text-[#e8d5be]/75">
+        Two stretches of training with {formatGap(eras.gapDays)} between them. Read them side by
+        side rather than as a difference — they aren’t the same kind of training, so subtracting one
+        from the other would produce a number about nothing.
+      </p>
+
+      <div className="mt-5 grid gap-4 sm:grid-cols-2">
+        <EraColumn era={eras.then} title="Then" testId="era-then" />
+        <EraColumn era={eras.now} title="Now" testId="era-now" />
+      </div>
+
+      <div className="mt-6 border-t border-white/10 pt-4">
+        <h3 className="font-mono text-[10px] uppercase tracking-[0.22em] text-[#e8d5be]/70">
+          What was trained
+        </h3>
+        <dl className="mt-3 flex flex-col gap-3 text-sm leading-6">
+          <RosterRow
+            testId="era-roster-shared"
+            term={`Both eras · ${eras.roster.shared.length}`}
+            slugs={eras.roster.shared}
+            labels={exerciseLabels}
+            empty="Nothing carried across the layoff."
+          />
+          <RosterRow
+            testId="era-roster-then-only"
+            term={`Only then · ${eras.roster.thenOnly.length}`}
+            slugs={eras.roster.thenOnly}
+            labels={exerciseLabels}
+            empty="Everything from the archive is still trained."
+          />
+          <RosterRow
+            testId="era-roster-now-only"
+            term={`Only now · ${eras.roster.nowOnly.length}`}
+            slugs={eras.roster.nowOnly}
+            labels={exerciseLabels}
+            empty="Nothing new has been added since."
+          />
+        </dl>
+      </div>
+    </section>
+  )
+}
+
+/** Props for {@link EraColumn}. */
+interface EraColumnProps {
+  /** The era to describe. */
+  era: LogEra
+  /** Column heading. */
+  title: string
+  /** Test id for the column. */
+  testId: string
+}
+
+/** One era's shape, on its own terms. */
+function EraColumn({ era, title, testId }: EraColumnProps): JSX.Element {
+  const loadedPct = Math.round(era.loadedShare * 100)
+  return (
+    <div data-testid={testId} className="rounded-[1rem] border border-white/10 bg-white/[0.03] p-4">
+      <p className="font-mono text-[10px] uppercase tracking-[0.22em] text-amber-300/70">{title}</p>
+      <p className="mt-1 font-mono text-[11px] text-[#e8d5be]/60">
+        {formatDayKey(era.startDayKey, { month: 'short', year: 'numeric' })} –{' '}
+        {formatDayKey(era.endDayKey, { month: 'short', year: 'numeric' })}
+      </p>
+
+      <dl className="mt-3 grid grid-cols-2 gap-x-3 gap-y-2 font-mono text-[11px]">
+        <Stat label="Training days" value={era.trainingDays.toLocaleString()} />
+        <Stat label="Movements" value={String(era.movements)} />
+        <Stat label="Sets" value={era.sets.toLocaleString()} />
+        <Stat label="Reps" value={era.reps.toLocaleString()} />
+      </dl>
+
+      <div className="mt-4">
+        <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-[#e8d5be]/60">
+          Loaded sets · {loadedPct}%
+        </p>
+        {/* The change in kind, made visual: the proportion of work that carried
+            external weight at all. */}
+        <div
+          aria-hidden="true"
+          className="mt-1.5 h-2 w-full overflow-hidden rounded-full bg-white/8"
+        >
+          <div className="h-full bg-amber-300/70" style={{ width: `${loadedPct}%` }} />
+        </div>
+        <p className="mt-1.5 text-xs leading-5 text-[#e8d5be]/55">
+          {era.loadedSets.toLocaleString()} of {era.sets.toLocaleString()} sets carried weight.
+        </p>
+      </div>
+    </div>
+  )
+}
+
+/** Props for {@link Stat}. */
+interface StatProps {
+  /** What the number is. */
+  label: string
+  /** The number, already formatted. */
+  value: string
+}
+
+/** One labelled figure inside an era column. */
+function Stat({ label, value }: StatProps): JSX.Element {
+  return (
+    <div>
+      <dt className="text-[10px] uppercase tracking-[0.16em] text-[#e8d5be]/55">{label}</dt>
+      <dd className="text-base font-bold text-[#fff7ec]">{value}</dd>
+    </div>
+  )
+}
+
+/** Props for {@link RosterRow}. */
+interface RosterRowProps {
+  /** Test id for the row. */
+  testId: string
+  /** Row heading, including the count. */
+  term: string
+  /** Movement slugs in this bucket. */
+  slugs: readonly string[]
+  /** Slug → name lookup. */
+  labels: ExerciseLabels
+  /** Copy for an empty bucket, which is itself a finding. */
+  empty: string
+}
+
+/** One bucket of the movement roster, named rather than counted. */
+function RosterRow({ testId, term, slugs, labels, empty }: RosterRowProps): JSX.Element {
+  return (
+    <div data-testid={testId} className="grid gap-1 sm:grid-cols-[10rem_1fr] sm:gap-3">
+      <dt className="font-mono text-[10px] uppercase tracking-[0.16em] text-[#e8d5be]/70">
+        {term}
+      </dt>
+      <dd className="text-[#e8d5be]/80">
+        {slugs.length === 0 ? (
+          <span className="text-[#e8d5be]/55">{empty}</span>
+        ) : (
+          slugs.map(slug => slugLabel(slug, undefined, labels)).join(', ')
+        )}
+      </dd>
+    </div>
+  )
+}
+
+/** A layoff in months where that reads better than days. */
+function formatGap(days: number): string {
+  if (days < 60) return `${days} days`
+  const months = Math.round(days / 30.44)
+  return `${months} months`
+}

--- a/components/training-facility/weight-room/WeightRoomSubNav.tsx
+++ b/components/training-facility/weight-room/WeightRoomSubNav.tsx
@@ -14,7 +14,15 @@ import Link from 'next/link'
  * isn't on.
  */
 export type WeightRoomSubNavSection =
-  'today' | 'history' | 'workouts' | 'program' | 'exercises' | 'achievements' | 'settings' | 'log'
+  | 'today'
+  | 'history'
+  | 'workouts'
+  | 'program'
+  | 'exercises'
+  | 'eras'
+  | 'achievements'
+  | 'settings'
+  | 'log'
 
 /** Props for {@link WeightRoomSubNav}. */
 export interface WeightRoomSubNavProps {

--- a/e2e/eras.spec.ts
+++ b/e2e/eras.spec.ts
@@ -51,18 +51,42 @@ test.describe('two eras view', () => {
     expect(href).toContain(ERAS)
   })
 
-  test('does not widen the document', async ({ page }) => {
-    // The cadence chart spans five years of months and is meant to scroll
-    // inside its own card.
+  test('keeps the cadence chart inside its own scroller', async ({ page }) => {
+    // Measured on the card's scroll container, not the document: this page's
+    // root carries `overflow-hidden`, so `documentElement.scrollWidth` can
+    // never exceed its client width and a document-level assertion here passes
+    // no matter how badly the chart overflows.
     await page.goto(`${ERAS}?preview=demo`)
-    await expect(
-      page.getByTestId('era-contrast').or(page.getByTestId('era-empty')).first()
-    ).toBeVisible({ timeout: RENDER_TIMEOUT })
+    const cadence = page.getByTestId('era-cadence')
+    if ((await cadence.count()) === 0) {
+      // No layoff in this environment's data, so no chart to measure.
+      test.skip()
+      return
+    }
+    await expect(cadence).toBeVisible({ timeout: RENDER_TIMEOUT })
 
-    const doc = await page.evaluate(() => ({
-      scrollWidth: document.documentElement.scrollWidth,
-      clientWidth: document.documentElement.clientWidth,
-    }))
-    expect(doc.scrollWidth).toBeLessThanOrEqual(doc.clientWidth + 1)
+    const measured = await cadence.evaluate(section => {
+      const scroller = section.querySelector<HTMLElement>('.overflow-x-auto')
+      const svg = section.querySelector('svg')
+      return {
+        viewport: window.innerWidth,
+        hasScroller: scroller !== null,
+        scrollWidth: scroller?.scrollWidth ?? 0,
+        clientWidth: scroller?.clientWidth ?? 0,
+        svgWidth: Number(svg?.getAttribute('width') ?? 0),
+        sectionRight: section.getBoundingClientRect().right,
+      }
+    })
+
+    // The chart is a fixed-width SVG; the card is what scrolls it.
+    expect(measured.hasScroller).toBe(true)
+    expect(measured.svgWidth).toBeGreaterThan(0)
+    // The card itself never escapes the viewport, whatever the SVG measures.
+    expect(measured.sectionRight).toBeLessThanOrEqual(measured.viewport + 1)
+    if (measured.svgWidth > measured.clientWidth) {
+      // Wider than its container means the scroller has something to scroll —
+      // the precondition for `overflow-x-auto` to do anything.
+      expect(measured.scrollWidth).toBeGreaterThan(measured.clientWidth)
+    }
   })
 })

--- a/e2e/eras.spec.ts
+++ b/e2e/eras.spec.ts
@@ -1,0 +1,68 @@
+import { expect, test } from '@playwright/test'
+
+/**
+ * Pins the whole-log era view (#437).
+ *
+ * The route only has something to show when the log contains a long layoff, and
+ * CI's demo fixture is a couple of recent weeks — so the interesting assertions
+ * are environment-dependent. What holds everywhere: the page renders rather than
+ * erroring, it is reachable from History, and it shows exactly one of the two
+ * legitimate states (a comparison, or the note explaining there's nothing to
+ * compare). The split arithmetic is unit tested in
+ * `lib/training-facility/log-eras.test.ts`.
+ */
+
+const HISTORY = '/training-facility/weight-room/history'
+const ERAS = '/training-facility/weight-room/eras'
+
+/** Budget for a render of History or the eras page under parallel load. */
+const RENDER_TIMEOUT = 60_000
+
+test.describe('two eras view', () => {
+  test('renders exactly one of its two legitimate states', async ({ page }) => {
+    await page.goto(`${ERAS}?preview=demo`)
+
+    const contrast = page.getByTestId('era-contrast')
+    const empty = page.getByTestId('era-empty')
+    await expect(contrast.or(empty).first()).toBeVisible({ timeout: RENDER_TIMEOUT })
+
+    const hasContrast = (await contrast.count()) > 0
+    const hasEmpty = (await empty.count()) > 0
+    // Never both: a log either has a layoff to split on or it doesn't.
+    expect(hasContrast).not.toBe(hasEmpty)
+
+    if (hasContrast) {
+      // The cadence chart only exists alongside a real split.
+      await expect(page.getByTestId('era-cadence')).toBeVisible()
+      // Every roster bucket is stated, including the empty ones.
+      await expect(page.getByTestId('era-roster-shared')).toBeVisible()
+      await expect(page.getByTestId('era-roster-then-only')).toBeVisible()
+      await expect(page.getByTestId('era-roster-now-only')).toBeVisible()
+    }
+  })
+
+  test('is reachable from History', async ({ page }) => {
+    test.slow() // History is one of the heavier renders in the app.
+    await page.goto(`${HISTORY}?preview=demo`)
+
+    const link = page.getByTestId('eras-link')
+    await expect(link).toBeVisible({ timeout: RENDER_TIMEOUT })
+    const href = await link.getAttribute('href')
+    expect(href).toContain(ERAS)
+  })
+
+  test('does not widen the document', async ({ page }) => {
+    // The cadence chart spans five years of months and is meant to scroll
+    // inside its own card.
+    await page.goto(`${ERAS}?preview=demo`)
+    await expect(
+      page.getByTestId('era-contrast').or(page.getByTestId('era-empty')).first()
+    ).toBeVisible({ timeout: RENDER_TIMEOUT })
+
+    const doc = await page.evaluate(() => ({
+      scrollWidth: document.documentElement.scrollWidth,
+      clientWidth: document.documentElement.clientWidth,
+    }))
+    expect(doc.scrollWidth).toBeLessThanOrEqual(doc.clientWidth + 1)
+  })
+})

--- a/lib/training-facility/log-eras.test.ts
+++ b/lib/training-facility/log-eras.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Tests for the whole-log era split (#437).
+ *
+ * The load-bearing cases: the split lands on the *longest* layoff rather than
+ * the first one over the threshold, the empty months between the eras are
+ * present rather than skipped, and a log with no real layoff refuses to split
+ * instead of manufacturing a comparison.
+ */
+import { describe, expect, it } from 'vitest'
+
+import type { StrengthSet, WeightRoomExercise } from '@/types/weight-room'
+
+import { buildLogEras } from './log-eras'
+
+/** A set on a given Pacific day. */
+function set(dayKey: string, exercise: string, reps = 10, weight?: number): StrengthSet {
+  return {
+    id: `${dayKey}-${exercise}-${reps}-${weight ?? 'bw'}`,
+    logged_at: `${dayKey}T20:00:00Z`,
+    exercise,
+    reps,
+    ...(weight === undefined ? {} : { weight_lbs: weight }),
+  }
+}
+
+const CATALOG: WeightRoomExercise[] = [
+  { slug: 'barbell-bench-press', display_name: 'Barbell Bench Press', load_multiplier: 1 },
+  { slug: 'pushups', display_name: 'Pushups', load_multiplier: 0 },
+  { slug: 'pullups', display_name: 'Pullups', load_multiplier: 0 },
+] as unknown as WeightRoomExercise[]
+
+/**
+ * An archive era of loaded work, a long layoff, then a bodyweight era.
+ *
+ * The archive days are spread across its span on purpose: leaving a two-year
+ * hole *inside* it would make that the longest gap, and the split would land
+ * there rather than on the layoff under test.
+ */
+const TWO_ERAS: StrengthSet[] = [
+  set('2022-03-03', 'barbell-bench-press', 8, 135),
+  set('2022-03-10', 'barbell-bench-press', 8, 145),
+  set('2022-03-10', 'pullups', 6),
+  set('2022-09-14', 'barbell-bench-press', 6, 155),
+  set('2023-03-21', 'barbell-bench-press', 6, 165),
+  set('2023-10-04', 'pullups', 7),
+  set('2024-04-18', 'barbell-bench-press', 5, 185),
+  // 767-day layoff.
+  set('2026-05-25', 'pushups', 25),
+  set('2026-08-09', 'pushups', 30),
+  set('2026-08-09', 'pullups', 8),
+]
+
+describe('buildLogEras', () => {
+  it('splits at the layoff and describes each side', () => {
+    const eras = buildLogEras(TWO_ERAS, CATALOG)
+    expect(eras).not.toBeNull()
+    expect(eras?.then.startDayKey).toBe('2022-03-03')
+    expect(eras?.then.endDayKey).toBe('2024-04-18')
+    expect(eras?.now.startDayKey).toBe('2026-05-25')
+    expect(eras?.now.endDayKey).toBe('2026-08-09')
+    expect(eras?.gapDays).toBe(767)
+  })
+
+  it('counts loaded share per era, which is where the change in kind shows', () => {
+    const eras = buildLogEras(TWO_ERAS, CATALOG)
+    // Archive: 5 loaded bench sets out of 7. Current: nothing loaded at all.
+    expect(eras?.then.sets).toBe(7)
+    expect(eras?.then.loadedSets).toBe(5)
+    expect(eras?.then.loadedShare).toBeCloseTo(5 / 7)
+    expect(eras?.now.loadedSets).toBe(0)
+    expect(eras?.now.loadedShare).toBe(0)
+  })
+
+  it('counts a weighted bodyweight movement as loaded', () => {
+    // A weighted pushup is loaded work; `load_multiplier` is an implement
+    // count, not a bodyweight flag, so it never decides whether a set
+    // qualifies.
+    const eras = buildLogEras([...TWO_ERAS, set('2026-08-09', 'pushups', 20, 25)], CATALOG)
+    expect(eras?.now.loadedSets).toBe(1)
+  })
+
+  it('splits at the longest layoff, not the first one over the threshold', () => {
+    const twoGaps: StrengthSet[] = [
+      set('2020-01-01', 'pullups'),
+      // 200-day gap — over the threshold, but not the longest.
+      set('2020-07-19', 'pullups'),
+      // 900-day gap.
+      set('2023-01-05', 'pushups'),
+      set('2023-02-05', 'pushups'),
+    ]
+    const eras = buildLogEras(twoGaps, CATALOG)
+    expect(eras?.then.endDayKey).toBe('2020-07-19')
+    expect(eras?.now.startDayKey).toBe('2023-01-05')
+  })
+
+  it('refuses to split a log with no long layoff', () => {
+    // One continuous stretch has no "then"; inventing a boundary would
+    // manufacture the comparison the page exists to make.
+    const continuous = [set('2026-05-01', 'pushups'), set('2026-06-01', 'pushups')]
+    expect(buildLogEras(continuous, CATALOG)).toBeNull()
+  })
+
+  it('is null for an empty log', () => {
+    expect(buildLogEras([], CATALOG)).toBeNull()
+  })
+
+  it('keeps the empty months so the layoff occupies space', () => {
+    const eras = buildLogEras(TWO_ERAS, CATALOG)
+    const months = eras?.months ?? []
+    // Contiguous from the first month to the last, gaps included.
+    expect(months[0].monthKey).toBe('2022-03')
+    expect(months[months.length - 1].monthKey).toBe('2026-08')
+    const gapMonths = months.filter(m => m.era === 'gap')
+    expect(gapMonths.length).toBeGreaterThan(12)
+    expect(gapMonths.every(m => m.trainingDays === 0)).toBe(true)
+  })
+
+  it('rolls the calendar over a year boundary', () => {
+    const eras = buildLogEras(TWO_ERAS, CATALOG)
+    const keys = (eras?.months ?? []).map(m => m.monthKey)
+    expect(keys).toContain('2022-12')
+    expect(keys).toContain('2023-01')
+    // Strictly ascending, no repeats.
+    expect([...keys].sort()).toEqual(keys)
+    expect(new Set(keys).size).toBe(keys.length)
+  })
+
+  it('labels each month by the era it belongs to', () => {
+    const eras = buildLogEras(TWO_ERAS, CATALOG)
+    const months = eras?.months ?? []
+    expect(months.find(m => m.monthKey === '2022-03')?.era).toBe('then')
+    expect(months.find(m => m.monthKey === '2025-01')?.era).toBe('gap')
+    expect(months.find(m => m.monthKey === '2026-08')?.era).toBe('now')
+  })
+
+  it('separates movements exclusive to one era from the shared ones', () => {
+    const eras = buildLogEras(TWO_ERAS, CATALOG)
+    expect(eras?.roster.thenOnly).toEqual(['barbell-bench-press'])
+    expect(eras?.roster.shared).toEqual(['pullups'])
+    expect(eras?.roster.nowOnly).toEqual(['pushups'])
+  })
+
+  it('buckets a set on its Pacific day, not its UTC one', () => {
+    // 2026-05-26 03:00 UTC is still May 25 in Pacific.
+    const eras = buildLogEras(
+      [set('2022-03-03', 'pullups'), { ...set('x', 'pushups'), logged_at: '2026-05-26T03:00:00Z' }],
+      CATALOG
+    )
+    expect(eras?.now.startDayKey).toBe('2026-05-25')
+  })
+})

--- a/lib/training-facility/log-eras.ts
+++ b/lib/training-facility/log-eras.ts
@@ -1,0 +1,255 @@
+/**
+ * Whole-log era comparison (#437).
+ *
+ * #400 shipped a then-vs-now panel, but only per movement, and only for the six
+ * that span both stretches. Everything else in the archive — 42 movements the
+ * current log has never touched — had no comparative surface at all, and the
+ * per-movement view can't answer the more interesting question anyway: not "is
+ * my bench better", but "what did training *look like* then versus now".
+ *
+ * The two stretches differ in kind, not just amount. The archive is a
+ * six-template gym rotation, barbell-heavy, recorded set by set; the current log
+ * is mostly grease-the-groove bodyweight work. So this module deliberately
+ * reports each era's shape *side by side* and never subtracts one from the
+ * other: "volume is down" would be a lie assembled from barbell tonnage on one
+ * side and push-up reps on the other.
+ */
+import type { StrengthSet, WeightRoomExercise } from '@/types/weight-room'
+
+import { PACIFIC_CLOCK, type DayClock } from './clock'
+import { DEFAULT_MIN_GAP_DAYS, daysBetween } from './era-comparison'
+import { effectiveSetLoad, loadMultipliersBySlug } from './workout-stats'
+
+/** One stretch of training, described on its own terms. */
+export interface LogEra {
+  /** First training day, `YYYY-MM-DD`. */
+  startDayKey: string
+  /** Last training day, `YYYY-MM-DD`. */
+  endDayKey: string
+  /** Days on which anything was logged. Not the calendar span. */
+  trainingDays: number
+  /** Sets logged. */
+  sets: number
+  /** Reps logged. */
+  reps: number
+  /** Sets carrying an external load. */
+  loadedSets: number
+  /**
+   * Share of sets carrying an external load, `0`–`1`. The clearest single read
+   * on the change in *kind*: the archive sits near half, the current log near a
+   * seventh.
+   */
+  loadedShare: number
+  /** Distinct movements trained. */
+  movements: number
+}
+
+/** One month of the log, for the cadence series. */
+export interface EraMonth {
+  /** `YYYY-MM`. */
+  monthKey: string
+  /** Days trained in the month. */
+  trainingDays: number
+  /** Which stretch it belongs to — `'gap'` for the layoff between them. */
+  era: 'then' | 'gap' | 'now'
+}
+
+/** Which movements each era did and didn't have. */
+export interface MovementRoster {
+  /** Trained in the earlier era only, alphabetical. */
+  thenOnly: string[]
+  /** Trained in both. */
+  shared: string[]
+  /** Trained in the later era only. */
+  nowOnly: string[]
+}
+
+/** The whole log, split in two. */
+export interface LogEras {
+  /** The earlier stretch. */
+  then: LogEra
+  /** The later stretch. */
+  now: LogEra
+  /** Calendar days between the last day of {@link then} and the first of {@link now}. */
+  gapDays: number
+  /**
+   * Every month from the log's first to its last, contiguous — including the
+   * empty ones. The layoff is ~25 months, and a series that simply omits them
+   * draws the two eras adjacent, which is the one thing this view must not do.
+   */
+  months: EraMonth[]
+  /** Movement overlap between the eras. */
+  roster: MovementRoster
+}
+
+/**
+ * Split the whole log at its longest layoff and describe each side.
+ *
+ * The split is the *training* gap rather than the row's `source`, which matters
+ * for the same reason #400's per-movement panel uses it: source records how the
+ * data arrived, not when the training happened, so a future import of older
+ * sessions would silently land on the wrong side of a source-based boundary.
+ * On today's data the two coincide exactly — the longest gap is 767 days, and
+ * the next is 101, well inside the threshold.
+ *
+ * @param sets Every logged set.
+ * @param exercises Movement roster, for the load multipliers that decide
+ *   whether a set counts as loaded.
+ * @param minGapDays Layoff that separates two eras; defaults to
+ *   {@link DEFAULT_MIN_GAP_DAYS}.
+ * @param clock Zone each day is measured in; defaults to Pacific (#429).
+ * @returns The two eras, or `null` when the log has no layoff long enough to
+ *   split on — one continuous stretch has no "then" to compare against, and
+ *   inventing a boundary would manufacture the comparison.
+ */
+export function buildLogEras(
+  sets: readonly StrengthSet[],
+  exercises: readonly WeightRoomExercise[] = [],
+  minGapDays: number = DEFAULT_MIN_GAP_DAYS,
+  clock: DayClock = PACIFIC_CLOCK
+): LogEras | null {
+  const byDay = new Map<string, StrengthSet[]>()
+  for (const set of sets) {
+    const dayKey = clock.safeDayKey(set.logged_at)
+    if (dayKey === '') continue
+    const existing = byDay.get(dayKey)
+    if (existing === undefined) byDay.set(dayKey, [set])
+    else existing.push(set)
+  }
+
+  const dayKeys = [...byDay.keys()].sort()
+  if (dayKeys.length === 0) return null
+
+  // The *longest* layoff, not the first over the threshold: a log with two long
+  // breaks should split at the one that actually separates its eras.
+  let splitIndex = -1
+  let longest = 0
+  for (let i = 1; i < dayKeys.length; i++) {
+    const gap = daysBetween(dayKeys[i - 1], dayKeys[i])
+    if (gap >= minGapDays && gap > longest) {
+      longest = gap
+      splitIndex = i
+    }
+  }
+  if (splitIndex === -1) return null
+
+  const multipliers = loadMultipliersBySlug(exercises)
+  const thenDays = dayKeys.slice(0, splitIndex)
+  const nowDays = dayKeys.slice(splitIndex)
+
+  return {
+    then: describeEra(thenDays, byDay, multipliers),
+    now: describeEra(nowDays, byDay, multipliers),
+    gapDays: longest,
+    months: buildMonths(dayKeys, splitIndex, byDay),
+    roster: buildRoster(thenDays, nowDays, byDay),
+  }
+}
+
+/** Summarize one contiguous run of training days. */
+function describeEra(
+  dayKeys: readonly string[],
+  byDay: ReadonlyMap<string, StrengthSet[]>,
+  multipliers: ReadonlyMap<string, number>
+): LogEra {
+  let setCount = 0
+  let reps = 0
+  let loadedSets = 0
+  const movements = new Set<string>()
+
+  for (const dayKey of dayKeys) {
+    for (const set of byDay.get(dayKey) ?? []) {
+      setCount += 1
+      reps += set.reps
+      movements.add(set.exercise)
+      // "Loaded" means the set carried external weight at all — a weighted
+      // pushup counts, because it is loaded work. The multiplier scales
+      // per-implement weight into pounds actually moved; it is an implement
+      // count, not a bodyweight flag, so it never changes whether a set
+      // qualifies, only by how much.
+      if (effectiveSetLoad(set, multipliers) > 0) loadedSets += 1
+    }
+  }
+
+  return {
+    startDayKey: dayKeys[0] ?? '',
+    endDayKey: dayKeys[dayKeys.length - 1] ?? '',
+    trainingDays: dayKeys.length,
+    sets: setCount,
+    reps,
+    loadedSets,
+    loadedShare: setCount === 0 ? 0 : loadedSets / setCount,
+    movements: movements.size,
+  }
+}
+
+/**
+ * Every month between the log's first and last, with the empty ones present.
+ *
+ * Walking the calendar rather than the data is the whole point: months with no
+ * training have to occupy space, or the layoff disappears and the two eras
+ * render adjacent.
+ */
+function buildMonths(
+  dayKeys: readonly string[],
+  splitIndex: number,
+  byDay: ReadonlyMap<string, StrengthSet[]>
+): EraMonth[] {
+  const lastThenDay = dayKeys[splitIndex - 1]
+  const firstNowDay = dayKeys[splitIndex]
+
+  const trained = new Map<string, number>()
+  for (const dayKey of dayKeys) {
+    if ((byDay.get(dayKey)?.length ?? 0) === 0) continue
+    const monthKey = dayKey.slice(0, 7)
+    trained.set(monthKey, (trained.get(monthKey) ?? 0) + 1)
+  }
+
+  const months: EraMonth[] = []
+  let cursor = dayKeys[0].slice(0, 7)
+  const finalMonth = dayKeys[dayKeys.length - 1].slice(0, 7)
+  while (cursor <= finalMonth) {
+    months.push({
+      monthKey: cursor,
+      trainingDays: trained.get(cursor) ?? 0,
+      era:
+        cursor <= lastThenDay.slice(0, 7)
+          ? 'then'
+          : cursor >= firstNowDay.slice(0, 7)
+            ? 'now'
+            : 'gap',
+    })
+    cursor = nextMonth(cursor)
+  }
+  return months
+}
+
+/** The `YYYY-MM` after this one. */
+function nextMonth(monthKey: string): string {
+  const year = Number(monthKey.slice(0, 4))
+  const month = Number(monthKey.slice(5, 7))
+  return month === 12 ? `${year + 1}-01` : `${year}-${String(month + 1).padStart(2, '0')}`
+}
+
+/** Which movements belong to which era. */
+function buildRoster(
+  thenDays: readonly string[],
+  nowDays: readonly string[],
+  byDay: ReadonlyMap<string, StrengthSet[]>
+): MovementRoster {
+  const collect = (dayKeys: readonly string[]): Set<string> => {
+    const found = new Set<string>()
+    for (const dayKey of dayKeys) {
+      for (const set of byDay.get(dayKey) ?? []) found.add(set.exercise)
+    }
+    return found
+  }
+
+  const thenSet = collect(thenDays)
+  const nowSet = collect(nowDays)
+  return {
+    thenOnly: [...thenSet].filter(slug => !nowSet.has(slug)).sort(),
+    shared: [...thenSet].filter(slug => nowSet.has(slug)).sort(),
+    nowOnly: [...nowSet].filter(slug => !thenSet.has(slug)).sort(),
+  }
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -42,7 +42,7 @@ export default defineConfig({
     {
       name: 'training-facility-enabled',
       testMatch:
-        /(?:training-facility-enabled|draft-room-enabled|draft-room-live|chart-overflow|heatmap-span|workout-filters|template-detail)\.spec\.ts/,
+        /(?:training-facility-enabled|draft-room-enabled|draft-room-live|chart-overflow|heatmap-span|workout-filters|template-detail|eras)\.spec\.ts/,
       use: {
         baseURL: TRAINING_FACILITY_BASE_URL,
       },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -59,7 +59,7 @@ export default defineConfig({
       // don't vary by engine. This runs only the two specs whose assertions
       // are about rendering.
       name: 'mobile-webkit',
-      testMatch: /(?:svg-fragments|chart-overflow)\.spec\.ts/,
+      testMatch: /(?:svg-fragments|chart-overflow|eras)\.spec\.ts/,
       use: {
         ...devices['iPhone 14'],
         // `browserName` must be set explicitly, *after* the device spread.


### PR DESCRIPTION
## Summary

`/training-facility/weight-room/eras` — the whole log either side of the layoff.

#400 shipped a then-vs-now comparison, but per movement, and only for the six that span both stretches. That left **42 archive movements with no comparative surface at all**, and it couldn't answer the more interesting question anyway: not "is my bench better", but "what did training *look like* then versus now".

Mostly, it changed in **kind**:

| | Then (Mar 2022 – Apr 2024) | Now (May 2026 – Aug 2026) |
|---|---|---|
| Training days | 181 | 65 |
| Movements | 48 | 6 |
| Sets | 5,109 | 1,564 |
| Reps | 53,459 | 16,212 |
| **Loaded sets** | **54%** | **14%** |

## Decisions worth reviewing

**Nothing is subtracted.** A barbell gym rotation became bodyweight grease-the-groove, so "volume is down" assembled from barbell tonnage on one side and push-up reps on the other would be a number about nothing. Each era is stated on its own terms and there is no headline figure — a test asserts the panel never renders a combined total.

**The roster diff is the sharpest finding, and it's one-directional.** 6 movements carried across, **42 exist only in the archive**, and **nothing at all has been added since**. Each bucket is named rather than counted, including the empty one — "nothing new" is the finding, not an absence to hide.

**Split on the training gap, not `source`.** The issue proposed `weight_room_sets.source` as the discriminator. I used the longest training layoff instead: source records how data *arrived*, not when training happened, so a future import of older sessions would land on the wrong side of a source boundary. On today's data the two coincide exactly — the longest gap is 767 days, the next is 101, well inside the 180-day threshold. A log with no long layoff returns `null` and the page says why rather than inventing a boundary.

**The gap occupies space.** Cadence is a bar per month across the whole span *including* the ~25 empty ones. `RoughBar` gains an optional `xTickLabel` for this — five years of months named individually is an illegible smear, so only January is written. I left its existing "zero renders as a 1px baseline" behaviour alone: that's a deliberate prior decision and it serves the gap too, so the layoff is also named explicitly beneath the chart.

## Test plan

- [ ] History → "Two eras · then vs now across the whole log →"
- [ ] `/eras` — both columns match the table above; loaded-share bars differ visibly
- [ ] "Only now · 0" reads *"Nothing new has been added since."*
- [ ] "Only then · 42" names all of them (barbell squat, deadlift, sled push, leg press…)
- [ ] Cadence chart: bars 2022–2024, a long empty stretch, bars in 2026; axis labelled by year
- [ ] Note beneath names the layoff window and month count
- [ ] On a phone the chart scrolls inside its card and the page doesn't slide sideways

Verified: `tsc --noEmit` clean, `eslint` clean, `next build` compiles, 2538 vitest tests pass under `TZ=UTC`, 84 Playwright tests pass.

Closes #437.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Weight Room “Two eras” history view comparing earlier and later training periods.
  - Shows training dates, activity metrics, movement rosters, loaded-set percentages, and layoff duration.
  - Added monthly cadence charts that include inactive months and highlight training gaps.
  - Added navigation from History to the new comparison view, including preview support.
  - Added empty-state and feature-access messaging.

- **Bug Fixes**
  - Improved chart labeling and scrolling for long training histories.

- **Tests**
  - Added coverage for era comparisons, cadence charts, navigation, and overflow behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->