### PR TITLE
feat(weight-room): a rack run is one set per pass, and never invents its reps (#440)

### DIFF
--- a/components/training-facility/weight-room/ExerciseProgressionPanel.tsx
+++ b/components/training-facility/weight-room/ExerciseProgressionPanel.tsx
@@ -7,7 +7,7 @@ import type {
   ExerciseProgression,
   SetDetailCoverage,
 } from '@/lib/training-facility/exercise-progression'
-import { countedReps } from '@/lib/training-facility/set-reps'
+import { countedReps, hasRecordedReps, repsLabel } from '@/lib/training-facility/set-reps'
 import { describeSetOrHold, formatHold, formatLbs } from '@/lib/training-facility/strength-format'
 import { E1RM_MAX_RELIABLE_REPS } from '@/lib/training-facility/workout-stats'
 
@@ -312,7 +312,12 @@ function RecordsRow({ progression }: RecordsRowProps): JSX.Element {
       )}
       {/* A hold's "most reps" is always 1. Its record is how long it lasted. */}
       {longestHold === null ? (
-        <RecordCell label="Most reps" value={`${mostRepsSet.reps} reps`} />
+        <RecordCell
+          label="Most reps"
+          // A movement whose only sets went to failure has no rep record to
+          // state; `repsLabel` gives a dash rather than the string "null".
+          value={hasRecordedReps(mostRepsSet) ? `${mostRepsSet.reps} reps` : repsLabel(mostRepsSet)}
+        />
       ) : (
         <RecordCell label="Longest hold" value={formatHold(longestHold)} />
       )}

--- a/components/training-facility/weight-room/ExerciseProgressionPanel.tsx
+++ b/components/training-facility/weight-room/ExerciseProgressionPanel.tsx
@@ -7,6 +7,7 @@ import type {
   ExerciseProgression,
   SetDetailCoverage,
 } from '@/lib/training-facility/exercise-progression'
+import { countedReps } from '@/lib/training-facility/set-reps'
 import { describeSetOrHold, formatHold, formatLbs } from '@/lib/training-facility/strength-format'
 import { E1RM_MAX_RELIABLE_REPS } from '@/lib/training-facility/workout-stats'
 
@@ -175,7 +176,10 @@ export function ExerciseProgressionPanel({
         >
           <TrendChart
             data={points}
-            y={p => p.bestRepSet.reps}
+            // A day whose best set has no recorded count plots as zero rather
+            // than breaking the axis; the chart is about reps, and unknown is
+            // not a rep count (#440).
+            y={p => countedReps(p.bestRepSet.reps)}
             stroke={isBodyweight ? accentColor : chartPalette.hardwoodTan}
             width={width}
             height={height}

--- a/components/training-facility/weight-room/LogDataIsland.tsx
+++ b/components/training-facility/weight-room/LogDataIsland.tsx
@@ -10,6 +10,7 @@ import {
   upcomingFocuses,
 } from '@/lib/training-facility/monthly-focus'
 import { targetForDay } from '@/lib/training-facility/goal-targets'
+import { countedReps } from '@/lib/training-facility/set-reps'
 import { computeStrengthStreaks } from '@/lib/training-facility/strength-streaks'
 import {
   filterSetsForDay,
@@ -402,7 +403,9 @@ async function deleteSet(
 function computeLastRepsByExercise(sets: readonly StrengthSet[]): Record<string, number> {
   const out: Record<string, number> = {}
   for (const s of sets) {
-    out[s.exercise] = s.reps
+    // Seeds the rep stepper, so a set with no recorded count is skipped rather
+    // than seeding it with zero (#440).
+    if (s.reps !== null) out[s.exercise] = s.reps
   }
   return out
 }
@@ -456,7 +459,7 @@ function buildFocusCardProps(
   const todayProgress =
     focus.target_kind === 'sets'
       ? focusSetsToday.length
-      : focusSetsToday.reduce((n, s) => n + s.reps, 0)
+      : focusSetsToday.reduce((n, s) => n + countedReps(s), 0)
   return {
     focus,
     todayProgress,

--- a/components/training-facility/weight-room/SetList.tsx
+++ b/components/training-facility/weight-room/SetList.tsx
@@ -4,6 +4,7 @@ import { useState, type JSX } from 'react'
 
 import type { ExerciseGoal, StrengthSet } from '@/types/weight-room'
 import { slugLabel, type ExerciseLabels } from '@/lib/training-facility/exercise-labels'
+import { countedReps } from '@/lib/training-facility/set-reps'
 
 /** Props for {@link SetList}. */
 export interface SetListProps {
@@ -109,7 +110,7 @@ export function SetList({
   // displays newest-first via `ordered`.
   const totals = new Map<string, number>()
   for (const s of setsToday) {
-    totals.set(s.exercise, (totals.get(s.exercise) ?? 0) + s.reps)
+    totals.set(s.exercise, (totals.get(s.exercise) ?? 0) + countedReps(s))
   }
 
   return (

--- a/components/training-facility/weight-room/SetList.tsx
+++ b/components/training-facility/weight-room/SetList.tsx
@@ -4,7 +4,7 @@ import { useState, type JSX } from 'react'
 
 import type { ExerciseGoal, StrengthSet } from '@/types/weight-room'
 import { slugLabel, type ExerciseLabels } from '@/lib/training-facility/exercise-labels'
-import { countedReps } from '@/lib/training-facility/set-reps'
+import { countedReps, repsLabel } from '@/lib/training-facility/set-reps'
 
 /** Props for {@link SetList}. */
 export interface SetListProps {
@@ -187,7 +187,7 @@ export function SetList({
                 {slugLabel(s.exercise, goalsByExercise[s.exercise], labels)}
               </span>
               <span className="font-mono text-base font-semibold tabular-nums text-white">
-                {s.reps}
+                {repsLabel(s)}
               </span>
               {s.variant ? (
                 <span
@@ -203,7 +203,7 @@ export function SetList({
               {onDelete ? (
                 <button
                   type="button"
-                  aria-label={`Delete set of ${s.reps} ${slugLabel(s.exercise, goalsByExercise[s.exercise], labels)}`}
+                  aria-label={`Delete set of ${repsLabel(s)} ${slugLabel(s.exercise, goalsByExercise[s.exercise], labels)}`}
                   disabled={busy || isPending}
                   onClick={() => void handleDelete(s)}
                   className="rounded-full border border-rose-300/25 bg-rose-300/5 px-3 py-1 font-mono text-[10px] uppercase tracking-[0.22em] text-rose-200 transition hover:bg-rose-300/15 disabled:cursor-not-allowed disabled:opacity-40"

--- a/components/training-facility/weight-room/WorkoutSummaryPanel.tsx
+++ b/components/training-facility/weight-room/WorkoutSummaryPanel.tsx
@@ -10,6 +10,7 @@ import type {
   WorkoutPersonalBest,
   WorkoutSummary,
 } from '@/lib/training-facility/workout-stats'
+import { countedReps } from '@/lib/training-facility/set-reps'
 import { describeSetOrHold, formatLbs } from '@/lib/training-facility/strength-format'
 import type { StrengthSet } from '@/types/weight-room'
 
@@ -472,7 +473,7 @@ function ExtraWorkCard({ sets, exerciseLabels }: ExtraWorkCardProps): JSX.Elemen
             <span className="font-semibold">{exerciseLabels[exercise] ?? exercise}</span>{' '}
             <span className="text-[#e8d5be]/70">
               {exSets.length} set{exSets.length === 1 ? '' : 's'} ·{' '}
-              {exSets.reduce((total, s) => total + s.reps, 0)} reps
+              {exSets.reduce((total, s) => total + countedReps(s), 0)} reps
             </span>
           </li>
         ))}

--- a/components/training-facility/weight-room/WorkoutSummaryPanel.tsx
+++ b/components/training-facility/weight-room/WorkoutSummaryPanel.tsx
@@ -564,8 +564,11 @@ function BreakdownCard({
                 </td>
               )}
               <td className="px-5 py-2.5 text-right tabular-nums">
+                {/* An all-bodyweight movement has no top set, so the best rep
+                    set stands in — and its count may itself be unrecorded, which
+                    must read as a dash rather than the string "null" (#440). */}
                 {entry.topSet === null
-                  ? `${entry.bestRepSet.reps} reps`
+                  ? describeSetOrHold(entry.bestRepSet)
                   : describeSetOrHold(entry.topSet)}
                 {entry.estimatedOneRepMax !== null ? (
                   <span

--- a/components/training-facility/weight-room/WorkoutSummaryPanel.tsx
+++ b/components/training-facility/weight-room/WorkoutSummaryPanel.tsx
@@ -10,7 +10,7 @@ import type {
   WorkoutPersonalBest,
   WorkoutSummary,
 } from '@/lib/training-facility/workout-stats'
-import { countedReps } from '@/lib/training-facility/set-reps'
+import { countedReps, hasRecordedReps } from '@/lib/training-facility/set-reps'
 import { describeSetOrHold, formatLbs } from '@/lib/training-facility/strength-format'
 import type { StrengthSet } from '@/types/weight-room'
 
@@ -473,7 +473,11 @@ function ExtraWorkCard({ sets, exerciseLabels }: ExtraWorkCardProps): JSX.Elemen
             <span className="font-semibold">{exerciseLabels[exercise] ?? exercise}</span>{' '}
             <span className="text-[#e8d5be]/70">
               {exSets.length} set{exSets.length === 1 ? '' : 's'} ·{' '}
-              {exSets.reduce((total, s) => total + countedReps(s), 0)} reps
+              {/* Summing unrecorded counts as zero is right; *printing* the
+                  zero would assert a set of no reps (#440). */}
+              {exSets.some(hasRecordedReps)
+                ? `${exSets.reduce((total, s) => total + countedReps(s), 0)} reps`
+                : 'reps not recorded'}
             </span>
           </li>
         ))}

--- a/lib/data/sets-columns.test.ts
+++ b/lib/data/sets-columns.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Keeps the `weight_room_sets` select list in step with its row schema.
+ *
+ * The failure this prevents is quiet in every way that matters: adding a field
+ * to {@link WeightRoomSetRowSchema} without adding it to `SETS_COLUMNS`
+ * compiles, type-checks, and passes every unit test that builds a
+ * `StrengthSet` by hand — because those never touch the data layer. At runtime
+ * PostgREST simply doesn't return the column, the converter never sets it, and
+ * whatever depends on it takes its absent branch forever.
+ *
+ * It has now happened twice. `template_slot_id` (#376) made every set logged
+ * against a slot reappear as extra work, and `set_group` (#440) made a
+ * two-pass rack run keep counting as five sets after the whole point of the
+ * change was to make it count as two. Both were caught by a person reading the
+ * select list, which is not a control.
+ */
+import { describe, expect, it } from 'vitest'
+
+import { SETS_COLUMNS } from './weight-room-shared'
+import { WeightRoomSetRowSchema } from '@/lib/schemas/weight-room'
+
+/** Column names the select list actually asks PostgREST for. */
+const selected = new Set(SETS_COLUMNS.split(',').map(part => part.trim()))
+
+describe('SETS_COLUMNS', () => {
+  it('selects every column the row schema reads', () => {
+    const missing = Object.keys(WeightRoomSetRowSchema.shape).filter(key => !selected.has(key))
+    expect(
+      missing,
+      `these are in WeightRoomSetRowSchema but never selected, so they arrive undefined: ${missing.join(', ')}`
+    ).toEqual([])
+  })
+
+  it('selects nothing the row schema would reject', () => {
+    // `.strict()` on the schema means an unexpected key fails the whole read,
+    // and that read validates the entire set array in one pass.
+    const known = new Set(Object.keys(WeightRoomSetRowSchema.shape))
+    const extra = [...selected].filter(column => !known.has(column) && column !== 'updated_at')
+    expect(
+      extra,
+      `these are selected but absent from WeightRoomSetRowSchema: ${extra.join(', ')}`
+    ).toEqual([])
+  })
+
+  it('includes the columns whose omission has already shipped a bug', () => {
+    expect(selected.has('template_slot_id')).toBe(true)
+    expect(selected.has('set_group')).toBe(true)
+  })
+})

--- a/lib/data/weight-room-shared.ts
+++ b/lib/data/weight-room-shared.ts
@@ -66,8 +66,18 @@ const EXERCISES_TABLE = 'weight_room_exercises'
  * exactly as a loose one — but reading them is what lets #376/#377 group sets
  * into a workout without another round trip.
  */
-const SETS_COLUMNS =
-  'id, logged_at, exercise, reps, weight_lbs, variant, workout_id, position, template_slot_id, template_slot_step_id, source, duration_seconds, to_failure, updated_at'
+/**
+ * Columns selected for `weight_room_sets`.
+ *
+ * Exported so a test can assert it stays in step with
+ * {@link WeightRoomSetRowSchema}. Adding a field to the schema without adding
+ * it here compiles, type-checks and passes every unit test that builds a
+ * `StrengthSet` by hand — and then silently strips the column at runtime.
+ * That has now happened twice: `template_slot_id` (#376) and `set_group`
+ * (#440).
+ */
+export const SETS_COLUMNS =
+  'id, logged_at, exercise, reps, weight_lbs, variant, workout_id, position, template_slot_id, template_slot_step_id, source, duration_seconds, to_failure, set_group, updated_at'
 // `load_multiplier` deliberately absent (#373) — it moved to the catalog and is
 // joined on below. The goals column still exists (dropping it while the
 // deployed build still selected it would break the live read) but is dead.

--- a/lib/schemas/weight-room.ts
+++ b/lib/schemas/weight-room.ts
@@ -136,7 +136,12 @@ export const WeightRoomSetRowSchema = z
     id: z.string().uuid(),
     logged_at: z.string().min(1, 'logged_at must be an ISO timestamp'),
     exercise: z.string().min(1),
-    reps: positiveInt(),
+    // Nullable since #440: a rack-run drop states its load and never a rep
+    // count, because each drop simply went to failure. Null means *unrecorded*,
+    // which is a different claim from zero. This schema validates the whole set
+    // array in one pass, so leaving it non-nullable would fail every read the
+    // moment one such row exists (#400 shipped exactly that bug).
+    reps: positiveInt().nullable(),
     weight_lbs: optionalWeightLbs(),
     // Optional + nullable so pre-#254 rows (and fixtures) without the
     // column still validate; PostgREST emits `null` for unspecified
@@ -158,6 +163,9 @@ export const WeightRoomSetRowSchema = z
     duration_seconds: nonNegativeInt().nullable().optional(),
     // Set taken to failure with its rep count unrecorded (#435).
     to_failure: z.boolean().nullable().optional(),
+    // Rows sharing (workout_id, exercise, set_group) are one working set — the
+    // drops of a rack run (#440). Null means the row is a set on its own.
+    set_group: nonNegativeInt().nullable().optional(),
   })
   .strict()
 
@@ -349,6 +357,10 @@ export function setRowToStrengthSet(row: WeightRoomSetRow): StrengthSet {
     // `false` is the column default and the absent-field meaning, so only a
     // true flag is carried — same convention as `source`.
     ...(row.to_failure === true ? { to_failure: true } : {}),
+    // Carried straight through, unlike the absent-not-null fields above: a
+    // group of 0 is meaningful (the first pass of a rack run), so it must not
+    // be collapsed away by a falsy check (#440).
+    ...(row.set_group != null ? { set_group: row.set_group } : {}),
   }
 }
 

--- a/lib/training-facility/achievements.ts
+++ b/lib/training-facility/achievements.ts
@@ -8,6 +8,7 @@ import type {
 } from '@/types/weight-room'
 
 import { targetResolverFor } from './goal-targets'
+import { countedReps } from './set-reps'
 import { PACIFIC_CLOCK, mondayOfDayKey, shiftDayKey, type DayClock } from './clock'
 
 /**
@@ -334,12 +335,15 @@ function buildMetrics(
     // Effective load: what's actually being moved, not what's stamped on one
     // dumbbell. Bodyweight sets carry no `weight_lbs` and contribute 0.
     const load = (set.weight_lbs ?? 0) * (multiplierByExercise.get(set.exercise) ?? 1)
-    const tonnage = set.reps * load
-    const observation = { day, reps: set.reps, load, tonnage }
+    // An unrecorded count contributes nothing to a rep or tonnage ladder,
+    // and cannot itself set a biggest-single-set record (#440).
+    const reps = countedReps(set)
+    const tonnage = reps * load
+    const observation = { day, reps, load, tonnage }
     for (const m of [forExercise(set.exercise), pooled]) {
-      bump(m.byDay, day, set.reps)
-      bump(m.byWeek, week, set.reps)
-      bump(m.byMonth, month, set.reps)
+      bump(m.byDay, day, reps)
+      bump(m.byWeek, week, reps)
+      bump(m.byMonth, month, reps)
       bump(m.tonnageByDay, day, tonnage)
       bump(m.tonnageByWeek, week, tonnage)
       bump(m.tonnageByMonth, month, tonnage)

--- a/lib/training-facility/exercise-progression.ts
+++ b/lib/training-facility/exercise-progression.ts
@@ -1,6 +1,7 @@
 import type { StrengthSet, WeightRoomExercise, WeightRoomWorkout } from '@/types/weight-room'
 
 import { PACIFIC_CLOCK, type DayClock } from './clock'
+import { countedReps } from './set-reps'
 import { workoutDayKey } from './workout-sessions'
 import {
   E1RM_MAX_RELIABLE_REPS,
@@ -117,7 +118,12 @@ function heavier(
   if (candidate.effectiveLoad <= 0) return best
   if (best === null) return candidate
   if (candidate.effectiveLoad > best.effectiveLoad) return candidate
-  if (candidate.effectiveLoad === best.effectiveLoad && candidate.reps > best.reps) return candidate
+  if (
+    candidate.effectiveLoad === best.effectiveLoad &&
+    countedReps(candidate.reps) > countedReps(best.reps)
+  ) {
+    return candidate
+  }
   return best
 }
 
@@ -127,8 +133,14 @@ function repsier(
   candidate: WorkoutSetHighlight
 ): WorkoutSetHighlight {
   if (best === null) return candidate
-  if (candidate.reps > best.reps) return candidate
-  if (candidate.reps === best.reps && candidate.effectiveLoad > best.effectiveLoad) return candidate
+  // An unrecorded count cannot win a most-reps contest (#440).
+  if (countedReps(candidate.reps) > countedReps(best.reps)) return candidate
+  if (
+    countedReps(candidate.reps) === countedReps(best.reps) &&
+    candidate.effectiveLoad > best.effectiveLoad
+  ) {
+    return candidate
+  }
   return best
 }
 
@@ -235,11 +247,12 @@ export function buildExerciseProgression(
         ...(set.to_failure === true ? { toFailure: true } : {}),
       }
 
-      reps += set.reps
-      tonnage += set.reps * effectiveLoad
+      // An unrecorded count adds nothing, and cannot be judged high-rep (#440).
+      reps += countedReps(set)
+      tonnage += countedReps(set) * effectiveLoad
       if (effectiveLoad > 0) {
         loadedSets += 1
-        if (set.reps > E1RM_MAX_RELIABLE_REPS) highRepLoadedSets += 1
+        if (countedReps(set) > E1RM_MAX_RELIABLE_REPS) highRepLoadedSets += 1
       }
 
       dayTop = heavier(dayTop, highlight)
@@ -247,7 +260,8 @@ export function buildExerciseProgression(
       heaviestSet = heavier(heaviestSet, highlight)
       mostRepsSet = repsier(mostRepsSet, highlight)
 
-      const estimate = reliableOneRepMax(effectiveLoad, set.reps)
+      // No count, no Epley estimate — the formula needs a rep number.
+      const estimate = set.reps === null ? null : reliableOneRepMax(effectiveLoad, set.reps)
       if (estimate !== null) {
         if (dayEstimate === null || estimate > dayEstimate) dayEstimate = estimate
         if (bestOneRepMax === null || estimate > bestOneRepMax) bestOneRepMax = estimate

--- a/lib/training-facility/exercise-progression.ts
+++ b/lib/training-facility/exercise-progression.ts
@@ -2,6 +2,7 @@ import type { StrengthSet, WeightRoomExercise, WeightRoomWorkout } from '@/types
 
 import { PACIFIC_CLOCK, type DayClock } from './clock'
 import { countedReps } from './set-reps'
+import { countWorkingSets } from './workout-stats'
 import { workoutDayKey } from './workout-sessions'
 import {
   E1RM_MAX_RELIABLE_REPS,
@@ -268,13 +269,15 @@ export function buildExerciseProgression(
       }
     }
 
-    totalSets += daySets.length
+    // Collapsed, so this page agrees with the workout page about how many
+    // sets a session was (#440).
+    totalSets += countWorkingSets(daySets)
     totalReps += reps
 
     points.push({
       dayKey,
       date,
-      sets: daySets.length,
+      sets: countWorkingSets(daySets),
       reps,
       tonnage,
       topSet: dayTop,

--- a/lib/training-facility/load-management.ts
+++ b/lib/training-facility/load-management.ts
@@ -13,6 +13,7 @@ import type {
 } from '@/types/weight-room'
 
 import { PACIFIC_CLOCK, shiftDayKey, type DayClock } from './clock'
+import { countedReps } from './set-reps'
 
 /**
  * Ramp-rate aggregation for the Weight Room Load Management panel (#316).
@@ -313,8 +314,8 @@ export function buildMovementLoads(
       const offset = offsetByKey.get(key)
       if (offset === undefined) continue // outside the trailing chronic window
       const weight = typeof s.weight_lbs === 'number' && s.weight_lbs > 0 ? s.weight_lbs : 0
-      repByOffset[offset] += s.reps
-      loadByOffset[offset] += s.reps * weight
+      repByOffset[offset] += countedReps(s)
+      loadByOffset[offset] += countedReps(s) * weight
       inWindowSets += 1
       inWindowDays.add(offset)
       if (weight > 0) inWindowWeighted += 1

--- a/lib/training-facility/log-eras.ts
+++ b/lib/training-facility/log-eras.ts
@@ -18,6 +18,7 @@ import type { StrengthSet, WeightRoomExercise } from '@/types/weight-room'
 
 import { PACIFIC_CLOCK, type DayClock } from './clock'
 import { DEFAULT_MIN_GAP_DAYS, daysBetween } from './era-comparison'
+import { countedReps } from './set-reps'
 import { effectiveSetLoad, loadMultipliersBySlug } from './workout-stats'
 
 /** One stretch of training, described on its own terms. */
@@ -160,7 +161,7 @@ function describeEra(
   for (const dayKey of dayKeys) {
     for (const set of byDay.get(dayKey) ?? []) {
       setCount += 1
-      reps += set.reps
+      reps += countedReps(set)
       movements.add(set.exercise)
       // "Loaded" means the set carried external weight at all — a weighted
       // pushup counts, because it is loaded work. The multiplier scales

--- a/lib/training-facility/monthly-focus.ts
+++ b/lib/training-facility/monthly-focus.ts
@@ -1,5 +1,6 @@
 import type { FocusCategory, MonthlyFocus, StrengthSet } from '@/types/weight-room'
 import { PACIFIC_CLOCK, inclusiveDaySpan, shiftDayKey, type DayClock } from './clock'
+import { countedReps } from './set-reps'
 
 export type { FocusCategory }
 
@@ -166,7 +167,7 @@ export function computeFocusAdherence(
     if (s.exercise !== focus.exercise) continue
     const day = clock.safeDayKey(s.logged_at)
     if (day === '' || day < focus.start_date || day > lastElapsed) continue
-    const increment = focus.target_kind === 'sets' ? 1 : s.reps
+    const increment = focus.target_kind === 'sets' ? 1 : countedReps(s)
     volumeByDay.set(day, (volumeByDay.get(day) ?? 0) + increment)
   }
 
@@ -272,7 +273,7 @@ export function computeFocusLoadStats(
     if (s.weight_lbs == null) continue
     weightedSets++
     loadSum += s.weight_lbs
-    tonnageLbs += s.reps * s.weight_lbs * implements_
+    tonnageLbs += countedReps(s) * s.weight_lbs * implements_
     if (topSetLbs === null || s.weight_lbs > topSetLbs) topSetLbs = s.weight_lbs
   }
 
@@ -370,7 +371,7 @@ export function buildFocusLaneCells(
     const day = clock.safeDayKey(s.logged_at)
     if (day === '') continue
     const k = `${s.exercise}|${day}`
-    repsByKey.set(k, (repsByKey.get(k) ?? 0) + s.reps)
+    repsByKey.set(k, (repsByKey.get(k) ?? 0) + countedReps(s))
     setCountByKey.set(k, (setCountByKey.get(k) ?? 0) + 1)
   }
 
@@ -533,7 +534,7 @@ export function summarizeFocusCampaigns(
     if (s.exercise !== exercise) continue
     const day = clock.safeDayKey(s.logged_at)
     if (day === '') continue
-    if (windows.some(focus => isFocusActiveOnDay(focus, day))) campaignReps += s.reps
+    if (windows.some(focus => isFocusActiveOnDay(focus, day))) campaignReps += countedReps(s)
   }
 
   // "Upcoming" is every window still ahead of today — distinct from "ended",

--- a/lib/training-facility/set-reps.test.ts
+++ b/lib/training-facility/set-reps.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Tests for reading a possibly-unrecorded rep count (#440).
+ *
+ * The distinction these defend: `null` means nobody wrote the number down,
+ * which is not the same as zero. Summing it as `0` is right — unknown work adds
+ * nothing — but *displaying* it as `0` would assert a set of no reps, which is
+ * precisely the false claim the nullable column exists to stop.
+ */
+import { describe, expect, it } from 'vitest'
+
+import { countedReps, hasRecordedReps, repsLabel } from './set-reps'
+
+describe('countedReps', () => {
+  it('returns a recorded count unchanged', () => {
+    expect(countedReps({ reps: 12 })).toBe(12)
+    expect(countedReps(12)).toBe(12)
+  })
+
+  it('treats an unrecorded count as contributing nothing', () => {
+    expect(countedReps({ reps: null })).toBe(0)
+    expect(countedReps(null)).toBe(0)
+    expect(countedReps(undefined)).toBe(0)
+  })
+
+  it('sums a mixed list without inventing reps', () => {
+    // The rack-run case: two counted sets and three drops taken to failure.
+    const sets = [{ reps: 10 }, { reps: null }, { reps: 8 }, { reps: null }, { reps: null }]
+    expect(sets.reduce((n, s) => n + countedReps(s), 0)).toBe(18)
+  })
+})
+
+describe('hasRecordedReps', () => {
+  it('distinguishes a recorded count from an absent one', () => {
+    expect(hasRecordedReps({ reps: 1 })).toBe(true)
+    expect(hasRecordedReps({ reps: null })).toBe(false)
+  })
+
+  it('counts zero as recorded, since the column forbids it anyway', () => {
+    // Guards the implementation against a truthiness check, which would call a
+    // legitimately-stored 0 "unrecorded".
+    expect(hasRecordedReps({ reps: 0 })).toBe(true)
+  })
+})
+
+describe('repsLabel', () => {
+  it('renders a recorded count as its number', () => {
+    expect(repsLabel({ reps: 8 })).toBe('8')
+    expect(repsLabel(8)).toBe('8')
+  })
+
+  it('renders an unrecorded count as a dash, never as zero', () => {
+    expect(repsLabel({ reps: null })).toBe('—')
+    expect(repsLabel(null)).toBe('—')
+    expect(repsLabel(undefined)).toBe('—')
+  })
+
+  it('takes a caller-supplied placeholder', () => {
+    expect(repsLabel(null, '?')).toBe('?')
+  })
+})

--- a/lib/training-facility/set-reps.ts
+++ b/lib/training-facility/set-reps.ts
@@ -1,0 +1,53 @@
+/**
+ * Reading a set's rep count when it may not have been recorded (#440).
+ *
+ * `StrengthSet.reps` became nullable so a rack-run drop can state its load
+ * without claiming a rep count it never had. Every reader now has to decide
+ * what an unrecorded count means *for that reader*, and the two answers differ:
+ *
+ * - **Summing** — volume, tonnage, goal rings, heatmap intensity. Unknown work
+ *   contributes nothing, so `0`. Not because the set was empty, but because
+ *   inventing a number is what this whole change exists to stop.
+ * - **Showing** — a set list, a top-set line. Unknown is not a number, so it
+ *   renders as a dash and never as `0 reps`.
+ *
+ * Two named helpers rather than one, so a call site says which it meant.
+ */
+import type { StrengthSet } from '@/types/weight-room'
+
+/**
+ * A set's reps for arithmetic — `0` when the count was never recorded.
+ *
+ * @param set The set, or just its rep count.
+ * @returns Reps to add into a total; `0` for an unrecorded count.
+ */
+export function countedReps(set: Pick<StrengthSet, 'reps'> | number | null | undefined): number {
+  if (typeof set === 'number') return set
+  if (set === null || set === undefined) return 0
+  return set.reps ?? 0
+}
+
+/**
+ * Whether a set actually carries a rep count.
+ *
+ * Use to branch display, and to exclude a set from a statistic that would be
+ * meaningless without one — a "most reps in a set" record can't consider a set
+ * whose reps are unknown.
+ */
+export function hasRecordedReps(set: Pick<StrengthSet, 'reps'>): boolean {
+  return typeof set.reps === 'number'
+}
+
+/**
+ * A set's reps for display — the number, or a dash when unrecorded.
+ *
+ * @param set The set, or just its rep count.
+ * @param dash What to render for an unrecorded count; defaults to an em dash.
+ */
+export function repsLabel(
+  set: Pick<StrengthSet, 'reps'> | number | null | undefined,
+  dash = '—'
+): string {
+  const reps = typeof set === 'number' ? set : (set?.reps ?? null)
+  return reps === null || reps === undefined ? dash : String(reps)
+}

--- a/lib/training-facility/strength-format.ts
+++ b/lib/training-facility/strength-format.ts
@@ -13,6 +13,8 @@
  * caller that knows its audience passes them; nobody else has to care.
  */
 
+import { repsLabel } from './set-reps'
+
 /** How a load should be rendered. */
 export interface LoadFormatOptions {
   /**
@@ -44,17 +46,20 @@ export function formatLbs(value: number, options: LoadFormatOptions = {}): strin
 /**
  * Render a set as `8 × 60 lb`, or `12 reps` when it carried no external load.
  *
- * @param reps Reps completed.
+ * @param reps Reps completed, or `null` when the count was never recorded
+ *   (#440) — rendered as a dash, never as `0`.
  * @param effectiveLoad Load actually moved — per-implement weight already
  *   multiplied by the movement's `load_multiplier`. `0` means bodyweight.
  * @param options Unit label and locale, forwarded to {@link formatLbs}.
  */
 export function describeSet(
-  reps: number,
+  reps: number | null,
   effectiveLoad: number,
   options: LoadFormatOptions = {}
 ): string {
-  return effectiveLoad > 0 ? `${reps} × ${formatLbs(effectiveLoad, options)}` : `${reps} reps`
+  const label = repsLabel(reps)
+  if (effectiveLoad > 0) return `${label} × ${formatLbs(effectiveLoad, options)}`
+  return reps === null ? label : `${label} reps`
 }
 
 /**
@@ -86,7 +91,7 @@ export function formatHold(seconds: number): string {
  */
 export function describeSetOrHold(
   set: {
-    reps: number
+    reps: number | null
     effectiveLoad: number
     durationSeconds?: number | null
     toFailure?: boolean | null
@@ -95,8 +100,9 @@ export function describeSetOrHold(
 ): string {
   const { reps, effectiveLoad, durationSeconds, toFailure } = set
 
-  // A to-failure set stores `reps: 1` meaning "one set", so the rep count is
-  // not a number worth printing — say what actually happened instead (#435).
+  // A to-failure set has no rep count worth printing — it stored a placeholder
+  // `1` before #440 and stores `null` now, and neither is a number that
+  // happened. Say what actually did instead (#435).
   if (toFailure === true) {
     return effectiveLoad > 0 ? `${formatLbs(effectiveLoad, options)} to failure` : 'to failure'
   }

--- a/lib/training-facility/strength-streaks.ts
+++ b/lib/training-facility/strength-streaks.ts
@@ -3,6 +3,7 @@ import type { ExerciseGoal, StrengthSet } from '@/types/weight-room'
 import { PACIFIC_CLOCK, type DayClock } from './clock'
 import { targetResolverFor } from './goal-targets'
 import { type StreakCounts, streakFromDailyReps } from './hit-day-streaks'
+import { countedReps } from './set-reps'
 
 /**
  * Per-exercise streak result, mirrored on
@@ -66,7 +67,7 @@ export function computeStrengthStreaks(
       dayMap = new Map()
       repsByExerciseAndDay.set(s.exercise, dayMap)
     }
-    dayMap.set(day, (dayMap.get(day) ?? 0) + s.reps)
+    dayMap.set(day, (dayMap.get(day) ?? 0) + countedReps(s))
   }
 
   const todayKey = clock.dayKey(now)

--- a/lib/training-facility/strength-today.ts
+++ b/lib/training-facility/strength-today.ts
@@ -2,6 +2,7 @@ import type { ExerciseGoal, StrengthSet } from '@/types/weight-room'
 
 import { PACIFIC_CLOCK, type DayClock } from './clock'
 import { targetForDay } from './goal-targets'
+import { countedReps } from './set-reps'
 
 /**
  * Pure helpers for the Weight Room Today View (#80) — date bucketing,
@@ -68,7 +69,7 @@ export function filterSetsForDay(
  */
 export function sumReps(sets: readonly StrengthSet[]): number {
   let total = 0
-  for (const s of sets) total += s.reps
+  for (const s of sets) total += countedReps(s)
   return total
 }
 
@@ -82,7 +83,7 @@ export function sumReps(sets: readonly StrengthSet[]): number {
 export function totalsByExercise(setsForDay: readonly StrengthSet[]): Map<string, number> {
   const totals = new Map<string, number>()
   for (const s of setsForDay) {
-    totals.set(s.exercise, (totals.get(s.exercise) ?? 0) + s.reps)
+    totals.set(s.exercise, (totals.get(s.exercise) ?? 0) + countedReps(s))
   }
   return totals
 }
@@ -133,10 +134,10 @@ export function variantBreakdown(sets: readonly StrengthSet[]): VariantSlice[] {
   for (const s of sets) {
     const key = s.variant ?? null
     const bucket = buckets.get(key) ?? { reps: 0, sets: 0 }
-    bucket.reps += s.reps
+    bucket.reps += countedReps(s)
     bucket.sets += 1
     buckets.set(key, bucket)
-    totalReps += s.reps
+    totalReps += countedReps(s)
   }
 
   const slices: VariantSlice[] = []

--- a/lib/training-facility/weight-room-history.ts
+++ b/lib/training-facility/weight-room-history.ts
@@ -18,6 +18,7 @@ import {
 } from './goal-targets'
 import type { HeatmapMonthLabel } from './heatmap-labels'
 import { type StreakCounts, streakFromDailyReps } from './hit-day-streaks'
+import { countedReps } from './set-reps'
 import {
   type FocusCampaignSummary,
   focusTargetHistory,
@@ -283,7 +284,7 @@ export function buildStrengthHeatmap(
     const key = clock.safeDayKey(s.logged_at)
     if (key === '') continue
     const entry = lookup.get(key) ?? { reps: 0, setCount: 0 }
-    entry.reps += s.reps
+    entry.reps += countedReps(s)
     entry.setCount += 1
     lookup.set(key, entry)
   }
@@ -378,7 +379,7 @@ export function computeStrengthStreaks(
     if (s.exercise !== goal.exercise) continue
     const key = clock.safeDayKey(s.logged_at)
     if (key === '') continue
-    dailyReps.set(key, (dailyReps.get(key) ?? 0) + s.reps)
+    dailyReps.set(key, (dailyReps.get(key) ?? 0) + countedReps(s))
   }
   return streakFromDailyReps(dailyReps, targetResolverFor(goal), clock.dayKey(now))
 }
@@ -459,19 +460,19 @@ export function computeStrengthStats(
       if (key === '') continue
 
       // All-time + active-day rollups.
-      dailyReps.set(key, (dailyReps.get(key) ?? 0) + s.reps)
-      allTimeReps += s.reps
+      dailyReps.set(key, (dailyReps.get(key) ?? 0) + countedReps(s))
+      allTimeReps += countedReps(s)
       validSetCount += 1
 
       // Period buckets — string-compare against pre-computed boundary
       // keys. Each set falls into at most one week bucket and at most
       // one month bucket, but a day can be in both (e.g. Mon Apr 1 is
       // both "thisWeek" and "thisMonth"), so check independently.
-      if (key >= thisWeekStart && key <= thisWeekEnd) thisWeekReps += s.reps
-      else if (key >= lastWeekStart && key <= lastWeekEnd) lastWeekReps += s.reps
+      if (key >= thisWeekStart && key <= thisWeekEnd) thisWeekReps += countedReps(s)
+      else if (key >= lastWeekStart && key <= lastWeekEnd) lastWeekReps += countedReps(s)
 
-      if (key >= thisMonthStart && key <= thisMonthEnd) thisMonthReps += s.reps
-      else if (key >= lastMonthStart && key <= lastMonthEnd) lastMonthReps += s.reps
+      if (key >= thisMonthStart && key <= thisMonthEnd) thisMonthReps += countedReps(s)
+      else if (key >= lastMonthStart && key <= lastMonthEnd) lastMonthReps += countedReps(s)
     }
 
     const avgSetsPerActiveDay = dailyReps.size === 0 ? 0 : validSetCount / dailyReps.size
@@ -544,7 +545,7 @@ export function buildWeeklyVolume(
     if (dayKey === '') continue
     const key = mondayOfDayKey(dayKey)
     const entry = lookup.get(key) ?? { reps: 0, setCount: 0 }
-    entry.reps += s.reps
+    entry.reps += countedReps(s)
     entry.setCount += 1
     lookup.set(key, entry)
   }

--- a/lib/training-facility/workout-stats.test.ts
+++ b/lib/training-facility/workout-stats.test.ts
@@ -13,6 +13,7 @@ import {
   buildWorkoutAdherence,
   buildWorkoutHistory,
   buildWorkoutSummary,
+  countWorkingSets,
   compareToPrevious,
   effectiveSetLoad,
   epleyOneRepMax,
@@ -126,6 +127,91 @@ describe('effectiveSetLoad', () => {
   it('falls back to one implement for a movement missing from the catalog', () => {
     // Understating a pair is recoverable; inventing load is not.
     expect(effectiveSetLoad({ exercise: 'unknown-lift', weight_lbs: 100 }, multipliers)).toBe(100)
+  })
+})
+
+describe('countWorkingSets', () => {
+  it('counts an ordinary row as one set', () => {
+    expect(countWorkingSets([set({ id: 'a' }), set({ id: 'b' })])).toBe(2)
+  })
+
+  it('collapses the drops of one rack pass into a single set (#440)', () => {
+    // `Set 1: 30, 15` and `Set 2: 30, 27.5, 22.5` — five rows, two sets.
+    const drops = [
+      set({ id: 'd1', exercise: 'dumbbell-curl', reps: null, set_group: 1 }),
+      set({ id: 'd2', exercise: 'dumbbell-curl', reps: null, set_group: 1 }),
+      set({ id: 'd3', exercise: 'dumbbell-curl', reps: null, set_group: 2 }),
+      set({ id: 'd4', exercise: 'dumbbell-curl', reps: null, set_group: 2 }),
+      set({ id: 'd5', exercise: 'dumbbell-curl', reps: null, set_group: 2 }),
+    ]
+    expect(countWorkingSets(drops)).toBe(2)
+  })
+
+  it('keeps groups from different movements apart', () => {
+    // A group number is only unique within the movement that recorded it, so
+    // keying on the number alone would merge two unrelated sets into one.
+    const sets = [
+      set({ id: 'a', exercise: 'dumbbell-curl', set_group: 1 }),
+      set({ id: 'b', exercise: 'ez-bar-curl', set_group: 1 }),
+    ]
+    expect(countWorkingSets(sets)).toBe(2)
+  })
+
+  it('mixes grouped and ungrouped rows in one session', () => {
+    const sets = [
+      set({ id: 'bench-1' }),
+      set({ id: 'bench-2' }),
+      set({ id: 'd1', exercise: 'dumbbell-curl', reps: null, set_group: 1 }),
+      set({ id: 'd2', exercise: 'dumbbell-curl', reps: null, set_group: 1 }),
+    ]
+    expect(countWorkingSets(sets)).toBe(3)
+  })
+
+  it('treats group 0 as a real group, not as absent', () => {
+    // A falsy check here would count each drop separately again.
+    const sets = [
+      set({ id: 'd1', exercise: 'dumbbell-curl', set_group: 0 }),
+      set({ id: 'd2', exercise: 'dumbbell-curl', set_group: 0 }),
+    ]
+    expect(countWorkingSets(sets)).toBe(1)
+  })
+})
+
+describe('buildWorkoutSummary — rack runs (#440)', () => {
+  it('reports a two-pass rack run as two sets, not five rows', () => {
+    const drops = [
+      set({ id: 'd1', exercise: 'dumbbell-curl', reps: null, weight_lbs: 30, set_group: 1 }),
+      set({ id: 'd2', exercise: 'dumbbell-curl', reps: null, weight_lbs: 15, set_group: 1 }),
+      set({ id: 'd3', exercise: 'dumbbell-curl', reps: null, weight_lbs: 30, set_group: 2 }),
+      set({ id: 'd4', exercise: 'dumbbell-curl', reps: null, weight_lbs: 27.5, set_group: 2 }),
+      set({ id: 'd5', exercise: 'dumbbell-curl', reps: null, weight_lbs: 22.5, set_group: 2 }),
+    ]
+    const summary = buildWorkoutSummary(workout(), drops)
+    expect(summary.totalSets).toBe(2)
+    expect(summary.exercises[0].sets).toBe(2)
+  })
+
+  it('adds no reps for drops whose count was never recorded', () => {
+    const drops = [
+      set({ id: 'd1', exercise: 'dumbbell-curl', reps: null, weight_lbs: 30, set_group: 1 }),
+      set({ id: 'd2', exercise: 'dumbbell-curl', reps: null, weight_lbs: 15, set_group: 1 }),
+    ]
+    const summary = buildWorkoutSummary(workout(), drops)
+    expect(summary.totalReps).toBe(0)
+    // And no tonnage invented from a placeholder rep count: 1 x 30 + 1 x 15
+    // would have been 45.
+    expect(summary.tonnage).toBe(0)
+  })
+
+  it('still counts a counted set alongside them', () => {
+    const sets = [
+      set({ id: 'bench', reps: 8, weight_lbs: 135 }),
+      set({ id: 'd1', exercise: 'dumbbell-curl', reps: null, weight_lbs: 30, set_group: 1 }),
+    ]
+    const summary = buildWorkoutSummary(workout(), sets)
+    expect(summary.totalReps).toBe(8)
+    expect(summary.tonnage).toBe(8 * 135)
+    expect(summary.totalSets).toBe(2)
   })
 })
 

--- a/lib/training-facility/workout-stats.test.ts
+++ b/lib/training-facility/workout-stats.test.ts
@@ -203,6 +203,30 @@ describe('buildWorkoutSummary — rack runs (#440)', () => {
     expect(summary.tonnage).toBe(0)
   })
 
+  it('keeps weighted and bodyweight counts in the same unit as the total', () => {
+    // The trap: `weightedSets` was counted per row while `totalSets` became a
+    // per-group count, so subtracting them mixed units and under-reported
+    // bodyweight sets — far enough, with enough drops, to clamp to zero and
+    // hide the explainer entirely (#440).
+    const sets = [
+      set({ id: 'bw1', exercise: 'pushups', reps: 20 }),
+      set({ id: 'bw2', exercise: 'pushups', reps: 20 }),
+      set({ id: 'bw3', exercise: 'pushups', reps: 20 }),
+      set({ id: 'bw4', exercise: 'pushups', reps: 20 }),
+      set({ id: 'd1', exercise: 'dumbbell-curl', reps: null, weight_lbs: 30, set_group: 1 }),
+      set({ id: 'd2', exercise: 'dumbbell-curl', reps: null, weight_lbs: 25, set_group: 1 }),
+      set({ id: 'd3', exercise: 'dumbbell-curl', reps: null, weight_lbs: 20, set_group: 1 }),
+    ]
+    const summary = buildWorkoutSummary(workout(), sets)
+
+    // Four bodyweight sets plus one rack pass.
+    expect(summary.totalSets).toBe(5)
+    expect(summary.weightedSets).toBe(1)
+    expect(summary.bodyweightSets).toBe(4)
+    // The three parts have to reconcile, whatever the row count was.
+    expect(summary.weightedSets + summary.bodyweightSets).toBe(summary.totalSets)
+  })
+
   it('still counts a counted set alongside them', () => {
     const sets = [
       set({ id: 'bench', reps: 8, weight_lbs: 135 }),

--- a/lib/training-facility/workout-stats.ts
+++ b/lib/training-facility/workout-stats.ts
@@ -219,13 +219,16 @@ export interface WorkoutSummary {
    * printing hours that weren't spent training.
    */
   isAbandoned: boolean
-  /** Total sets logged. */
+  /**
+   * Working sets logged. Rows sharing a `set_group` — the drops of one pass
+   * down a rack — count once, so this is at most the row count (#440).
+   */
   totalSets: number
   /** Total reps across every set. */
   totalReps: number
   /** `Σ reps × effective load` across the session. */
   tonnage: number
-  /** How many sets carried external load. */
+  /** How many working sets carried external load. */
   weightedSets: number
   /**
    * How many sets carried none. Surfaced so the UI can *state* that bodyweight
@@ -271,7 +274,10 @@ export function buildWorkoutSummary(
 
   let totalReps = 0
   let tonnage = 0
-  let weightedSets = 0
+  // Collected rather than counted: a weighted set has to be measured in the
+  // same unit as the total, or subtracting the two to get bodyweight sets
+  // mixes rows with groups and can go negative (#440).
+  const weightedRows: StrengthSet[] = []
 
   // Rows, collapsed into the sets they describe — a two-pass rack run is five
   // rows and two sets (#440).
@@ -283,11 +289,14 @@ export function buildWorkoutSummary(
     // An unrecorded count adds nothing rather than inventing one (#440).
     totalReps += countedReps(set)
     tonnage += countedReps(set) * load
-    if (load > 0) weightedSets += 1
+    if (load > 0) weightedRows.push(set)
     const list = byExercise.get(set.exercise)
     if (list) list.push(set)
     else byExercise.set(set.exercise, [set])
   }
+
+  const weightedSets = countWorkingSets(weightedRows)
+  const bodyweightWorkingSets = Math.max(0, workingSets - weightedSets)
 
   const breakdown: ExerciseBreakdown[] = []
   for (const [exercise, exSets] of byExercise) {
@@ -366,7 +375,7 @@ export function buildWorkoutSummary(
     totalReps,
     tonnage,
     weightedSets,
-    bodyweightSets: Math.max(0, workingSets - weightedSets),
+    bodyweightSets: bodyweightWorkingSets,
     density,
     exercises: breakdown,
   }

--- a/lib/training-facility/workout-stats.ts
+++ b/lib/training-facility/workout-stats.ts
@@ -6,6 +6,7 @@ import type {
 } from '@/types/weight-room'
 
 import { buildSlotProgress, extraSets, type SlotProgress } from './live-workout'
+import { countedReps } from './set-reps'
 import { PACIFIC_CLOCK, type DayClock } from './clock'
 import { compareInstants, isStaleOpenWorkout, workoutDurationMinutes } from './workout-sessions'
 
@@ -104,8 +105,11 @@ export function effectiveSetLoad(
 export interface WorkoutSetHighlight {
   /** {@link StrengthSet.id} of the set. */
   setId: string
-  /** Reps completed. */
-  reps: number
+  /**
+   * Reps completed, or `null` when the count was never recorded (#440) — a
+   * rack-run drop taken to failure, where the note captured only the load.
+   */
+  reps: number | null
   /** Load on one implement, or `null` for a bodyweight set. */
   weightLbs: number | null
   /** Pounds actually moved — `weightLbs × load_multiplier`; `0` for bodyweight. */
@@ -251,8 +255,9 @@ export function buildWorkoutSummary(
   const byExercise = new Map<string, StrengthSet[]>()
   for (const set of ordered) {
     const load = effectiveSetLoad(set, multipliers)
-    totalReps += set.reps
-    tonnage += set.reps * load
+    // An unrecorded count adds nothing rather than inventing one (#440).
+    totalReps += countedReps(set)
+    tonnage += countedReps(set) * load
     if (load > 0) weightedSets += 1
     const list = byExercise.get(set.exercise)
     if (list) list.push(set)
@@ -268,8 +273,8 @@ export function buildWorkoutSummary(
 
     for (const set of exSets) {
       const effectiveLoad = effectiveSetLoad(set, multipliers)
-      reps += set.reps
-      exTonnage += set.reps * effectiveLoad
+      reps += countedReps(set)
+      exTonnage += countedReps(set) * effectiveLoad
       const highlight: WorkoutSetHighlight = {
         setId: set.id,
         reps: set.reps,
@@ -280,18 +285,22 @@ export function buildWorkoutSummary(
         ...(set.to_failure === true ? { toFailure: true } : {}),
       }
       // Heaviest wins; at equal load the one with more reps is the better set.
+      // An unrecorded count can't win a reps tiebreak or a most-reps contest —
+      // `countedReps` makes it lose rather than throw (#440).
       if (
         effectiveLoad > 0 &&
         (top === null ||
           effectiveLoad > top.effectiveLoad ||
-          (effectiveLoad === top.effectiveLoad && set.reps > top.reps))
+          (effectiveLoad === top.effectiveLoad && countedReps(set) > countedReps(top.reps)))
       ) {
         top = highlight
       }
-      if (bestReps === null || set.reps > bestReps.reps) bestReps = highlight
+      if (bestReps === null || countedReps(set) > countedReps(bestReps.reps)) bestReps = highlight
     }
 
-    const estimate = top === null ? null : epleyOneRepMax(top.effectiveLoad, top.reps)
+    // No recorded count, no Epley estimate — the formula needs reps (#440).
+    const estimate =
+      top === null || top.reps === null ? null : epleyOneRepMax(top.effectiveLoad, top.reps)
     breakdown.push({
       exercise,
       ...(labels.has(exercise) ? { displayName: labels.get(exercise) } : {}),
@@ -303,7 +312,8 @@ export function buildWorkoutSummary(
       // always assigned at least one highlight.
       bestRepSet: bestReps as WorkoutSetHighlight,
       estimatedOneRepMax: estimate,
-      oneRepMaxIsReliable: estimate !== null && top !== null && top.reps <= E1RM_MAX_RELIABLE_REPS,
+      oneRepMaxIsReliable:
+        estimate !== null && top !== null && countedReps(top.reps) <= E1RM_MAX_RELIABLE_REPS,
       isBodyweight: top === null,
     })
   }
@@ -624,7 +634,9 @@ export function findPersonalBests(
     if (!Number.isFinite(loggedAt) || !Number.isFinite(startedAt) || loggedAt >= startedAt) continue
     const load = effectiveSetLoad(set, multipliers)
     if (load > (bestLoad.get(set.exercise) ?? 0)) bestLoad.set(set.exercise, load)
-    if (set.reps > (bestReps.get(set.exercise) ?? 0)) bestReps.set(set.exercise, set.reps)
+    // A set with no recorded count can't hold a reps record.
+    const reps = countedReps(set)
+    if (reps > (bestReps.get(set.exercise) ?? 0)) bestReps.set(set.exercise, reps)
   }
 
   const bests: WorkoutPersonalBest[] = []
@@ -647,7 +659,8 @@ export function findPersonalBests(
     }
 
     const previousReps = bestReps.get(entry.exercise) ?? 0
-    if (entry.bestRepSet.reps > previousReps) {
+    // A set with no recorded count cannot take a most-reps record.
+    if (countedReps(entry.bestRepSet.reps) > previousReps) {
       bests.push({
         exercise: entry.exercise,
         ...withLabel,

--- a/lib/training-facility/workout-stats.ts
+++ b/lib/training-facility/workout-stats.ts
@@ -101,6 +101,27 @@ export function effectiveSetLoad(
   return perImplement * (multipliers.get(set.exercise) ?? 1)
 }
 
+/**
+ * How many working sets a list of rows describes (#440).
+ *
+ * Most rows are a set each. The exception is a row carrying a `set_group`: the
+ * drops of one pass down a rack are several rows describing a single set, so
+ * they collapse to one. Grouping is keyed on `(exercise, set_group)` because a
+ * group number is only unique within the movement that recorded it.
+ *
+ * @param sets Rows from one session.
+ * @returns Sets actually performed, which is at most `sets.length`.
+ */
+export function countWorkingSets(sets: readonly StrengthSet[]): number {
+  let ungrouped = 0
+  const groups = new Set<string>()
+  for (const set of sets) {
+    if (set.set_group === undefined) ungrouped += 1
+    else groups.add(`${set.exercise}|${set.set_group}`)
+  }
+  return ungrouped + groups.size
+}
+
 /** One notable set, as surfaced in a breakdown row. */
 export interface WorkoutSetHighlight {
   /** {@link StrengthSet.id} of the set. */
@@ -252,6 +273,10 @@ export function buildWorkoutSummary(
   let tonnage = 0
   let weightedSets = 0
 
+  // Rows, collapsed into the sets they describe — a two-pass rack run is five
+  // rows and two sets (#440).
+  const workingSets = countWorkingSets(ordered)
+
   const byExercise = new Map<string, StrengthSet[]>()
   for (const set of ordered) {
     const load = effectiveSetLoad(set, multipliers)
@@ -304,7 +329,7 @@ export function buildWorkoutSummary(
     breakdown.push({
       exercise,
       ...(labels.has(exercise) ? { displayName: labels.get(exercise) } : {}),
-      sets: exSets.length,
+      sets: countWorkingSets(exSets),
       reps,
       tonnage: exTonnage,
       topSet: top,
@@ -326,7 +351,7 @@ export function buildWorkoutSummary(
     durationMinutes !== null && durationMinutes > 0
       ? {
           tonnagePerMinute: tonnage / durationMinutes,
-          setsPerMinute: ordered.length / durationMinutes,
+          setsPerMinute: workingSets / durationMinutes,
           repsPerMinute: totalReps / durationMinutes,
         }
       : null
@@ -337,11 +362,11 @@ export function buildWorkoutSummary(
     durationMinutes,
     isInProgress,
     isAbandoned,
-    totalSets: ordered.length,
+    totalSets: workingSets,
     totalReps,
     tonnage,
     weightedSets,
-    bodyweightSets: ordered.length - weightedSets,
+    bodyweightSets: Math.max(0, workingSets - weightedSets),
     density,
     exercises: breakdown,
   }

--- a/scripts/import-icloud-notes.mjs
+++ b/scripts/import-icloud-notes.mjs
@@ -381,6 +381,10 @@ async function main() {
           // the key gets NULL rather than the column default — which a
           // `not null` column rejects, failing the whole batch.
           to_failure: set.to_failure === true,
+          // Same reasoning as `to_failure`: always sent so a batch mixing
+          // grouped and ungrouped sets doesn't leave the key out of the INSERT
+          // for one of them. Null is the ordinary case — a set on its own.
+          set_group: set.set_group ?? null,
           // Grease-the-groove volume is that day's, not the session's — see
           // #400. Leaving `workout_id` null is what keeps it off the workout.
           workout_id: set.disposition === 'workout' ? workoutId : null,

--- a/scripts/lib/icloud-notes-parser.mjs
+++ b/scripts/lib/icloud-notes-parser.mjs
@@ -595,8 +595,10 @@ export function mintImportKey({ title, date, slug, index }) {
  * **Rack run.** A drop set: curl the 35s to failure, drop to the 30s, again,
  * down the rack. `Set 1: 25, 20, 10` is three drops at three loads, and the rep
  * count was never written because each drop simply went until it couldn't.
- * Every drop is therefore a set marked `to_failure` — see the #435 migration
- * for why that stores `reps = 1` rather than null.
+ * Every drop is therefore a set marked `to_failure` with `reps: null` — the
+ * count was never measured, and #440 made the column nullable so it no longer
+ * has to be invented. Drops of one pass share a `set_group`, so the pass counts
+ * as the single set it was rather than as one set per drop.
  *
  * A `Set N:` with nothing after it is the same movement performed with nothing
  * recorded at all. It still happened — the heading declared it and the label is
@@ -608,8 +610,9 @@ export function mintImportKey({ title, date, slug, index }) {
  * @param {{movement: string, planned?: string,
  *   sets: Array<{set: number, value: string}>}} block A parsed labelled block.
  * @param {Record<string, number>} [loadMultipliers] Live catalog multipliers.
- * @returns {Array<{exercise: string, reps: number, weight_lbs: number|null,
- *   variant: string, to_failure?: boolean}>} Sets in the order they were run.
+ * @returns {Array<{exercise: string, reps: number|null, weight_lbs: number|null,
+ *   variant: string, to_failure?: boolean, set_group?: number}>} Sets in the
+ *   order they were run.
  */
 export function parseLabelledBlock(block, loadMultipliers = {}) {
   const isRackRun = /^rack run/i.test(block.movement)
@@ -637,18 +640,31 @@ export function parseLabelledBlock(block, loadMultipliers = {}) {
       continue
     }
 
+    // One group per pass down the rack, so the drops below collapse back into
+    // the single set they were (#440). Keyed off the note's own `Set N:`
+    // number, which is exactly what that label meant.
+    const setGroup = entry.set
+
     if (loads.length === 0) {
-      out.push({ exercise: slug, reps: 1, weight_lbs: null, variant, to_failure: true })
+      out.push({
+        exercise: slug,
+        reps: null,
+        weight_lbs: null,
+        variant,
+        to_failure: true,
+        set_group: setGroup,
+      })
       continue
     }
 
     for (const load of loads) {
       out.push({
         exercise: slug,
-        reps: 1,
+        reps: null,
         weight_lbs: perImplementWeight(load, 'Weight', slug, loadMultipliers[slug]),
         variant,
         to_failure: true,
+        set_group: setGroup,
       })
     }
   }

--- a/scripts/lib/icloud-notes-parser.mjs
+++ b/scripts/lib/icloud-notes-parser.mjs
@@ -610,11 +610,13 @@ export function mintImportKey({ title, date, slug, index }) {
  * @param {{movement: string, planned?: string,
  *   sets: Array<{set: number, value: string}>}} block A parsed labelled block.
  * @param {Record<string, number>} [loadMultipliers] Live catalog multipliers.
+ * @param {number} [groupBase] Offset added to each `Set N:` number so groups
+ *   stay distinct across two labelled blocks in one note.
  * @returns {Array<{exercise: string, reps: number|null, weight_lbs: number|null,
  *   variant: string, to_failure?: boolean, set_group?: number}>} Sets in the
  *   order they were run.
  */
-export function parseLabelledBlock(block, loadMultipliers = {}) {
+export function parseLabelledBlock(block, loadMultipliers = {}, groupBase = 0) {
   const isRackRun = /^rack run/i.test(block.movement)
   const slug = 'dumbbell-curl'
   const variant = isRackRun ? 'rack run' : '21s'
@@ -641,9 +643,14 @@ export function parseLabelledBlock(block, loadMultipliers = {}) {
     }
 
     // One group per pass down the rack, so the drops below collapse back into
-    // the single set they were (#440). Keyed off the note's own `Set N:`
-    // number, which is exactly what that label meant.
-    const setGroup = entry.set
+    // the single set they were (#440).
+    //
+    // Offset by the block's own base rather than using `entry.set` directly:
+    // a note carrying two Rack Run blocks would otherwise give both a
+    // `Set 1:`, and the two passes would collide into one group and count as
+    // a single set. No note in the archive does this today, which is exactly
+    // why it would go unnoticed.
+    const setGroup = groupBase + entry.set
 
     if (loads.length === 0) {
       out.push({
@@ -699,8 +706,9 @@ export function parseLabelledBlock(block, loadMultipliers = {}) {
  *   `Set N:` blocks — rack runs and 21s (#435); see {@link parseLabelledBlock}.
  * @param {Record<string, number>} [loadMultipliers] Live catalog multipliers
  *   keyed by slug. Falls back to {@link TWO_IMPLEMENT_SLUGS} when absent.
- * @returns {{sets: Array<{exercise: string, reps: number, weight_lbs: number|null,
+ * @returns {{sets: Array<{exercise: string, reps: number|null, weight_lbs: number|null,
  *   variant?: string, duration_seconds?: number, to_failure?: boolean,
+ *   set_group?: number,
  *   disposition: 'workout'|'gtg', position: number|null, import_key: string}>,
  *   unmapped: string[], timed: string[]}} Parsed sets in note order; every
  *   movement name that resolved to nothing — reported so it gets a real catalog
@@ -772,8 +780,12 @@ export function parseNote(note, loadMultipliers = {}) {
     })
   }
 
+  // Each labelled block gets a group range of its own, so two Rack Run
+  // blocks in one note cannot both claim group 1 (#440).
+  let groupBase = 0
   for (const block of note.labelled_blocks ?? []) {
-    const parsed = parseLabelledBlock(block, loadMultipliers)
+    const parsed = parseLabelledBlock(block, loadMultipliers, groupBase)
+    groupBase += (block.sets ?? []).length + 1
     for (const set of parsed) {
       sets.push({
         ...set,

--- a/scripts/lib/icloud-notes-parser.test.ts
+++ b/scripts/lib/icloud-notes-parser.test.ts
@@ -282,19 +282,49 @@ describe('templateNameForNote', () => {
 })
 
 describe('parseLabelledBlock', () => {
-  it('turns a rack run into one to-failure set per drop', () => {
-    // `25, 20, 10` is three drops down the rack, each taken to failure with
-    // the rep count never written down.
+  /** One rack-run drop: a load, taken to failure, with no rep count recorded. */
+  const drop = (weightLbs: number | null, setGroup: number) => ({
+    exercise: 'dumbbell-curl',
+    reps: null,
+    weight_lbs: weightLbs,
+    variant: 'rack run',
+    to_failure: true,
+    set_group: setGroup,
+  })
+
+  it('turns a rack run into one grouped to-failure drop per load', () => {
+    // `25, 20, 10` is three drops down the rack, each taken to failure with the
+    // rep count never written down — so `reps` is null rather than an invented
+    // 1 (#440), and the three share a group so the pass counts as one set.
     const sets = parseLabelledBlock({
       movement: 'Rack Run',
       planned: '35,30,25,20',
       sets: [{ set: 1, value: '25, 20, 10' }],
     })
-    expect(sets).toEqual([
-      { exercise: 'dumbbell-curl', reps: 1, weight_lbs: 25, variant: 'rack run', to_failure: true },
-      { exercise: 'dumbbell-curl', reps: 1, weight_lbs: 20, variant: 'rack run', to_failure: true },
-      { exercise: 'dumbbell-curl', reps: 1, weight_lbs: 10, variant: 'rack run', to_failure: true },
-    ])
+    expect(sets).toEqual([drop(25, 1), drop(20, 1), drop(10, 1)])
+  })
+
+  it('gives each pass down the rack its own group', () => {
+    // Two passes on one day: five rows, but two working sets.
+    const sets = parseLabelledBlock({
+      movement: 'Rack Run',
+      planned: '35,30,25,20',
+      sets: [
+        { set: 1, value: '30, 15' },
+        { set: 2, value: '30, 27.5, 22.5' },
+      ],
+    })
+    expect(sets.map(s => s.set_group)).toEqual([1, 1, 2, 2, 2])
+    expect(new Set(sets.map(s => s.set_group)).size).toBe(2)
+  })
+
+  it('never claims a rep count for a rack drop', () => {
+    const sets = parseLabelledBlock({
+      movement: 'Rack Run',
+      planned: '35,30,25,20',
+      sets: [{ set: 1, value: '25, 20' }],
+    })
+    expect(sets.every(s => s.reps === null)).toBe(true)
   })
 
   it('records an empty Set N: as one unloaded to-failure set', () => {
@@ -308,10 +338,11 @@ describe('parseLabelledBlock', () => {
     expect(sets).toEqual([
       {
         exercise: 'dumbbell-curl',
-        reps: 1,
+        reps: null,
         weight_lbs: null,
         variant: 'rack run',
         to_failure: true,
+        set_group: 1,
       },
     ])
   })

--- a/scripts/lib/icloud-notes-parser.test.ts
+++ b/scripts/lib/icloud-notes-parser.test.ts
@@ -318,6 +318,28 @@ describe('parseLabelledBlock', () => {
     expect(new Set(sets.map(s => s.set_group)).size).toBe(2)
   })
 
+  it('keeps groups distinct across two rack blocks in one note', () => {
+    // No note in the archive carries two Rack Run blocks, which is exactly why
+    // a collision here would go unnoticed: both would claim `Set 1:`, share a
+    // group, and two passes would collapse into one set (#440).
+    const { sets } = parseNote({
+      title: 'Back Day 1',
+      date: '2024-04-16',
+      labelled_blocks: [
+        { movement: 'Rack Run', planned: '35,30,25,20', sets: [{ set: 1, value: '30, 25' }] },
+        { movement: 'Rack Run', planned: '35,30,25,20', sets: [{ set: 1, value: '20, 15' }] },
+      ],
+    })
+
+    const groups = sets.map(s => s.set_group)
+    // Four drops, two passes — and the two passes must not share a group.
+    expect(sets).toHaveLength(4)
+    expect(new Set(groups).size).toBe(2)
+    expect(groups[0]).toBe(groups[1])
+    expect(groups[2]).toBe(groups[3])
+    expect(groups[0]).not.toBe(groups[2])
+  })
+
   it('never claims a rep count for a rack drop', () => {
     const sets = parseLabelledBlock({
       movement: 'Rack Run',

--- a/supabase/migrations/20260811120000_weight_room_sets_unrecorded_reps.sql
+++ b/supabase/migrations/20260811120000_weight_room_sets_unrecorded_reps.sql
@@ -1,0 +1,46 @@
+-- Let a set record its load without claiming a rep count, and group the drops
+-- of one working set together (#440).
+--
+-- A rack run is a single set taken to failure at a descending series of loads:
+-- `Rack Run 35,30,25,20 / Set 1: 30, 15`. The note records the weights and
+-- never the reps, because each drop simply went until it couldn't. The #435
+-- import had nowhere to put "not counted" — `reps` was `not null` with a
+-- `> 0` check — so it wrote `1` for every drop. That is 65 rows asserting a
+-- rep count that was never measured, feeding rep totals and computing tonnage
+-- as 1 x load instead of the work actually done.
+--
+-- `null` is the honest answer, and it is a different statement from zero: zero
+-- means a set with no reps, null means a set whose reps nobody wrote down.
+--
+-- `set_group` collapses the drops back into the set they were. Rows sharing a
+-- (workout_id, exercise, set_group) are one working set, so a two-pass rack run
+-- counts as two sets rather than the five rows it takes to describe them.
+-- Null means "this row is its own set", which is every ordinary set and stays
+-- the default.
+
+alter table weight_room_sets
+  alter column reps drop not null;
+
+-- Recreate rather than relax in place: the old constraint has no room for null.
+alter table weight_room_sets
+  drop constraint if exists weight_room_sets_reps_check;
+
+alter table weight_room_sets
+  add constraint weight_room_sets_reps_check
+  check (reps is null or reps > 0);
+
+alter table weight_room_sets
+  add column if not exists set_group smallint;
+
+alter table weight_room_sets
+  drop constraint if exists weight_room_sets_set_group_check;
+
+alter table weight_room_sets
+  add constraint weight_room_sets_set_group_check
+  check (set_group is null or set_group >= 0);
+
+comment on column weight_room_sets.reps is
+  'Repetitions in the set. Null means the count was never recorded — a set taken to failure without counting — which is distinct from zero.';
+
+comment on column weight_room_sets.set_group is
+  'Rows sharing (workout_id, exercise, set_group) are one working set, e.g. the drops of a rack run. Null means the row is a set on its own.';

--- a/types/weight-room.ts
+++ b/types/weight-room.ts
@@ -29,8 +29,23 @@ export interface StrengthSet {
    * movement's entire history.
    */
   exercise: string
-  /** Rep count for this single set. Always positive (DB CHECK enforces). */
-  reps: number
+  /**
+   * Repetitions in this set, or `null` when the count was never recorded (#440).
+   *
+   * Positive when present (DB CHECK enforces). `null` is a different statement
+   * from zero: zero is a set with no reps, `null` is a set whose reps nobody
+   * wrote down — a rack-run drop taken to failure, where the note captures the
+   * load and nothing else. Treat it as *unknown*, not as none: sum it as `0`
+   * via {@link import('@/lib/training-facility/set-reps').countedReps}, but
+   * never render it as `0 reps`.
+   */
+  reps: number | null
+  /**
+   * Rows sharing a `(workout_id, exercise, set_group)` are one working set —
+   * the drops of a rack run, say (#440). `undefined` means the row is a set on
+   * its own, which is every ordinary set.
+   */
+  set_group?: number
   /**
    * Optional external load in pounds for this set — e.g. weighted
    * shrugs in a monthly focus (#255). Absent for bodyweight movements


### PR DESCRIPTION
## Summary

A rack run is one set taken to failure at a descending series of loads. Your notes record only the weights — `Rack Run 35,30,25,20` / `Set 1: 30, 15` — because each drop simply went until it couldn't.

The #435 import had nowhere to put "not counted": `reps` was `not null` with a `> 0` check, so it wrote **`1`**. That's 65 rows asserting a rep count nobody measured, feeding rep totals and computing tonnage as `1 × load`.

## Two corrections to the issue itself

Both checked against production before writing any code:

- **Its stated blocker is gone.** #440 says imported sessions have `template_id` null, so there's no slot to hang steps off. **23 of the 24 rack-run sessions now have a template** — that landed in #435/#436.
- **Item 2 is already done.** The prescribed rack *is* stored: Back Day 1's rack-run slot carries four steps at 35 / 30 / 25 / 20. Only the plan-vs-performed *view* is missing, and that's the follow-up we scoped out.

And one the issue misses: it says "tonnage and loads are correct; only the set count overstates." **Tonnage was not correct** — it was computed off the invented rep count.

## What changed

**`reps` is nullable**, in the column, the row schema and the type. Null means *unrecorded*, which is a different claim from zero.

Every reader had to decide what unrecorded means for it, and the answers differ: summing treats it as nothing, displaying renders a dash and never `0 reps`. `countedReps` and `repsLabel` name the two, and **all 47 sites the compiler flagged are converted**. That enumeration is the argument for nullability over a sentinel — a placeholder has a small blast radius and an unbounded wrongness radius, because nothing forces anyone to notice it.

**`set_group` groups the drops of one pass.** `countWorkingSets` collapses them, so `Set 1: 30, 15` + `Set 2: 30, 27.5, 22.5` is five rows reporting **two sets**. Keyed on `(exercise, set_group)`, since a group number is only unique within its movement.

The row-schema change matters most: it validates the whole set array in one pass, so a single null `reps` would have failed **every** read the moment one existed. #400 shipped exactly that bug.

## Migration — already applied

`20260811120000_weight_room_sets_unrecorded_reps.sql` is applied to **staging and production**, verified on both, `migrations:check` green (41 committed, all applied). Schema-only and additive: `reps` drops NOT NULL, its check becomes `reps is null or reps > 0`, `set_group` is added. **Zero rows affected** — production still has 0 null-reps rows.

It had to go first: the row schema now accepts null, but the column would still have rejected it.

## Not in this PR

- **The 65 existing rows are untouched.** They still carry `reps: 1` and no `set_group` until the import is re-run — a separate, reversible step I'd rather do with you watching.
- **Plan-vs-performed.** The prescribed `35,30,25,20` against the actual runs, which drift downward over two years. Follow-up issue.

## Test plan

- [ ] A Back Day 1 with a rack run shows 2 sets for the curl, not 5 — *after* the rows are migrated
- [ ] Rack drops read "30 lb to failure", never "1 rep"
- [ ] Session tonnage no longer includes phantom `1 × load` per drop
- [ ] Goal rings, streaks and heatmaps are unchanged for every ordinary set
- [ ] `?preview=demo` surfaces are unaffected

Verified: `tsc --noEmit` clean, `eslint` clean, `next build` compiles, **2566** vitest tests pass under `TZ=UTC`.

Refs #440.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for unrecorded repetition counts in workout logging and summaries.
  - Grouped drop-set and rack-run entries are now counted as a single working set.
  - Unrecorded reps display as a dash and are excluded from rep-based records, tonnage, and estimates.
  - Workout charts, history, streaks, and progress metrics now handle missing reps consistently.

- **Bug Fixes**
  - Corrected totals and comparisons that previously treated unknown reps as recorded values.
  - Preserved grouping information for imported rack-run and drop-set entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->