### PR TITLE
fix(scripts): sync the Weight Room tables staging actually needs

### DIFF
--- a/scripts/sync-staging.mjs
+++ b/scripts/sync-staging.mjs
@@ -38,6 +38,8 @@
  *                                                 secret key
  */
 
+import { pathToFileURL } from 'node:url'
+
 const PROD_URL = process.env.PROD_SUPABASE_URL?.replace(/\/$/, '')
 const PROD_KEY = process.env.PROD_SUPABASE_ANON_KEY
 const STAGING_URL = process.env.STAGING_SUPABASE_URL?.replace(/\/$/, '')
@@ -84,7 +86,7 @@ const WRITE_BATCH = 500
  * the anon read would return nothing, and live-panel run history has no bearing
  * on what a preview deploy renders.
  */
-const TABLES = [
+export const TABLES = [
   { name: 'movement_benchmarks', conflict: 'date' },
   { name: 'cardio_sessions', conflict: 'started_at' },
   { name: 'cardio_session_hr_samples', conflict: 'session_started_at,sample_at' },
@@ -98,7 +100,23 @@ const TABLES = [
   { name: 'cardio_active_energy_trend', conflict: 'date' },
   { name: 'otf_sessions', conflict: 'started_at' },
   { name: 'otf_mileage_awards', conflict: 'label' },
+  // Weight Room, in foreign-key order. Everything below references
+  // `weight_room_exercises`, so the roster has to land first; slots reference
+  // templates, workouts reference templates, and sets reference all of them.
+  //
+  // The order is load-bearing, not cosmetic. Before #400 nearly every set was
+  // loose — `workout_id` null — so sets could be written with no session in
+  // staging and nothing complained. The import attached sets to sessions, and
+  // the next sync failed outright on the foreign key. Adding a table here
+  // means placing it after everything it points at.
+  { name: 'weight_room_exercises', conflict: 'slug' },
+  { name: 'weight_room_workout_templates', conflict: 'id' },
+  { name: 'weight_room_template_slots', conflict: 'id' },
+  { name: 'weight_room_template_slot_steps', conflict: 'id' },
+  { name: 'weight_room_template_alternates', conflict: 'id' },
+  { name: 'weight_room_workouts', conflict: 'id' },
   { name: 'weight_room_goals', conflict: 'exercise' },
+  { name: 'weight_room_goal_targets', conflict: 'id' },
   { name: 'weight_room_achievements', mode: 'replace', key: 'id' },
   { name: 'weight_room_monthly_focus', mode: 'replace', key: 'id' },
   // Real logged data, not migration-seeded: its uuids originate in production
@@ -196,7 +214,7 @@ function project(row, allowed) {
 
 async function copyTable({ name, conflict, mode, key }, allowed) {
   const dropped = new Set()
-  const noteDropped = (page) => {
+  const noteDropped = page => {
     for (const row of page) {
       for (const k of Object.keys(row)) if (!allowed.includes(k)) dropped.add(k)
     }
@@ -215,7 +233,7 @@ async function copyTable({ name, conflict, mode, key }, allowed) {
       const page = await readPage(name, offset)
       if (page.length === 0) break
       noteDropped(page)
-      rows.push(...page.map((r) => project(r, allowed)))
+      rows.push(...page.map(r => project(r, allowed)))
       if (page.length < READ_PAGE) break
     }
     await clearTable(name, key)
@@ -234,7 +252,7 @@ async function copyTable({ name, conflict, mode, key }, allowed) {
     const page = await readPage(name, offset)
     if (page.length === 0) break
     noteDropped(page)
-    const rows = page.map((r) => project(r, allowed))
+    const rows = page.map(r => project(r, allowed))
     for (let i = 0; i < rows.length; i += WRITE_BATCH) {
       await writeBatch(name, conflict, rows.slice(i, i + WRITE_BATCH))
     }
@@ -281,7 +299,8 @@ async function main() {
     try {
       const { copied, dropped, mode } = await copyTable(table, allowed)
       total += copied
-      const note = dropped.length > 0 ? `  (dropped ahead-of-staging columns: ${dropped.join(', ')})` : ''
+      const note =
+        dropped.length > 0 ? `  (dropped ahead-of-staging columns: ${dropped.join(', ')})` : ''
       const how = mode === 'replace' ? ' [replaced]' : ''
       console.log(`${copied === 0 ? '·' : '✓'} ${table.name}: ${copied}${how}${note}`)
     } catch (err) {
@@ -290,11 +309,17 @@ async function main() {
     }
   }
 
-  console.log(`\n${failed === 0 ? '✓' : '!'} staging sync: ${total} rows across ${TABLES.length - failed}/${TABLES.length} tables.`)
+  console.log(
+    `\n${failed === 0 ? '✓' : '!'} staging sync: ${total} rows across ${TABLES.length - failed}/${TABLES.length} tables.`
+  )
   if (failed > 0) process.exitCode = 1
 }
 
-main().catch((err) => {
-  console.error(err.message ?? err)
-  process.exitCode = 2
-})
+// Only when run as a script. Guarded so the table manifest can be imported and
+// asserted on without kicking off a sync as a side effect of `import`.
+if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch(err => {
+    console.error(err.message ?? err)
+    process.exitCode = 2
+  })
+}

--- a/scripts/sync-staging.mjs
+++ b/scripts/sync-staging.mjs
@@ -114,9 +114,18 @@ export const TABLES = [
   { name: 'weight_room_template_slots', conflict: 'id' },
   { name: 'weight_room_template_slot_steps', conflict: 'id' },
   { name: 'weight_room_template_alternates', conflict: 'id' },
-  { name: 'weight_room_workouts', conflict: 'id' },
+  // `replace`, not an id upsert. Staging already held sessions with different
+  // uuids than production's, so conflicting on `id` never matched and the
+  // insert tripped the natural key instead — 23505 on `(source, started_at)`.
+  // Conflicting on that natural key would resolve the collision but keep
+  // *staging's* ids, and `weight_room_sets.workout_id` carries production's, so
+  // every set would then fail its foreign key. Replace is the only mode that
+  // gets production's ids across, which is what the child table needs.
+  { name: 'weight_room_workouts', mode: 'replace', key: 'id' },
   { name: 'weight_room_goals', conflict: 'exercise' },
-  { name: 'weight_room_goal_targets', conflict: 'id' },
+  // Same collision, on `(exercise, effective_from)`. Nothing references this
+  // table, so replace costs nothing.
+  { name: 'weight_room_goal_targets', mode: 'replace', key: 'id' },
   { name: 'weight_room_achievements', mode: 'replace', key: 'id' },
   { name: 'weight_room_monthly_focus', mode: 'replace', key: 'id' },
   // Real logged data, not migration-seeded: its uuids originate in production

--- a/scripts/sync-staging.mjs
+++ b/scripts/sync-staging.mjs
@@ -109,11 +109,30 @@ export const TABLES = [
   // staging and nothing complained. The import attached sets to sessions, and
   // the next sync failed outright on the foreign key. Adding a table here
   // means placing it after everything it points at.
+  // `slug` is the primary key — a natural one that means the same thing in
+  // both projects, so an upsert matches.
   { name: 'weight_room_exercises', conflict: 'slug' },
-  { name: 'weight_room_workout_templates', conflict: 'id' },
-  { name: 'weight_room_template_slots', conflict: 'id' },
-  { name: 'weight_room_template_slot_steps', conflict: 'id' },
-  { name: 'weight_room_template_alternates', conflict: 'id' },
+  // The template graph is `replace` for the reason the doc above describes and
+  // this table demonstrates: both projects ran
+  // `20260803120200_seed_workout_templates.sql` independently, so the same six
+  // templates carry different `gen_random_uuid()` ids in each. Upserting on
+  // `id` matched nothing and — because template names carry no unique
+  // constraint — quietly *inserted a second copy of every one*, which is
+  // exactly what the first run of this fix did to staging: 12 templates under 6
+  // distinct names, and 80 slots against production's 40.
+  //
+  // Replace also carries production's ids across, which the children need:
+  // `weight_room_sets.template_slot_id` and `.template_slot_step_id` reference
+  // them. Deleting a template cascades to its slots, steps and alternates, so
+  // the four have to stay in this order.
+  { name: 'weight_room_workout_templates', mode: 'replace', key: 'id' },
+  { name: 'weight_room_template_slots', mode: 'replace', key: 'id' },
+  { name: 'weight_room_template_slot_steps', mode: 'replace', key: 'id' },
+  { name: 'weight_room_template_alternates', mode: 'replace', key: 'id' },
+  // After the templates, not before: `weight_room_workouts.template_id` is
+  // `on delete set null`, so replacing templates while workouts already exist
+  // would blank every session's template.
+  //
   // `replace`, not an id upsert. Staging already held sessions with different
   // uuids than production's, so conflicting on `id` never matched and the
   // insert tripped the natural key instead — 23505 on `(source, started_at)`.

--- a/scripts/sync-staging.test.ts
+++ b/scripts/sync-staging.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Guards the staging sync's table ordering.
+ *
+ * The sync copies tables one at a time in the order they're declared, so a
+ * table has to come after everything it points at. That was silently untrue for
+ * a long time and didn't matter: nearly every `weight_room_sets` row was loose,
+ * with a null `workout_id`, so no foreign key was exercised. The #400 import
+ * attached sets to sessions and the next sync died on
+ * `weight_room_sets_workout_id_fkey` — with `weight_room_workouts` not in the
+ * manifest at all, staging could never be refreshed again, and every preview
+ * deploy silently rendered a truncated log.
+ *
+ * The dependency map below is hand-maintained against the production schema
+ * (`information_schema.table_constraints`). Adding a table to the sync means
+ * adding its parents here too.
+ */
+import { describe, expect, it } from 'vitest'
+
+import { TABLES } from './sync-staging.mjs'
+
+/** child table → tables it holds foreign keys into. */
+const FOREIGN_KEYS: Readonly<Record<string, readonly string[]>> = {
+  weight_room_goals: ['weight_room_exercises'],
+  weight_room_goal_targets: ['weight_room_goals'],
+  weight_room_monthly_focus: ['weight_room_exercises'],
+  weight_room_workout_templates: [],
+  weight_room_template_slots: ['weight_room_workout_templates', 'weight_room_exercises'],
+  weight_room_template_slot_steps: ['weight_room_template_slots', 'weight_room_exercises'],
+  weight_room_template_alternates: ['weight_room_template_slots', 'weight_room_exercises'],
+  weight_room_workouts: ['weight_room_workout_templates'],
+  weight_room_sets: [
+    'weight_room_exercises',
+    'weight_room_workouts',
+    'weight_room_template_slots',
+    'weight_room_template_slot_steps',
+  ],
+}
+
+describe('staging sync manifest', () => {
+  const names = TABLES.map(t => t.name)
+
+  it('lists every table exactly once', () => {
+    expect(new Set(names).size).toBe(names.length)
+  })
+
+  it('places each table after every table it references', () => {
+    for (const [child, parents] of Object.entries(FOREIGN_KEYS)) {
+      const childIndex = names.indexOf(child)
+      if (childIndex === -1) continue
+      for (const parent of parents) {
+        const parentIndex = names.indexOf(parent)
+        expect(
+          parentIndex,
+          `${child} references ${parent}, which is missing from the sync manifest`
+        ).not.toBe(-1)
+        expect(parentIndex, `${parent} must be synced before ${child}`).toBeLessThan(childIndex)
+      }
+    }
+  })
+
+  it('carries the Weight Room tables a populated preview needs', () => {
+    // Sets alone render a log with no sessions, no templates and no movement
+    // names — which is what the preview deploy was actually showing.
+    for (const required of [
+      'weight_room_exercises',
+      'weight_room_workouts',
+      'weight_room_workout_templates',
+      'weight_room_sets',
+    ]) {
+      expect(names).toContain(required)
+    }
+  })
+
+  it('gives every table a conflict target or an explicit replace key', () => {
+    for (const table of TABLES) {
+      const hasKey =
+        ('conflict' in table && typeof table.conflict === 'string') ||
+        (table.mode === 'replace' && typeof table.key === 'string')
+      expect(hasKey, `${table.name} has no upsert key`).toBe(true)
+    }
+  })
+})

--- a/scripts/sync-staging.test.ts
+++ b/scripts/sync-staging.test.ts
@@ -71,6 +71,36 @@ describe('staging sync manifest', () => {
     }
   })
 
+  it('replaces the tables whose ids are seeded independently in each project', () => {
+    // These carry `gen_random_uuid()` primary keys assigned by a migration that
+    // both projects ran separately, so the same logical row has a different id
+    // in each. An `id` upsert matches nothing; with no unique constraint on the
+    // business key it then *inserts a duplicate* rather than failing loudly —
+    // which is how staging ended up with 12 workout templates under 6 names.
+    // Replace is also the only mode that carries production's ids across, which
+    // `weight_room_sets` needs to resolve its slot and workout references.
+    for (const name of [
+      'weight_room_workout_templates',
+      'weight_room_template_slots',
+      'weight_room_template_slot_steps',
+      'weight_room_template_alternates',
+      'weight_room_workouts',
+      'weight_room_goal_targets',
+    ]) {
+      const table = TABLES.find(t => t.name === name)
+      expect(table, `${name} is missing from the manifest`).toBeDefined()
+      expect(table?.mode, `${name} must be replaced, not upserted on id`).toBe('replace')
+    }
+  })
+
+  it('syncs templates before the workouts that point at them', () => {
+    // `weight_room_workouts.template_id` is `on delete set null`, so replacing
+    // templates after the workouts land would blank every session's template.
+    expect(names.indexOf('weight_room_workout_templates')).toBeLessThan(
+      names.indexOf('weight_room_workouts')
+    )
+  })
+
   it('gives every table a conflict target or an explicit replace key', () => {
     for (const table of TABLES) {
       const hasKey =


### PR DESCRIPTION
## Summary

**The staging refresh has been failing outright**, so preview deploys have been rendering a truncated log. Staging currently holds 1,500 current-era sets and **none** of the 2022–2024 archive — which is why the #437 two-eras preview shows its empty state and the #446 template previews have nothing to chart.

`weight_room_workouts`, `weight_room_exercises` and the four template tables were **never in the sync manifest at all**. That was survivable while nearly every set was loose — `workout_id` was null, so no foreign key was exercised and sets could land with no session behind them. #400 attached sets to sessions, and the next sync died:

```
✗ weight_room_sets: 409 {"code":"23503",
  "details":"Key (workout_id)=(6f882f67-…) is not present in table \"weight_room_workouts\"",
  "message":"… violates foreign key constraint \"weight_room_sets_workout_id_fkey\""}
! staging sync: 47329 rows across 16/17 tables.
```

The failure mode is the bad part: staging became unrefreshable and went **silently stale** rather than loudly broken, so every preview since has been quietly showing less data than production has.

## What changed

Adds the missing tables in foreign-key order (`exercises` → `workout_templates` → `template_slots` → `slot_steps` / `alternates` → `workouts` → `goals` → `goal_targets` → … → `sets`), derived from `information_schema.table_constraints` on production.

Exports the manifest and guards the entry point with a `pathToFileURL(process.argv[1])` check, so importing the module for a test doesn't start a sync as a side effect.

`scripts/sync-staging.test.ts` walks a hand-maintained dependency map and fails when a table is declared before something it references, or is missing while a child needs it. **Verified by reintroducing the bug** — removing `weight_room_workouts` fails with `weight_room_sets references weight_room_workouts, which is missing from the sync manifest`.

## Test plan

- [x] `TZ=UTC npm test` — 2521 pass
- [x] Ordering test fails when `weight_room_workouts` is removed, passes when restored
- [x] `tsc --noEmit` and `eslint` clean
- [ ] After merge: run the **Staging sync** workflow and confirm it reports 17/17 tables
- [ ] Confirm staging then has `icloud_notes` sets back to 2022-03

No production writes — the sync reads production with an anon key and only ever writes staging, and refuses if the two URLs match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved staging data synchronization with more reliable table ordering and conflict handling.
  - Added support for synchronizing Weight Room exercises, templates, workouts, goals, and related data.
  - Improved handling of independently seeded records and foreign-key relationships.
  - The synchronization tooling can now be safely reused in other workflows without triggering unintended actions.

- **Tests**
  - Added automated validation for table coverage, dependency order, and synchronization rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->